### PR TITLE
Set automatic extractor defaults from user location

### DIFF
--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
@@ -4,8 +4,8 @@ import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AutomaticRunTab } from "./AutomaticRunTab";
 
-const { getCachedOrDetectedUserCountryKeyMock } = vi.hoisted(() => ({
-  getCachedOrDetectedUserCountryKeyMock: vi.fn((): string | null => null),
+const { getDetectedCountryKeyMock } = vi.hoisted(() => ({
+  getDetectedCountryKeyMock: vi.fn((): string | null => null),
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -22,17 +22,17 @@ vi.mock("@/components/ui/tooltip", () => ({
 }));
 
 vi.mock("@/lib/user-location", () => ({
-  getCachedOrDetectedUserCountryKey: getCachedOrDetectedUserCountryKeyMock,
+  getDetectedCountryKey: getDetectedCountryKeyMock,
 }));
 
 describe("AutomaticRunTab", () => {
   beforeEach(() => {
-    getCachedOrDetectedUserCountryKeyMock.mockReset();
-    getCachedOrDetectedUserCountryKeyMock.mockReturnValue(null);
+    getDetectedCountryKeyMock.mockReset();
+    getDetectedCountryKeyMock.mockReturnValue(null);
   });
 
   it("uses detected country when location settings are still defaults", () => {
-    getCachedOrDetectedUserCountryKeyMock.mockReturnValueOnce("united states");
+    getDetectedCountryKeyMock.mockReturnValueOnce("united states");
 
     render(
       <AutomaticRunTab

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
@@ -27,7 +27,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { getCachedOrDetectedUserCountryKey } from "@/lib/user-location";
+import { getDetectedCountryKey } from "@/lib/user-location";
 import { sourceLabel } from "@/lib/utils";
 import {
   AUTOMATIC_PRESETS,
@@ -191,7 +191,7 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
         settings?.searchCities?.override,
     );
     const defaultLocationCountry = !hasExplicitLocationOverride
-      ? getCachedOrDetectedUserCountryKey()
+      ? getDetectedCountryKey()
       : null;
     const rememberedCountry = normalizeUiCountryKey(
       hasExplicitLocationOverride

--- a/orchestrator/src/lib/user-location.test.ts
+++ b/orchestrator/src/lib/user-location.test.ts
@@ -1,8 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  detectUserCountryKey,
-  getCachedOrDetectedUserCountryKey,
-} from "./user-location";
+import { detectUserCountryKey, getDetectedCountryKey } from "./user-location";
 
 describe("user-location", () => {
   beforeEach(() => {
@@ -39,7 +36,7 @@ describe("user-location", () => {
       }),
     );
 
-    const result = getCachedOrDetectedUserCountryKey();
+    const result = getDetectedCountryKey();
 
     expect(result).toBe("united kingdom");
   });
@@ -53,7 +50,7 @@ describe("user-location", () => {
       configurable: true,
       value: "en-US",
     });
-    const result = getCachedOrDetectedUserCountryKey();
+    const result = getDetectedCountryKey();
     const cached = localStorage.getItem("jobops.user-country-cache.v1");
 
     expect(result).toBe("united states");

--- a/orchestrator/src/lib/user-location.ts
+++ b/orchestrator/src/lib/user-location.ts
@@ -184,7 +184,7 @@ function writeCachedUserCountry(country: string, now: number): void {
   }
 }
 
-export function getCachedOrDetectedUserCountryKey(): string | null {
+export function getDetectedCountryKey(): string | null {
   const now = Date.now();
   const cached = readCachedUserCountry(now);
   if (cached) return cached;


### PR DESCRIPTION
## Summary
- detect the user country in the browser (locale + timezone) and cache it in localStorage
- use the detected country as the automatic run default only when location settings are still uncustomized defaults
- add tests for location detection/cache and AutomaticRunTab initialization behavior

Closes #33

## Validation 

> job-ops-orchestrator@1.0.0 check:types
> tsc --noEmit
> job-ops-orchestrator@1.0.0 test:run
> vitest run src/client/pages/orchestrator/AutomaticRunTab.test.tsx src/lib/user-location.test.ts


 RUN  v4.0.16 /Users/ssarfaraz/coding/personal/job-ops/orchestrator

 ✓ src/lib/user-location.test.ts (4 tests) 10ms
 ✓ src/client/pages/orchestrator/AutomaticRunTab.test.tsx (9 tests) 179ms

 Test Files  2 passed (2)
      Tests  13 passed (13)
   Start at  14:03:27
   Duration  861ms (transform 140ms, setup 112ms, import 319ms, tests 189ms, environment 565ms)
