### PR TITLE
Gmail ingestion pipeline with 95/60 relevance gating

### DIFF
--- a/orchestrator/src/server/repositories/post-application-messages.ts
+++ b/orchestrator/src/server/repositories/post-application-messages.ts
@@ -1,0 +1,183 @@
+import { randomUUID } from "node:crypto";
+import type {
+  PostApplicationMessage,
+  PostApplicationProvider,
+  PostApplicationRelevanceDecision,
+  PostApplicationReviewStatus,
+} from "@shared/types";
+import { and, eq } from "drizzle-orm";
+import { db, schema } from "../db";
+
+const { postApplicationMessages } = schema;
+
+type UpsertPostApplicationMessageInput = {
+  provider: PostApplicationProvider;
+  accountKey: string;
+  integrationId: string | null;
+  syncRunId: string | null;
+  externalMessageId: string;
+  externalThreadId?: string | null;
+  fromAddress: string;
+  fromDomain?: string | null;
+  senderName?: string | null;
+  subject: string;
+  receivedAt: number;
+  snippet: string;
+  classificationLabel?: string | null;
+  classificationConfidence?: number | null;
+  classificationPayload?: Record<string, unknown> | null;
+  relevanceKeywordScore: number;
+  relevanceLlmScore?: number | null;
+  relevanceFinalScore: number;
+  relevanceDecision: PostApplicationRelevanceDecision;
+  reviewStatus: PostApplicationReviewStatus;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+};
+
+function mapRowToPostApplicationMessage(
+  row: typeof postApplicationMessages.$inferSelect,
+): PostApplicationMessage {
+  return {
+    id: row.id,
+    provider: row.provider,
+    accountKey: row.accountKey,
+    integrationId: row.integrationId,
+    syncRunId: row.syncRunId,
+    externalMessageId: row.externalMessageId,
+    externalThreadId: row.externalThreadId,
+    fromAddress: row.fromAddress,
+    fromDomain: row.fromDomain,
+    senderName: row.senderName,
+    subject: row.subject,
+    receivedAt: row.receivedAt,
+    snippet: row.snippet,
+    classificationLabel: row.classificationLabel,
+    classificationConfidence: row.classificationConfidence,
+    classificationPayload:
+      (row.classificationPayload as Record<string, unknown> | null) ?? null,
+    relevanceKeywordScore: row.relevanceKeywordScore,
+    relevanceLlmScore: row.relevanceLlmScore,
+    relevanceFinalScore: row.relevanceFinalScore,
+    relevanceDecision:
+      row.relevanceDecision as PostApplicationRelevanceDecision,
+    reviewStatus: row.reviewStatus as PostApplicationReviewStatus,
+    matchedJobId: row.matchedJobId,
+    decidedAt: row.decidedAt,
+    decidedBy: row.decidedBy,
+    errorCode: row.errorCode,
+    errorMessage: row.errorMessage,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+async function getPostApplicationMessageByExternalId(
+  provider: PostApplicationProvider,
+  accountKey: string,
+  externalMessageId: string,
+): Promise<PostApplicationMessage | null> {
+  const [row] = await db
+    .select()
+    .from(postApplicationMessages)
+    .where(
+      and(
+        eq(postApplicationMessages.provider, provider),
+        eq(postApplicationMessages.accountKey, accountKey),
+        eq(postApplicationMessages.externalMessageId, externalMessageId),
+      ),
+    );
+  return row ? mapRowToPostApplicationMessage(row) : null;
+}
+
+export async function upsertPostApplicationMessage(
+  input: UpsertPostApplicationMessageInput,
+): Promise<PostApplicationMessage> {
+  const nowIso = new Date().toISOString();
+  const existing = await getPostApplicationMessageByExternalId(
+    input.provider,
+    input.accountKey,
+    input.externalMessageId,
+  );
+
+  if (existing) {
+    await db
+      .update(postApplicationMessages)
+      .set({
+        integrationId: input.integrationId,
+        syncRunId: input.syncRunId,
+        externalThreadId: input.externalThreadId ?? null,
+        fromAddress: input.fromAddress,
+        fromDomain: input.fromDomain ?? null,
+        senderName: input.senderName ?? null,
+        subject: input.subject,
+        receivedAt: input.receivedAt,
+        snippet: input.snippet,
+        classificationLabel: input.classificationLabel ?? null,
+        classificationConfidence: input.classificationConfidence ?? null,
+        classificationPayload: input.classificationPayload ?? null,
+        relevanceKeywordScore: input.relevanceKeywordScore,
+        relevanceLlmScore: input.relevanceLlmScore ?? null,
+        relevanceFinalScore: input.relevanceFinalScore,
+        relevanceDecision: input.relevanceDecision,
+        reviewStatus: input.reviewStatus,
+        errorCode: input.errorCode ?? null,
+        errorMessage: input.errorMessage ?? null,
+        updatedAt: nowIso,
+      })
+      .where(eq(postApplicationMessages.id, existing.id));
+
+    const updated = await getPostApplicationMessageByExternalId(
+      input.provider,
+      input.accountKey,
+      input.externalMessageId,
+    );
+    if (!updated) {
+      throw new Error(
+        `Failed to load updated post-application message ${input.externalMessageId}.`,
+      );
+    }
+    return updated;
+  }
+
+  const id = randomUUID();
+  await db.insert(postApplicationMessages).values({
+    id,
+    provider: input.provider,
+    accountKey: input.accountKey,
+    integrationId: input.integrationId,
+    syncRunId: input.syncRunId,
+    externalMessageId: input.externalMessageId,
+    externalThreadId: input.externalThreadId ?? null,
+    fromAddress: input.fromAddress,
+    fromDomain: input.fromDomain ?? null,
+    senderName: input.senderName ?? null,
+    subject: input.subject,
+    receivedAt: input.receivedAt,
+    snippet: input.snippet,
+    classificationLabel: input.classificationLabel ?? null,
+    classificationConfidence: input.classificationConfidence ?? null,
+    classificationPayload: input.classificationPayload ?? null,
+    relevanceKeywordScore: input.relevanceKeywordScore,
+    relevanceLlmScore: input.relevanceLlmScore ?? null,
+    relevanceFinalScore: input.relevanceFinalScore,
+    relevanceDecision: input.relevanceDecision,
+    reviewStatus: input.reviewStatus,
+    errorCode: input.errorCode ?? null,
+    errorMessage: input.errorMessage ?? null,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  });
+
+  const created = await getPostApplicationMessageByExternalId(
+    input.provider,
+    input.accountKey,
+    input.externalMessageId,
+  );
+  if (!created) {
+    throw new Error(
+      `Failed to load created post-application message ${input.externalMessageId}.`,
+    );
+  }
+  return created;
+}

--- a/orchestrator/src/server/repositories/post-application-sync-runs.ts
+++ b/orchestrator/src/server/repositories/post-application-sync-runs.ts
@@ -1,0 +1,146 @@
+import { randomUUID } from "node:crypto";
+import type {
+  PostApplicationProvider,
+  PostApplicationSyncRun,
+  PostApplicationSyncRunStatus,
+} from "@shared/types";
+import { and, desc, eq } from "drizzle-orm";
+import { db, schema } from "../db";
+
+const { postApplicationSyncRuns } = schema;
+
+type StartPostApplicationSyncRunInput = {
+  provider: PostApplicationProvider;
+  accountKey: string;
+  integrationId: string | null;
+};
+
+type CompletePostApplicationSyncRunInput = {
+  id: string;
+  status: Exclude<PostApplicationSyncRunStatus, "running">;
+  messagesDiscovered: number;
+  messagesRelevant: number;
+  messagesClassified: number;
+  messagesMatched?: number;
+  messagesApproved?: number;
+  messagesDenied?: number;
+  messagesErrored: number;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+};
+
+function mapRowToSyncRun(
+  row: typeof postApplicationSyncRuns.$inferSelect,
+): PostApplicationSyncRun {
+  return {
+    id: row.id,
+    provider: row.provider,
+    accountKey: row.accountKey,
+    integrationId: row.integrationId,
+    status: row.status as PostApplicationSyncRunStatus,
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+    messagesDiscovered: row.messagesDiscovered,
+    messagesRelevant: row.messagesRelevant,
+    messagesClassified: row.messagesClassified,
+    messagesMatched: row.messagesMatched,
+    messagesApproved: row.messagesApproved,
+    messagesDenied: row.messagesDenied,
+    messagesErrored: row.messagesErrored,
+    errorCode: row.errorCode,
+    errorMessage: row.errorMessage,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export async function startPostApplicationSyncRun(
+  input: StartPostApplicationSyncRunInput,
+): Promise<PostApplicationSyncRun> {
+  const id = randomUUID();
+  const nowEpoch = Date.now();
+  const nowIso = new Date(nowEpoch).toISOString();
+
+  await db.insert(postApplicationSyncRuns).values({
+    id,
+    provider: input.provider,
+    accountKey: input.accountKey,
+    integrationId: input.integrationId,
+    status: "running",
+    startedAt: nowEpoch,
+    completedAt: null,
+    messagesDiscovered: 0,
+    messagesRelevant: 0,
+    messagesClassified: 0,
+    messagesMatched: 0,
+    messagesApproved: 0,
+    messagesDenied: 0,
+    messagesErrored: 0,
+    errorCode: null,
+    errorMessage: null,
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  });
+
+  const run = await getPostApplicationSyncRunById(id);
+  if (!run) {
+    throw new Error(`Failed to load created post-application sync run ${id}.`);
+  }
+  return run;
+}
+
+export async function completePostApplicationSyncRun(
+  input: CompletePostApplicationSyncRunInput,
+): Promise<PostApplicationSyncRun | null> {
+  const nowEpoch = Date.now();
+  const nowIso = new Date(nowEpoch).toISOString();
+
+  await db
+    .update(postApplicationSyncRuns)
+    .set({
+      status: input.status,
+      completedAt: nowEpoch,
+      messagesDiscovered: input.messagesDiscovered,
+      messagesRelevant: input.messagesRelevant,
+      messagesClassified: input.messagesClassified,
+      messagesMatched: input.messagesMatched ?? 0,
+      messagesApproved: input.messagesApproved ?? 0,
+      messagesDenied: input.messagesDenied ?? 0,
+      messagesErrored: input.messagesErrored,
+      errorCode: input.errorCode ?? null,
+      errorMessage: input.errorMessage ?? null,
+      updatedAt: nowIso,
+    })
+    .where(eq(postApplicationSyncRuns.id, input.id));
+
+  return getPostApplicationSyncRunById(input.id);
+}
+
+export async function getPostApplicationSyncRunById(
+  id: string,
+): Promise<PostApplicationSyncRun | null> {
+  const [row] = await db
+    .select()
+    .from(postApplicationSyncRuns)
+    .where(eq(postApplicationSyncRuns.id, id));
+  return row ? mapRowToSyncRun(row) : null;
+}
+
+export async function listPostApplicationSyncRuns(
+  provider: PostApplicationProvider,
+  accountKey: string,
+  limit = 20,
+): Promise<PostApplicationSyncRun[]> {
+  const rows = await db
+    .select()
+    .from(postApplicationSyncRuns)
+    .where(
+      and(
+        eq(postApplicationSyncRuns.provider, provider),
+        eq(postApplicationSyncRuns.accountKey, accountKey),
+      ),
+    )
+    .orderBy(desc(postApplicationSyncRuns.startedAt))
+    .limit(limit);
+  return rows.map(mapRowToSyncRun);
+}

--- a/orchestrator/src/server/services/post-application/ingestion/gmail-sync.ts
+++ b/orchestrator/src/server/services/post-application/ingestion/gmail-sync.ts
@@ -1,0 +1,688 @@
+import { logger } from "@infra/logger";
+import {
+  getPostApplicationIntegration,
+  updatePostApplicationIntegrationSyncState,
+  upsertConnectedPostApplicationIntegration,
+} from "@server/repositories/post-application-integrations";
+import { upsertPostApplicationMessage } from "@server/repositories/post-application-messages";
+import {
+  completePostApplicationSyncRun,
+  startPostApplicationSyncRun,
+} from "@server/repositories/post-application-sync-runs";
+import { getSetting } from "@server/repositories/settings";
+import {
+  type JsonSchemaDefinition,
+  LlmService,
+} from "@server/services/llm-service";
+import {
+  classifyByKeywords,
+  computeKeywordRelevanceScore,
+  computePolicyDecision,
+  POST_APPLICATION_RELEVANCE_MIN_THRESHOLD,
+} from "./relevance";
+
+const DEFAULT_SEARCH_DAYS = 90;
+const DEFAULT_MAX_MESSAGES = 100;
+
+const LLM_CLASSIFICATION_SCHEMA: JsonSchemaDefinition = {
+  name: "post_application_email_classification",
+  schema: {
+    type: "object",
+    properties: {
+      relevanceScore: {
+        type: "integer",
+        description:
+          "Relevance score between 0-100 for job application tracking relevance.",
+      },
+      classificationLabel: {
+        type: "string",
+        description: "Best matching job application label.",
+      },
+      confidence: {
+        type: "number",
+        description: "Model confidence from 0 to 1.",
+      },
+      companyName: {
+        type: "string",
+        description: "Company name if present.",
+      },
+      jobTitle: {
+        type: "string",
+        description: "Job title if present.",
+      },
+      reason: {
+        type: "string",
+        description: "One sentence reason for the classification.",
+      },
+    },
+    required: ["relevanceScore", "classificationLabel", "confidence", "reason"],
+    additionalProperties: false,
+  },
+};
+
+type GmailCredentials = {
+  refreshToken: string;
+  accessToken?: string;
+  expiryDate?: number;
+  scope?: string;
+  tokenType?: string;
+  email?: string;
+};
+
+type GmailListMessage = {
+  id: string;
+  threadId: string;
+};
+
+type GmailHeader = { name?: string; value?: string };
+
+type GmailMetadataMessage = {
+  id: string;
+  threadId: string;
+  snippet: string;
+  headers: GmailHeader[];
+};
+
+type GmailFullMessage = GmailMetadataMessage & {
+  payload?: {
+    mimeType?: string;
+    body?: { data?: string };
+    parts?: Array<{
+      mimeType?: string;
+      body?: { data?: string };
+      parts?: unknown[];
+    }>;
+  };
+};
+
+type LlmClassificationResult = {
+  relevanceScore: number;
+  classificationLabel: string;
+  confidence: number;
+  companyName?: string;
+  jobTitle?: string;
+  reason: string;
+};
+
+export type GmailSyncSummary = {
+  discovered: number;
+  relevant: number;
+  classified: number;
+  errored: number;
+};
+
+function asString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseGmailCredentials(
+  credentials: Record<string, unknown> | null,
+): GmailCredentials | null {
+  if (!credentials) return null;
+  const refreshToken = asString(credentials.refreshToken);
+  if (!refreshToken) return null;
+
+  const accessToken = asString(credentials.accessToken) ?? undefined;
+  const expiryDate =
+    typeof credentials.expiryDate === "number" &&
+    Number.isFinite(credentials.expiryDate)
+      ? credentials.expiryDate
+      : undefined;
+
+  return {
+    refreshToken,
+    accessToken,
+    expiryDate,
+    scope: asString(credentials.scope) ?? undefined,
+    tokenType: asString(credentials.tokenType) ?? undefined,
+    email: asString(credentials.email) ?? undefined,
+  };
+}
+
+async function resolveGmailAccessToken(
+  credentials: GmailCredentials,
+): Promise<GmailCredentials> {
+  const now = Date.now();
+  if (
+    credentials.accessToken &&
+    credentials.expiryDate &&
+    credentials.expiryDate > now + 60_000
+  ) {
+    return credentials;
+  }
+
+  const clientId = asString(process.env.GMAIL_OAUTH_CLIENT_ID);
+  const clientSecret = asString(process.env.GMAIL_OAUTH_CLIENT_SECRET);
+  if (!clientId || !clientSecret) {
+    throw new Error(
+      "Missing GMAIL_OAUTH_CLIENT_ID or GMAIL_OAUTH_CLIENT_SECRET for Gmail token refresh.",
+    );
+  }
+
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    grant_type: "refresh_token",
+    refresh_token: credentials.refreshToken,
+  });
+
+  const response = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const data = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    throw new Error(`Gmail token refresh failed with HTTP ${response.status}.`);
+  }
+
+  const accessToken = asString(data?.access_token);
+  const expiresIn =
+    typeof data?.expires_in === "number" && Number.isFinite(data.expires_in)
+      ? data.expires_in
+      : 3600;
+  if (!accessToken) {
+    throw new Error(
+      "Gmail token refresh response did not include access_token.",
+    );
+  }
+
+  return {
+    ...credentials,
+    accessToken,
+    expiryDate: Date.now() + expiresIn * 1000,
+  };
+}
+
+async function gmailApi<T>(token: string, url: string): Promise<T> {
+  const response = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(`Gmail API request failed (${response.status}).`);
+  }
+  return data as T;
+}
+
+function buildGmailQuery(searchDays: number): string {
+  return `newer_than:${searchDays}d (application OR interview OR recruiter OR hiring OR offer OR assessment OR referral)`;
+}
+
+async function listMessageIds(
+  token: string,
+  searchDays: number,
+  maxMessages: number,
+): Promise<GmailListMessage[]> {
+  const messages: GmailListMessage[] = [];
+  let pageToken: string | undefined;
+
+  do {
+    const q = encodeURIComponent(buildGmailQuery(searchDays));
+    const listUrl = `https://gmail.googleapis.com/gmail/v1/users/me/messages?q=${q}&maxResults=${Math.min(
+      100,
+      maxMessages,
+    )}${pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : ""}`;
+
+    const page = await gmailApi<{
+      messages?: Array<{ id?: string; threadId?: string }>;
+      nextPageToken?: string;
+    }>(token, listUrl);
+
+    for (const message of page.messages ?? []) {
+      if (!message.id || !message.threadId) continue;
+      messages.push({ id: message.id, threadId: message.threadId });
+      if (messages.length >= maxMessages) {
+        return messages;
+      }
+    }
+    pageToken = page.nextPageToken;
+  } while (pageToken && messages.length < maxMessages);
+
+  return messages;
+}
+
+function headerValue(headers: GmailHeader[], name: string): string {
+  const found = headers.find(
+    (header) => (header.name ?? "").toLowerCase() === name.toLowerCase(),
+  );
+  return String(found?.value ?? "");
+}
+
+function parseFromHeader(fromHeader: string): {
+  fromAddress: string;
+  fromDomain: string | null;
+  senderName: string | null;
+} {
+  const match = fromHeader.match(/^(.*?)<([^>]+)>$/);
+  const senderName = match?.[1]?.trim() || null;
+  const fromAddress = (match?.[2] || fromHeader).trim().toLowerCase();
+  const atIndex = fromAddress.indexOf("@");
+  const fromDomain =
+    atIndex > 0 ? fromAddress.slice(atIndex + 1).toLowerCase() : null;
+
+  return { fromAddress, fromDomain, senderName };
+}
+
+function parseReceivedAt(dateHeader: string): number {
+  const parsed = Date.parse(dateHeader);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(padded, "base64").toString("utf8");
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractBodyText(payload: GmailFullMessage["payload"]): string {
+  if (!payload) return "";
+  const chunks: string[] = [];
+
+  const walk = (part: NonNullable<GmailFullMessage["payload"]>): void => {
+    const mimeType = String(part.mimeType ?? "").toLowerCase();
+    const data = part.body?.data;
+    if (data) {
+      const decoded = decodeBase64Url(data);
+      if (mimeType.includes("text/html")) {
+        chunks.push(htmlToText(decoded));
+      } else if (mimeType.startsWith("text/")) {
+        chunks.push(decoded);
+      }
+    }
+
+    for (const child of part.parts ?? []) {
+      walk(child as NonNullable<GmailFullMessage["payload"]>);
+    }
+  };
+
+  walk(payload);
+  return chunks.filter(Boolean).join("\n\n").trim();
+}
+
+function buildEmailText(input: {
+  from: string;
+  subject: string;
+  date: string;
+  snippet: string;
+  body: string;
+}): string {
+  return `From: ${input.from}
+Subject: ${input.subject}
+Date: ${input.date}
+Snippet: ${input.snippet}
+Body:
+${input.body}`.trim();
+}
+
+async function classifyWithLlm(
+  emailText: string,
+): Promise<LlmClassificationResult> {
+  const overrideModel = await getSetting("model");
+  const model =
+    overrideModel || process.env.MODEL || "google/gemini-3-flash-preview";
+
+  const llm = new LlmService();
+  const result = await llm.callJson<LlmClassificationResult>({
+    model,
+    messages: [
+      {
+        role: "system",
+        content:
+          "You classify post-application emails. Return concise, factual JSON.",
+      },
+      {
+        role: "user",
+        content: `Classify the email for post-application tracking.
+- Return relevanceScore (0-100).
+- Return classificationLabel using one of:
+Application confirmation, Rejection, Availability request, Information request, Assessment sent, Interview invitation, Referral - Action required, Did not apply - inbound request, Action required from company, Hiring freeze notification, Withdrew application, Offer made, False positive.
+- Return confidence between 0 and 1.
+- Return reason in one sentence.
+- Optionally return companyName and jobTitle.
+
+Email:
+${emailText.slice(0, 12000)}`,
+      },
+    ],
+    jsonSchema: LLM_CLASSIFICATION_SCHEMA,
+    maxRetries: 1,
+    retryDelayMs: 400,
+  });
+
+  if (!result.success) {
+    throw new Error(`LLM classification failed: ${result.error}`);
+  }
+
+  const relevanceScore = Math.max(
+    0,
+    Math.min(100, Math.round(result.data.relevanceScore)),
+  );
+  const confidence =
+    typeof result.data.confidence === "number" &&
+    Number.isFinite(result.data.confidence)
+      ? Math.max(0, Math.min(1, result.data.confidence))
+      : 0;
+
+  return {
+    relevanceScore,
+    classificationLabel: String(result.data.classificationLabel ?? "").trim(),
+    confidence,
+    companyName: asString(result.data.companyName) ?? undefined,
+    jobTitle: asString(result.data.jobTitle) ?? undefined,
+    reason: String(result.data.reason ?? "").trim(),
+  };
+}
+
+async function getMessageMetadata(
+  token: string,
+  messageId: string,
+): Promise<GmailMetadataMessage> {
+  const message = await gmailApi<{
+    id?: string;
+    threadId?: string;
+    snippet?: string;
+    payload?: { headers?: GmailHeader[] };
+  }>(
+    token,
+    `https://gmail.googleapis.com/gmail/v1/users/me/messages/${encodeURIComponent(
+      messageId,
+    )}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`,
+  );
+
+  return {
+    id: message.id ?? messageId,
+    threadId: message.threadId ?? "",
+    snippet: message.snippet ?? "",
+    headers: message.payload?.headers ?? [],
+  };
+}
+
+async function getMessageFull(
+  token: string,
+  messageId: string,
+): Promise<GmailFullMessage> {
+  const message = await gmailApi<{
+    id?: string;
+    threadId?: string;
+    snippet?: string;
+    payload?: GmailFullMessage["payload"];
+  }>(
+    token,
+    `https://gmail.googleapis.com/gmail/v1/users/me/messages/${encodeURIComponent(
+      messageId,
+    )}?format=full`,
+  );
+
+  return {
+    id: message.id ?? messageId,
+    threadId: message.threadId ?? "",
+    snippet: message.snippet ?? "",
+    headers: [],
+    payload: message.payload,
+  };
+}
+
+function normalizeErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return "Unknown error";
+}
+
+export async function runGmailIngestionSync(args: {
+  accountKey: string;
+  maxMessages?: number;
+  searchDays?: number;
+}): Promise<GmailSyncSummary> {
+  const integration = await getPostApplicationIntegration(
+    "gmail",
+    args.accountKey,
+  );
+  const parsedCredentials = parseGmailCredentials(
+    integration?.credentials ?? null,
+  );
+  if (!integration || !parsedCredentials) {
+    throw new Error(`Gmail account '${args.accountKey}' is not connected.`);
+  }
+
+  const searchDays = Math.max(1, args.searchDays ?? DEFAULT_SEARCH_DAYS);
+  const maxMessages = Math.max(1, args.maxMessages ?? DEFAULT_MAX_MESSAGES);
+
+  const syncRun = await startPostApplicationSyncRun({
+    provider: "gmail",
+    accountKey: args.accountKey,
+    integrationId: integration.id,
+  });
+
+  let discovered = 0;
+  let relevant = 0;
+  let classified = 0;
+  let errored = 0;
+
+  try {
+    const resolvedCredentials =
+      await resolveGmailAccessToken(parsedCredentials);
+    if (!resolvedCredentials.accessToken) {
+      throw new Error("Gmail sync failed to resolve access token.");
+    }
+
+    if (
+      resolvedCredentials.accessToken !== parsedCredentials.accessToken ||
+      resolvedCredentials.expiryDate !== parsedCredentials.expiryDate
+    ) {
+      await upsertConnectedPostApplicationIntegration({
+        provider: "gmail",
+        accountKey: args.accountKey,
+        displayName: integration.displayName,
+        credentials: {
+          refreshToken: resolvedCredentials.refreshToken,
+          accessToken: resolvedCredentials.accessToken,
+          expiryDate: resolvedCredentials.expiryDate,
+          scope: resolvedCredentials.scope,
+          tokenType: resolvedCredentials.tokenType,
+          email: resolvedCredentials.email,
+        },
+      });
+    }
+
+    const messageIds = await listMessageIds(
+      resolvedCredentials.accessToken,
+      searchDays,
+      maxMessages,
+    );
+
+    for (const message of messageIds) {
+      discovered += 1;
+
+      try {
+        const metadata = await getMessageMetadata(
+          resolvedCredentials.accessToken,
+          message.id,
+        );
+        const from = headerValue(metadata.headers, "From");
+        const subject = headerValue(metadata.headers, "Subject");
+        const date = headerValue(metadata.headers, "Date");
+        const { fromAddress, fromDomain, senderName } = parseFromHeader(from);
+        const receivedAt = parseReceivedAt(date);
+
+        const keywordScore = computeKeywordRelevanceScore({
+          from,
+          subject,
+          snippet: metadata.snippet,
+        });
+        const policyDecision = computePolicyDecision(keywordScore);
+
+        if (!policyDecision.shouldUseLlm && !policyDecision.isRelevant) {
+          await upsertPostApplicationMessage({
+            provider: "gmail",
+            accountKey: args.accountKey,
+            integrationId: integration.id,
+            syncRunId: syncRun.id,
+            externalMessageId: metadata.id,
+            externalThreadId: metadata.threadId,
+            fromAddress,
+            fromDomain,
+            senderName,
+            subject,
+            receivedAt,
+            snippet: metadata.snippet,
+            relevanceKeywordScore: keywordScore,
+            relevanceLlmScore: null,
+            relevanceFinalScore: keywordScore,
+            relevanceDecision: "not_relevant",
+            reviewStatus: "not_relevant",
+          });
+          continue;
+        }
+
+        if (!policyDecision.shouldUseLlm && policyDecision.isRelevant) {
+          const classificationLabel = classifyByKeywords({
+            subject,
+            snippet: metadata.snippet,
+          });
+
+          await upsertPostApplicationMessage({
+            provider: "gmail",
+            accountKey: args.accountKey,
+            integrationId: integration.id,
+            syncRunId: syncRun.id,
+            externalMessageId: metadata.id,
+            externalThreadId: metadata.threadId,
+            fromAddress,
+            fromDomain,
+            senderName,
+            subject,
+            receivedAt,
+            snippet: metadata.snippet,
+            classificationLabel,
+            classificationConfidence: 0.95,
+            classificationPayload: {
+              method: "keyword",
+            },
+            relevanceKeywordScore: keywordScore,
+            relevanceLlmScore: null,
+            relevanceFinalScore: keywordScore,
+            relevanceDecision: "relevant",
+            reviewStatus: "pending_review",
+          });
+          relevant += 1;
+          classified += 1;
+          continue;
+        }
+
+        const fullMessage = await getMessageFull(
+          resolvedCredentials.accessToken,
+          message.id,
+        );
+        const body = extractBodyText(fullMessage.payload);
+        const emailText = buildEmailText({
+          from,
+          subject,
+          date,
+          snippet: metadata.snippet,
+          body,
+        });
+        const llmResult = await classifyWithLlm(emailText);
+        const finalScore = llmResult.relevanceScore;
+        const isRelevant =
+          finalScore >= POST_APPLICATION_RELEVANCE_MIN_THRESHOLD &&
+          llmResult.classificationLabel.toLowerCase() !== "false positive";
+
+        await upsertPostApplicationMessage({
+          provider: "gmail",
+          accountKey: args.accountKey,
+          integrationId: integration.id,
+          syncRunId: syncRun.id,
+          externalMessageId: metadata.id,
+          externalThreadId: metadata.threadId,
+          fromAddress,
+          fromDomain,
+          senderName,
+          subject,
+          receivedAt,
+          snippet: metadata.snippet,
+          classificationLabel: llmResult.classificationLabel,
+          classificationConfidence: llmResult.confidence,
+          classificationPayload: {
+            method: "llm",
+            reason: llmResult.reason,
+            companyName: llmResult.companyName ?? null,
+            jobTitle: llmResult.jobTitle ?? null,
+          },
+          relevanceKeywordScore: keywordScore,
+          relevanceLlmScore: llmResult.relevanceScore,
+          relevanceFinalScore: finalScore,
+          relevanceDecision: isRelevant ? "relevant" : "not_relevant",
+          reviewStatus: isRelevant ? "pending_review" : "not_relevant",
+        });
+
+        if (isRelevant) relevant += 1;
+        classified += 1;
+      } catch (error) {
+        errored += 1;
+        logger.warn("Failed to ingest Gmail message", {
+          provider: "gmail",
+          accountKey: args.accountKey,
+          externalMessageId: message.id,
+          syncRunId: syncRun.id,
+          error: normalizeErrorMessage(error),
+        });
+      }
+    }
+
+    await completePostApplicationSyncRun({
+      id: syncRun.id,
+      status: "completed",
+      messagesDiscovered: discovered,
+      messagesRelevant: relevant,
+      messagesClassified: classified,
+      messagesErrored: errored,
+    });
+    await updatePostApplicationIntegrationSyncState({
+      provider: "gmail",
+      accountKey: args.accountKey,
+      lastSyncedAt: Date.now(),
+      lastError: null,
+      status: "connected",
+    });
+
+    return { discovered, relevant, classified, errored };
+  } catch (error) {
+    const errorMessage = normalizeErrorMessage(error);
+    await completePostApplicationSyncRun({
+      id: syncRun.id,
+      status: "failed",
+      messagesDiscovered: discovered,
+      messagesRelevant: relevant,
+      messagesClassified: classified,
+      messagesErrored: errored,
+      errorCode: "GMAIL_SYNC_FAILED",
+      errorMessage,
+    });
+    await updatePostApplicationIntegrationSyncState({
+      provider: "gmail",
+      accountKey: args.accountKey,
+      lastSyncedAt: Date.now(),
+      lastError: errorMessage,
+      status: "error",
+    });
+
+    throw error;
+  }
+}

--- a/orchestrator/src/server/services/post-application/ingestion/relevance.test.ts
+++ b/orchestrator/src/server/services/post-application/ingestion/relevance.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyByKeywords,
+  computeKeywordRelevanceScore,
+  computePolicyDecision,
+  POST_APPLICATION_RELEVANCE_HIGH_CONFIDENCE_THRESHOLD,
+  POST_APPLICATION_RELEVANCE_MIN_THRESHOLD,
+} from "./relevance";
+
+describe("post-application keyword relevance", () => {
+  it("scores clear application confirmations above high-confidence threshold", () => {
+    const score = computeKeywordRelevanceScore({
+      from: "Workable <noreply@candidates.workablemail.com>",
+      subject: "Thanks for applying to Example Corp - application received",
+      snippet:
+        "Thank you for your application. We have received your application.",
+    });
+
+    expect(score).toBeGreaterThanOrEqual(
+      POST_APPLICATION_RELEVANCE_HIGH_CONFIDENCE_THRESHOLD,
+    );
+  });
+
+  it("scores clear non-job newsletters as not relevant", () => {
+    const score = computeKeywordRelevanceScore({
+      from: "newsletter@example.com",
+      subject: "Weekly newsletter and webinar invitation",
+      snippet: "unsubscribe to stop receiving updates",
+    });
+
+    expect(score).toBe(0);
+  });
+
+  it("classifies common application subject lines", () => {
+    expect(
+      classifyByKeywords({
+        subject: "Thank you for applying",
+        snippet: "Your application was received",
+      }),
+    ).toBe("Application confirmation");
+
+    expect(
+      classifyByKeywords({
+        subject: "We regret to inform you",
+        snippet: "we are not moving forward",
+      }),
+    ).toBe("Rejection");
+  });
+});
+
+describe("post-application relevance gating policy", () => {
+  it("marks >=95 as relevant and skips LLM", () => {
+    expect(computePolicyDecision(95)).toEqual({
+      shouldUseLlm: false,
+      isRelevant: true,
+    });
+  });
+
+  it("marks 60-94 as LLM required", () => {
+    expect(
+      computePolicyDecision(POST_APPLICATION_RELEVANCE_MIN_THRESHOLD),
+    ).toEqual({
+      shouldUseLlm: true,
+      isRelevant: false,
+    });
+    expect(
+      computePolicyDecision(
+        POST_APPLICATION_RELEVANCE_HIGH_CONFIDENCE_THRESHOLD - 1,
+      ),
+    ).toEqual({
+      shouldUseLlm: true,
+      isRelevant: false,
+    });
+  });
+
+  it("marks <60 as not relevant without LLM", () => {
+    expect(computePolicyDecision(59)).toEqual({
+      shouldUseLlm: false,
+      isRelevant: false,
+    });
+  });
+});

--- a/orchestrator/src/server/services/post-application/ingestion/relevance.ts
+++ b/orchestrator/src/server/services/post-application/ingestion/relevance.ts
@@ -1,0 +1,171 @@
+export const POST_APPLICATION_RELEVANCE_HIGH_CONFIDENCE_THRESHOLD = 95;
+export const POST_APPLICATION_RELEVANCE_MIN_THRESHOLD = 60;
+
+type Rule = {
+  term: string;
+  weight: number;
+};
+
+const SUBJECT_RULES: Rule[] = [
+  { term: "thank you for applying", weight: 45 },
+  { term: "thanks for applying", weight: 45 },
+  { term: "application received", weight: 45 },
+  { term: "application submitted", weight: 45 },
+  { term: "interview", weight: 35 },
+  { term: "assessment", weight: 35 },
+  { term: "offer", weight: 35 },
+  { term: "rejection", weight: 35 },
+  { term: "regret to inform", weight: 35 },
+  { term: "not moving forward", weight: 35 },
+  { term: "hiring team", weight: 25 },
+  { term: "recruiter", weight: 25 },
+  { term: "referral", weight: 25 },
+];
+
+const FROM_RULES: Rule[] = [
+  { term: "careers@", weight: 40 },
+  { term: "jobs@", weight: 40 },
+  { term: "recruiting@", weight: 40 },
+  { term: "talent@", weight: 40 },
+  { term: "@greenhouse.io", weight: 35 },
+  { term: "@greenhouse-mail.io", weight: 35 },
+  { term: "@lever.co", weight: 35 },
+  { term: "@smartrecruiters.com", weight: 35 },
+  { term: "@workdaymail.com", weight: 35 },
+  { term: "@myworkday.com", weight: 35 },
+  { term: "@workablemail.com", weight: 35 },
+  { term: "@ashbyhq.com", weight: 35 },
+];
+
+const SNIPPET_RULES: Rule[] = [
+  { term: "we have received your application", weight: 45 },
+  { term: "thank you for your application", weight: 45 },
+  { term: "please share your availability", weight: 40 },
+  { term: "interview", weight: 35 },
+  { term: "assessment", weight: 35 },
+  { term: "coding challenge", weight: 35 },
+  { term: "offer", weight: 35 },
+  { term: "not moving forward", weight: 35 },
+  { term: "regret to inform", weight: 35 },
+];
+
+const EXCLUSION_TERMS = [
+  "newsletter",
+  "weekly roundup",
+  "course",
+  "promotion",
+  "discount",
+  "event invitation",
+  "webinar",
+  "unsubscribe",
+];
+
+function toHaystack(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function matchScore(value: string, rules: Rule[]): number {
+  const haystack = toHaystack(value);
+  if (!haystack) return 0;
+
+  let total = 0;
+  for (const rule of rules) {
+    if (haystack.includes(rule.term)) {
+      total += rule.weight;
+    }
+  }
+  return total;
+}
+
+export function computeKeywordRelevanceScore(args: {
+  from: string;
+  subject: string;
+  snippet: string;
+}): number {
+  const from = toHaystack(args.from);
+  const subject = toHaystack(args.subject);
+  const snippet = toHaystack(args.snippet);
+  const joined = `${subject} ${snippet}`;
+
+  if (EXCLUSION_TERMS.some((term) => joined.includes(term))) {
+    return 0;
+  }
+
+  const score =
+    matchScore(subject, SUBJECT_RULES) +
+    matchScore(from, FROM_RULES) +
+    matchScore(snippet, SNIPPET_RULES);
+
+  return Math.max(0, Math.min(100, score));
+}
+
+type KeywordClassification =
+  | "Application confirmation"
+  | "Interview invitation"
+  | "Assessment sent"
+  | "Offer made"
+  | "Rejection"
+  | "Availability request"
+  | "Referral - Action required"
+  | "False positive";
+
+export function classifyByKeywords(args: {
+  subject: string;
+  snippet: string;
+}): KeywordClassification {
+  const text = toHaystack(`${args.subject} ${args.snippet}`);
+
+  if (
+    text.includes("not moving forward") ||
+    text.includes("regret to inform") ||
+    text.includes("rejection")
+  ) {
+    return "Rejection";
+  }
+  if (text.includes("offer")) return "Offer made";
+  if (
+    text.includes("availability") ||
+    text.includes("when are you free") ||
+    text.includes("please share your availability")
+  ) {
+    return "Availability request";
+  }
+  if (
+    text.includes("assessment") ||
+    text.includes("coding challenge") ||
+    text.includes("take-home")
+  ) {
+    return "Assessment sent";
+  }
+  if (
+    text.includes("interview") ||
+    text.includes("schedule") ||
+    text.includes("invitation")
+  ) {
+    return "Interview invitation";
+  }
+  if (text.includes("referral") || text.includes("referred")) {
+    return "Referral - Action required";
+  }
+  if (
+    text.includes("thank you for applying") ||
+    text.includes("application received") ||
+    text.includes("application submitted")
+  ) {
+    return "Application confirmation";
+  }
+  return "False positive";
+}
+
+export function computePolicyDecision(keywordScore: number): {
+  shouldUseLlm: boolean;
+  isRelevant: boolean;
+} {
+  if (keywordScore >= POST_APPLICATION_RELEVANCE_HIGH_CONFIDENCE_THRESHOLD) {
+    return { shouldUseLlm: false, isRelevant: true };
+  }
+  if (keywordScore < POST_APPLICATION_RELEVANCE_MIN_THRESHOLD) {
+    return { shouldUseLlm: false, isRelevant: false };
+  }
+  return { shouldUseLlm: true, isRelevant: false };
+}


### PR DESCRIPTION
## Summary
- implement Gmail sync ingestion pipeline in provider layer (`gmail.sync`) with persisted sync runs/messages
- add keyword relevance policy module with thresholds:
  - `>=95`: relevant without LLM relevance call
  - `60-94`: LLM relevance/classification fallback
  - `<60`: not relevant, stop processing
- persist only canonical metadata and snippet to `post_application_messages` (no full body stored)
- add repositories for sync runs and message upserts with provider/account idempotency
- update integration sync state (`last_synced_at`, `last_error`, status) on success/failure
- add policy unit tests for relevance scoring, keyword classification, and 95/60 gating behavior

## Notes
- Gmail token refresh uses env vars `GMAIL_OAUTH_CLIENT_ID` and `GMAIL_OAUTH_CLIENT_SECRET`.
- For LLM fallback, the pipeline uses existing `LlmService` and current configured model.

## Verification
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`
