### PR TITLE
manual import should move to ready directly

### DIFF
--- a/orchestrator/src/client/components/ManualImportFlow.tsx
+++ b/orchestrator/src/client/components/ManualImportFlow.tsx
@@ -216,7 +216,7 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
       const payload = toPayload(draft);
       const created = await api.importManualJob({ job: payload });
       toast.success("Job imported", {
-        description: "The job is now in the discovered column.",
+        description: "The job was tailored and moved to the ready column.",
       });
       await onImported(created.id);
       onClose();

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -177,7 +177,7 @@ export const OrchestratorPage: React.FC = () => {
   const handleManualImported = useCallback(
     async (importedJobId: string) => {
       await loadJobs();
-      navigateWithContext("discovered", importedJobId);
+      navigateWithContext("ready", importedJobId);
     },
     [loadJobs, navigateWithContext],
   );

--- a/orchestrator/src/server/api/routes/manual-jobs.test.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.test.ts
@@ -63,6 +63,7 @@ describe.sequential("Manual jobs API routes", () => {
   });
 
   it("imports manual jobs and generates a fallback URL", async () => {
+    const { processJob } = await import("../../pipeline/index");
     const { scoreJobSuitability } = await import("../../services/scorer");
     vi.mocked(scoreJobSuitability).mockResolvedValue({
       score: 88,
@@ -84,6 +85,7 @@ describe.sequential("Manual jobs API routes", () => {
     expect(body.ok).toBe(true);
     expect(body.data.source).toBe("manual");
     expect(body.data.jobUrl).toMatch(/^manual:\/\//);
+    expect(vi.mocked(processJob)).toHaveBeenCalledWith(body.data.id);
     await new Promise((resolve) => setTimeout(resolve, 25));
   });
 });


### PR DESCRIPTION
manual import should move to ready directly. 

current flow is "move to discovered" then i have to tailor and move to ready. 

if im manually pasting in a job, clearly i already like it, and im planning to apply, so move to ready with tailoring and all applied directly.