### PR TITLE
Add RXRESUME_URL to .env.example (fixes #224)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ MODEL=google/gemini-3-flash-preview
 
 # Self-hosted RxResume base URL, e.g., http://rxresume.local.net
 # Defaults to https://v4.rxresu.me
-RXRESUME_URL=
+# RXRESUME_URL=
 
 # RXResume credentials for PDF generation
 # Create an account at: https://v4.rxresu.me


### PR DESCRIPTION
Fixes #224. Add self-hosted RxResume base URL configuration.