### PR TITLE
fix: make docs-version workflow reliably install Biome Linux CLI

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -103,6 +103,7 @@
     "vitest": "^4.0.16"
   },
   "optionalDependencies": {
+    "@biomejs/cli-linux-x64": "^2.3.12",
     "@rollup/rollup-linux-arm64-gnu": "^4.30.0",
     "@rollup/rollup-linux-x64-gnu": "^4.30.0",
     "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2242,6 +2242,22 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.3.12",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.12.tgz",
+      "integrity": "sha512-CQtqrJ+qEEI8tgRSTjjzk6wJAwfH3wQlkIGsM5dlecfRZaoT+XCms/mf7G4kWNexrke6mnkRzNy6w8ebV177ow==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
     "node_modules/@borewit/text-codec": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.1.tgz",
@@ -24666,6 +24682,7 @@
       "name": "job-ops-orchestrator",
       "version": "1.0.0",
       "dependencies": {
+        "@biomejs/cli-linux-x64": "2.3.12",
         "@hookform/resolvers": "^5.2.2",
         "@paralleldrive/cuid2": "^3.0.6",
         "@radix-ui/react-accordion": "^1.2.12",
@@ -24743,6 +24760,7 @@
         "vitest": "^4.0.16"
       },
       "optionalDependencies": {
+        "@biomejs/cli-linux-x64": "^2.3.12",
         "@rollup/rollup-linux-arm64-gnu": "^4.30.0",
         "@rollup/rollup-linux-x64-gnu": "^4.30.0",
         "@tailwindcss/oxide-linux-arm64-gnu": "4.1.18",


### PR DESCRIPTION
Summary: add @biomejs/cli-linux-x64 as an orchestrator optional dependency and update package-lock.json so Linux CI can resolve Biome during docs version formatting