### PR TITLE
Filter command bar results by relevance

### DIFF
--- a/docs-site/docs/features/job-search-bar.md
+++ b/docs-site/docs/features/job-search-bar.md
@@ -24,6 +24,8 @@ Search matches job fields with fuzzy ranking:
 - company/employer
 - location
 
+By default, very low-relevance matches are hidden so results stay focused on likely intent.
+
 Results are grouped by status sections:
 
 - Ready

--- a/orchestrator/src/client/pages/orchestrator/JobCommandBar.utils.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/JobCommandBar.utils.test.ts
@@ -19,7 +19,7 @@ describe("JobCommandBar score helpers", () => {
     expect(score).toBe(0);
   });
 
-  it("ranks exact and fuzzy matches above non-matches for a query", () => {
+  it("keeps only relevant matches when a query is provided", () => {
     const grouped = groupJobsForCommandBar(
       [
         createJob({
@@ -44,10 +44,22 @@ describe("JobCommandBar score helpers", () => {
       "backend",
     );
 
-    expect(grouped.ready.map((job) => job.id)).toEqual([
-      "exact",
-      "fuzzy",
-      "no-match",
-    ]);
+    expect(grouped.ready.map((job) => job.id)).toEqual(["exact", "fuzzy"]);
+  });
+
+  it("filters out weak fuzzy matches below the relevance floor", () => {
+    const grouped = groupJobsForCommandBar(
+      [
+        createJob({
+          id: "weak-fuzzy",
+          title: "Backend Engineer",
+          employer: "Platform Co",
+          discoveredAt: "2025-01-02T00:00:00Z",
+        }),
+      ],
+      "bde",
+    );
+
+    expect(grouped.ready).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- hide low-relevance command bar matches by default with a minimum score floor of 600
- keep existing sort/group behavior for results that pass the floor
- add/update command bar utility tests for relevance filtering
- document the sane-default behavior in the job search bar docs

## Validation
- ./orchestrator/node_modules/.bin/biome ci .
- npm run check:types:shared
- npm --workspace orchestrator run check:types
- npm --workspace gradcracker-extractor run check:types
- npm --workspace ukvisajobs-extractor run check:types
- npm --workspace orchestrator run build:client
- npm --workspace orchestrator run test:run

Closes #181
