### PR TITLE
feat: add option to fetch from a link

### DIFF
--- a/orchestrator/package-lock.json
+++ b/orchestrator/package-lock.json
@@ -47,6 +47,7 @@
         "@types/better-sqlite3": "^7.6.8",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
+        "@types/jsdom": "^27.0.0",
         "@types/node": "^22.10.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -3345,6 +3346,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3456,6 +3468,12 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -59,6 +59,7 @@
     "@types/better-sqlite3": "^7.6.8",
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
+    "@types/jsdom": "^27.0.0",
     "@types/node": "^22.10.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -17,6 +17,7 @@ import type {
   CreateJobInput,
   ManualJobDraft,
   ManualJobInferenceResponse,
+  ManualJobFetchResponse,
   VisaSponsorSearchResponse,
   VisaSponsorStatusResponse,
   VisaSponsor,
@@ -38,7 +39,16 @@ async function fetchApi<T>(
     },
   });
 
-  const data: ApiResponse<T> = await response.json();
+  const text = await response.text();
+
+  let data: ApiResponse<T>;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    // If the response is not JSON, it's likely an HTML error page
+    console.error('API returned non-JSON response:', text.substring(0, 500));
+    throw new Error(`Server error (${response.status}): Expected JSON but received HTML. Is the backend server running?`);
+  }
 
   if (!data.success) {
     throw new Error(data.error || 'API request failed');
@@ -148,6 +158,15 @@ export async function importUkVisaJobs(input: {
 }
 
 // Manual Job Import API
+export async function fetchJobFromUrl(input: {
+  url: string;
+}): Promise<ManualJobFetchResponse> {
+  return fetchApi<ManualJobFetchResponse>('/manual-jobs/fetch', {
+    method: 'POST',
+    body: JSON.stringify(input),
+  });
+}
+
 export async function inferManualJob(input: {
   jobDescription: string;
 }): Promise<ManualJobInferenceResponse> {

--- a/orchestrator/src/server/api/routes/manual-jobs.test.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.test.ts
@@ -16,6 +16,28 @@ describe.sequential('Manual jobs API routes', () => {
     await stopServer({ server, closeDb, tempDir });
   });
 
+  describe('POST /api/manual-jobs/fetch', () => {
+    it('rejects invalid URLs', async () => {
+      const res = await fetch(`${baseUrl}/api/manual-jobs/fetch`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ url: 'not-a-valid-url' }),
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty payload', async () => {
+      const res = await fetch(`${baseUrl}/api/manual-jobs/fetch`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
   it('infers manual jobs and rejects empty payloads', async () => {
     const badRes = await fetch(`${baseUrl}/api/manual-jobs/infer`, {
       method: 'POST',

--- a/orchestrator/src/server/api/routes/manual-jobs.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.ts
@@ -1,16 +1,21 @@
 import { Router, Request, Response } from 'express';
 import { randomUUID } from 'crypto';
 import { z } from 'zod';
+import { JSDOM } from 'jsdom';
 import * as jobsRepo from '../../repositories/jobs.js';
 import { inferManualJobDetails } from '../../services/manualJob.js';
 import { scoreJobSuitability } from '../../services/scorer.js';
 import { getProfile } from '../../services/profile.js';
-import type { ApiResponse, ManualJobInferenceResponse } from '../../../shared/types.js';
+import type { ApiResponse, ManualJobInferenceResponse, ManualJobFetchResponse } from '../../../shared/types.js';
 
 export const manualJobsRouter = Router();
 
+const manualJobFetchSchema = z.object({
+  url: z.string().trim().url().max(2000),
+});
+
 const manualJobInferenceSchema = z.object({
-  jobDescription: z.string().trim().min(1).max(40000),
+  jobDescription: z.string().trim().min(1).max(60000),
 });
 
 const manualJobImportSchema = z.object({
@@ -37,6 +42,110 @@ const cleanOptional = (value?: string | null) => {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
 };
+
+/**
+ * POST /api/manual-jobs/fetch - Fetch and extract job content from a URL
+ */
+manualJobsRouter.post('/fetch', async (req: Request, res: Response) => {
+  try {
+    const input = manualJobFetchSchema.parse(req.body ?? {});
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 15000);
+
+    const response = await fetch(input.url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+      },
+    });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      return res.status(400).json({
+        success: false,
+        error: `Failed to fetch URL: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    const html = await response.text();
+    const dom = new JSDOM(html);
+    const document = dom.window.document;
+
+    // Extract page title (often contains job title)
+    const pageTitle = document.querySelector('title')?.textContent?.trim() || '';
+
+    // Extract meta description
+    const metaDescription = document.querySelector('meta[name="description"]')?.getAttribute('content')?.trim() || '';
+
+    // Extract Open Graph data
+    const ogTitle = document.querySelector('meta[property="og:title"]')?.getAttribute('content')?.trim() || '';
+    const ogDescription = document.querySelector('meta[property="og:description"]')?.getAttribute('content')?.trim() || '';
+    const ogSiteName = document.querySelector('meta[property="og:site-name"]')?.getAttribute('content')?.trim() || '';
+
+    // Remove non-content elements
+    const elementsToRemove = document.querySelectorAll(
+      'script, style, nav, header, footer, aside, iframe, noscript, ' +
+      '[role="navigation"], [role="banner"], [role="contentinfo"], ' +
+      '.nav, .navbar, .header, .footer, .sidebar, .menu, .cookie, .popup, .modal, .ad, .advertisement'
+    );
+    elementsToRemove.forEach((el) => el.remove());
+
+    // Try to find the main job content area
+    const mainContent =
+      document.querySelector(
+        'main, [role="main"], article, ' +
+        '.job-description, .job-details, .job-content, .vacancy-description, ' +
+        '#job-description, #job-details, #job-content, ' +
+        '[class*="job-desc"], [class*="jobDesc"], [class*="vacancy"], [class*="posting"]'
+      ) || document.body;
+
+    // Get text content
+    let textContent = mainContent?.textContent || '';
+
+    // Clean up whitespace
+    textContent = textContent
+      .replace(/[\t ]+/g, ' ')
+      .replace(/\n\s*\n/g, '\n\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
+
+    // Build enriched content with extracted metadata
+    let enrichedContent = '';
+    if (pageTitle) enrichedContent += `Page Title: ${pageTitle}\n`;
+    if (ogTitle && ogTitle !== pageTitle) enrichedContent += `Job Title: ${ogTitle}\n`;
+    if (ogSiteName) enrichedContent += `Company/Site: ${ogSiteName}\n`;
+    if (ogDescription) enrichedContent += `Summary: ${ogDescription}\n`;
+    if (metaDescription && metaDescription !== ogDescription) enrichedContent += `Description: ${metaDescription}\n`;
+    if (enrichedContent) enrichedContent += '\n---\n\n';
+    enrichedContent += textContent;
+
+    // Limit to reasonable size
+    if (enrichedContent.length > 50000) {
+      enrichedContent = enrichedContent.substring(0, 50000);
+    }
+
+    const result: ApiResponse<ManualJobFetchResponse> = {
+      success: true,
+      data: {
+        content: enrichedContent,
+        url: input.url,
+      },
+    };
+
+    res.json(result);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return res.status(400).json({ success: false, error: error.message });
+    }
+    if (error instanceof Error && error.name === 'AbortError') {
+      return res.status(408).json({ success: false, error: 'Request timed out' });
+    }
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    res.status(500).json({ success: false, error: message });
+  }
+});
 
 /**
  * POST /api/manual-jobs/infer - Infer job details from a pasted description

--- a/orchestrator/src/shared/types.ts
+++ b/orchestrator/src/shared/types.ts
@@ -154,6 +154,11 @@ export interface ManualJobInferenceResponse {
   warning?: string | null;
 }
 
+export interface ManualJobFetchResponse {
+  content: string;
+  url: string;
+}
+
 export interface UpdateJobInput {
   status?: JobStatus;
   jobDescription?: string;


### PR DESCRIPTION
- Added ability to fetch job details directly from a URL in the Manual Import sheet  
- Enter a job posting URL and click "Fetch" to automatically extract and analyze the 
  job details                                                                          
- The button dynamically switches between "Paste" (clipboard paste) and "Fetch" (URL 
  fetch) based on whether the URL field has content                                    
                                                                                       
  How it works                                                                         
                                                                                       
  1. User enters a job posting URL                                                     
  2. Server fetches the HTML from the URL                                              
  3. jsdom extracts clean text content and metadata (title, Open Graph tags, etc.)     
  4. AI analyses the extracted text to infer job fields                                
  5. User reviews and imports                                                          
                                                                                       
  Why jsdom instead of raw HTML to AI?                                                 
                                                                                       
  We initially tried sending raw HTML directly to the AI for extraction, but this      
  caused PayloadTooLargeError - Express has a default body size limit (~100KB), and job
   posting pages often exceed this with their HTML markup, scripts, stylesheets, and   
  other content.                                                                       
                                                                                       
  Using jsdom to pre-process the HTML:                                                 
  - Removes non-content elements (scripts, styles, nav, footer, ads)                   
  - Extracts metadata from <title> and Open Graph tags                                 
  - Finds the main job content area                                                    
  - Reduces payload from 100KB+ raw HTML to ~10-50KB clean text                        
  - Results in faster, cheaper AI inference with better accuracy   