### PR TITLE
⚡ Bolt: Remove debug timeouts in Gradcracker extractor

### DIFF
--- a/extractors/gradcracker/src/routes.ts
+++ b/extractors/gradcracker/src/routes.ts
@@ -91,9 +91,6 @@ router.addHandler(
     // Wait until the job cards are rendered
     await page.waitForSelector("article[wire\\:key]", { timeout: 10000 });
 
-    // Add delay to see the page load
-    await page.waitForTimeout(3000);
-
     const toAbsolute = (href: string | null) => {
       if (!href) return null;
       try {
@@ -245,9 +242,6 @@ router.addHandler(
 
     // Wait for job content to be present
     await page.waitForSelector(".body-content", { timeout: 10000 });
-
-    // Optional delay if you want to visually see it while debugging
-    await page.waitForTimeout(2000);
 
     const jobDescription =
       (await page.locator(".body-content").textContent())?.trim() || null;


### PR DESCRIPTION
This PR removes unnecessary `waitForTimeout` calls in the Gradcracker extractor that were added for debugging purposes.

**Why:**
- `await page.waitForTimeout(3000);` was adding a 3-second delay to every list page processing.
- `await page.waitForTimeout(2000);` was adding a 2-second delay to every single job page processing.

**Impact:**
- Significant reduction in overall scraping time. For 100 jobs, this saves approximately 200+ seconds.
- The scraper still uses `waitForSelector` to ensure content is loaded before proceeding, maintaining reliability.

**Verification:**
- Verified that `waitForSelector` calls remain to handle page loading.
- Ran `npm run check:types:gradcracker` to ensure type safety.

---
*PR created automatically by Jules for task [8129293864052936461](https://jules.google.com/task/8129293864052936461) started by @DaKheera47*