### PR TITLE
fix: keep search term chips when backspacing empty input

### DIFF
--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
@@ -1,5 +1,5 @@
 import { createAppSettings } from "@shared/testing/factories.js";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type React from "react";
 import { describe, expect, it, vi } from "vitest";
 import { AutomaticRunTab } from "./AutomaticRunTab";
@@ -154,5 +154,34 @@ describe("AutomaticRunTab", () => {
     expect(glassdoorButton.getAttribute("title")).toContain(
       "Set a Glassdoor city in Advanced settings to enable Glassdoor.",
     );
+  });
+
+  it("does not remove existing search terms when Backspace is pressed on an empty input", () => {
+    render(
+      <AutomaticRunTab
+        open
+        settings={createAppSettings({
+          searchTerms: ["backend engineer", "frontend engineer"],
+          jobspyCountryIndeed: "united kingdom",
+          jobspyLocation: "",
+        })}
+        enabledSources={["linkedin"]}
+        pipelineSources={["linkedin"]}
+        onToggleSource={vi.fn()}
+        onSetPipelineSources={vi.fn()}
+        isPipelineRunning={false}
+        onSaveAndRun={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Type and press Enter");
+    fireEvent.keyDown(input, { key: "Backspace" });
+
+    expect(
+      screen.getByRole("button", { name: "Remove backend engineer" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Remove frontend engineer" }),
+    ).toBeInTheDocument();
   });
 });

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
@@ -479,15 +479,6 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                   setValue("searchTermDraft", "");
                   return;
                 }
-                if (
-                  event.key === "Backspace" &&
-                  searchTermDraft.length === 0 &&
-                  searchTerms.length > 0
-                ) {
-                  setValue("searchTerms", searchTerms.slice(0, -1), {
-                    shouldDirty: true,
-                  });
-                }
               }}
               onBlur={() => {
                 addSearchTerms(searchTermDraft);


### PR DESCRIPTION
## Summary
- remove the Backspace shortcut that deleted the last search-term chip when the input is empty
- keep chip removal explicit via each chip's X button only
- add a regression test covering Backspace on an empty search-terms input

## Validation
- ./orchestrator/node_modules/.bin/biome ci .
- npm run check:types:shared
- npm --workspace orchestrator run check:types
- npm --workspace gradcracker-extractor run check:types
- npm --workspace ukvisajobs-extractor run check:types
- npm --workspace orchestrator run build:client
- npm --workspace orchestrator run test:run

Fixes #214