### PR TITLE
feat(post-application): provider framework + registry (ticket #137)

### DIFF
--- a/orchestrator/src/server/services/post-application/providers/errors.ts
+++ b/orchestrator/src/server/services/post-application/providers/errors.ts
@@ -1,0 +1,87 @@
+import {
+  AppError,
+  badRequest,
+  serviceUnavailable,
+  upstreamError,
+} from "@infra/errors";
+
+export type PostApplicationProviderErrorKind =
+  | "invalid_request"
+  | "not_implemented"
+  | "service_unavailable"
+  | "upstream";
+
+export class PostApplicationProviderError extends Error {
+  constructor(
+    readonly kind: PostApplicationProviderErrorKind,
+    message: string,
+    readonly details?: unknown,
+  ) {
+    super(message);
+    this.name = "PostApplicationProviderError";
+  }
+}
+
+export function providerInvalidRequest(
+  message: string,
+  details?: unknown,
+): PostApplicationProviderError {
+  return new PostApplicationProviderError("invalid_request", message, details);
+}
+
+export function providerNotImplemented(
+  message: string,
+  details?: unknown,
+): PostApplicationProviderError {
+  return new PostApplicationProviderError("not_implemented", message, details);
+}
+
+export function providerServiceUnavailable(
+  message: string,
+  details?: unknown,
+): PostApplicationProviderError {
+  return new PostApplicationProviderError(
+    "service_unavailable",
+    message,
+    details,
+  );
+}
+
+export function providerUpstreamError(
+  message: string,
+  details?: unknown,
+): PostApplicationProviderError {
+  return new PostApplicationProviderError("upstream", message, details);
+}
+
+export function toProviderAppError(error: unknown): AppError {
+  if (error instanceof AppError) return error;
+
+  if (error instanceof PostApplicationProviderError) {
+    if (error.kind === "invalid_request") {
+      return badRequest(error.message, error.details);
+    }
+
+    if (error.kind === "upstream") {
+      return upstreamError(error.message, error.details);
+    }
+
+    return serviceUnavailable(error.message);
+  }
+
+  if (error instanceof Error) {
+    return new AppError({
+      status: 500,
+      code: "INTERNAL_ERROR",
+      message: error.message || "Provider action failed",
+      cause: error,
+    });
+  }
+
+  return new AppError({
+    status: 500,
+    code: "INTERNAL_ERROR",
+    message: "Provider action failed",
+    details: error,
+  });
+}

--- a/orchestrator/src/server/services/post-application/providers/gmail.ts
+++ b/orchestrator/src/server/services/post-application/providers/gmail.ts
@@ -1,0 +1,57 @@
+import { providerNotImplemented } from "./errors";
+import type {
+  PostApplicationProviderActionResult,
+  PostApplicationProviderAdapter,
+  PostApplicationProviderConnectArgs,
+  PostApplicationProviderDisconnectArgs,
+  PostApplicationProviderStatusArgs,
+  PostApplicationProviderSyncArgs,
+} from "./types";
+
+function buildDisconnectedStatus(
+  accountKey: string,
+): PostApplicationProviderActionResult {
+  return {
+    status: {
+      provider: "gmail",
+      accountKey,
+      connected: false,
+      integration: null,
+    },
+    message: "Gmail provider framework is installed but not connected.",
+  };
+}
+
+export const gmailProvider: PostApplicationProviderAdapter = {
+  key: "gmail",
+
+  async connect(
+    args: PostApplicationProviderConnectArgs,
+  ): Promise<PostApplicationProviderActionResult> {
+    throw providerNotImplemented(
+      `Gmail connect is not implemented yet for account '${args.accountKey}'.`,
+    );
+  },
+
+  async status(
+    args: PostApplicationProviderStatusArgs,
+  ): Promise<PostApplicationProviderActionResult> {
+    return buildDisconnectedStatus(args.accountKey);
+  },
+
+  async sync(
+    args: PostApplicationProviderSyncArgs,
+  ): Promise<PostApplicationProviderActionResult> {
+    throw providerNotImplemented(
+      `Gmail sync is not implemented yet for account '${args.accountKey}'.`,
+    );
+  },
+
+  async disconnect(
+    args: PostApplicationProviderDisconnectArgs,
+  ): Promise<PostApplicationProviderActionResult> {
+    throw providerNotImplemented(
+      `Gmail disconnect is not implemented yet for account '${args.accountKey}'.`,
+    );
+  },
+};

--- a/orchestrator/src/server/services/post-application/providers/imap.ts
+++ b/orchestrator/src/server/services/post-application/providers/imap.ts
@@ -1,0 +1,43 @@
+import { providerNotImplemented } from "./errors";
+import type {
+  PostApplicationProviderActionResult,
+  PostApplicationProviderAdapter,
+  PostApplicationProviderConnectArgs,
+  PostApplicationProviderDisconnectArgs,
+  PostApplicationProviderStatusArgs,
+  PostApplicationProviderSyncArgs,
+} from "./types";
+
+function notImplemented(accountKey: string): never {
+  throw providerNotImplemented(
+    `IMAP provider is not implemented yet for account '${accountKey}'.`,
+  );
+}
+
+export const imapProvider: PostApplicationProviderAdapter = {
+  key: "imap",
+
+  async connect(
+    args: PostApplicationProviderConnectArgs,
+  ): Promise<PostApplicationProviderActionResult> {
+    return notImplemented(args.accountKey);
+  },
+
+  async status(
+    args: PostApplicationProviderStatusArgs,
+  ): Promise<PostApplicationProviderActionResult> {
+    return notImplemented(args.accountKey);
+  },
+
+  async sync(
+    args: PostApplicationProviderSyncArgs,
+  ): Promise<PostApplicationProviderActionResult> {
+    return notImplemented(args.accountKey);
+  },
+
+  async disconnect(
+    args: PostApplicationProviderDisconnectArgs,
+  ): Promise<PostApplicationProviderActionResult> {
+    return notImplemented(args.accountKey);
+  },
+};

--- a/orchestrator/src/server/services/post-application/providers/index.ts
+++ b/orchestrator/src/server/services/post-application/providers/index.ts
@@ -1,0 +1,24 @@
+export {
+  PostApplicationProviderError,
+  providerInvalidRequest,
+  providerNotImplemented,
+  providerServiceUnavailable,
+  providerUpstreamError,
+  toProviderAppError,
+} from "./errors";
+export { gmailProvider } from "./gmail";
+export { imapProvider } from "./imap";
+export {
+  listPostApplicationProviders,
+  resolvePostApplicationProvider,
+} from "./registry";
+export { executePostApplicationProviderAction } from "./service";
+export type {
+  ExecutePostApplicationProviderActionInput,
+  PostApplicationProviderActionResult,
+  PostApplicationProviderAdapter,
+  PostApplicationProviderConnectArgs,
+  PostApplicationProviderDisconnectArgs,
+  PostApplicationProviderStatusArgs,
+  PostApplicationProviderSyncArgs,
+} from "./types";

--- a/orchestrator/src/server/services/post-application/providers/registry.ts
+++ b/orchestrator/src/server/services/post-application/providers/registry.ts
@@ -1,0 +1,37 @@
+import type { PostApplicationProvider } from "@shared/types";
+import { POST_APPLICATION_PROVIDERS } from "@shared/types";
+import { providerInvalidRequest } from "./errors";
+import { gmailProvider } from "./gmail";
+import { imapProvider } from "./imap";
+import type { PostApplicationProviderAdapter } from "./types";
+
+const providerRegistry: Record<
+  PostApplicationProvider,
+  PostApplicationProviderAdapter
+> = {
+  gmail: gmailProvider,
+  imap: imapProvider,
+};
+
+function isPostApplicationProvider(
+  value: string,
+): value is PostApplicationProvider {
+  return (POST_APPLICATION_PROVIDERS as readonly string[]).includes(value);
+}
+
+export function resolvePostApplicationProvider(
+  provider: string,
+): PostApplicationProviderAdapter {
+  if (!isPostApplicationProvider(provider)) {
+    throw providerInvalidRequest(`Unsupported provider '${provider}'.`, {
+      provider,
+      supportedProviders: POST_APPLICATION_PROVIDERS,
+    });
+  }
+
+  return providerRegistry[provider];
+}
+
+export function listPostApplicationProviders(): PostApplicationProvider[] {
+  return [...POST_APPLICATION_PROVIDERS];
+}

--- a/orchestrator/src/server/services/post-application/providers/service.test.ts
+++ b/orchestrator/src/server/services/post-application/providers/service.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  PostApplicationProviderError,
+  providerUpstreamError,
+  toProviderAppError,
+} from "./errors";
+import {
+  listPostApplicationProviders,
+  resolvePostApplicationProvider,
+} from "./registry";
+import { executePostApplicationProviderAction } from "./service";
+
+describe("post-application provider registry", () => {
+  it("lists registered providers", () => {
+    expect(listPostApplicationProviders()).toEqual(["gmail", "imap"]);
+  });
+
+  it("resolves a known provider", () => {
+    const provider = resolvePostApplicationProvider("gmail");
+    expect(provider.key).toBe("gmail");
+  });
+
+  it("throws explicit invalid-request error for unknown provider", () => {
+    expect(() => resolvePostApplicationProvider("exchange")).toThrowError(
+      PostApplicationProviderError,
+    );
+
+    try {
+      resolvePostApplicationProvider("exchange");
+      throw new Error("expected resolve to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PostApplicationProviderError);
+      expect((error as PostApplicationProviderError).kind).toBe(
+        "invalid_request",
+      );
+    }
+  });
+});
+
+describe("post-application provider action dispatcher", () => {
+  it("dispatches status action to gmail provider", async () => {
+    const response = await executePostApplicationProviderAction({
+      provider: "gmail",
+      action: "status",
+      accountKey: "account:gmail:test",
+    });
+
+    expect(response).toEqual({
+      provider: "gmail",
+      action: "status",
+      accountKey: "account:gmail:test",
+      status: {
+        provider: "gmail",
+        accountKey: "account:gmail:test",
+        connected: false,
+        integration: null,
+      },
+    });
+  });
+
+  it("maps IMAP not-implemented errors to service unavailable app errors", async () => {
+    await expect(
+      executePostApplicationProviderAction({
+        provider: "imap",
+        action: "connect",
+        accountKey: "account:imap:test",
+      }),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "SERVICE_UNAVAILABLE",
+      message:
+        "IMAP provider is not implemented yet for account 'account:imap:test'.",
+    });
+  });
+
+  it("maps upstream provider errors to upstream app errors", () => {
+    const appError = toProviderAppError(
+      providerUpstreamError("Provider API timed out"),
+    );
+
+    expect(appError.status).toBe(502);
+    expect(appError.code).toBe("UPSTREAM_ERROR");
+    expect(appError.message).toBe("Provider API timed out");
+  });
+});

--- a/orchestrator/src/server/services/post-application/providers/service.ts
+++ b/orchestrator/src/server/services/post-application/providers/service.ts
@@ -1,0 +1,51 @@
+import { logger } from "@infra/logger";
+import type { PostApplicationProviderActionResponse } from "@shared/types";
+import { toProviderAppError } from "./errors";
+import { resolvePostApplicationProvider } from "./registry";
+import type { ExecutePostApplicationProviderActionInput } from "./types";
+
+export async function executePostApplicationProviderAction(
+  input: ExecutePostApplicationProviderActionInput,
+): Promise<PostApplicationProviderActionResponse> {
+  const provider = resolvePostApplicationProvider(input.provider);
+
+  try {
+    const result =
+      input.action === "connect"
+        ? await provider.connect({
+            accountKey: input.accountKey,
+            initiatedBy: input.initiatedBy,
+            payload: input.connectPayload,
+          })
+        : input.action === "status"
+          ? await provider.status({
+              accountKey: input.accountKey,
+            })
+          : input.action === "sync"
+            ? await provider.sync({
+                accountKey: input.accountKey,
+                initiatedBy: input.initiatedBy,
+                payload: input.syncPayload,
+              })
+            : await provider.disconnect({
+                accountKey: input.accountKey,
+                initiatedBy: input.initiatedBy,
+              });
+
+    return {
+      provider: provider.key,
+      action: input.action,
+      accountKey: input.accountKey,
+      status: result.status,
+    };
+  } catch (error) {
+    logger.warn("Post-application provider action failed", {
+      provider: provider.key,
+      action: input.action,
+      accountKey: input.accountKey,
+      initiatedBy: input.initiatedBy ?? null,
+      error,
+    });
+    throw toProviderAppError(error);
+  }
+}

--- a/orchestrator/src/server/services/post-application/providers/types.ts
+++ b/orchestrator/src/server/services/post-application/providers/types.ts
@@ -1,0 +1,62 @@
+import type {
+  PostApplicationProvider,
+  PostApplicationProviderActionConnectRequest,
+  PostApplicationProviderActionResponse,
+  PostApplicationProviderActionSyncRequest,
+  PostApplicationProviderStatus,
+} from "@shared/types";
+
+export type PostApplicationProviderConnectArgs = {
+  accountKey: string;
+  initiatedBy?: string | null;
+  payload?: PostApplicationProviderActionConnectRequest;
+};
+
+export type PostApplicationProviderStatusArgs = {
+  accountKey: string;
+};
+
+export type PostApplicationProviderSyncArgs = {
+  accountKey: string;
+  initiatedBy?: string | null;
+  payload?: PostApplicationProviderActionSyncRequest;
+};
+
+export type PostApplicationProviderDisconnectArgs = {
+  accountKey: string;
+  initiatedBy?: string | null;
+};
+
+export type PostApplicationProviderActionResult = {
+  status: PostApplicationProviderStatus;
+  message?: string;
+};
+
+export interface PostApplicationProviderAdapter {
+  readonly key: PostApplicationProvider;
+
+  connect(
+    args: PostApplicationProviderConnectArgs,
+  ): Promise<PostApplicationProviderActionResult>;
+
+  status(
+    args: PostApplicationProviderStatusArgs,
+  ): Promise<PostApplicationProviderActionResult>;
+
+  sync(
+    args: PostApplicationProviderSyncArgs,
+  ): Promise<PostApplicationProviderActionResult>;
+
+  disconnect(
+    args: PostApplicationProviderDisconnectArgs,
+  ): Promise<PostApplicationProviderActionResult>;
+}
+
+export type ExecutePostApplicationProviderActionInput = {
+  provider: string;
+  action: PostApplicationProviderActionResponse["action"];
+  accountKey: string;
+  initiatedBy?: string | null;
+  connectPayload?: PostApplicationProviderActionConnectRequest;
+  syncPayload?: PostApplicationProviderActionSyncRequest;
+};


### PR DESCRIPTION
Summary:\n- add a provider contract for post-application ingestion actions: connect, status, sync, disconnect\n- add provider registry/dispatcher with strict provider resolution for gmail and imap keys\n- add gmail implementation slot (status implemented, connect/sync/disconnect explicitly not implemented)\n- add imap stub provider with explicit not-implemented behavior for all actions\n- add provider error model and mapping into AppError codes for API-safe handling\n- add unit tests for registry resolution, action dispatch, and provider error mapping\n\nLinked issues:\n- Part of #135\n- Implements #137\n\nValidation:\n- PASS: ./orchestrator/node_modules/.bin/biome ci .\n- PASS: npm run check:types:shared\n- PASS: npm --workspace orchestrator run check:types\n- PASS: npm --workspace gradcracker-extractor run check:types\n- PASS: npm --workspace ukvisajobs-extractor run check:types\n- PASS: npm --workspace orchestrator run build:client\n- PASS: npm --workspace orchestrator run test:run\n\nNotes:\n- This PR is framework-only and does not add API routes yet (covered by next ticket).