### PR TITLE
Gmail provider: OAuth persistence in integration store

### DIFF
--- a/orchestrator/src/server/repositories/post-application-integrations.ts
+++ b/orchestrator/src/server/repositories/post-application-integrations.ts
@@ -1,0 +1,143 @@
+import { randomUUID } from "node:crypto";
+import type {
+  PostApplicationIntegration,
+  PostApplicationIntegrationStatus,
+  PostApplicationProvider,
+} from "@shared/types";
+import { and, eq } from "drizzle-orm";
+import { db, schema } from "../db";
+
+const { postApplicationIntegrations } = schema;
+
+type IntegrationCredentials = Record<string, unknown>;
+
+type UpsertConnectedIntegrationInput = {
+  provider: PostApplicationProvider;
+  accountKey: string;
+  displayName?: string | null;
+  credentials: IntegrationCredentials;
+};
+
+function asCredentials(value: unknown): IntegrationCredentials | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  return value as IntegrationCredentials;
+}
+
+function mapRowToIntegration(
+  row: typeof postApplicationIntegrations.$inferSelect,
+): PostApplicationIntegration {
+  return {
+    id: row.id,
+    provider: row.provider,
+    accountKey: row.accountKey,
+    displayName: row.displayName,
+    status: row.status as PostApplicationIntegrationStatus,
+    credentials: asCredentials(row.credentials),
+    lastConnectedAt: row.lastConnectedAt,
+    lastSyncedAt: row.lastSyncedAt,
+    lastError: row.lastError,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export async function getPostApplicationIntegration(
+  provider: PostApplicationProvider,
+  accountKey: string,
+): Promise<PostApplicationIntegration | null> {
+  const [row] = await db
+    .select()
+    .from(postApplicationIntegrations)
+    .where(
+      and(
+        eq(postApplicationIntegrations.provider, provider),
+        eq(postApplicationIntegrations.accountKey, accountKey),
+      ),
+    );
+
+  return row ? mapRowToIntegration(row) : null;
+}
+
+export async function upsertConnectedPostApplicationIntegration(
+  input: UpsertConnectedIntegrationInput,
+): Promise<PostApplicationIntegration> {
+  const nowEpoch = Date.now();
+  const nowIso = new Date(nowEpoch).toISOString();
+  const existing = await getPostApplicationIntegration(
+    input.provider,
+    input.accountKey,
+  );
+
+  if (existing) {
+    await db
+      .update(postApplicationIntegrations)
+      .set({
+        displayName: input.displayName ?? existing.displayName,
+        status: "connected",
+        credentials: input.credentials,
+        lastConnectedAt: nowEpoch,
+        lastError: null,
+        updatedAt: nowIso,
+      })
+      .where(eq(postApplicationIntegrations.id, existing.id));
+
+    const updated = await getPostApplicationIntegration(
+      input.provider,
+      input.accountKey,
+    );
+    if (!updated) {
+      throw new Error(
+        `Failed to load updated integration ${input.provider}/${input.accountKey}.`,
+      );
+    }
+    return updated;
+  }
+
+  const id = randomUUID();
+  await db.insert(postApplicationIntegrations).values({
+    id,
+    provider: input.provider,
+    accountKey: input.accountKey,
+    displayName: input.displayName ?? null,
+    status: "connected",
+    credentials: input.credentials,
+    lastConnectedAt: nowEpoch,
+    lastError: null,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  });
+
+  const created = await getPostApplicationIntegration(
+    input.provider,
+    input.accountKey,
+  );
+  if (!created) {
+    throw new Error(
+      `Failed to load created integration ${input.provider}/${input.accountKey}.`,
+    );
+  }
+  return created;
+}
+
+export async function disconnectPostApplicationIntegration(
+  provider: PostApplicationProvider,
+  accountKey: string,
+): Promise<PostApplicationIntegration | null> {
+  const existing = await getPostApplicationIntegration(provider, accountKey);
+  if (!existing) return null;
+
+  const nowIso = new Date().toISOString();
+  await db
+    .update(postApplicationIntegrations)
+    .set({
+      status: "disconnected",
+      credentials: null,
+      lastError: null,
+      updatedAt: nowIso,
+    })
+    .where(eq(postApplicationIntegrations.id, existing.id));
+
+  return getPostApplicationIntegration(provider, accountKey);
+}

--- a/orchestrator/src/server/services/post-application/providers/gmail.ts
+++ b/orchestrator/src/server/services/post-application/providers/gmail.ts
@@ -1,4 +1,15 @@
-import { providerNotImplemented } from "./errors";
+import { logger } from "@infra/logger";
+import {
+  disconnectPostApplicationIntegration,
+  getPostApplicationIntegration,
+  upsertConnectedPostApplicationIntegration,
+} from "@server/repositories/post-application-integrations";
+import type { PostApplicationIntegration } from "@shared/types";
+import {
+  providerInvalidRequest,
+  providerNotImplemented,
+  providerUpstreamError,
+} from "./errors";
 import type {
   PostApplicationProviderActionResult,
   PostApplicationProviderAdapter,
@@ -8,35 +19,187 @@ import type {
   PostApplicationProviderSyncArgs,
 } from "./types";
 
-function buildDisconnectedStatus(
+type GmailCredentialPayload = {
+  refreshToken: string;
+  accessToken?: string;
+  expiryDate?: number;
+  scope?: string;
+  tokenType?: string;
+  email?: string;
+  displayName?: string;
+};
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function parseGmailCredentials(
+  args: PostApplicationProviderConnectArgs,
+): GmailCredentialPayload {
+  const raw = args.payload?.payload;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw providerInvalidRequest(
+      "Gmail connect requires payload credentials in body.payload.",
+    );
+  }
+
+  const refreshToken = asString((raw as Record<string, unknown>).refreshToken);
+  if (!refreshToken) {
+    throw providerInvalidRequest(
+      "Gmail connect requires a non-empty refreshToken in body.payload.refreshToken.",
+    );
+  }
+
+  return {
+    refreshToken,
+    accessToken: asString((raw as Record<string, unknown>).accessToken),
+    expiryDate: asNumber((raw as Record<string, unknown>).expiryDate),
+    scope: asString((raw as Record<string, unknown>).scope),
+    tokenType: asString((raw as Record<string, unknown>).tokenType),
+    email: asString((raw as Record<string, unknown>).email),
+    displayName: asString((raw as Record<string, unknown>).displayName),
+  };
+}
+
+function toPublicIntegration(
+  integration: PostApplicationIntegration | null,
+): PostApplicationIntegration | null {
+  if (!integration) return null;
+
+  const credentials = integration.credentials ?? {};
+  return {
+    ...integration,
+    credentials: {
+      hasRefreshToken:
+        typeof credentials.refreshToken === "string" &&
+        credentials.refreshToken.length > 0,
+      hasAccessToken:
+        typeof credentials.accessToken === "string" &&
+        credentials.accessToken.length > 0,
+      scope: asString(credentials.scope) ?? null,
+      tokenType: asString(credentials.tokenType) ?? null,
+      expiryDate: asNumber(credentials.expiryDate) ?? null,
+      email: asString(credentials.email) ?? null,
+    },
+  };
+}
+
+function buildStatus(
   accountKey: string,
+  integration: PostApplicationIntegration | null,
+  message?: string,
 ): PostApplicationProviderActionResult {
+  const publicIntegration = toPublicIntegration(integration);
+  const hasRefreshToken = Boolean(
+    publicIntegration?.credentials?.hasRefreshToken,
+  );
+
   return {
     status: {
       provider: "gmail",
       accountKey,
-      connected: false,
-      integration: null,
+      connected: publicIntegration?.status === "connected" && hasRefreshToken,
+      integration: publicIntegration,
     },
-    message: "Gmail provider framework is installed but not connected.",
+    message,
   };
+}
+
+async function revokeGoogleToken(token: string): Promise<void> {
+  const timeoutMs = 5_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const body = new URLSearchParams({ token });
+    const response = await fetch("https://oauth2.googleapis.com/revoke", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+      signal: controller.signal,
+    });
+    if (!response.ok) {
+      throw providerUpstreamError(
+        `Google token revoke failed with HTTP ${response.status}.`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw providerUpstreamError("Google token revoke request timed out.");
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export const gmailProvider: PostApplicationProviderAdapter = {
   key: "gmail",
-
   async connect(
     args: PostApplicationProviderConnectArgs,
   ): Promise<PostApplicationProviderActionResult> {
-    throw providerNotImplemented(
-      `Gmail connect is not implemented yet for account '${args.accountKey}'.`,
+    const credentials = parseGmailCredentials(args);
+    const displayName =
+      credentials.displayName ??
+      credentials.email ??
+      `Gmail (${args.accountKey})`;
+
+    const integration = await upsertConnectedPostApplicationIntegration({
+      provider: "gmail",
+      accountKey: args.accountKey,
+      displayName,
+      credentials: {
+        refreshToken: credentials.refreshToken,
+        ...(credentials.accessToken
+          ? { accessToken: credentials.accessToken }
+          : {}),
+        ...(typeof credentials.expiryDate === "number"
+          ? { expiryDate: credentials.expiryDate }
+          : {}),
+        ...(credentials.scope ? { scope: credentials.scope } : {}),
+        ...(credentials.tokenType ? { tokenType: credentials.tokenType } : {}),
+        ...(credentials.email ? { email: credentials.email } : {}),
+      },
+    });
+
+    logger.info("Gmail integration connected", {
+      provider: "gmail",
+      accountKey: args.accountKey,
+      initiatedBy: args.initiatedBy ?? null,
+      integrationId: integration.id,
+    });
+
+    return buildStatus(
+      args.accountKey,
+      integration,
+      "Gmail integration connected.",
     );
   },
 
   async status(
     args: PostApplicationProviderStatusArgs,
   ): Promise<PostApplicationProviderActionResult> {
-    return buildDisconnectedStatus(args.accountKey);
+    const integration = await getPostApplicationIntegration(
+      "gmail",
+      args.accountKey,
+    );
+    if (!integration) {
+      return buildStatus(
+        args.accountKey,
+        null,
+        "Gmail provider is not connected.",
+      );
+    }
+
+    return buildStatus(args.accountKey, integration);
   },
 
   async sync(
@@ -50,8 +213,53 @@ export const gmailProvider: PostApplicationProviderAdapter = {
   async disconnect(
     args: PostApplicationProviderDisconnectArgs,
   ): Promise<PostApplicationProviderActionResult> {
-    throw providerNotImplemented(
-      `Gmail disconnect is not implemented yet for account '${args.accountKey}'.`,
+    const integration = await getPostApplicationIntegration(
+      "gmail",
+      args.accountKey,
+    );
+    const refreshToken =
+      integration?.credentials &&
+      typeof integration.credentials.refreshToken === "string" &&
+      integration.credentials.refreshToken.length > 0
+        ? integration.credentials.refreshToken
+        : null;
+
+    let revokeWarning: string | null = null;
+    if (refreshToken) {
+      try {
+        await revokeGoogleToken(refreshToken);
+      } catch (error) {
+        revokeWarning =
+          error instanceof Error
+            ? error.message
+            : "Google token revoke failed before disconnect.";
+        logger.warn("Gmail token revoke failed during disconnect", {
+          provider: "gmail",
+          accountKey: args.accountKey,
+          initiatedBy: args.initiatedBy ?? null,
+          revokeWarning,
+        });
+      }
+    }
+
+    const disconnected = await disconnectPostApplicationIntegration(
+      "gmail",
+      args.accountKey,
+    );
+    logger.info("Gmail integration disconnected", {
+      provider: "gmail",
+      accountKey: args.accountKey,
+      initiatedBy: args.initiatedBy ?? null,
+      integrationId: disconnected?.id ?? integration?.id ?? null,
+      tokenRevoked: Boolean(refreshToken && !revokeWarning),
+    });
+
+    return buildStatus(
+      args.accountKey,
+      disconnected,
+      revokeWarning
+        ? "Gmail disconnected locally. Token revoke should be retried."
+        : "Gmail integration disconnected.",
     );
   },
 };

--- a/orchestrator/src/server/services/post-application/providers/service.test.ts
+++ b/orchestrator/src/server/services/post-application/providers/service.test.ts
@@ -1,4 +1,57 @@
-import { describe, expect, it } from "vitest";
+import type { PostApplicationIntegration } from "@shared/types";
+import type { Mock } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@server/repositories/post-application-integrations", () => ({
+  getPostApplicationIntegration: vi.fn().mockResolvedValue(null),
+  upsertConnectedPostApplicationIntegration: vi.fn().mockImplementation(
+    async ({
+      provider,
+      accountKey,
+      displayName,
+      credentials,
+    }: {
+      provider: "gmail";
+      accountKey: string;
+      displayName: string;
+      credentials: Record<string, unknown>;
+    }) =>
+      ({
+        id: "integration-test",
+        provider,
+        accountKey,
+        displayName,
+        status: "connected",
+        credentials,
+        lastConnectedAt: Date.now(),
+        lastSyncedAt: null,
+        lastError: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }) satisfies PostApplicationIntegration,
+  ),
+  disconnectPostApplicationIntegration: vi.fn().mockImplementation(
+    async (provider: "gmail", accountKey: string) =>
+      ({
+        id: "integration-test",
+        provider,
+        accountKey,
+        displayName: "Gmail (default)",
+        status: "disconnected",
+        credentials: null,
+        lastConnectedAt: Date.now(),
+        lastSyncedAt: null,
+        lastError: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      }) satisfies PostApplicationIntegration,
+  ),
+}));
+
+const integrationRepo = await import(
+  "@server/repositories/post-application-integrations"
+);
+
 import {
   PostApplicationProviderError,
   providerUpstreamError,
@@ -9,6 +62,11 @@ import {
   resolvePostApplicationProvider,
 } from "./registry";
 import { executePostApplicationProviderAction } from "./service";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, status: 200 }));
+});
 
 describe("post-application provider registry", () => {
   it("lists registered providers", () => {
@@ -38,6 +96,39 @@ describe("post-application provider registry", () => {
 });
 
 describe("post-application provider action dispatcher", () => {
+  it("connects gmail and persists credentials in the integrations store", async () => {
+    const response = await executePostApplicationProviderAction({
+      provider: "gmail",
+      action: "connect",
+      accountKey: "account:gmail:test",
+      connectPayload: {
+        payload: {
+          refreshToken: "refresh-token",
+          accessToken: "access-token",
+          email: "candidate@example.com",
+          scope: "https://www.googleapis.com/auth/gmail.readonly",
+        },
+      },
+    });
+
+    expect(
+      integrationRepo.upsertConnectedPostApplicationIntegration,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "gmail",
+        accountKey: "account:gmail:test",
+      }),
+    );
+    expect(response.status.connected).toBe(true);
+    expect(response.status.integration?.credentials).toEqual(
+      expect.objectContaining({
+        hasRefreshToken: true,
+        hasAccessToken: true,
+        email: "candidate@example.com",
+      }),
+    );
+  });
+
   it("dispatches status action to gmail provider", async () => {
     const response = await executePostApplicationProviderAction({
       provider: "gmail",
@@ -55,6 +146,58 @@ describe("post-application provider action dispatcher", () => {
         connected: false,
         integration: null,
       },
+    });
+  });
+
+  it("disconnects gmail and clears credentials from integration store", async () => {
+    const getIntegrationMock =
+      integrationRepo.getPostApplicationIntegration as Mock;
+    getIntegrationMock.mockResolvedValueOnce({
+      id: "integration-test",
+      provider: "gmail",
+      accountKey: "account:gmail:test",
+      displayName: "Gmail (default)",
+      status: "connected",
+      credentials: {
+        refreshToken: "refresh-token",
+      },
+      lastConnectedAt: Date.now(),
+      lastSyncedAt: null,
+      lastError: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    } satisfies PostApplicationIntegration);
+
+    const response = await executePostApplicationProviderAction({
+      provider: "gmail",
+      action: "disconnect",
+      accountKey: "account:gmail:test",
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(
+      integrationRepo.disconnectPostApplicationIntegration,
+    ).toHaveBeenCalledWith("gmail", "account:gmail:test");
+    expect(response.status.connected).toBe(false);
+    expect(response.status.integration?.credentials).toEqual(
+      expect.objectContaining({
+        hasRefreshToken: false,
+        hasAccessToken: false,
+      }),
+    );
+  });
+
+  it("returns invalid request when gmail connect payload is missing refresh token", async () => {
+    await expect(
+      executePostApplicationProviderAction({
+        provider: "gmail",
+        action: "connect",
+        accountKey: "account:gmail:test",
+        connectPayload: { payload: {} },
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "INVALID_REQUEST",
     });
   });
 


### PR DESCRIPTION
## Summary
- add a post-application integrations repository for provider/account upsert, lookup, and disconnect operations
- implement Gmail provider connect/status/disconnect actions with credential persistence in `post_application_integrations.credentials`
- return redacted integration credential metadata from status responses (never raw tokens)
- attempt Google token revocation on disconnect, then always clear local credentials
- add provider action tests for Gmail connect/disconnect/status and invalid payload handling

## Verification
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`
