### PR TITLE
feat: Cloudflare WAF resilience layer for Playwright extractors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,7 @@ COPY extractors/workingnomads/package*.json ./extractors/workingnomads/
 COPY extractors/golangjobs/package*.json ./extractors/golangjobs/
 COPY extractors/ukvisajobs/package*.json ./extractors/ukvisajobs/
 COPY extractors/seek/package*.json ./extractors/seek/
+COPY extractors/browser-utils/package*.json ./extractors/browser-utils/
 
 # Install Node dependencies with npm cache (dev deps needed for build).
 RUN --mount=type=cache,target=/root/.npm \
@@ -90,6 +91,7 @@ COPY extractors/workingnomads ./extractors/workingnomads
 COPY extractors/golangjobs ./extractors/golangjobs
 COPY extractors/ukvisajobs ./extractors/ukvisajobs
 COPY extractors/seek ./extractors/seek
+COPY extractors/browser-utils ./extractors/browser-utils
 
 # ============================================================================
 # PARALLEL BUILD STAGES
@@ -122,6 +124,7 @@ COPY extractors/workingnomads/package*.json ./extractors/workingnomads/
 COPY extractors/golangjobs/package*.json ./extractors/golangjobs/
 COPY extractors/ukvisajobs/package*.json ./extractors/ukvisajobs/
 COPY extractors/seek/package*.json ./extractors/seek/
+COPY extractors/browser-utils/package*.json ./extractors/browser-utils/
 
 # Install production Node dependencies only.
 RUN --mount=type=cache,target=/root/.npm \
@@ -176,6 +179,7 @@ COPY extractors/workingnomads ./extractors/workingnomads
 COPY extractors/golangjobs ./extractors/golangjobs
 COPY extractors/ukvisajobs ./extractors/ukvisajobs
 COPY extractors/seek ./extractors/seek
+COPY extractors/browser-utils ./extractors/browser-utils
 
 # Create runtime directories.
 RUN mkdir -p /app/data/pdfs /app/codex-home

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,6 +111,11 @@ RUN npm run build:client
 # ============================================================================
 FROM runtime-base AS runtime-node-deps
 
+# Install virtual display dependencies for the headed Cloudflare challenge solver.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    xvfb x11vnc novnc websockify && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
 # Copy package files for production dependency installation.
 COPY package*.json ./
 COPY docs-site/package*.json ./docs-site/
@@ -184,10 +189,17 @@ COPY extractors/browser-utils ./extractors/browser-utils
 # Create runtime directories.
 RUN mkdir -p /app/data/pdfs /app/codex-home
 
+ENV DISPLAY=:99
+ENV NOVNC_PORT=6080
+
 EXPOSE 3001
+EXPOSE 6080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:3001/health || exit 1
 
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
 WORKDIR /app/orchestrator
-CMD ["sh", "-c", "npx tsx src/server/db/migrate.ts && npm run start"]
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -191,9 +191,10 @@ RUN mkdir -p /app/data/pdfs /app/codex-home
 
 ENV DISPLAY=:99
 ENV NOVNC_PORT=6080
+ENV NOVNC_HOST=127.0.0.1
+ENV VNC_HOST=127.0.0.1
 
 EXPOSE 3001
-EXPOSE 6080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:3001/health || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,7 @@ COPY extractors/seek ./extractors/seek
 COPY extractors/browser-utils ./extractors/browser-utils
 
 # Create runtime directories.
-RUN mkdir -p /app/data/pdfs /app/codex-home
+RUN mkdir -p /app/data/pdfs /app/data/cloudflare-cookies /app/codex-home
 
 ENV DISPLAY=:99
 ENV NOVNC_PORT=6080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     container_name: job-ops
     ports:
       - "3005:3001"
-      - "6080:6080"
     volumes:
       # Persist database and generated PDFs
       - ./data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
     container_name: job-ops
     ports:
       - "3005:3001"
+      - "6080:6080"
     volumes:
       # Persist database and generated PDFs
       - ./data:/app/data

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Virtual display + VNC for the CF challenge solver in Docker.
+#
+# The CF solver needs a headed (visible) browser because a human must click
+# through the challenge. Docker has no display server, so we run:
+#   Xvfb (virtual framebuffer) -> x11vnc (VNC server) -> noVNC (web client)
+#
+# When idle, these use ~5-10MB RAM and the noVNC port shows a black screen.
+# When the Solve button is clicked, the solver launches Firefox on DISPLAY=:99
+# and the user interacts via the noVNC web viewer on port 6080.
+#
+# Why not on-demand? Starting/stopping Xvfb per solve adds process lifecycle
+# complexity for minimal savings. Always-on is simpler and cheap.
+
+# Start Xvfb (virtual framebuffer) on display :99
+Xvfb :99 -screen 0 1280x720x24 -nolisten tcp &
+
+# Wait for display to be ready
+sleep 1
+
+# Start x11vnc (VNC server) on the virtual display, no password
+x11vnc -display :99 -forever -nopw -quiet &
+
+# Start noVNC (browser-based VNC client) via websockify
+# Serves the noVNC web app and proxies WebSocket to x11vnc
+NOVNC_PATH=$(find /usr -path "*/novnc/utils/novnc_proxy" -o -path "*/novnc/utils/launch.sh" 2>/dev/null | head -1)
+if [ -n "$NOVNC_PATH" ]; then
+  "$NOVNC_PATH" --vnc localhost:5900 --listen "${NOVNC_PORT:-6080}" &
+else
+  # Fallback: use websockify directly with noVNC web root
+  NOVNC_WEB=$(find /usr -type d -name novnc 2>/dev/null | head -1)
+  websockify --web "$NOVNC_WEB" "${NOVNC_PORT:-6080}" localhost:5900 &
+fi
+
+# Run the app
+cd /app/orchestrator
+exec sh -c "npx tsx src/server/db/migrate.ts && npm run start"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,36 +1,9 @@
 #!/bin/sh
-# Virtual display + VNC for the CF challenge solver in Docker.
+# Job Ops container entrypoint.
 #
-# The CF solver needs a headed (visible) browser because a human must click
-# through the challenge. Docker has no display server, so we run:
-#   Xvfb (virtual framebuffer) -> x11vnc (VNC server) -> noVNC (web client)
-#
-# When idle, these use ~5-10MB RAM and the noVNC port shows a black screen.
-# When the Solve button is clicked, the solver launches Firefox on DISPLAY=:99
-# and the user interacts via the noVNC web viewer on port 6080.
-#
-# Why not on-demand? Starting/stopping Xvfb per solve adds process lifecycle
-# complexity for minimal savings. Always-on is simpler and cheap.
-
-# Start Xvfb (virtual framebuffer) on display :99
-Xvfb :99 -screen 0 1280x720x24 -nolisten tcp &
-
-# Wait for display to be ready
-sleep 1
-
-# Start x11vnc (VNC server) on the virtual display, no password
-x11vnc -display :99 -forever -nopw -quiet &
-
-# Start noVNC (browser-based VNC client) via websockify
-# Serves the noVNC web app and proxies WebSocket to x11vnc
-NOVNC_PATH=$(find /usr -path "*/novnc/utils/novnc_proxy" -o -path "*/novnc/utils/launch.sh" 2>/dev/null | head -1)
-if [ -n "$NOVNC_PATH" ]; then
-  "$NOVNC_PATH" --vnc localhost:5900 --listen "${NOVNC_PORT:-6080}" &
-else
-  # Fallback: use websockify directly with noVNC web root
-  NOVNC_WEB=$(find /usr -type d -name novnc 2>/dev/null | head -1)
-  websockify --web "$NOVNC_WEB" "${NOVNC_PORT:-6080}" localhost:5900 &
-fi
+# The Cloudflare challenge viewer is started lazily by the server only when a
+# challenge needs human interaction. Keeping it out of startup avoids carrying
+# idle Xvfb/x11vnc/noVNC processes on every normal pipeline run.
 
 # Run the app
 cd /app/orchestrator

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -120,6 +120,7 @@ flowchart TD
 
 - SQLite DB: `data/jobs.db`
 - Generated PDFs: `data/pdfs/`
+- Cloudflare challenge cookies: `data/cloudflare-cookies/`
 
 ## Public demo mode
 

--- a/docs-site/versioned_docs/version-0.4.0/getting-started/self-hosting.md
+++ b/docs-site/versioned_docs/version-0.4.0/getting-started/self-hosting.md
@@ -118,6 +118,7 @@ flowchart TD
 
 - SQLite DB: `data/jobs.db`
 - Generated PDFs: `data/pdfs/`
+- Cloudflare challenge cookies: `data/cloudflare-cookies/`
 
 ## Public demo mode
 

--- a/extractors/browser-utils/package.json
+++ b/extractors/browser-utils/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "browser-utils",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Shared browser resilience utilities for Playwright-based extractors",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./*": "./src/*"
+  },
+  "dependencies": {
+    "camoufox-js": "^0.9.2"
+  },
+  "peerDependencies": {
+    "playwright": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "playwright": "*",
+    "typescript": "~5.9.0"
+  },
+  "scripts": {
+    "check:types": "tsc --noEmit"
+  },
+  "license": "SEE LICENSE IN ../../LICENSE"
+}

--- a/extractors/browser-utils/src/challenge.ts
+++ b/extractors/browser-utils/src/challenge.ts
@@ -44,7 +44,7 @@ export function isChallengeResponse(response: Response): boolean {
   const status = response.status();
   // CF challenges typically return 403 or 503 with specific headers
   if (status !== 403 && status !== 503) return false;
-  const server = response.headers()["server"] ?? "";
+  const server = response.headers().server ?? "";
   return server.toLowerCase().includes("cloudflare");
 }
 

--- a/extractors/browser-utils/src/challenge.ts
+++ b/extractors/browser-utils/src/challenge.ts
@@ -1,0 +1,136 @@
+import type { Page, Response } from "playwright";
+
+export type ChallengeResult =
+  | { status: "passed" }
+  | { status: "not-a-challenge" }
+  | { status: "failed"; reason: string }
+  | { status: "timeout" };
+
+/**
+ * Content markers that indicate a Cloudflare challenge page.
+ * Gathered empirically from CF challenge/interstitial HTML — these will
+ * need updating if Cloudflare changes their challenge page structure.
+ */
+const CF_CHALLENGE_MARKERS = [
+  "cf-challenge-running",
+  "cf-turnstile",
+  "Checking your browser",
+  "challenges.cloudflare.com",
+  "Just a moment...",
+  // Cloudflare's "managed challenge" / interstitial
+  "cf-please-wait",
+  "cf_chl_opt",
+] as const;
+
+/**
+ * Checks whether a page is currently showing a Cloudflare challenge.
+ * Works by inspecting page content — no network interception needed.
+ */
+export async function isChallengePage(page: Page): Promise<boolean> {
+  try {
+    const html = await page.content();
+    return CF_CHALLENGE_MARKERS.some((marker) => html.includes(marker));
+  } catch {
+    // Page may have navigated or crashed — treat as not a challenge
+    return false;
+  }
+}
+
+/**
+ * Checks whether an HTTP response looks like a Cloudflare block.
+ * Use this to inspect responses from page.goto() or page.waitForResponse().
+ */
+export function isChallengeResponse(response: Response): boolean {
+  const status = response.status();
+  // CF challenges typically return 403 or 503 with specific headers
+  if (status !== 403 && status !== 503) return false;
+  const server = response.headers()["server"] ?? "";
+  return server.toLowerCase().includes("cloudflare");
+}
+
+/**
+ * Waits for a Cloudflare challenge to resolve on the current page.
+ *
+ * Cloudflare challenges work by showing an interstitial that auto-navigates
+ * to the target page once solved. This function polls for the challenge
+ * markers to disappear, indicating either success or failure.
+ *
+ * @param page - Playwright page currently showing a challenge
+ * @param timeoutMs - Max time to wait (default 30s — challenges can take 5-15s)
+ * @param pollIntervalMs - How often to check (default 1s)
+ */
+export async function waitForChallengeResolution(
+  page: Page,
+  timeoutMs = 30_000,
+  pollIntervalMs = 1_000,
+): Promise<ChallengeResult> {
+  const start = Date.now();
+
+  while (Date.now() - start < timeoutMs) {
+    // Check if we've navigated away from the challenge page
+    const stillChallenge = await isChallengePage(page);
+    if (!stillChallenge) {
+      return { status: "passed" };
+    }
+
+    await page.waitForTimeout(pollIntervalMs);
+  }
+
+  return { status: "timeout" };
+}
+
+/**
+ * Navigates to a URL and handles Cloudflare challenges transparently.
+ * Returns the final response after any challenge is resolved.
+ *
+ * This is the main entry point most extractors should use instead of
+ * raw page.goto(). It handles:
+ * - Initial navigation
+ * - Challenge detection
+ * - Waiting for challenge resolution
+ * - Reporting what happened
+ */
+export async function navigateWithChallenge(
+  page: Page,
+  url: string,
+  options: {
+    waitUntil?: "load" | "domcontentloaded" | "networkidle" | "commit";
+    challengeTimeoutMs?: number;
+    navigationTimeoutMs?: number;
+  } = {},
+): Promise<{
+  response: Response | null;
+  challengeResult: ChallengeResult;
+}> {
+  const {
+    waitUntil = "domcontentloaded",
+    challengeTimeoutMs = 30_000,
+    navigationTimeoutMs = 30_000,
+  } = options;
+
+  const response = await page.goto(url, {
+    waitUntil,
+    timeout: navigationTimeoutMs,
+  });
+
+  // Check if the response itself is a CF challenge
+  if (response && isChallengeResponse(response)) {
+    const challengeResult = await waitForChallengeResolution(
+      page,
+      challengeTimeoutMs,
+    );
+    return { response, challengeResult };
+  }
+
+  // Response looked fine, but page content might still be a challenge
+  // (some CF challenges return 200 with challenge HTML)
+  if (await isChallengePage(page)) {
+    const challengeResult = await waitForChallengeResolution(
+      page,
+      challengeTimeoutMs,
+    );
+    return { response, challengeResult };
+  }
+
+  return { response, challengeResult: { status: "not-a-challenge" } };
+}

--- a/extractors/browser-utils/src/challenge.ts
+++ b/extractors/browser-utils/src/challenge.ts
@@ -122,8 +122,9 @@ export async function navigateWithChallenge(
     return { response, challengeResult };
   }
 
-  // Response looked fine, but page content might still be a challenge
-  // (some CF challenges return 200 with challenge HTML)
+  // Response looked fine HTTP-wise, but page content might still be a challenge.
+  // CF's "managed challenge" variant returns HTTP 200 with challenge HTML —
+  // checking headers alone would miss it.
   if (await isChallengePage(page)) {
     const challengeResult = await waitForChallengeResolution(
       page,

--- a/extractors/browser-utils/src/cookies.ts
+++ b/extractors/browser-utils/src/cookies.ts
@@ -1,0 +1,99 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { BrowserContext, Cookie } from "playwright";
+
+/** Cookies worth persisting — CF clearance and common session cookies. */
+const PERSIST_COOKIE_NAMES = new Set([
+  "cf_clearance",
+  "__cf_bm",
+  "cf_chl_2",
+  "cf_chl_prog",
+  "__cflb",
+]);
+
+interface PersistedCookieJar {
+  extractorId: string;
+  savedAt: string;
+  cookies: Cookie[];
+}
+
+function cookiePath(storageDir: string, extractorId: string): string {
+  return `${storageDir}/${extractorId}-cookies.json`;
+}
+
+function isExpired(cookie: Cookie): boolean {
+  // expires = -1 means session cookie (no expiry) — keep it, it's still valid
+  // for the current process lifetime
+  if (cookie.expires === -1) return false;
+  return cookie.expires < Date.now() / 1000;
+}
+
+/**
+ * Saves the browser context's cookies to disk, filtered to CF-relevant cookies.
+ * Call this after a successful navigation through a CF challenge.
+ *
+ * @param context - Playwright browser context to extract cookies from
+ * @param extractorId - Unique extractor name (used as filename prefix)
+ * @param storageDir - Directory to store cookie files (default: ./storage)
+ */
+export async function saveCookies(
+  context: BrowserContext,
+  extractorId: string,
+  storageDir = "./storage",
+): Promise<void> {
+  const allCookies = await context.cookies();
+
+  // Keep CF-related cookies plus any with "session" or "auth" in the name
+  const relevant = allCookies.filter(
+    (c) =>
+      PERSIST_COOKIE_NAMES.has(c.name) ||
+      c.name.toLowerCase().includes("session") ||
+      c.name.toLowerCase().includes("auth"),
+  );
+
+  if (relevant.length === 0) return;
+
+  const jar: PersistedCookieJar = {
+    extractorId,
+    savedAt: new Date().toISOString(),
+    cookies: relevant,
+  };
+
+  const path = cookiePath(storageDir, extractorId);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(jar, null, 2));
+}
+
+/**
+ * Loads previously saved cookies into a browser context.
+ * Skips expired cookies automatically.
+ *
+ * Call this before navigating to a CF-protected site — if we have a valid
+ * cf_clearance cookie from a previous run, the challenge may be skipped entirely.
+ *
+ * @param context - Playwright browser context to inject cookies into
+ * @param extractorId - Must match the ID used when saving
+ * @param storageDir - Directory where cookie files are stored (default: ./storage)
+ * @returns Number of cookies loaded (0 if no saved cookies or all expired)
+ */
+export async function loadCookies(
+  context: BrowserContext,
+  extractorId: string,
+  storageDir = "./storage",
+): Promise<number> {
+  const path = cookiePath(storageDir, extractorId);
+
+  let jar: PersistedCookieJar;
+  try {
+    const data = await readFile(path, "utf-8");
+    jar = JSON.parse(data) as PersistedCookieJar;
+  } catch {
+    return 0; // no saved cookies
+  }
+
+  const valid = jar.cookies.filter((c) => !isExpired(c));
+  if (valid.length === 0) return 0;
+
+  await context.addCookies(valid);
+  return valid.length;
+}

--- a/extractors/browser-utils/src/cookies.ts
+++ b/extractors/browser-utils/src/cookies.ts
@@ -1,8 +1,12 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import type { BrowserContext, Cookie } from "playwright";
 
-/** Cookies worth persisting — CF clearance and common session cookies. */
+/**
+ * Cookies worth persisting — CF clearance and common session cookies.
+ * cf_clearance is the main one: it proves the browser passed a challenge.
+ * The others are supporting cookies CF uses during challenge flow.
+ */
 const PERSIST_COOKIE_NAMES = new Set([
   "cf_clearance",
   "__cf_bm",
@@ -15,6 +19,12 @@ interface PersistedCookieJar {
   extractorId: string;
   savedAt: string;
   cookies: Cookie[];
+  userAgent?: string;
+}
+
+export interface CookieJarInfo {
+  hasCookies: boolean;
+  userAgent?: string;
 }
 
 function cookiePath(storageDir: string, extractorId: string): string {
@@ -96,4 +106,44 @@ export async function loadCookies(
 
   await context.addCookies(valid);
   return valid.length;
+}
+
+/**
+ * Reads cookie jar metadata without needing a Playwright BrowserContext.
+ * Use this to check whether valid cookies exist and retrieve the persisted
+ * User-Agent before creating a browser context (Playwright requires UA at
+ * `newContext()` time).
+ */
+export async function readCookieJar(
+  extractorId: string,
+  storageDir = "./storage",
+): Promise<CookieJarInfo> {
+  const path = cookiePath(storageDir, extractorId);
+
+  let jar: PersistedCookieJar;
+  try {
+    const data = await readFile(path, "utf-8");
+    jar = JSON.parse(data) as PersistedCookieJar;
+  } catch {
+    return { hasCookies: false };
+  }
+
+  const hasValid = jar.cookies.some((c) => !isExpired(c));
+  return { hasCookies: hasValid, userAgent: jar.userAgent };
+}
+
+/**
+ * Deletes the cookie jar file for an extractor.
+ * Call this when cookies are known to be stale (e.g. after a CF re-challenge).
+ */
+export async function invalidateCookies(
+  extractorId: string,
+  storageDir = "./storage",
+): Promise<void> {
+  const path = cookiePath(storageDir, extractorId);
+  try {
+    await unlink(path);
+  } catch {
+    // File doesn't exist — nothing to invalidate
+  }
 }

--- a/extractors/browser-utils/src/cookies.ts
+++ b/extractors/browser-utils/src/cookies.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import type { BrowserContext, Cookie } from "playwright";
 
 /**
@@ -28,7 +28,7 @@ export interface CookieJarInfo {
 }
 
 function cookiePath(storageDir: string, extractorId: string): string {
-  return `${storageDir}/${extractorId}-cookies.json`;
+  return join(storageDir, `${extractorId}-cookies.json`);
 }
 
 function isExpired(cookie: Cookie): boolean {
@@ -63,10 +63,21 @@ export async function saveCookies(
 
   if (relevant.length === 0) return;
 
+  // Auto-capture the browser's User-Agent so headless retries can reuse it.
+  // CF ties cf_clearance to the UA + TLS fingerprint — without matching UA
+  // the cookie is useless. We grab it from the first open page; there's
+  // always at least one when saving cookies after navigation.
+  let userAgent: string | undefined;
+  const page = context.pages()[0];
+  if (page) {
+    userAgent = await page.evaluate(() => navigator.userAgent);
+  }
+
   const jar: PersistedCookieJar = {
     extractorId,
     savedAt: new Date().toISOString(),
     cookies: relevant,
+    userAgent,
   };
 
   const path = cookiePath(storageDir, extractorId);

--- a/extractors/browser-utils/src/cookies.ts
+++ b/extractors/browser-utils/src/cookies.ts
@@ -14,6 +14,8 @@ const PERSIST_COOKIE_NAMES = new Set([
   "cf_chl_prog",
   "__cflb",
 ]);
+const DEFAULT_COOKIE_STORAGE_DIR = "./storage";
+const DATA_DIR_COOKIE_STORAGE_DIRNAME = "cloudflare-cookies";
 
 interface PersistedCookieJar {
   extractorId: string;
@@ -25,6 +27,15 @@ interface PersistedCookieJar {
 export interface CookieJarInfo {
   hasCookies: boolean;
   userAgent?: string;
+}
+
+export function getCloudflareCookieStorageDir(storageDir?: string): string {
+  if (storageDir) return storageDir;
+
+  const dataDir = (process.env.DATA_DIR || "").trim();
+  if (dataDir) return join(dataDir, DATA_DIR_COOKIE_STORAGE_DIRNAME);
+
+  return DEFAULT_COOKIE_STORAGE_DIR;
 }
 
 function cookiePath(storageDir: string, extractorId: string): string {
@@ -44,13 +55,14 @@ function isExpired(cookie: Cookie): boolean {
  *
  * @param context - Playwright browser context to extract cookies from
  * @param extractorId - Unique extractor name (used as filename prefix)
- * @param storageDir - Directory to store cookie files (default: ./storage)
+ * @param storageDir - Directory to store cookie files (default: DATA_DIR/cloudflare-cookies when DATA_DIR is set, otherwise ./storage)
  */
 export async function saveCookies(
   context: BrowserContext,
   extractorId: string,
-  storageDir = "./storage",
+  storageDir?: string,
 ): Promise<void> {
+  const resolvedStorageDir = getCloudflareCookieStorageDir(storageDir);
   const allCookies = await context.cookies();
 
   // Keep CF-related cookies plus any with "session" or "auth" in the name
@@ -80,7 +92,7 @@ export async function saveCookies(
     userAgent,
   };
 
-  const path = cookiePath(storageDir, extractorId);
+  const path = cookiePath(resolvedStorageDir, extractorId);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(jar, null, 2));
 }
@@ -94,15 +106,18 @@ export async function saveCookies(
  *
  * @param context - Playwright browser context to inject cookies into
  * @param extractorId - Must match the ID used when saving
- * @param storageDir - Directory where cookie files are stored (default: ./storage)
+ * @param storageDir - Directory where cookie files are stored (default: DATA_DIR/cloudflare-cookies when DATA_DIR is set, otherwise ./storage)
  * @returns Number of cookies loaded (0 if no saved cookies or all expired)
  */
 export async function loadCookies(
   context: BrowserContext,
   extractorId: string,
-  storageDir = "./storage",
+  storageDir?: string,
 ): Promise<number> {
-  const path = cookiePath(storageDir, extractorId);
+  const path = cookiePath(
+    getCloudflareCookieStorageDir(storageDir),
+    extractorId,
+  );
 
   let jar: PersistedCookieJar;
   try {
@@ -127,9 +142,12 @@ export async function loadCookies(
  */
 export async function readCookieJar(
   extractorId: string,
-  storageDir = "./storage",
+  storageDir?: string,
 ): Promise<CookieJarInfo> {
-  const path = cookiePath(storageDir, extractorId);
+  const path = cookiePath(
+    getCloudflareCookieStorageDir(storageDir),
+    extractorId,
+  );
 
   let jar: PersistedCookieJar;
   try {
@@ -149,9 +167,12 @@ export async function readCookieJar(
  */
 export async function invalidateCookies(
   extractorId: string,
-  storageDir = "./storage",
+  storageDir?: string,
 ): Promise<void> {
-  const path = cookiePath(storageDir, extractorId);
+  const path = cookiePath(
+    getCloudflareCookieStorageDir(storageDir),
+    extractorId,
+  );
   try {
     await unlink(path);
   } catch {

--- a/extractors/browser-utils/src/index.ts
+++ b/extractors/browser-utils/src/index.ts
@@ -17,7 +17,13 @@ export {
   navigateWithChallenge,
   waitForChallengeResolution,
 } from "./challenge.js";
-export { loadCookies, saveCookies } from "./cookies.js";
+export {
+  type CookieJarInfo,
+  invalidateCookies,
+  loadCookies,
+  readCookieJar,
+  saveCookies,
+} from "./cookies.js";
 export {
   type BrowserLaunchOptions,
   createLaunchOptions,
@@ -29,4 +35,4 @@ export {
   type RetryOptions,
   withRetry,
 } from "./retry.js";
-export { solveChallenge, type SolverResult } from "./solver.js";
+export { type SolverResult, solveChallenge } from "./solver.js";

--- a/extractors/browser-utils/src/index.ts
+++ b/extractors/browser-utils/src/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared browser resilience utilities for Playwright-based extractors.
+ *
+ * Use this package when your extractor navigates pages with Playwright and
+ * needs to handle Cloudflare WAF challenges, retry transient failures, or
+ * persist cookies between runs.
+ *
+ * NOT for: HTTP-only extractors (adzuna, startupjobs) or Python-based
+ * extractors (jobspy). Those don't use Playwright and can't benefit from
+ * browser-level anti-detection.
+ */
+
+export {
+  type ChallengeResult,
+  isChallengePage,
+  isChallengeResponse,
+  navigateWithChallenge,
+  waitForChallengeResolution,
+} from "./challenge.js";
+export { loadCookies, saveCookies } from "./cookies.js";
+export {
+  type BrowserLaunchOptions,
+  createLaunchOptions,
+} from "./launch.js";
+export {
+  type NavigateWithRetryOptions,
+  type NavigateWithRetryResult,
+  navigateWithRetry,
+  type RetryOptions,
+  withRetry,
+} from "./retry.js";
+export { solveChallenge, type SolverResult } from "./solver.js";

--- a/extractors/browser-utils/src/index.ts
+++ b/extractors/browser-utils/src/index.ts
@@ -19,6 +19,7 @@ export {
 } from "./challenge.js";
 export {
   type CookieJarInfo,
+  getCloudflareCookieStorageDir,
   invalidateCookies,
   loadCookies,
   readCookieJar,

--- a/extractors/browser-utils/src/launch.ts
+++ b/extractors/browser-utils/src/launch.ts
@@ -1,0 +1,67 @@
+import type { LaunchOptions } from "playwright";
+
+export interface BrowserLaunchOptions {
+  /** Run headless (default true) */
+  headless?: boolean;
+  /** Enable Camoufox humanization — random mouse movements, typing delays (default true) */
+  humanize?: boolean;
+  /** Spoof geolocation based on IP (default true) */
+  geoip?: boolean;
+  /** Block WebRTC to prevent IP leaks (default true) */
+  block_webrtc?: boolean;
+  /** Additional args passed to the browser */
+  args?: string[];
+}
+
+const DEFAULTS: Required<Omit<BrowserLaunchOptions, "args">> = {
+  headless: true,
+  humanize: true,
+  geoip: true,
+  block_webrtc: true,
+  // block_images intentionally omitted — camoufox warns it triggers WAF detection
+};
+
+/**
+ * Creates Playwright launch options using Camoufox for anti-detection.
+ * Falls back to vanilla Firefox if Camoufox fails to initialize.
+ *
+ * This centralizes the launch config so all extractors use the same
+ * anti-detection settings. Update this one place when Camoufox options change.
+ *
+ * @returns Launch options and a flag indicating whether Camoufox was used
+ */
+export async function createLaunchOptions(
+  options: BrowserLaunchOptions = {},
+): Promise<{ launchOptions: LaunchOptions; usedCamoufox: boolean }> {
+  const merged = { ...DEFAULTS, ...options };
+
+  try {
+    const { launchOptions } = await import("camoufox-js");
+
+    const opts = await launchOptions({
+      headless: merged.headless,
+      humanize: merged.humanize,
+      geoip: merged.geoip,
+      block_webrtc: merged.block_webrtc,
+      args: options.args,
+    });
+
+    return { launchOptions: opts, usedCamoufox: true };
+  } catch (error) {
+    // Camoufox binary missing or incompatible — fall back to vanilla Firefox.
+    // This happens in CI or when the binary hasn't been fetched yet.
+    console.warn(
+      `[browser-utils] Camoufox unavailable, falling back to vanilla Firefox: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+
+    return {
+      launchOptions: {
+        headless: merged.headless,
+        args: options.args,
+      },
+      usedCamoufox: false,
+    };
+  }
+}

--- a/extractors/browser-utils/src/launch.ts
+++ b/extractors/browser-utils/src/launch.ts
@@ -18,7 +18,8 @@ const DEFAULTS: Required<Omit<BrowserLaunchOptions, "args">> = {
   humanize: true,
   geoip: true,
   block_webrtc: true,
-  // block_images intentionally omitted — camoufox warns it triggers WAF detection
+  // block_images intentionally NOT set — camoufox docs warn it triggers WAF
+  // detection because CF checks whether images are loaded by the browser
 };
 
 /**

--- a/extractors/browser-utils/src/retry.ts
+++ b/extractors/browser-utils/src/retry.ts
@@ -1,0 +1,133 @@
+import type { Page, Response } from "playwright";
+import { type ChallengeResult, navigateWithChallenge } from "./challenge.js";
+
+export interface RetryOptions {
+  /** Maximum number of attempts (default 3) */
+  maxAttempts?: number;
+  /** Base delay in ms — doubled each retry (default 2000) */
+  baseDelayMs?: number;
+  /** Optional predicate: return true to retry, false to stop */
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+}
+
+/**
+ * Generic retry wrapper with exponential backoff.
+ * Works with any async function — not browser-specific.
+ */
+export async function withRetry<T>(
+  fn: (attempt: number) => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const { maxAttempts = 3, baseDelayMs = 2_000, shouldRetry } = options;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === maxAttempts) break;
+      if (shouldRetry && !shouldRetry(error, attempt)) break;
+
+      const delay = baseDelayMs * 2 ** (attempt - 1);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
+export interface NavigateWithRetryOptions {
+  /** Max navigation attempts (default 3) */
+  maxAttempts?: number;
+  /** Base delay between retries in ms (default 2000) */
+  baseDelayMs?: number;
+  /** Playwright waitUntil option (default "domcontentloaded") */
+  waitUntil?: "load" | "domcontentloaded" | "networkidle" | "commit";
+  /** Max time to wait for a CF challenge to resolve per attempt (default 30s) */
+  challengeTimeoutMs?: number;
+  /** Max time for the page.goto call itself (default 30s) */
+  navigationTimeoutMs?: number;
+  /** Called on each retry with context — useful for logging */
+  onRetry?: (info: { attempt: number; reason: string; url: string }) => void;
+}
+
+export interface NavigateWithRetryResult {
+  response: Response | null;
+  challengeResult: ChallengeResult;
+  attempts: number;
+}
+
+/**
+ * Navigates to a URL with automatic retry and Cloudflare challenge handling.
+ *
+ * On each attempt:
+ * 1. Navigates to the URL
+ * 2. Checks for CF challenge, waits for resolution if found
+ * 3. Retries with backoff if the challenge times out or navigation fails
+ *
+ * This is the primary function extractors should use for page navigation.
+ */
+export async function navigateWithRetry(
+  page: Page,
+  url: string,
+  options: NavigateWithRetryOptions = {},
+): Promise<NavigateWithRetryResult> {
+  const {
+    maxAttempts = 3,
+    baseDelayMs = 2_000,
+    waitUntil = "domcontentloaded",
+    challengeTimeoutMs = 30_000,
+    navigationTimeoutMs = 30_000,
+    onRetry,
+  } = options;
+
+  let lastResult: NavigateWithRetryResult | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const { response, challengeResult } = await navigateWithChallenge(
+        page,
+        url,
+        { waitUntil, challengeTimeoutMs, navigationTimeoutMs },
+      );
+
+      // Challenge resolved or wasn't one — success
+      if (
+        challengeResult.status === "passed" ||
+        challengeResult.status === "not-a-challenge"
+      ) {
+        return { response, challengeResult, attempts: attempt };
+      }
+
+      // Challenge timed out — retry
+      lastResult = { response, challengeResult, attempts: attempt };
+
+      if (attempt < maxAttempts) {
+        const reason =
+          challengeResult.status === "timeout"
+            ? "challenge timeout"
+            : `challenge ${challengeResult.status}`;
+        onRetry?.({ attempt, reason, url });
+        const delay = baseDelayMs * 2 ** (attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    } catch (error) {
+      // Navigation error (network, timeout, etc.) — retry
+      if (attempt < maxAttempts) {
+        const reason = error instanceof Error ? error.message : "unknown error";
+        onRetry?.({ attempt, reason, url });
+        const delay = baseDelayMs * 2 ** (attempt - 1);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      } else {
+        throw error;
+      }
+    }
+  }
+
+  // All retries exhausted — return last result
+  // biome-ignore lint/style/noNonNullAssertion: loop guarantees at least one attempt
+  return lastResult!;
+}

--- a/extractors/browser-utils/src/retry.ts
+++ b/extractors/browser-utils/src/retry.ts
@@ -20,6 +20,10 @@ export async function withRetry<T>(
 ): Promise<T> {
   const { maxAttempts = 3, baseDelayMs = 2_000, shouldRetry } = options;
 
+  if (maxAttempts < 1) {
+    throw new Error(`withRetry: maxAttempts must be >= 1, got ${maxAttempts}`);
+  }
+
   let lastError: unknown;
 
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {

--- a/extractors/browser-utils/src/solver.ts
+++ b/extractors/browser-utils/src/solver.ts
@@ -8,6 +8,16 @@ export type SolverResult =
   | { status: "timeout" }
   | { status: "error"; message: string };
 
+const SOLVED_PAGE = `data:text/html,${encodeURIComponent(`<!DOCTYPE html>
+<html><head><style>
+  body { margin:0; height:100vh; display:flex; align-items:center; justify-content:center;
+         background:#0a0a0a; color:#4ade80; font-family:system-ui,sans-serif; text-align:center; }
+  h1 { font-size:2rem; font-weight:600; margin-bottom:0.5rem; }
+  p { color:#a1a1aa; font-size:1.1rem; }
+</style></head><body>
+  <div><h1>Challenge solved</h1><p>You can close this tab and return to Job Ops.</p></div>
+</body></html>`)}`;
+
 /**
  * Opens a headed browser for a human to solve a Cloudflare challenge.
  *
@@ -54,6 +64,7 @@ export async function solveChallenge(
     // browser session established a valid cf_clearance
     if (!(await isChallengePage(page))) {
       await saveCookies(context, extractorId, storageDir);
+      await showSolvedPage(page);
       return { status: "solved" };
     }
 
@@ -66,6 +77,7 @@ export async function solveChallenge(
 
       if (!(await isChallengePage(page))) {
         await saveCookies(context, extractorId, storageDir);
+        await showSolvedPage(page);
         return { status: "solved" };
       }
     }
@@ -78,5 +90,19 @@ export async function solveChallenge(
     };
   } finally {
     await browser?.close();
+  }
+}
+
+/** Show a "challenge solved" page so the VNC user knows they can close the tab. */
+async function showSolvedPage(page: {
+  goto: (url: string, opts?: { timeout?: number }) => Promise<unknown>;
+  waitForTimeout: (ms: number) => Promise<void>;
+}): Promise<void> {
+  try {
+    await page.goto(SOLVED_PAGE, { timeout: 5_000 });
+    // Brief pause so the user sees the message before the browser closes
+    await page.waitForTimeout(3_000);
+  } catch {
+    // Non-critical - the solve already succeeded
   }
 }

--- a/extractors/browser-utils/src/solver.ts
+++ b/extractors/browser-utils/src/solver.ts
@@ -1,0 +1,77 @@
+import type { BrowserContext } from "playwright";
+import { isChallengePage } from "./challenge.js";
+import { saveCookies } from "./cookies.js";
+import { createLaunchOptions } from "./launch.js";
+
+export type SolverResult =
+  | { status: "solved" }
+  | { status: "timeout" }
+  | { status: "error"; message: string };
+
+/**
+ * Opens a headed browser for a human to solve a Cloudflare challenge.
+ *
+ * This is the "2FA for scraping" flow: the system can't solve the challenge
+ * headless, so it opens a visible browser, lets the human interact, detects
+ * when the challenge is resolved, saves the cookies, and closes.
+ *
+ * The saved cookies (especially cf_clearance) allow subsequent headless runs
+ * to skip the challenge until the cookie expires.
+ *
+ * @param url - The URL that triggered the challenge
+ * @param extractorId - Used to namespace the saved cookies
+ * @param storageDir - Where to save cookies (e.g. "./storage")
+ * @param timeoutMs - Max time to wait for the human (default 5 minutes)
+ */
+export async function solveChallenge(
+  url: string,
+  extractorId: string,
+  storageDir: string,
+  timeoutMs = 5 * 60 * 1000,
+): Promise<SolverResult> {
+  let context: BrowserContext | undefined;
+  let browser: Awaited<ReturnType<typeof import("playwright").firefox.launch>> | undefined;
+
+  try {
+    const { firefox } = await import("playwright");
+    // Always headed — the whole point is the human needs to see and interact
+    const { launchOptions } = await createLaunchOptions({ headless: false });
+    browser = await firefox.launch(launchOptions);
+    context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(url, {
+      waitUntil: "domcontentloaded",
+      timeout: 30_000,
+    });
+
+    // If there's no challenge, we're done — save cookies anyway since the
+    // browser session established a valid cf_clearance
+    if (!(await isChallengePage(page))) {
+      await saveCookies(context, extractorId, storageDir);
+      return { status: "solved" };
+    }
+
+    // Poll until the challenge is resolved or timeout
+    const start = Date.now();
+    const pollInterval = 2_000;
+
+    while (Date.now() - start < timeoutMs) {
+      await page.waitForTimeout(pollInterval);
+
+      if (!(await isChallengePage(page))) {
+        await saveCookies(context, extractorId, storageDir);
+        return { status: "solved" };
+      }
+    }
+
+    return { status: "timeout" };
+  } catch (error) {
+    return {
+      status: "error",
+      message: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    await browser?.close();
+  }
+}

--- a/extractors/browser-utils/src/solver.ts
+++ b/extractors/browser-utils/src/solver.ts
@@ -30,11 +30,16 @@ export async function solveChallenge(
   timeoutMs = 5 * 60 * 1000,
 ): Promise<SolverResult> {
   let context: BrowserContext | undefined;
-  let browser: Awaited<ReturnType<typeof import("playwright").firefox.launch>> | undefined;
+  let browser:
+    | Awaited<ReturnType<typeof import("playwright").firefox.launch>>
+    | undefined;
 
   try {
     const { firefox } = await import("playwright");
-    // Always headed — the whole point is the human needs to see and interact
+    // Always headed — the whole point is a human needs to see the challenge
+    // and click through it. The solved cf_clearance cookie is tied to this
+    // browser's UA + TLS fingerprint, so extractors must reuse the same UA
+    // (persisted in the cookie jar) when creating their headless context.
     const { launchOptions } = await createLaunchOptions({ headless: false });
     browser = await firefox.launch(launchOptions);
     context = await browser.newContext();

--- a/extractors/browser-utils/tests/cookies.test.ts
+++ b/extractors/browser-utils/tests/cookies.test.ts
@@ -113,9 +113,7 @@ describe("cookies", () => {
             value: c.value ?? "v",
             domain: c.domain ?? ".example.com",
             path: "/",
-            expires: c.expires
-              ? Number(c.expires)
-              : Date.now() / 1000 + 3600,
+            expires: c.expires ? Number(c.expires) : Date.now() / 1000 + 3600,
             httpOnly: true,
             secure: true,
             sameSite: "None" as const,

--- a/extractors/browser-utils/tests/cookies.test.ts
+++ b/extractors/browser-utils/tests/cookies.test.ts
@@ -1,0 +1,129 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invalidateCookies, readCookieJar } from "../src/cookies.js";
+
+// loadCookies / saveCookies need a real Playwright BrowserContext which is
+// heavy to set up.  We test the file-level functions that don't need one:
+// readCookieJar, invalidateCookies.
+
+function storageDir() {
+  const dir = join(tmpdir(), `browser-utils-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeCookieJar(
+  dir: string,
+  extractorId: string,
+  overrides: Record<string, unknown> = {},
+) {
+  const jar = {
+    extractorId,
+    savedAt: new Date().toISOString(),
+    cookies: [
+      {
+        name: "cf_clearance",
+        value: "fake",
+        domain: ".example.com",
+        path: "/",
+        // Expires 1 hour from now
+        expires: Date.now() / 1000 + 3600,
+        httpOnly: true,
+        secure: true,
+        sameSite: "None",
+      },
+    ],
+    ...overrides,
+  };
+  writeFileSync(
+    join(dir, `${extractorId}-cookies.json`),
+    JSON.stringify(jar, null, 2),
+  );
+}
+
+describe("cookies", () => {
+  describe("readCookieJar", () => {
+    it("returns hasCookies false when no file exists", async () => {
+      const dir = storageDir();
+      const result = await readCookieJar("nonexistent", dir);
+      expect(result).toEqual({ hasCookies: false });
+    });
+
+    it("returns saved userAgent and hasCookies true", async () => {
+      const dir = storageDir();
+      writeCookieJar(dir, "hiringcafe", {
+        userAgent: "Mozilla/5.0 SolverUA",
+      });
+
+      const result = await readCookieJar("hiringcafe", dir);
+      expect(result.hasCookies).toBe(true);
+      expect(result.userAgent).toBe("Mozilla/5.0 SolverUA");
+    });
+
+    it("returns hasCookies false when all cookies are expired", async () => {
+      const dir = storageDir();
+      writeCookieJar(dir, "hiringcafe", {
+        cookies: [
+          {
+            name: "cf_clearance",
+            value: "old",
+            domain: ".example.com",
+            path: "/",
+            expires: Date.now() / 1000 - 3600, // expired 1 hour ago
+            httpOnly: true,
+            secure: true,
+            sameSite: "None",
+          },
+        ],
+        userAgent: "Mozilla/5.0 StaleUA",
+      });
+
+      const result = await readCookieJar("hiringcafe", dir);
+      expect(result.hasCookies).toBe(false);
+      // UA is still returned — caller decides whether to use it
+      expect(result.userAgent).toBe("Mozilla/5.0 StaleUA");
+    });
+
+    it("returns undefined userAgent when jar has no UA field", async () => {
+      const dir = storageDir();
+      writeCookieJar(dir, "gradcracker"); // no userAgent override
+
+      const result = await readCookieJar("gradcracker", dir);
+      expect(result.hasCookies).toBe(true);
+      expect(result.userAgent).toBeUndefined();
+    });
+  });
+
+  describe("invalidateCookies", () => {
+    it("deletes the cookie file", async () => {
+      const dir = storageDir();
+      writeCookieJar(dir, "hiringcafe");
+      const path = join(dir, "hiringcafe-cookies.json");
+      expect(existsSync(path)).toBe(true);
+
+      await invalidateCookies("hiringcafe", dir);
+      expect(existsSync(path)).toBe(false);
+    });
+
+    it("does not throw when file does not exist", async () => {
+      const dir = storageDir();
+      await expect(
+        invalidateCookies("nonexistent", dir),
+      ).resolves.toBeUndefined();
+    });
+
+    it("makes readCookieJar return hasCookies false after invalidation", async () => {
+      const dir = storageDir();
+      writeCookieJar(dir, "hiringcafe", {
+        userAgent: "Mozilla/5.0 SolverUA",
+      });
+
+      expect((await readCookieJar("hiringcafe", dir)).hasCookies).toBe(true);
+      await invalidateCookies("hiringcafe", dir);
+      expect((await readCookieJar("hiringcafe", dir)).hasCookies).toBe(false);
+    });
+  });
+});

--- a/extractors/browser-utils/tests/cookies.test.ts
+++ b/extractors/browser-utils/tests/cookies.test.ts
@@ -1,9 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { invalidateCookies, readCookieJar } from "../src/cookies.js";
+import { describe, expect, it } from "vitest";
+import {
+  invalidateCookies,
+  readCookieJar,
+  saveCookies,
+} from "../src/cookies.js";
 
 // loadCookies / saveCookies need a real Playwright BrowserContext which is
 // heavy to set up.  We test the file-level functions that don't need one:
@@ -94,6 +98,83 @@ describe("cookies", () => {
       const result = await readCookieJar("gradcracker", dir);
       expect(result.hasCookies).toBe(true);
       expect(result.userAgent).toBeUndefined();
+    });
+  });
+
+  describe("saveCookies", () => {
+    function mockContext(
+      cookies: Record<string, string>[],
+      userAgent = "Mozilla/5.0 TestUA",
+    ) {
+      return {
+        cookies: async () =>
+          cookies.map((c) => ({
+            name: c.name,
+            value: c.value ?? "v",
+            domain: c.domain ?? ".example.com",
+            path: "/",
+            expires: c.expires
+              ? Number(c.expires)
+              : Date.now() / 1000 + 3600,
+            httpOnly: true,
+            secure: true,
+            sameSite: "None" as const,
+          })),
+        pages: () => [
+          {
+            evaluate: async () => userAgent,
+          },
+        ],
+      } as unknown as import("playwright").BrowserContext;
+    }
+
+    it("persists userAgent from the browser context", async () => {
+      const dir = storageDir();
+      const ctx = mockContext(
+        [{ name: "cf_clearance" }],
+        "Mozilla/5.0 Camoufox/123",
+      );
+
+      await saveCookies(ctx, "test-extractor", dir);
+
+      const jar = await readCookieJar("test-extractor", dir);
+      expect(jar.hasCookies).toBe(true);
+      expect(jar.userAgent).toBe("Mozilla/5.0 Camoufox/123");
+    });
+
+    it("writes undefined userAgent when no pages are open", async () => {
+      const dir = storageDir();
+      const ctx = {
+        cookies: async () => [
+          {
+            name: "cf_clearance",
+            value: "v",
+            domain: ".example.com",
+            path: "/",
+            expires: Date.now() / 1000 + 3600,
+            httpOnly: true,
+            secure: true,
+            sameSite: "None" as const,
+          },
+        ],
+        pages: () => [],
+      } as unknown as import("playwright").BrowserContext;
+
+      await saveCookies(ctx, "no-pages", dir);
+
+      const jar = await readCookieJar("no-pages", dir);
+      expect(jar.hasCookies).toBe(true);
+      expect(jar.userAgent).toBeUndefined();
+    });
+
+    it("does not write jar when no relevant cookies exist", async () => {
+      const dir = storageDir();
+      const ctx = mockContext([{ name: "irrelevant_cookie" }]);
+
+      await saveCookies(ctx, "empty", dir);
+
+      const jar = await readCookieJar("empty", dir);
+      expect(jar.hasCookies).toBe(false);
     });
   });
 

--- a/extractors/browser-utils/tests/cookies.test.ts
+++ b/extractors/browser-utils/tests/cookies.test.ts
@@ -2,8 +2,9 @@ import { randomUUID } from "node:crypto";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
+  getCloudflareCookieStorageDir,
   invalidateCookies,
   readCookieJar,
   saveCookies,
@@ -49,6 +50,32 @@ function writeCookieJar(
 }
 
 describe("cookies", () => {
+  const originalDataDir = process.env.DATA_DIR;
+
+  afterEach(() => {
+    if (originalDataDir === undefined) {
+      delete process.env.DATA_DIR;
+    } else {
+      process.env.DATA_DIR = originalDataDir;
+    }
+  });
+
+  describe("getCloudflareCookieStorageDir", () => {
+    it("stores cookies under DATA_DIR when configured", () => {
+      process.env.DATA_DIR = "/tmp/job-ops-data";
+      expect(getCloudflareCookieStorageDir()).toBe(
+        join("/tmp/job-ops-data", "cloudflare-cookies"),
+      );
+    });
+
+    it("uses explicit storage dirs for direct callers", () => {
+      process.env.DATA_DIR = "/tmp/job-ops-data";
+      expect(getCloudflareCookieStorageDir("/tmp/custom-cookies")).toBe(
+        "/tmp/custom-cookies",
+      );
+    });
+  });
+
   describe("readCookieJar", () => {
     it("returns hasCookies false when no file exists", async () => {
       const dir = storageDir();

--- a/extractors/browser-utils/tests/retry.test.ts
+++ b/extractors/browser-utils/tests/retry.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { withRetry } from "../src/retry.js";
+
+describe("withRetry", () => {
+  it("throws on maxAttempts < 1", async () => {
+    await expect(
+      withRetry(() => Promise.resolve(), { maxAttempts: 0 }),
+    ).rejects.toThrow("maxAttempts must be >= 1");
+  });
+
+  it("throws on negative maxAttempts", async () => {
+    await expect(
+      withRetry(() => Promise.resolve(), { maxAttempts: -5 }),
+    ).rejects.toThrow("maxAttempts must be >= 1");
+  });
+});

--- a/extractors/browser-utils/tsconfig.json
+++ b/extractors/browser-utils/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "target": "ES2022",
+    "outDir": "dist",
+    "strict": true,
+    "noUnusedLocals": false,
+    "lib": ["DOM"],
+    "baseUrl": ".",
+    "skipLibCheck": true
+  },
+  "include": ["./src/**/*"]
+}

--- a/extractors/gradcracker/manifest.ts
+++ b/extractors/gradcracker/manifest.ts
@@ -43,6 +43,7 @@ export const manifest: ExtractorManifest = {
         success: false,
         jobs: [],
         error: result.error,
+        challengeRequired: result.challengeRequired,
       };
     }
 

--- a/extractors/gradcracker/package.json
+++ b/extractors/gradcracker/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "description": "This is an example of a Crawlee project.",
   "dependencies": {
-    "camoufox-js": "^0.8.0",
+    "browser-utils": "^0.0.1",
+    "camoufox-js": "^0.9.2",
     "crawlee": "^3.0.0",
     "playwright": "*",
     "tsx": "^4.4.0"

--- a/extractors/gradcracker/src/main.ts
+++ b/extractors/gradcracker/src/main.ts
@@ -2,8 +2,10 @@
 
 import {
   createLaunchOptions,
+  invalidateCookies,
   isChallengePage,
   loadCookies,
+  readCookieJar,
   saveCookies,
   waitForChallengeResolution,
 } from "browser-utils";
@@ -67,6 +69,10 @@ initJobOpsProgress(startUrls.length);
 const EXTRACTOR_ID = "gradcracker";
 const STORAGE_DIR = "./storage";
 
+// Read saved UA before launching - CF ties cf_clearance to the UA that
+// solved the challenge, so we must reuse it.
+const cookieJar = await readCookieJar(EXTRACTOR_ID, STORAGE_DIR);
+
 const { launchOptions } = await createLaunchOptions({ headless: true });
 
 // Track whether we've loaded cookies for the first request
@@ -90,6 +96,9 @@ const crawler = new PlaywrightCrawler({
   launchContext: {
     launcher: firefox,
     launchOptions,
+    // Reuse the UA from the last challenge solve so cf_clearance cookies match.
+    // CF ties the cookie to the UA + TLS fingerprint that solved the challenge.
+    ...(cookieJar.userAgent ? { userAgent: cookieJar.userAgent } : {}),
   },
 
   // Load saved CF cookies before navigation — may skip challenges entirely
@@ -121,6 +130,8 @@ const crawler = new PlaywrightCrawler({
         // Persist cookies so future requests (and runs) can skip the challenge
         await saveCookies(page.context(), EXTRACTOR_ID, STORAGE_DIR);
       } else {
+        // Stale cookies won't help - wipe them so the solver starts fresh
+        await invalidateCookies(EXTRACTOR_ID, STORAGE_DIR);
         // Signal the orchestrator that a human needs to solve this challenge
         emitChallengeRequired(request.url);
         // Throw to trigger Crawlee's built-in retry

--- a/extractors/gradcracker/src/main.ts
+++ b/extractors/gradcracker/src/main.ts
@@ -82,7 +82,9 @@ const crawler = new PlaywrightCrawler({
   requestHandlerTimeoutSecs: 100,
   maxRequestRetries: 3,
   browserPoolOptions: {
-    // Disable the default fingerprint spoofing to avoid conflicts with Camoufox.
+    // Crawlee injects its own fingerprints by default. Camoufox already handles
+    // fingerprint spoofing at the C++ level — having both active causes conflicts
+    // (double-spoofed values that look obviously fake to CF).
     useFingerprints: false,
   },
   launchContext: {

--- a/extractors/gradcracker/src/main.ts
+++ b/extractors/gradcracker/src/main.ts
@@ -1,8 +1,15 @@
 // For more information, see https://crawlee.dev/
-import { launchOptions } from "camoufox-js";
-import { PlaywrightCrawler } from "crawlee";
+
+import {
+  createLaunchOptions,
+  isChallengePage,
+  loadCookies,
+  saveCookies,
+  waitForChallengeResolution,
+} from "browser-utils";
+import { log, PlaywrightCrawler } from "crawlee";
 import { firefox } from "playwright";
-import { initJobOpsProgress } from "./progress.js";
+import { emitChallengeRequired, initJobOpsProgress } from "./progress.js";
 import { router } from "./routes.js";
 
 // locations
@@ -57,29 +64,70 @@ const startUrls = gradcrackerUrls.map(({ url, role }) => ({
 
 initJobOpsProgress(startUrls.length);
 
+const EXTRACTOR_ID = "gradcracker";
+const STORAGE_DIR = "./storage";
+
+const { launchOptions } = await createLaunchOptions({ headless: true });
+
+// Track whether we've loaded cookies for the first request
+// Crawlee reuses the browser context across requests, so we only need to
+// inject cookies once. The flag prevents redundant disk reads on every request.
+let cookiesLoaded = false;
+
 const crawler = new PlaywrightCrawler({
-  // proxyConfiguration: new ProxyConfiguration({ proxyUrls: ['...'] }),
   requestHandler: router,
-  // Comment this option to scrape the full website.
-  // maxRequestsPerCrawl: 2000,
-  // Add delay between requests to slow down the process
   minConcurrency: 1,
   maxConcurrency: 2,
   navigationTimeoutSecs: 60,
-  // Add delay between requests (in milliseconds)
   requestHandlerTimeoutSecs: 100,
+  maxRequestRetries: 3,
   browserPoolOptions: {
     // Disable the default fingerprint spoofing to avoid conflicts with Camoufox.
     useFingerprints: false,
   },
   launchContext: {
     launcher: firefox,
-    launchOptions: await launchOptions({
-      headless: true,
-      humanize: true,
-      geoip: true,
-    }),
+    launchOptions,
   },
+
+  // Load saved CF cookies before navigation — may skip challenges entirely
+  preNavigationHooks: [
+    async ({ page }) => {
+      if (!cookiesLoaded) {
+        const context = page.context();
+        const loaded = await loadCookies(context, EXTRACTOR_ID, STORAGE_DIR);
+        if (loaded > 0) {
+          log.info(`Loaded ${loaded} cached cookies for ${EXTRACTOR_ID}`);
+        }
+        cookiesLoaded = true;
+      }
+    },
+  ],
+
+  // After navigation: detect CF challenges, wait for resolution, save cookies
+  postNavigationHooks: [
+    async ({ page, request }) => {
+      if (!(await isChallengePage(page))) return;
+
+      log.warning(
+        `Cloudflare challenge detected on ${request.url}, waiting for resolution...`,
+      );
+      const result = await waitForChallengeResolution(page, 30_000);
+
+      if (result.status === "passed") {
+        log.info(`Challenge passed for ${request.url}`);
+        // Persist cookies so future requests (and runs) can skip the challenge
+        await saveCookies(page.context(), EXTRACTOR_ID, STORAGE_DIR);
+      } else {
+        // Signal the orchestrator that a human needs to solve this challenge
+        emitChallengeRequired(request.url);
+        // Throw to trigger Crawlee's built-in retry
+        throw new Error(
+          `Cloudflare challenge ${result.status} on ${request.url}`,
+        );
+      }
+    },
+  ],
 });
 
 await crawler.run(startUrls);

--- a/extractors/gradcracker/src/main.ts
+++ b/extractors/gradcracker/src/main.ts
@@ -2,6 +2,7 @@
 
 import {
   createLaunchOptions,
+  getCloudflareCookieStorageDir,
   invalidateCookies,
   isChallengePage,
   loadCookies,
@@ -67,7 +68,7 @@ const startUrls = gradcrackerUrls.map(({ url, role }) => ({
 initJobOpsProgress(startUrls.length);
 
 const EXTRACTOR_ID = "gradcracker";
-const STORAGE_DIR = "./storage";
+const STORAGE_DIR = getCloudflareCookieStorageDir();
 
 // Read saved UA before launching - CF ties cf_clearance to the UA that
 // solved the challenge, so we must reuse it.

--- a/extractors/gradcracker/src/progress.ts
+++ b/extractors/gradcracker/src/progress.ts
@@ -80,3 +80,10 @@ export function markJobPageDone(params: { currentUrl: string }): void {
   state.currentUrl = params.currentUrl;
   emit();
 }
+
+export function emitChallengeRequired(url: string): void {
+  if (!isEnabled()) return;
+  process.stdout.write(
+    `${PROGRESS_PREFIX}${JSON.stringify({ event: "challenge_required", url })}\n`,
+  );
+}

--- a/extractors/gradcracker/src/run.ts
+++ b/extractors/gradcracker/src/run.ts
@@ -101,7 +101,10 @@ export async function runCrawler(
           try {
             const parsed = JSON.parse(raw) as Record<string, unknown>;
             // Detect challenge_required signal from the child process
-            if (parsed.event === "challenge_required" && typeof parsed.url === "string") {
+            if (
+              parsed.event === "challenge_required" &&
+              typeof parsed.url === "string"
+            ) {
               challengeRequired = parsed.url;
               return;
             }

--- a/extractors/gradcracker/src/run.ts
+++ b/extractors/gradcracker/src/run.ts
@@ -30,6 +30,8 @@ export interface CrawlerResult {
   success: boolean;
   jobs: CreateJobInput[];
   error?: string;
+  /** URL that needs a human to solve a Cloudflare challenge in a headed browser */
+  challengeRequired?: string;
 }
 
 export interface RunCrawlerOptions {
@@ -64,6 +66,8 @@ async function writeExistingJobUrlsFile(
 export async function runCrawler(
   options: RunCrawlerOptions = {},
 ): Promise<CrawlerResult> {
+  let challengeRequired: string | undefined;
+
   try {
     await clearStorageDataset();
     const existingJobUrlsFile = await writeExistingJobUrlsFile(
@@ -95,8 +99,13 @@ export async function runCrawler(
         if (line.startsWith(JOBOPS_PROGRESS_PREFIX)) {
           const raw = line.slice(JOBOPS_PROGRESS_PREFIX.length).trim();
           try {
-            const parsed = JSON.parse(raw) as JobExtractorProgress;
-            options.onProgress?.(parsed);
+            const parsed = JSON.parse(raw) as Record<string, unknown>;
+            // Detect challenge_required signal from the child process
+            if (parsed.event === "challenge_required" && typeof parsed.url === "string") {
+              challengeRequired = parsed.url;
+              return;
+            }
+            options.onProgress?.(parsed as unknown as JobExtractorProgress);
           } catch {
             // ignore malformed progress lines
           }
@@ -129,10 +138,13 @@ export async function runCrawler(
     });
 
     const jobs = await readCrawledJobs();
+    if (challengeRequired && jobs.length === 0) {
+      return { success: false, jobs: [], challengeRequired };
+    }
     return { success: true, jobs };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    return { success: false, jobs: [], error: message };
+    return { success: false, jobs: [], error: message, challengeRequired };
   }
 }
 

--- a/extractors/hiringcafe/manifest.ts
+++ b/extractors/hiringcafe/manifest.ts
@@ -85,6 +85,7 @@ export const manifest: ExtractorManifest = {
         success: false,
         jobs: [],
         error: result.error,
+        challengeRequired: result.challengeRequired,
       };
     }
 

--- a/extractors/hiringcafe/package.json
+++ b/extractors/hiringcafe/package.json
@@ -5,7 +5,8 @@
   "description": "Hiring Cafe extractor - fetches jobs via browser-backed API requests",
   "main": "src/main.ts",
   "dependencies": {
-    "camoufox-js": "^0.8.0",
+    "browser-utils": "^0.0.1",
+    "camoufox-js": "^0.9.2",
     "job-ops-shared": "^1.0.0",
     "playwright": "^1.57.0",
     "tsx": "^4.4.0"

--- a/extractors/hiringcafe/src/main.ts
+++ b/extractors/hiringcafe/src/main.ts
@@ -661,6 +661,9 @@ async function run(): Promise<void> {
         page,
         BASE_URL,
         {
+          // Single attempt: hiring.cafe's CF challenge is deterministic - if it
+          // shows up, retrying with the same fingerprint won't help. The pipeline
+          // pauses and the solver handles it with a fresh headed browser instead.
           maxAttempts: 1,
           waitUntil: "domcontentloaded",
           navigationTimeoutMs: 60_000,

--- a/extractors/hiringcafe/src/main.ts
+++ b/extractors/hiringcafe/src/main.ts
@@ -661,10 +661,9 @@ async function run(): Promise<void> {
         page,
         BASE_URL,
         {
+          maxAttempts: 1,
           waitUntil: "domcontentloaded",
           navigationTimeoutMs: 60_000,
-          onRetry: ({ attempt, reason }) =>
-            console.warn(`Initial navigation retry ${attempt}: ${reason}`),
         },
       );
 

--- a/extractors/hiringcafe/src/main.ts
+++ b/extractors/hiringcafe/src/main.ts
@@ -2,7 +2,14 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { JobLocationEvidence } from "@shared/types/jobs";
-import { launchOptions } from "camoufox-js";
+import {
+  createLaunchOptions,
+  invalidateCookies,
+  loadCookies,
+  navigateWithRetry,
+  readCookieJar,
+  saveCookies,
+} from "browser-utils";
 import { parseSearchTerms } from "job-ops-shared/utils/search-terms";
 import {
   toNumberOrNull,
@@ -622,26 +629,68 @@ async function run(): Promise<void> {
     process.env.HIRING_CAFE_WORKPLACE_TYPES,
   );
 
-  let browser = await firefox.launch(
-    await launchOptions({
-      headless,
-      humanize: true,
-      geoip: true,
-    }),
+  const EXTRACTOR_ID = "hiringcafe";
+  const STORAGE_DIR = join(__dirname, "../storage");
+
+  // Read saved UA before launching - CF ties cf_clearance to the UA that
+  // solved the challenge, so we must reuse it. Playwright requires UA at
+  // newContext() time (can't change after).
+  const cookieJar = await readCookieJar(EXTRACTOR_ID, STORAGE_DIR);
+
+  const { launchOptions, usedCamoufox } = await createLaunchOptions({
+    headless,
+  });
+  let browser = await firefox.launch(launchOptions);
+  let context = await browser.newContext(
+    cookieJar.userAgent ? { userAgent: cookieJar.userAgent } : undefined,
   );
-  let context = await browser.newContext();
   let page = await context.newPage();
 
   const allJobs: ExtractedJob[] = [];
   const seen = new Set<string>();
 
   try {
+    // Restore CF cookies from a previous run — may skip the challenge entirely
+    const loaded = await loadCookies(context, EXTRACTOR_ID, STORAGE_DIR);
+    if (loaded > 0) {
+      console.log(`Loaded ${loaded} cached cookies for ${EXTRACTOR_ID}`);
+    }
+
     const initializePage = async () => {
-      await page.goto(BASE_URL, {
-        waitUntil: "domcontentloaded",
-        timeout: 60_000,
-      });
-      await page.waitForTimeout(2_000);
+      const { challengeResult, attempts } = await navigateWithRetry(
+        page,
+        BASE_URL,
+        {
+          waitUntil: "domcontentloaded",
+          navigationTimeoutMs: 60_000,
+          onRetry: ({ attempt, reason }) =>
+            console.warn(`Initial navigation retry ${attempt}: ${reason}`),
+        },
+      );
+
+      if (challengeResult.status === "timeout") {
+        // Stale cookies + UA won't help the solver - wipe them so the next
+        // run starts fresh with the solver's new UA/cookies.
+        await invalidateCookies(EXTRACTOR_ID, STORAGE_DIR);
+        // Signal the orchestrator that a human needs to solve this challenge.
+        // The JOBOPS_PROGRESS line is parsed by run.ts to set challengeRequired.
+        emitProgress({ event: "challenge_required", url: BASE_URL });
+        throw new Error("Cloudflare challenge timed out after all retries");
+      }
+
+      if (
+        challengeResult.status === "passed" ||
+        challengeResult.status === "not-a-challenge"
+      ) {
+        // Persist cookies so next run can skip the challenge
+        await saveCookies(context, EXTRACTOR_ID, STORAGE_DIR);
+      }
+
+      if (attempts > 1 || challengeResult.status === "passed") {
+        console.log(
+          `Initial navigation: ${challengeResult.status} after ${attempts} attempt(s)`,
+        );
+      }
     };
 
     try {
@@ -649,11 +698,13 @@ async function run(): Promise<void> {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.warn(
-        `Camoufox browser startup was unstable, retrying with vanilla Firefox: ${message}`,
+        `${usedCamoufox ? "Camoufox" : "Firefox"} startup failed, retrying with vanilla Firefox: ${message}`,
       );
       await browser.close();
       browser = await firefox.launch({ headless });
-      context = await browser.newContext();
+      context = await browser.newContext(
+        cookieJar.userAgent ? { userAgent: cookieJar.userAgent } : undefined,
+      );
       page = await context.newPage();
       await initializePage();
     }

--- a/extractors/hiringcafe/src/main.ts
+++ b/extractors/hiringcafe/src/main.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import type { JobLocationEvidence } from "@shared/types/jobs";
 import {
   createLaunchOptions,
+  getCloudflareCookieStorageDir,
   invalidateCookies,
   loadCookies,
   navigateWithRetry,
@@ -630,7 +631,7 @@ async function run(): Promise<void> {
   );
 
   const EXTRACTOR_ID = "hiringcafe";
-  const STORAGE_DIR = join(__dirname, "../storage");
+  const STORAGE_DIR = getCloudflareCookieStorageDir();
 
   // Read saved UA before launching - CF ties cf_clearance to the UA that
   // solved the challenge, so we must reuse it. Playwright requires UA at

--- a/extractors/hiringcafe/src/run.ts
+++ b/extractors/hiringcafe/src/run.ts
@@ -64,6 +64,8 @@ export interface HiringCafeResult {
   success: boolean;
   jobs: CreateJobInput[];
   error?: string;
+  /** URL that needs a human to solve a Cloudflare challenge in a headed browser */
+  challengeRequired?: string;
 }
 
 function resolveTsxCliPath(): string | null {
@@ -200,6 +202,8 @@ export async function runHiringCafe(
     };
   }
 
+  let challengeRequired: string | undefined;
+
   try {
     const jobs: CreateJobInput[] = [];
     const seen = new Set<string>();
@@ -250,6 +254,20 @@ export async function runHiringCafe(
             })();
 
         const handleLine = (line: string, stream: NodeJS.WriteStream) => {
+          if (line.startsWith(JOBOPS_PROGRESS_PREFIX)) {
+            const raw = line.slice(JOBOPS_PROGRESS_PREFIX.length).trim();
+            try {
+              const parsed = JSON.parse(raw) as Record<string, unknown>;
+              // Detect challenge_required signal from the child process
+              if (parsed.event === "challenge_required" && typeof parsed.url === "string") {
+                challengeRequired = parsed.url;
+                return;
+              }
+            } catch {
+              // ignore parse failures
+            }
+          }
+
           const progressEvent = parseProgressLine(line);
           if (progressEvent) {
             const termOffset = runIndex * searchTerms.length;
@@ -298,6 +316,6 @@ export async function runHiringCafe(
     return { success: true, jobs };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
-    return { success: false, jobs: [], error: message };
+    return { success: false, jobs: [], error: message, challengeRequired };
   }
 }

--- a/extractors/hiringcafe/src/run.ts
+++ b/extractors/hiringcafe/src/run.ts
@@ -259,7 +259,10 @@ export async function runHiringCafe(
             try {
               const parsed = JSON.parse(raw) as Record<string, unknown>;
               // Detect challenge_required signal from the child process
-              if (parsed.event === "challenge_required" && typeof parsed.url === "string") {
+              if (
+                parsed.event === "challenge_required" &&
+                typeof parsed.url === "string"
+              ) {
                 challengeRequired = parsed.url;
                 return;
               }

--- a/extractors/ukvisajobs/manifest.ts
+++ b/extractors/ukvisajobs/manifest.ts
@@ -91,6 +91,7 @@ export const manifest: ExtractorManifest = {
         success: false,
         jobs: [],
         error: result.error,
+        challengeRequired: result.challengeRequired,
       };
     }
 

--- a/extractors/ukvisajobs/package.json
+++ b/extractors/ukvisajobs/package.json
@@ -5,10 +5,11 @@
   "description": "UK Visa Jobs extractor - fetches job listings that may sponsor work visas",
   "main": "src/main.ts",
   "dependencies": {
-    "camoufox-js": "^0.8.0",
+    "browser-utils": "^0.0.1",
+    "camoufox-js": "^0.9.2",
+    "job-ops-shared": "^1.0.0",
     "playwright": "^1.57.0",
-    "tsx": "^4.4.0",
-    "job-ops-shared": "^1.0.0"
+    "tsx": "^4.4.0"
   },
   "devDependencies": {
     "@apify/tsconfig": "^0.1.0",

--- a/extractors/ukvisajobs/src/main.ts
+++ b/extractors/ukvisajobs/src/main.ts
@@ -18,8 +18,10 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createLaunchOptions,
+  invalidateCookies,
   loadCookies,
   navigateWithChallenge,
+  readCookieJar,
   saveCookies,
 } from "browser-utils";
 import {
@@ -343,13 +345,19 @@ async function loginWithBrowser(
 ): Promise<UkVisaJobsAuthSession> {
   const { firefox } = await import("playwright");
   const headless = process.env.UKVISAJOBS_HEADLESS !== "false";
-  const { launchOptions } = await createLaunchOptions({ headless });
-  const browser = await firefox.launch(launchOptions);
-  const context = await browser.newContext();
-  const page = await context.newPage();
-
   const EXTRACTOR_ID = "ukvisajobs";
   const STORAGE_DIR = join(__dirname, "../storage");
+
+  // Read saved UA before launching - CF ties cf_clearance to the UA that
+  // solved the challenge, so we must reuse it.
+  const cookieJar = await readCookieJar(EXTRACTOR_ID, STORAGE_DIR);
+
+  const { launchOptions } = await createLaunchOptions({ headless });
+  const browser = await firefox.launch(launchOptions);
+  const context = await browser.newContext(
+    cookieJar.userAgent ? { userAgent: cookieJar.userAgent } : undefined,
+  );
+  const page = await context.newPage();
 
   try {
     // Restore CF cookies from a previous run — may skip the challenge
@@ -363,6 +371,7 @@ async function loginWithBrowser(
       challengeTimeoutMs: 30_000,
     });
     if (challengeResult.status === "timeout") {
+      await invalidateCookies(EXTRACTOR_ID, STORAGE_DIR);
       emitProgress("challenge_required", { url: SIGNIN_URL });
       throw new Error("Cloudflare challenge timed out on sign-in page");
     }
@@ -390,6 +399,7 @@ async function loginWithBrowser(
       { waitUntil: "networkidle", challengeTimeoutMs: 30_000 },
     );
     if (jobsChallenge.status === "timeout") {
+      await invalidateCookies(EXTRACTOR_ID, STORAGE_DIR);
       emitProgress("challenge_required", { url: OPEN_JOBS_URL });
       throw new Error("Cloudflare challenge timed out on open-jobs page");
     }

--- a/extractors/ukvisajobs/src/main.ts
+++ b/extractors/ukvisajobs/src/main.ts
@@ -17,6 +17,12 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  createLaunchOptions,
+  loadCookies,
+  navigateWithChallenge,
+  saveCookies,
+} from "browser-utils";
+import {
   toNumberOrNull,
   toStringOrNull,
 } from "job-ops-shared/utils/type-conversion";
@@ -101,6 +107,7 @@ interface UkVisaJobsAuthSession {
   authToken: string;
   csrfToken: string;
   ciSession: string;
+  userAgent: string;
   fetchedAt: string;
   source: "cache" | "browser";
 }
@@ -142,8 +149,7 @@ async function fetchPage(
       cookie: cookies,
       origin: "https://my.ukvisajobs.com",
       referer: `https://my.ukvisajobs.com/open-jobs/1?is_global=0&sortBy=desc&pageNo=${pageNo}&visaAcceptance=false&applicants_outside_uk=false`,
-      "user-agent":
-        "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Mobile Safari/537.36",
+      "user-agent": session.userAgent,
     },
     body: formData,
   });
@@ -248,11 +254,13 @@ async function loadCachedAuthSession(): Promise<UkVisaJobsAuthSession | null> {
     const data = await readFile(AUTH_CACHE_PATH, "utf8");
     const parsed = JSON.parse(data) as UkVisaJobsAuthSession;
     if (!parsed?.token) return null;
+    if (!parsed.userAgent) return null; // stale cache without UA — force re-login
     return {
       token: parsed.token,
       authToken: parsed.authToken || parsed.token,
       csrfToken: parsed.csrfToken || "",
       ciSession: parsed.ciSession || "",
+      userAgent: parsed.userAgent,
       fetchedAt: parsed.fetchedAt || new Date().toISOString(),
       source: "cache",
     };
@@ -269,6 +277,7 @@ async function saveCachedAuthSession(
     authToken: session.authToken,
     csrfToken: session.csrfToken,
     ciSession: session.ciSession,
+    userAgent: session.userAgent,
     fetchedAt: session.fetchedAt,
     source: session.source,
   };
@@ -332,23 +341,36 @@ async function loginWithBrowser(
   email: string,
   password: string,
 ): Promise<UkVisaJobsAuthSession> {
-  const [{ launchOptions }, { firefox }] = await Promise.all([
-    import("camoufox-js"),
-    import("playwright"),
-  ]);
+  const { firefox } = await import("playwright");
   const headless = process.env.UKVISAJOBS_HEADLESS !== "false";
-  const browser = await firefox.launch(
-    await launchOptions({
-      headless,
-      humanize: true,
-      geoip: true,
-    }),
-  );
+  const { launchOptions } = await createLaunchOptions({ headless });
+  const browser = await firefox.launch(launchOptions);
   const context = await browser.newContext();
   const page = await context.newPage();
 
+  const EXTRACTOR_ID = "ukvisajobs";
+  const STORAGE_DIR = join(__dirname, "../storage");
+
   try {
-    await page.goto(SIGNIN_URL, { waitUntil: "domcontentloaded" });
+    // Restore CF cookies from a previous run — may skip the challenge
+    const loaded = await loadCookies(context, EXTRACTOR_ID, STORAGE_DIR);
+    if (loaded > 0) {
+      console.log(`Loaded ${loaded} cached CF cookies for ${EXTRACTOR_ID}`);
+    }
+
+    const { challengeResult } = await navigateWithChallenge(page, SIGNIN_URL, {
+      waitUntil: "domcontentloaded",
+      challengeTimeoutMs: 30_000,
+    });
+    if (challengeResult.status === "timeout") {
+      emitProgress("challenge_required", { url: SIGNIN_URL });
+      throw new Error("Cloudflare challenge timed out on sign-in page");
+    }
+    if (challengeResult.status === "passed") {
+      console.log("Cloudflare challenge passed on sign-in page");
+      await saveCookies(context, EXTRACTOR_ID, STORAGE_DIR);
+    }
+
     await page.waitForSelector("#email", { timeout: 15000 });
     await page.fill("#email", email);
     await page.fill("#password", password);
@@ -362,7 +384,19 @@ async function loginWithBrowser(
       { timeout: 30000 },
     );
 
-    await page.goto(OPEN_JOBS_URL, { waitUntil: "networkidle" });
+    const { challengeResult: jobsChallenge } = await navigateWithChallenge(
+      page,
+      OPEN_JOBS_URL,
+      { waitUntil: "networkidle", challengeTimeoutMs: 30_000 },
+    );
+    if (jobsChallenge.status === "timeout") {
+      emitProgress("challenge_required", { url: OPEN_JOBS_URL });
+      throw new Error("Cloudflare challenge timed out on open-jobs page");
+    }
+    if (jobsChallenge.status === "passed") {
+      console.log("Cloudflare challenge passed on open-jobs page");
+      await saveCookies(context, EXTRACTOR_ID, STORAGE_DIR);
+    }
     await page.waitForTimeout(5000);
 
     let fetchRequest: Request | null = null;
@@ -387,11 +421,17 @@ async function loginWithBrowser(
       throw new Error("Failed to locate auth token from browser session.");
     }
 
+    // Capture the UA that Camoufox generated for this session so subsequent
+    // fetch() calls use the same fingerprint. A mismatch (e.g. mobile Chrome UA
+    // from a desktop Firefox session) is a signal Cloudflare can flag.
+    const userAgent = await page.evaluate(() => navigator.userAgent);
+
     return {
       token,
       authToken: authToken || token,
       csrfToken,
       ciSession,
+      userAgent,
       fetchedAt: new Date().toISOString(),
       source: "browser",
     };

--- a/extractors/ukvisajobs/src/main.ts
+++ b/extractors/ukvisajobs/src/main.ts
@@ -18,6 +18,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   createLaunchOptions,
+  getCloudflareCookieStorageDir,
   invalidateCookies,
   loadCookies,
   navigateWithChallenge,
@@ -346,7 +347,7 @@ async function loginWithBrowser(
   const { firefox } = await import("playwright");
   const headless = process.env.UKVISAJOBS_HEADLESS !== "false";
   const EXTRACTOR_ID = "ukvisajobs";
-  const STORAGE_DIR = join(__dirname, "../storage");
+  const STORAGE_DIR = getCloudflareCookieStorageDir();
 
   // Read saved UA before launching - CF ties cf_clearance to the UA that
   // solved the challenge, so we must reuse it.

--- a/extractors/ukvisajobs/src/run.ts
+++ b/extractors/ukvisajobs/src/run.ts
@@ -316,7 +316,10 @@ export async function runUkVisaJobs(
               const raw = line.slice(JOBOPS_PROGRESS_PREFIX.length).trim();
               try {
                 const parsed = JSON.parse(raw) as Record<string, unknown>;
-                if (parsed.event === "challenge_required" && typeof parsed.url === "string") {
+                if (
+                  parsed.event === "challenge_required" &&
+                  typeof parsed.url === "string"
+                ) {
                   challengeRequired = parsed.url;
                   return;
                 }

--- a/extractors/ukvisajobs/src/run.ts
+++ b/extractors/ukvisajobs/src/run.ts
@@ -39,6 +39,7 @@ interface UkVisaJobsAuthSession {
   authToken?: string;
   csrfToken?: string;
   ciSession?: string;
+  userAgent?: string;
 }
 
 export interface RunUkVisaJobsOptions {
@@ -52,6 +53,8 @@ export interface UkVisaJobsResult {
   success: boolean;
   jobs: CreateJobInput[];
   error?: string;
+  /** URL that needs a human to solve a Cloudflare challenge in a headed browser */
+  challengeRequired?: string;
 }
 
 type UkVisaJobsExtractorProgressEvent =
@@ -221,10 +224,10 @@ async function fetchJobDescription(url: string): Promise<string | null> {
     const token = authSession?.authToken || authSession?.token;
     if (token) cookieParts.push(`authToken=${token}`);
 
-    const headers: Record<string, string> = {
-      "User-Agent":
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-    };
+    const headers: Record<string, string> = {};
+    if (authSession?.userAgent) {
+      headers["User-Agent"] = authSession.userAgent;
+    }
 
     if (cookieParts.length > 0) {
       headers.Cookie = cookieParts.join("; ");
@@ -286,6 +289,7 @@ export async function runUkVisaJobs(
     const allJobs: CreateJobInput[] = [];
     const seenIds = new Set<string>();
     const termTotal = terms.length;
+    let challengeRequired: string | undefined;
 
     for (let i = 0; i < terms.length; i += 1) {
       const term = terms[i];
@@ -308,6 +312,19 @@ export async function runUkVisaJobs(
           });
 
           const handleLine = (line: string, stream: NodeJS.WriteStream) => {
+            if (line.startsWith(JOBOPS_PROGRESS_PREFIX)) {
+              const raw = line.slice(JOBOPS_PROGRESS_PREFIX.length).trim();
+              try {
+                const parsed = JSON.parse(raw) as Record<string, unknown>;
+                if (parsed.event === "challenge_required" && typeof parsed.url === "string") {
+                  challengeRequired = parsed.url;
+                  return;
+                }
+              } catch {
+                // ignore parse failures
+              }
+            }
+
             const progressEvent = parseUkVisaJobsProgressLine(line);
             if (progressEvent) {
               options.onProgress?.({
@@ -394,6 +411,9 @@ export async function runUkVisaJobs(
       }
     }
 
+    if (challengeRequired && allJobs.length === 0) {
+      return { success: false, jobs: [], challengeRequired };
+    }
     return { success: true, jobs: allJobs };
   } finally {
     isUkVisaJobsRunning = false;

--- a/extractors/ukvisajobs/src/run.ts
+++ b/extractors/ukvisajobs/src/run.ts
@@ -414,7 +414,7 @@ export async function runUkVisaJobs(
       }
     }
 
-    if (challengeRequired && allJobs.length === 0) {
+    if (challengeRequired) {
       return { success: false, jobs: [], challengeRequired };
     }
     return { success: true, jobs: allJobs };

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -18,7 +18,7 @@ orchestrator/
 │   │   ├── components/   # UI components
 │   │   └── styles/       # CSS design system
 │   └── shared/           # Shared types
-├── data/                 # SQLite DB + generated PDFs (gitignored)
+├── data/                 # SQLite DB, generated PDFs, and runtime cookies (gitignored)
 └── public/               # Static assets
 ```
 

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -55,6 +55,7 @@
     "@tiptap/starter-kit": "^3.22.2",
     "@umami/node": "^0.4.0",
     "better-sqlite3": "^11.6.0",
+    "browser-utils": "^0.0.1",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/orchestrator/src/client/api/client.pipeline.test.ts
+++ b/orchestrator/src/client/api/client.pipeline.test.ts
@@ -123,4 +123,55 @@ describe("pipeline client helpers", () => {
       expect.any(Object),
     );
   });
+
+  it("prepares the challenge viewer through the authenticated API client", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: {
+          available: true,
+          viewerUrl: "/challenge-viewer/session/viewer-token/vnc.html",
+          reason: null,
+        },
+        meta: { requestId: "req-viewer" },
+      }),
+    );
+
+    await expect(api.prepareChallengeViewer()).resolves.toEqual({
+      available: true,
+      viewerUrl: "/challenge-viewer/session/viewer-token/vnc.html",
+      reason: null,
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/pipeline/challenge-viewer",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("sends challenge solve requests through the authenticated API client", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: {
+          status: "solved",
+          extractorId: "gradcracker",
+          challengesRemaining: 0,
+        },
+        meta: { requestId: "req-solve" },
+      }),
+    );
+
+    await expect(api.solvePipelineChallenge("gradcracker")).resolves.toEqual({
+      status: "solved",
+      extractorId: "gradcracker",
+      challengesRemaining: 0,
+    });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/pipeline/solve-challenge",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ extractorId: "gradcracker" }),
+      }),
+    );
+  });
 });

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -1416,6 +1416,35 @@ export async function getPipelineRuns(): Promise<PipelineRun[]> {
   return fetchApi<PipelineRun[]>("/pipeline/runs");
 }
 
+export async function prepareChallengeViewer(): Promise<{
+  available: boolean;
+  viewerUrl: string | null;
+  reason: string | null;
+}> {
+  return fetchApi<{
+    available: boolean;
+    viewerUrl: string | null;
+    reason: string | null;
+  }>("/pipeline/challenge-viewer", {
+    method: "POST",
+  });
+}
+
+export async function solvePipelineChallenge(extractorId: string): Promise<{
+  status: "solved";
+  extractorId: string;
+  challengesRemaining: number;
+}> {
+  return fetchApi<{
+    status: "solved";
+    extractorId: string;
+    challengesRemaining: number;
+  }>("/pipeline/solve-challenge", {
+    method: "POST",
+    body: JSON.stringify({ extractorId }),
+  });
+}
+
 export async function getPipelineRunInsights(
   id: string,
 ): Promise<PipelineRunInsights> {

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -2,7 +2,11 @@
  * Live pipeline progress display component.
  */
 
-import { getPipelineProgressSnapshot } from "@client/api";
+import {
+  getPipelineProgressSnapshot,
+  prepareChallengeViewer,
+  solvePipelineChallenge,
+} from "@client/api";
 import {
   sourceLabel as getSourceLabel,
   isExtractorSourceId,
@@ -76,28 +80,12 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
   const handleSolveChallenge = useCallback(async (extractorId: string) => {
     setSolvingExtractor(extractorId);
     try {
-      const viewerRes = await fetch("/api/pipeline/challenge-viewer", {
-        method: "POST",
-      });
-      if (viewerRes.ok) {
-        const viewerPayload = (await viewerRes.json()) as {
-          data?: { available?: boolean; viewerUrl?: string | null };
-        };
-        const viewerUrl = viewerPayload.data?.viewerUrl;
-        if (viewerPayload.data?.available && viewerUrl) {
-          window.open(viewerUrl, "_blank", "noopener");
-        }
+      const viewer = await prepareChallengeViewer();
+      if (viewer.available && viewer.viewerUrl) {
+        window.open(viewer.viewerUrl, "_blank", "noopener");
       }
 
-      const res = await fetch("/api/pipeline/solve-challenge", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ extractorId }),
-      });
-      if (!res.ok) {
-        const data = (await res.json()) as { error?: string };
-        console.error("Solve challenge failed:", data.error ?? res.statusText);
-      }
+      await solvePipelineChallenge(extractorId);
     } catch (err) {
       console.error("Solve challenge request failed:", err);
     } finally {

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -8,11 +8,12 @@ import {
   isExtractorSourceId,
 } from "@shared/extractors";
 import type { PipelineProgressState } from "@shared/types";
-import { Loader2 } from "lucide-react";
+import { Loader2, ShieldAlert } from "lucide-react";
 import type React from "react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { subscribeToEventSource } from "@/client/lib/sse";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
@@ -70,6 +71,26 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
   const [transport, setTransport] = useState<"connecting" | "live" | "polling">(
     "connecting",
   );
+  const [solvingExtractor, setSolvingExtractor] = useState<string | null>(null);
+
+  const handleSolveChallenge = useCallback(async (extractorId: string) => {
+    setSolvingExtractor(extractorId);
+    try {
+      const res = await fetch("/api/pipeline/solve-challenge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ extractorId }),
+      });
+      if (!res.ok) {
+        const data = (await res.json()) as { error?: string };
+        console.error("Solve challenge failed:", data.error ?? res.statusText);
+      }
+    } catch (err) {
+      console.error("Solve challenge request failed:", err);
+    } finally {
+      setSolvingExtractor(null);
+    }
+  }, []);
 
   const percentage = useMemo(() => {
     if (!progress) return 0;
@@ -381,6 +402,43 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
               </div>
             </>
           )}
+
+          {step === "challenge_required" &&
+            progress.pendingChallenges &&
+            progress.pendingChallenges.length > 0 && (
+              <div className="space-y-2">
+                <Separator />
+                {progress.pendingChallenges.map((challenge) => (
+                  <div
+                    key={challenge.extractorId}
+                    className="flex items-center justify-between rounded-md border border-orange-500/20 bg-orange-500/10 p-3"
+                  >
+                    <div className="flex items-center gap-2 text-sm text-orange-400">
+                      <ShieldAlert className="h-4 w-4 shrink-0" />
+                      <span>{challenge.extractorName}</span>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="border-orange-500/30 text-orange-400 hover:bg-orange-500/20"
+                      disabled={solvingExtractor === challenge.extractorId}
+                      onClick={() =>
+                        handleSolveChallenge(challenge.extractorId)
+                      }
+                    >
+                      {solvingExtractor === challenge.extractorId ? (
+                        <>
+                          <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+                          Solving…
+                        </>
+                      ) : (
+                        "Solve"
+                      )}
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
 
           {step === "failed" && progress.error && (
             <div className="rounded-md border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -76,6 +76,15 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
   const handleSolveChallenge = useCallback(async (extractorId: string) => {
     setSolvingExtractor(extractorId);
     try {
+      // Open noVNC viewer so the user can see and click the CF challenge.
+      // In Docker, the solver renders Firefox on a virtual display exposed
+      // via noVNC on port 6080. Locally (non-Docker) this tab won't connect
+      // but that's fine - the solver opens a native window instead.
+      // The tab opens BEFORE the POST because the solver blocks until
+      // the challenge is resolved or times out (up to 5 minutes).
+      const vncUrl = `${window.location.protocol}//${window.location.hostname}:6080/vnc.html?autoconnect=true`;
+      window.open(vncUrl, "_blank", "noopener");
+
       const res = await fetch("/api/pipeline/solve-challenge", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -79,14 +79,26 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
 
   const handleSolveChallenge = useCallback(async (extractorId: string) => {
     setSolvingExtractor(extractorId);
+    const viewerWindow = window.open("about:blank", "_blank");
+    if (viewerWindow) {
+      viewerWindow.opener = null;
+    }
+
     try {
       const viewer = await prepareChallengeViewer();
       if (viewer.available && viewer.viewerUrl) {
-        window.open(viewer.viewerUrl, "_blank", "noopener");
+        if (viewerWindow) {
+          viewerWindow.location.href = viewer.viewerUrl;
+        } else {
+          window.open(viewer.viewerUrl, "_blank", "noopener");
+        }
+      } else {
+        viewerWindow?.close();
       }
 
       await solvePipelineChallenge(extractorId);
     } catch (err) {
+      viewerWindow?.close();
       console.error("Solve challenge request failed:", err);
     } finally {
       setSolvingExtractor(null);

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -76,14 +76,18 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
   const handleSolveChallenge = useCallback(async (extractorId: string) => {
     setSolvingExtractor(extractorId);
     try {
-      // Open noVNC viewer so the user can see and click the CF challenge.
-      // In Docker, the solver renders Firefox on a virtual display exposed
-      // via noVNC on port 6080. Locally (non-Docker) this tab won't connect
-      // but that's fine - the solver opens a native window instead.
-      // The tab opens BEFORE the POST because the solver blocks until
-      // the challenge is resolved or times out (up to 5 minutes).
-      const vncUrl = `${window.location.protocol}//${window.location.hostname}:6080/vnc.html?autoconnect=true`;
-      window.open(vncUrl, "_blank", "noopener");
+      const viewerRes = await fetch("/api/pipeline/challenge-viewer", {
+        method: "POST",
+      });
+      if (viewerRes.ok) {
+        const viewerPayload = (await viewerRes.json()) as {
+          data?: { available?: boolean; viewerUrl?: string | null };
+        };
+        const viewerUrl = viewerPayload.data?.viewerUrl;
+        if (viewerPayload.data?.available && viewerUrl) {
+          window.open(viewerUrl, "_blank", "noopener");
+        }
+      }
 
       const res = await fetch("/api/pipeline/solve-challenge", {
         method: "POST",

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -25,6 +25,7 @@ interface PipelineProgressProps {
 const stepLabels: Record<PipelineProgressState["step"], string> = {
   idle: "Ready",
   crawling: "Crawling",
+  challenge_required: "Challenge",
   importing: "Importing",
   scoring: "Scoring",
   processing: "Processing",
@@ -36,6 +37,7 @@ const stepLabels: Record<PipelineProgressState["step"], string> = {
 const stepBadgeClasses: Record<PipelineProgressState["step"], string> = {
   idle: "bg-muted text-muted-foreground border-border",
   crawling: "bg-sky-500/10 text-sky-400 border-sky-500/20",
+  challenge_required: "bg-orange-500/10 text-orange-400 border-orange-500/20",
   importing: "bg-sky-500/10 text-sky-400 border-sky-500/20",
   scoring: "bg-amber-500/10 text-amber-400 border-amber-500/20",
   processing: "bg-primary/10 text-primary border-primary/20",
@@ -73,6 +75,8 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
     if (!progress) return 0;
 
     switch (progress.step) {
+      case "challenge_required":
+        return 15;
       case "crawling": {
         if (progress.crawlingTermsTotal > 0) {
           return clamp(

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
@@ -47,6 +47,7 @@ type PipelineTerminalSnapshot = {
 
 const ACTIVE_PIPELINE_STEPS: ReadonlySet<PipelineProgressStep> = new Set([
   "crawling",
+  "challenge_required",
   "importing",
   "scoring",
   "processing",

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -448,7 +448,7 @@ describe.sequential("Pipeline API routes", () => {
     expect(body.ok).toBe(true);
     expect(body.data).toEqual({
       available: true,
-      viewerUrl: "http://localhost:6080/vnc.html",
+      viewerUrl: "/challenge-viewer/session/viewer-token/vnc.html",
       reason: null,
     });
     expect(ensureChallengeViewer).toHaveBeenCalledTimes(1);

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -417,6 +417,42 @@ describe.sequential("Pipeline API routes", () => {
     expect(typeof body.meta.requestId).toBe("string");
   });
 
+  // -- Challenge endpoints --
+  // Route-level tests only: validates wiring, request validation, and 404 on
+  // unknown extractor. The actual solver (browser-utils/solver.ts) launches a
+  // headed browser for human interaction — not feasible to unit test. Deferring
+  // solver-level tests until a real regression justifies the complexity.
+
+  it("returns empty challenges when no pipeline is paused", async () => {
+    const res = await fetch(`${baseUrl}/api/pipeline/challenges`);
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.challenges).toEqual([]);
+  });
+
+  it("rejects solve-challenge with invalid payload", async () => {
+    const res = await fetch(`${baseUrl}/api/pipeline/solve-challenge`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when solving a challenge for unknown extractor", async () => {
+    const res = await fetch(`${baseUrl}/api/pipeline/solve-challenge`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        extractorId: "nonexistent",
+      }),
+    });
+    const body = await res.json();
+    expect(res.status).toBe(404);
+    expect(body.ok).toBe(false);
+  });
+
   it("streams pipeline progress over SSE", async () => {
     const controller = new AbortController();
     const res = await fetch(`${baseUrl}/api/pipeline/progress`, {

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -431,6 +431,29 @@ describe.sequential("Pipeline API routes", () => {
     expect(body.data.challenges).toEqual([]);
   });
 
+  it("prepares the challenge viewer lazily", async () => {
+    const { ensureChallengeViewer } = await import(
+      "@server/services/challenge-viewer"
+    );
+    vi.mocked(ensureChallengeViewer).mockResolvedValueOnce({
+      available: true,
+    });
+
+    const res = await fetch(`${baseUrl}/api/pipeline/challenge-viewer`, {
+      method: "POST",
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data).toEqual({
+      available: true,
+      viewerUrl: "http://localhost:6080/vnc.html",
+      reason: null,
+    });
+    expect(ensureChallengeViewer).toHaveBeenCalledTimes(1);
+  });
+
   it("rejects solve-challenge with invalid payload", async () => {
     const res = await fetch(`${baseUrl}/api/pipeline/solve-challenge`, {
       method: "POST",

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -29,6 +29,7 @@ import * as pipelineRepo from "@server/repositories/pipeline";
 import { trackCanonicalActivationEvent } from "@server/services/activation-funnel";
 import {
   buildChallengeViewerUrl,
+  createChallengeViewerSession,
   ensureChallengeViewer,
 } from "@server/services/challenge-viewer";
 import { simulatePipelineRun } from "@server/services/demo-simulator";
@@ -401,16 +402,14 @@ pipelineRouter.get("/challenges", (_req: Request, res: Response) => {
  */
 pipelineRouter.post(
   "/challenge-viewer",
-  async (req: Request, res: Response) => {
+  async (_req: Request, res: Response) => {
     try {
       const status = await ensureChallengeViewer();
+      const session = status.available ? createChallengeViewerSession() : null;
       ok(res, {
         available: status.available,
         viewerUrl: status.available
-          ? buildChallengeViewerUrl({
-              protocol: `${req.protocol}:`,
-              hostname: req.hostname,
-            })
+          ? buildChallengeViewerUrl({ token: session?.token ?? "" })
           : null,
         reason: status.available ? null : status.reason,
       });

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -1,4 +1,4 @@
-import { resolve } from "node:path";
+import { join } from "node:path";
 import {
   AppError,
   badRequest,
@@ -11,6 +11,7 @@ import { fail, ok, okWithMeta } from "@infra/http";
 import { logger } from "@infra/logger";
 import { runWithRequestContext } from "@infra/request-context";
 import { setupSse, startSseHeartbeat, writeSseData } from "@infra/sse";
+import { getDataDir } from "@server/config/dataDir";
 import { isDemoMode } from "@server/config/demo";
 import {
   type ExtractorRegistry,
@@ -465,14 +466,9 @@ pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
       url: challengeUrl,
     });
 
-    // Resolve the extractor's storage directory so cookies are saved where
-    // the extractor reads them from on the next headless run.
-    // Convention: each Playwright extractor stores cookies at
-    // extractors/<id>/storage/<id>-cookies.json  (see browser-utils/cookies.ts)
-    const storageDir = resolve(
-      process.cwd(),
-      `../extractors/${body.extractorId}/storage`,
-    );
+    // Cookies are runtime state, so keep them with the database/PDFs under
+    // DATA_DIR rather than under extractor source directories.
+    const storageDir = join(getDataDir(), "cloudflare-cookies");
 
     // Dynamic import: browser-utils pulls in playwright which is heavy.
     // A top-level import would slow down every server startup even though

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path";
 import {
   AppError,
   badRequest,
@@ -16,9 +17,11 @@ import {
   getExtractorRegistry,
 } from "@server/extractors/registry";
 import {
+  getPendingChallenges,
   getPipelineStatus,
   getProgress,
   requestPipelineCancel,
+  resolvePipelineChallenge,
   runPipeline,
   subscribeToProgress,
 } from "@server/pipeline/index";
@@ -377,3 +380,113 @@ pipelineRouter.post("/cancel", async (_req: Request, res: Response) => {
     );
   }
 });
+
+/**
+ * GET /api/pipeline/challenges - Returns pending Cloudflare challenges
+ *
+ * Non-empty only when the pipeline is paused at the "challenge_required" step.
+ */
+pipelineRouter.get("/challenges", (_req: Request, res: Response) => {
+  ok(res, { challenges: getPendingChallenges() });
+});
+
+/**
+ * POST /api/pipeline/solve-challenge - Opens a headed browser for a human to
+ * solve a Cloudflare challenge.
+ *
+ * Blocks until the challenge is solved or times out (~5 min). On success the
+ * pipeline automatically resumes — no separate "resume" call needed.
+ *
+ * The solved cookies are persisted to the extractor's storage directory so
+ * the subsequent headless retry (and future runs) can reuse them.
+ */
+const solveChallengeSchema = z.object({
+  extractorId: z.string().min(1),
+  url: z.string().url(),
+});
+
+pipelineRouter.post(
+  "/solve-challenge",
+  async (req: Request, res: Response) => {
+    try {
+      const body = solveChallengeSchema.parse(req.body);
+
+      const pending = getPendingChallenges();
+      const match = pending.find((c) => c.extractorId === body.extractorId);
+      if (!match) {
+        return fail(
+          res,
+          notFound(
+            `No pending challenge for extractor "${body.extractorId}"`,
+          ),
+        );
+      }
+
+      logger.info("Launching challenge solver", {
+        route: "/api/pipeline/solve-challenge",
+        extractorId: body.extractorId,
+        url: body.url,
+      });
+
+      // Resolve the extractor's storage directory so cookies are saved where
+      // the extractor reads them from on the next headless run.
+      // Convention: each Playwright extractor stores cookies at
+      // extractors/<id>/storage/<id>-cookies.json  (see browser-utils/cookies.ts)
+      const storageDir = resolve(
+        process.cwd(),
+        `../extractors/${body.extractorId}/storage`,
+      );
+
+      // Dynamic import: browser-utils pulls in playwright which is heavy.
+      // A top-level import would slow down every server startup even though
+      // most pipeline runs never hit a challenge.
+      const { solveChallenge } = await import("browser-utils");
+      const result = await solveChallenge(
+        body.url,
+        body.extractorId,
+        storageDir,
+      );
+
+      if (result.status === "solved") {
+        const { remaining } = resolvePipelineChallenge(body.extractorId);
+
+        logger.info("Challenge solved", {
+          route: "/api/pipeline/solve-challenge",
+          extractorId: body.extractorId,
+          challengesRemaining: remaining,
+        });
+
+        ok(res, {
+          status: "solved",
+          extractorId: body.extractorId,
+          challengesRemaining: remaining,
+        });
+      } else {
+        const message =
+          result.status === "timeout"
+            ? "Challenge timed out — browser was open for 5 minutes without the challenge being solved"
+            : `Solver error: ${result.message}`;
+
+        logger.warn("Challenge solver did not succeed", {
+          route: "/api/pipeline/solve-challenge",
+          extractorId: body.extractorId,
+          solverStatus: result.status,
+        });
+
+        fail(res, requestTimeout(message));
+      }
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return fail(res, badRequest(error.message, error.flatten()));
+      }
+      fail(
+        res,
+        new AppError({
+          status: 500,
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "Unknown error",
+        }),
+      );
+    }
+  },
+);

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -27,6 +27,10 @@ import {
 } from "@server/pipeline/index";
 import * as pipelineRepo from "@server/repositories/pipeline";
 import { trackCanonicalActivationEvent } from "@server/services/activation-funnel";
+import {
+  buildChallengeViewerUrl,
+  ensureChallengeViewer,
+} from "@server/services/challenge-viewer";
 import { simulatePipelineRun } from "@server/services/demo-simulator";
 import { PIPELINE_EXTRACTOR_SOURCE_IDS } from "@shared/extractors";
 import {
@@ -391,6 +395,39 @@ pipelineRouter.get("/challenges", (_req: Request, res: Response) => {
 });
 
 /**
+ * POST /api/pipeline/challenge-viewer - Lazily starts the noVNC challenge
+ * viewer when the server is running in Docker/Linux, and returns the URL the
+ * browser client should open before invoking the blocking solve endpoint.
+ */
+pipelineRouter.post(
+  "/challenge-viewer",
+  async (req: Request, res: Response) => {
+    try {
+      const status = await ensureChallengeViewer();
+      ok(res, {
+        available: status.available,
+        viewerUrl: status.available
+          ? buildChallengeViewerUrl({
+              protocol: `${req.protocol}:`,
+              hostname: req.hostname,
+            })
+          : null,
+        reason: status.available ? null : status.reason,
+      });
+    } catch (error) {
+      logger.warn("Challenge viewer failed to start", {
+        route: "/api/pipeline/challenge-viewer",
+        error,
+      });
+      fail(
+        res,
+        serviceUnavailable("Challenge viewer is unavailable on this server"),
+      );
+    }
+  },
+);
+
+/**
  * POST /api/pipeline/solve-challenge - Opens a headed browser for a human to
  * solve a Cloudflare challenge.
  *
@@ -441,6 +478,8 @@ pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
     // Dynamic import: browser-utils pulls in playwright which is heavy.
     // A top-level import would slow down every server startup even though
     // most pipeline runs never hit a challenge.
+    await ensureChallengeViewer();
+
     const { solveChallenge } = await import("browser-utils");
     const result = await solveChallenge(
       challengeUrl,

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -405,88 +405,79 @@ const solveChallengeSchema = z.object({
   url: z.string().url(),
 });
 
-pipelineRouter.post(
-  "/solve-challenge",
-  async (req: Request, res: Response) => {
-    try {
-      const body = solveChallengeSchema.parse(req.body);
+pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
+  try {
+    const body = solveChallengeSchema.parse(req.body);
 
-      const pending = getPendingChallenges();
-      const match = pending.find((c) => c.extractorId === body.extractorId);
-      if (!match) {
-        return fail(
-          res,
-          notFound(
-            `No pending challenge for extractor "${body.extractorId}"`,
-          ),
-        );
-      }
-
-      logger.info("Launching challenge solver", {
-        route: "/api/pipeline/solve-challenge",
-        extractorId: body.extractorId,
-        url: body.url,
-      });
-
-      // Resolve the extractor's storage directory so cookies are saved where
-      // the extractor reads them from on the next headless run.
-      // Convention: each Playwright extractor stores cookies at
-      // extractors/<id>/storage/<id>-cookies.json  (see browser-utils/cookies.ts)
-      const storageDir = resolve(
-        process.cwd(),
-        `../extractors/${body.extractorId}/storage`,
-      );
-
-      // Dynamic import: browser-utils pulls in playwright which is heavy.
-      // A top-level import would slow down every server startup even though
-      // most pipeline runs never hit a challenge.
-      const { solveChallenge } = await import("browser-utils");
-      const result = await solveChallenge(
-        body.url,
-        body.extractorId,
-        storageDir,
-      );
-
-      if (result.status === "solved") {
-        const { remaining } = resolvePipelineChallenge(body.extractorId);
-
-        logger.info("Challenge solved", {
-          route: "/api/pipeline/solve-challenge",
-          extractorId: body.extractorId,
-          challengesRemaining: remaining,
-        });
-
-        ok(res, {
-          status: "solved",
-          extractorId: body.extractorId,
-          challengesRemaining: remaining,
-        });
-      } else {
-        const message =
-          result.status === "timeout"
-            ? "Challenge timed out — browser was open for 5 minutes without the challenge being solved"
-            : `Solver error: ${result.message}`;
-
-        logger.warn("Challenge solver did not succeed", {
-          route: "/api/pipeline/solve-challenge",
-          extractorId: body.extractorId,
-          solverStatus: result.status,
-        });
-
-        fail(res, requestTimeout(message));
-      }
-    } catch (error) {
-      if (error instanceof z.ZodError) {
-        return fail(res, badRequest(error.message, error.flatten()));
-      }
-      fail(
+    const pending = getPendingChallenges();
+    const match = pending.find((c) => c.extractorId === body.extractorId);
+    if (!match) {
+      return fail(
         res,
-        new AppError({
-          status: 500,
-          code: "INTERNAL_ERROR",
-          message: error instanceof Error ? error.message : "Unknown error",
-        }),
+        notFound(`No pending challenge for extractor "${body.extractorId}"`),
       );
     }
-  },
-);
+
+    logger.info("Launching challenge solver", {
+      route: "/api/pipeline/solve-challenge",
+      extractorId: body.extractorId,
+      url: body.url,
+    });
+
+    // Resolve the extractor's storage directory so cookies are saved where
+    // the extractor reads them from on the next headless run.
+    // Convention: each Playwright extractor stores cookies at
+    // extractors/<id>/storage/<id>-cookies.json  (see browser-utils/cookies.ts)
+    const storageDir = resolve(
+      process.cwd(),
+      `../extractors/${body.extractorId}/storage`,
+    );
+
+    // Dynamic import: browser-utils pulls in playwright which is heavy.
+    // A top-level import would slow down every server startup even though
+    // most pipeline runs never hit a challenge.
+    const { solveChallenge } = await import("browser-utils");
+    const result = await solveChallenge(body.url, body.extractorId, storageDir);
+
+    if (result.status === "solved") {
+      const { remaining } = resolvePipelineChallenge(body.extractorId);
+
+      logger.info("Challenge solved", {
+        route: "/api/pipeline/solve-challenge",
+        extractorId: body.extractorId,
+        challengesRemaining: remaining,
+      });
+
+      ok(res, {
+        status: "solved",
+        extractorId: body.extractorId,
+        challengesRemaining: remaining,
+      });
+    } else {
+      const message =
+        result.status === "timeout"
+          ? "Challenge timed out — browser was open for 5 minutes without the challenge being solved"
+          : `Solver error: ${result.message}`;
+
+      logger.warn("Challenge solver did not succeed", {
+        route: "/api/pipeline/solve-challenge",
+        extractorId: body.extractorId,
+        solverStatus: result.status,
+      });
+
+      fail(res, requestTimeout(message));
+    }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail(res, badRequest(error.message, error.flatten()));
+    }
+    fail(
+      res,
+      new AppError({
+        status: 500,
+        code: "INTERNAL_ERROR",
+        message: error instanceof Error ? error.message : "Unknown error",
+      }),
+    );
+  }
+});

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -402,7 +402,6 @@ pipelineRouter.get("/challenges", (_req: Request, res: Response) => {
  */
 const solveChallengeSchema = z.object({
   extractorId: z.string().min(1),
-  url: z.string().url(),
 });
 
 pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
@@ -418,10 +417,16 @@ pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
       );
     }
 
+    // Use the server-side challenge URL, not the client-supplied one.
+    // The client sends url for display/convenience, but the server is the
+    // source of truth — prevents solving a different URL than the one that
+    // actually triggered the challenge.
+    const challengeUrl = match.url;
+
     logger.info("Launching challenge solver", {
       route: "/api/pipeline/solve-challenge",
       extractorId: body.extractorId,
-      url: body.url,
+      url: challengeUrl,
     });
 
     // Resolve the extractor's storage directory so cookies are saved where
@@ -437,7 +442,7 @@ pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
     // A top-level import would slow down every server startup even though
     // most pipeline runs never hit a challenge.
     const { solveChallenge } = await import("browser-utils");
-    const result = await solveChallenge(body.url, body.extractorId, storageDir);
+    const result = await solveChallenge(challengeUrl, body.extractorId, storageDir);
 
     if (result.status === "solved") {
       const { remaining } = resolvePipelineChallenge(body.extractorId);
@@ -454,18 +459,22 @@ pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
         challengesRemaining: remaining,
       });
     } else {
-      const message =
-        result.status === "timeout"
-          ? "Challenge timed out — browser was open for 5 minutes without the challenge being solved"
-          : `Solver error: ${result.message}`;
-
       logger.warn("Challenge solver did not succeed", {
         route: "/api/pipeline/solve-challenge",
         extractorId: body.extractorId,
         solverStatus: result.status,
       });
 
-      fail(res, requestTimeout(message));
+      if (result.status === "timeout") {
+        fail(
+          res,
+          requestTimeout(
+            "Challenge timed out — browser was open for 5 minutes without the challenge being solved",
+          ),
+        );
+      } else {
+        fail(res, serviceUnavailable(`Solver error: ${result.message}`));
+      }
     }
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -442,7 +442,11 @@ pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
     // A top-level import would slow down every server startup even though
     // most pipeline runs never hit a challenge.
     const { solveChallenge } = await import("browser-utils");
-    const result = await solveChallenge(challengeUrl, body.extractorId, storageDir);
+    const result = await solveChallenge(
+      challengeUrl,
+      body.extractorId,
+      storageDir,
+    );
 
     if (result.status === "solved") {
       const { remaining } = resolvePipelineChallenge(body.extractorId);

--- a/orchestrator/src/server/api/routes/test-utils.ts
+++ b/orchestrator/src/server/api/routes/test-utils.ts
@@ -89,7 +89,11 @@ vi.mock("@server/services/challenge-viewer", () => ({
   ensureChallengeViewer: vi
     .fn()
     .mockResolvedValue({ available: false, reason: "not a container" }),
-  buildChallengeViewerUrl: vi.fn(() => "http://localhost:6080/vnc.html"),
+  createChallengeViewerSession: vi.fn(() => ({ token: "viewer-token" })),
+  buildChallengeViewerUrl: vi.fn(
+    () => "/challenge-viewer/session/viewer-token/vnc.html",
+  ),
+  proxyChallengeViewerRequest: vi.fn(),
 }));
 
 vi.mock("@server/services/visa-sponsors/index", () => ({

--- a/orchestrator/src/server/api/routes/test-utils.ts
+++ b/orchestrator/src/server/api/routes/test-utils.ts
@@ -85,6 +85,13 @@ vi.mock("@server/services/activation-funnel", () => ({
     .mockResolvedValue(undefined),
 }));
 
+vi.mock("@server/services/challenge-viewer", () => ({
+  ensureChallengeViewer: vi
+    .fn()
+    .mockResolvedValue({ available: false, reason: "not a container" }),
+  buildChallengeViewerUrl: vi.fn(() => "http://localhost:6080/vnc.html"),
+}));
+
 vi.mock("@server/services/visa-sponsors/index", () => ({
   getStatus: vi.fn(),
   searchSponsors: vi.fn(),

--- a/orchestrator/src/server/api/routes/test-utils.ts
+++ b/orchestrator/src/server/api/routes/test-utils.ts
@@ -48,6 +48,8 @@ vi.mock("@server/pipeline/index", () => {
       alreadyRequested: false,
     })),
     isPipelineCancelRequested: vi.fn(() => false),
+    getPendingChallenges: vi.fn(() => []),
+    resolvePipelineChallenge: vi.fn(() => ({ resolved: false, remaining: 0 })),
     subscribeToProgress: vi.fn((listener: (data: unknown) => void) => {
       listener(progress);
       return () => {};

--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -21,6 +21,7 @@ import { runWithRequestContext } from "@infra/request-context";
 import { sanitizeUnknown } from "@infra/sanitize";
 import { verifyToken } from "@server/auth/jwt";
 import * as usersRepo from "@server/repositories/users";
+import { proxyChallengeViewerRequest } from "@server/services/challenge-viewer";
 import { DEFAULT_TENANT_ID } from "@server/tenancy/constants";
 import cors from "cors";
 import express from "express";
@@ -351,6 +352,10 @@ export function createApp() {
   // API routes
   app.use("/api", apiRouter);
   app.use(notFoundApiHandler());
+
+  app.use("/challenge-viewer/session", (req, res) => {
+    void proxyChallengeViewerRequest(req, res);
+  });
 
   app.get("/cv/:slug", async (req, res) => {
     const slug = req.params.slug?.trim();

--- a/orchestrator/src/server/config/dataDir.test.ts
+++ b/orchestrator/src/server/config/dataDir.test.ts
@@ -1,0 +1,39 @@
+import { mkdir, mkdtemp, realpath, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("getDataDir", () => {
+  const originalCwd = process.cwd();
+  const originalDataDir = process.env.DATA_DIR;
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalDataDir === undefined) {
+      delete process.env.DATA_DIR;
+    } else {
+      process.env.DATA_DIR = originalDataDir;
+    }
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+    vi.resetModules();
+  });
+
+  it("publishes the resolved fallback as DATA_DIR", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-data-dir-"));
+    const dataDir = join(tempDir, "data");
+    await mkdir(dataDir);
+    process.chdir(tempDir);
+    delete process.env.DATA_DIR;
+    vi.resetModules();
+
+    const { getDataDir } = await import("./dataDir");
+    const expectedDataDir = await realpath(dataDir);
+
+    expect(getDataDir()).toBe(expectedDataDir);
+    expect(process.env.DATA_DIR).toBe(expectedDataDir);
+  });
+});

--- a/orchestrator/src/server/config/dataDir.ts
+++ b/orchestrator/src/server/config/dataDir.ts
@@ -25,10 +25,12 @@ export function getDataDir(): string {
   for (const candidate of candidates) {
     if (existsSync(candidate)) {
       cachedDir = resolve(candidate);
+      process.env.DATA_DIR = cachedDir;
       return cachedDir;
     }
   }
 
   cachedDir = resolve(join(cwd, "data"));
+  process.env.DATA_DIR = cachedDir;
   return cachedDir;
 }

--- a/orchestrator/src/server/index.ts
+++ b/orchestrator/src/server/index.ts
@@ -15,6 +15,7 @@ import {
   setBackupSettings,
   startBackupScheduler,
 } from "./services/backup/index";
+import { attachChallengeViewerUpgradeProxy } from "./services/challenge-viewer";
 import { initializeDemoModeServices } from "./services/demo-mode";
 import { applyStoredEnvOverrides } from "./services/envSettings";
 import { initializeHistoricalServerEventReplaySafely } from "./services/historical-product-analytics";
@@ -60,7 +61,7 @@ async function startServer() {
   const PORT = process.env.PORT || 3001;
 
   // Start server
-  app.listen(PORT, async () => {
+  const server = app.listen(PORT, async () => {
     console.log(`
 ╔═══════════════════════════════════════════════════════════╗
 ║                                                           ║
@@ -153,6 +154,7 @@ async function startServer() {
     void initializeHistoricalServerEventReplaySafely();
     void initializeActivationAnalyticsSafely();
   });
+  attachChallengeViewerUpgradeProxy(server);
 }
 
 void startServer();

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -154,7 +154,9 @@ export function resolvePipelineChallenge(extractorId: string): {
   const remaining = challengeState.challenges.size;
 
   // Update progress so the UI reflects the change immediately
-  progressHelpers.challengeResolved(Array.from(challengeState.challenges.values()));
+  progressHelpers.challengeResolved(
+    Array.from(challengeState.challenges.values()),
+  );
 
   if (remaining === 0) {
     challengeState.resolve();
@@ -715,6 +717,8 @@ export function requestPipelineCancel(): {
   state.cancelRequestedAt = new Date().toISOString();
 
   // Unblock the challenge pause if the pipeline is waiting for human solving.
+  // Without this, cancellation during challenge_required would leave the
+  // pipeline stuck until challenges are solved or the server restarts.
   // ensureNotCancelled() runs immediately after the paused Promise resolves.
   if (state.activeChallengeState) {
     state.activeChallengeState.resolve();

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -26,7 +26,11 @@ import {
   resolveResumeProjectsSettings,
 } from "../services/resumeProjects";
 import { generateTailoring } from "../services/summary";
-import { progressHelpers, resetProgress } from "./progress";
+import {
+  type PendingChallenge,
+  progressHelpers,
+  resetProgress,
+} from "./progress";
 import {
   buildPipelineRunSavedDetails,
   createPipelineRunResultSummary,
@@ -58,6 +62,13 @@ type TenantPipelineState = {
   isRunning: boolean;
   activePipelineRunId: string | null;
   cancelRequestedAt: string | null;
+  activeChallengeState: ChallengeState | null;
+};
+
+type ChallengeState = {
+  challenges: Map<string, PendingChallenge>;
+  /** Resolves the Promise that blocks the pipeline in `runPipeline`. */
+  resolve: () => void;
 };
 
 const pipelineStateByTenant = new Map<string, TenantPipelineState>();
@@ -69,6 +80,7 @@ function getPipelineState(tenantId = getActiveTenantId()): TenantPipelineState {
       isRunning: false,
       activePipelineRunId: null,
       cancelRequestedAt: null,
+      activeChallengeState: null,
     };
     pipelineStateByTenant.set(tenantId, state);
   }
@@ -107,6 +119,51 @@ async function resolveLocationIntent(
     matchStrictness: settings.locationMatchStrictness,
   });
 }
+
+// ---------- Challenge pause/resume state ----------
+
+// The pipeline async function stays alive in memory while paused — there's no
+// state serialization. A server restart kills a paused pipeline, same as it
+// kills a running one. This is intentional: challenges happen at most once
+// per day per extractor, and the user is actively present to solve them.
+
+/**
+ * Returns the list of challenges currently blocking the pipeline, or empty if
+ * the pipeline is not paused on challenges.
+ */
+export function getPendingChallenges(): PendingChallenge[] {
+  const challengeState = getPipelineState().activeChallengeState;
+  if (!challengeState) return [];
+  return Array.from(challengeState.challenges.values());
+}
+
+/**
+ * Mark a single challenge as resolved (called by the solve-challenge API after
+ * the headed browser session succeeds).  When no challenges remain the blocked
+ * pipeline Promise is resolved and discovery re-runs the affected extractors.
+ */
+export function resolvePipelineChallenge(extractorId: string): {
+  resolved: boolean;
+  remaining: number;
+} {
+  const state = getPipelineState();
+  const challengeState = state.activeChallengeState;
+  if (!challengeState) return { resolved: false, remaining: 0 };
+
+  const deleted = challengeState.challenges.delete(extractorId);
+  const remaining = challengeState.challenges.size;
+
+  // Update progress so the UI reflects the change immediately
+  progressHelpers.challengeResolved(Array.from(challengeState.challenges.values()));
+
+  if (remaining === 0) {
+    challengeState.resolve();
+  }
+
+  return { resolved: deleted, remaining };
+}
+
+// ---------- Cancellation ----------
 
 class PipelineCancelledError extends Error {
   constructor(message = "Pipeline cancellation requested") {
@@ -198,15 +255,80 @@ export async function runPipeline(
 
       ensureNotCancelled(tenantId);
       await persistResultSummary({ stage: "discovery" });
-      const { discoveredJobs, sourceErrors } = await discoverJobsStep({
-        mergedConfig,
-        shouldCancel: () =>
-          getPipelineState(tenantId).cancelRequestedAt !== null,
-      });
+      let { discoveredJobs, sourceErrors, pendingChallenges } =
+        await discoverJobsStep({
+          mergedConfig,
+          shouldCancel: () =>
+            getPipelineState(tenantId).cancelRequestedAt !== null,
+        });
       await persistResultSummary({
         stage: "discovery",
         sourceErrors,
       });
+
+      // ---------- Challenge pause/resume ----------
+      if (pendingChallenges.length > 0) {
+        pipelineLogger.info("Challenges detected, pausing pipeline", {
+          challenges: pendingChallenges.map((c) => ({
+            extractorId: c.extractorId,
+            url: c.url,
+          })),
+        });
+
+        progressHelpers.challengeRequired(pendingChallenges);
+
+        // Block until all challenges are resolved by the solve-challenge API.
+        // The Promise is resolved by `resolvePipelineChallenge()`, which is
+        // called from the POST /api/pipeline/solve-challenge endpoint (4d).
+        // Cancellation still works: the cancel endpoint sets cancelRequestedAt,
+        // and ensureNotCancelled() fires after the Promise resolves.
+        const challengedSources = pendingChallenges.flatMap((c) => c.sources);
+
+        await new Promise<void>((resolve) => {
+          tenantState.activeChallengeState = {
+            challenges: new Map(
+              pendingChallenges.map((c) => [c.extractorId, c]),
+            ),
+            resolve,
+          };
+        });
+        tenantState.activeChallengeState = null;
+
+        ensureNotCancelled(tenantId);
+
+        // Re-run only the extractors that had challenges
+        pipelineLogger.info("Challenges resolved, re-running extractors", {
+          sources: challengedSources,
+        });
+
+        const retryConfig = { ...mergedConfig, sources: challengedSources };
+        const retryResult = await discoverJobsStep({
+          mergedConfig: retryConfig,
+          shouldCancel: () =>
+            getPipelineState(tenantId).cancelRequestedAt !== null,
+        });
+
+        discoveredJobs = [...discoveredJobs, ...retryResult.discoveredJobs];
+        sourceErrors = [...sourceErrors, ...retryResult.sourceErrors];
+        pendingChallenges = retryResult.pendingChallenges;
+
+        // If the retry itself hits challenges again (e.g. cookie expired
+        // between solve and retry), we don't loop — just continue with whatever
+        // the first run discovered.  The user will see partial results and can
+        // re-run the pipeline.
+        if (retryResult.pendingChallenges.length > 0) {
+          pipelineLogger.warn(
+            "Retry after challenge still has challenges — continuing with partial results",
+            {
+              retryPendingChallenges: retryResult.pendingChallenges.map(
+                (c) => c.extractorId,
+              ),
+            },
+          );
+        }
+
+        progressHelpers.crawlingComplete(discoveredJobs.length);
+      }
 
       ensureNotCancelled(tenantId);
       const { created } = await importJobsStep({ discoveredJobs });
@@ -339,6 +461,7 @@ export async function runPipeline(
       tenantState.isRunning = false;
       tenantState.activePipelineRunId = null;
       tenantState.cancelRequestedAt = null;
+      tenantState.activeChallengeState = null;
     }
   });
 }
@@ -590,6 +713,14 @@ export function requestPipelineCancel(): {
   }
 
   state.cancelRequestedAt = new Date().toISOString();
+
+  // Unblock the challenge pause if the pipeline is waiting for human solving.
+  // ensureNotCancelled() runs immediately after the paused Promise resolves.
+  if (state.activeChallengeState) {
+    state.activeChallengeState.resolve();
+    state.activeChallengeState = null;
+  }
+
   return {
     accepted: true,
     pipelineRunId,

--- a/orchestrator/src/server/pipeline/progress.ts
+++ b/orchestrator/src/server/pipeline/progress.ts
@@ -1,6 +1,7 @@
 import { logger } from "@infra/logger";
 import { getActiveTenantId } from "@server/tenancy/context";
 import type {
+  PipelinePendingChallenge,
   PipelineProgressState,
   PipelineProgressStep,
 } from "@shared/types";
@@ -10,6 +11,8 @@ import type {
  */
 
 export type PipelineStep = PipelineProgressStep;
+
+export type PendingChallenge = PipelinePendingChallenge;
 
 export type CrawlSource = string;
 
@@ -479,5 +482,27 @@ export const progressHelpers = {
       detail: error,
       error,
       completedAt: new Date().toISOString(),
+    }),
+
+  challengeRequired: (challenges: PendingChallenge[]) =>
+    updateProgress({
+      step: "challenge_required",
+      message: `${challenges.length} extractor${challenges.length > 1 ? "s need" : " needs"} a Cloudflare challenge solved`,
+      detail: challenges.map((c) => c.extractorName).join(", "),
+      pendingChallenges: challenges,
+    }),
+
+  challengeResolved: (remaining: PendingChallenge[]) =>
+    updateProgress({
+      step: "challenge_required",
+      message:
+        remaining.length > 0
+          ? `${remaining.length} challenge${remaining.length > 1 ? "s" : ""} remaining`
+          : "All challenges solved, resuming...",
+      detail:
+        remaining.length > 0
+          ? remaining.map((c) => c.extractorName).join(", ")
+          : "Re-running extractors",
+      pendingChallenges: remaining,
     }),
 };

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -4,6 +4,7 @@ import { getExtractorRegistry } from "@server/extractors/registry";
 import { getAllJobUrls } from "@server/repositories/jobs";
 import * as settingsRepo from "@server/repositories/settings";
 import { asyncPool } from "@server/utils/async-pool";
+import type { ExtractorSourceId } from "@shared/extractors";
 import { matchJobLocationIntent } from "@shared/job-matching.js";
 import {
   buildLocationEvidence as buildSharedLocationEvidence,
@@ -13,7 +14,6 @@ import {
 } from "@shared/location-domain.js";
 import { formatCountryLabel } from "@shared/location-support.js";
 import { normalizeStringArray } from "@shared/normalize-string-array.js";
-import type { ExtractorSourceId } from "@shared/extractors";
 import type { CreateJobInput, PipelineConfig } from "@shared/types";
 import {
   type CrawlSource,
@@ -343,6 +343,9 @@ export async function discoverJobsStep(args: {
     },
   });
 
+  // Collect challenges after ALL extractors finish, not on first failure.
+  // This way the user sees every challenged site at once and can solve them
+  // in a single batch, rather than solve-one → re-run → hit-next → solve-again.
   const pendingChallenges: PendingChallenge[] = [];
   for (const sourceResult of sourceResults) {
     discoveredJobs.push(...sourceResult.discoveredJobs);

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -13,14 +13,21 @@ import {
 } from "@shared/location-domain.js";
 import { formatCountryLabel } from "@shared/location-support.js";
 import { normalizeStringArray } from "@shared/normalize-string-array.js";
+import type { ExtractorSourceId } from "@shared/extractors";
 import type { CreateJobInput, PipelineConfig } from "@shared/types";
-import { type CrawlSource, progressHelpers, updateProgress } from "../progress";
+import {
+  type CrawlSource,
+  type PendingChallenge,
+  progressHelpers,
+  updateProgress,
+} from "../progress";
 
 const DISCOVERY_CONCURRENCY = 3;
 
 type DiscoveryTaskResult = {
   discoveredJobs: CreateJobInput[];
   sourceErrors: string[];
+  challenge?: PendingChallenge;
 };
 
 type DiscoverySourceTask = {
@@ -113,6 +120,7 @@ export async function discoverJobsStep(args: {
 }): Promise<{
   discoveredJobs: CreateJobInput[];
   sourceErrors: string[];
+  pendingChallenges: PendingChallenge[];
 }> {
   logger.info("Running discovery step");
 
@@ -269,6 +277,14 @@ export async function discoverJobsStep(args: {
             sourceErrors: [
               `${manifest.displayName || manifest.id}: ${result.error ?? "unknown error"} (sources: ${grouped.sources.join(",")})`,
             ],
+            challenge: result.challengeRequired
+              ? {
+                  extractorId: manifest.id,
+                  extractorName: manifest.displayName || manifest.id,
+                  url: result.challengeRequired,
+                  sources: grouped.sources as ExtractorSourceId[],
+                }
+              : undefined,
           };
         }
 
@@ -286,7 +302,7 @@ export async function discoverJobsStep(args: {
   progressHelpers.startCrawling(totalSources);
 
   if (args.shouldCancel?.()) {
-    return { discoveredJobs, sourceErrors };
+    return { discoveredJobs, sourceErrors, pendingChallenges: [] };
   }
 
   const sourceResults = await asyncPool({
@@ -327,9 +343,13 @@ export async function discoverJobsStep(args: {
     },
   });
 
+  const pendingChallenges: PendingChallenge[] = [];
   for (const sourceResult of sourceResults) {
     discoveredJobs.push(...sourceResult.discoveredJobs);
     sourceErrors.push(...sourceResult.sourceErrors);
+    if (sourceResult.challenge) {
+      pendingChallenges.push(sourceResult.challenge);
+    }
   }
 
   const locationFilterReasonCounts: Record<string, number> = {};
@@ -399,18 +419,44 @@ export async function discoverJobsStep(args: {
   }
 
   if (args.shouldCancel?.()) {
-    return { discoveredJobs: filteredDiscoveredJobs, sourceErrors };
+    return {
+      discoveredJobs: filteredDiscoveredJobs,
+      sourceErrors,
+      pendingChallenges,
+    };
   }
 
-  if (filteredDiscoveredJobs.length === 0 && sourceErrors.length > 0) {
+  // Don't throw "all sources failed" when challenges are pending — the
+  // orchestrator will pause, let the user solve them, then re-run those
+  // extractors.  Jobs from non-challenged extractors (if any) are kept.
+  if (
+    filteredDiscoveredJobs.length === 0 &&
+    sourceErrors.length > 0 &&
+    pendingChallenges.length === 0
+  ) {
     throw new Error(`All sources failed: ${sourceErrors.join("; ")}`);
   }
 
   if (sourceErrors.length > 0) {
-    logger.warn("Some discovery sources failed", { sourceErrors });
+    if (pendingChallenges.length > 0) {
+      logger.info("Some discovery sources hit challenges and will be retried", {
+        sourceErrors,
+        pendingChallenges,
+      });
+    } else {
+      logger.warn("Some discovery sources failed", { sourceErrors });
+    }
   }
 
-  progressHelpers.crawlingComplete(filteredDiscoveredJobs.length);
+  // Don't transition to "importing" yet if there are challenges to solve —
+  // the orchestrator will pause and re-run after challenges are resolved.
+  if (pendingChallenges.length === 0) {
+    progressHelpers.crawlingComplete(filteredDiscoveredJobs.length);
+  }
 
-  return { discoveredJobs: filteredDiscoveredJobs, sourceErrors };
+  return {
+    discoveredJobs: filteredDiscoveredJobs,
+    sourceErrors,
+    pendingChallenges,
+  };
 }

--- a/orchestrator/src/server/services/challenge-viewer.ts
+++ b/orchestrator/src/server/services/challenge-viewer.ts
@@ -1,5 +1,10 @@
 import { type ChildProcess, spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import type { IncomingMessage, Server } from "node:http";
+import { connect, type Socket } from "node:net";
 import { logger } from "@infra/logger";
+import { sanitizeUnknown } from "@infra/sanitize";
+import type { Request, Response } from "express";
 
 type ViewerStatus = { available: true } | { available: false; reason: string };
 
@@ -7,9 +12,24 @@ const STARTUP_DELAY_MS = 1_200;
 const DEFAULT_DISPLAY = ":99";
 const DEFAULT_NOVNC_PORT = "6080";
 const DEFAULT_VNC_PORT = "5900";
+const DEFAULT_LOOPBACK_HOST = "127.0.0.1";
+const VIEWER_TOKEN_TTL_MS = 5 * 60 * 1000;
+const CHALLENGE_VIEWER_PREFIX = "/challenge-viewer/session/";
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "content-length",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
 
 let viewerProcesses: ChildProcess[] = [];
 let startPromise: Promise<ViewerStatus> | null = null;
+const viewerTokens = new Map<string, number>();
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -56,15 +76,93 @@ function startProcess(command: string, args: string[], name: string) {
   return child;
 }
 
-function buildNoVncCommand(novncPort: string, vncPort: string): string {
+function pruneExpiredViewerTokens(now = Date.now()): void {
+  for (const [token, expiresAt] of viewerTokens) {
+    if (expiresAt <= now) viewerTokens.delete(token);
+  }
+}
+
+function validateViewerToken(token: string): boolean {
+  const now = Date.now();
+  pruneExpiredViewerTokens(now);
+  const expiresAt = viewerTokens.get(token);
+  return Boolean(expiresAt && expiresAt > now);
+}
+
+function getViewerProxyConfig() {
+  return {
+    novncHost: process.env.NOVNC_HOST || DEFAULT_LOOPBACK_HOST,
+    novncPort: process.env.NOVNC_PORT || DEFAULT_NOVNC_PORT,
+    vncHost: process.env.VNC_HOST || DEFAULT_LOOPBACK_HOST,
+    vncPort: process.env.VNC_PORT || DEFAULT_VNC_PORT,
+  };
+}
+
+function buildNoVncCommand(args: {
+  novncHost: string;
+  novncPort: string;
+  vncHost: string;
+  vncPort: string;
+}): string {
   return `
-NOVNC_PATH=$(find /usr -path "*/novnc/utils/novnc_proxy" -o -path "*/novnc/utils/launch.sh" 2>/dev/null | head -1)
-if [ -n "$NOVNC_PATH" ]; then
-  exec "$NOVNC_PATH" --vnc "localhost:${vncPort}" --listen "${novncPort}"
+NOVNC_LISTEN="${args.novncHost}:${args.novncPort}"
+NOVNC_WEB=$(find /usr -type d -path "*/share/novnc" -o -type d -name novnc 2>/dev/null | head -1)
+if [ -z "$NOVNC_WEB" ]; then
+  echo "noVNC web root not found" >&2
+  exit 1
 fi
-NOVNC_WEB=$(find /usr -type d -name novnc 2>/dev/null | head -1)
-exec websockify --web "$NOVNC_WEB" "${novncPort}" "localhost:${vncPort}"
+exec websockify --web "$NOVNC_WEB" "$NOVNC_LISTEN" "${args.vncHost}:${args.vncPort}"
 `;
+}
+
+function parseChallengeViewerPath(pathname: string): {
+  token: string;
+  upstreamPath: string;
+} | null {
+  if (!pathname.startsWith(CHALLENGE_VIEWER_PREFIX)) return null;
+  const rest = pathname.slice(CHALLENGE_VIEWER_PREFIX.length);
+  const slashIndex = rest.indexOf("/");
+  if (slashIndex < 0) return null;
+
+  const token = rest.slice(0, slashIndex);
+  const upstreamPath = rest.slice(slashIndex) || "/";
+  if (!token || !upstreamPath.startsWith("/")) return null;
+  return { token, upstreamPath };
+}
+
+function getChallengeViewerProxyTarget(originalUrl: string) {
+  const incomingUrl = new URL(originalUrl, "http://localhost");
+  const parsed = parseChallengeViewerPath(incomingUrl.pathname);
+  if (!parsed) return null;
+
+  const { novncHost, novncPort } = getViewerProxyConfig();
+  const upstreamUrl = new URL(`http://${novncHost}:${novncPort}`);
+  upstreamUrl.pathname = parsed.upstreamPath;
+  upstreamUrl.search = incomingUrl.search;
+  return { token: parsed.token, upstreamUrl };
+}
+
+function buildProxyHeaders(req: Request): Headers {
+  const headers = new Headers();
+  const { novncHost, novncPort } = getViewerProxyConfig();
+
+  for (const [key, value] of Object.entries(req.headers)) {
+    if (!value || HOP_BY_HOP_HEADERS.has(key.toLowerCase())) continue;
+    headers.set(key, Array.isArray(value) ? value.join(", ") : value);
+  }
+  headers.set("host", `${novncHost}:${novncPort}`);
+  return headers;
+}
+
+function writeUpgradeRejection(
+  socket: Socket,
+  statusCode: number,
+  message: string,
+): void {
+  socket.write(
+    `HTTP/1.1 ${statusCode} ${message}\r\nConnection: close\r\nContent-Length: 0\r\n\r\n`,
+  );
+  socket.destroy();
 }
 
 async function startViewer(): Promise<ViewerStatus> {
@@ -84,14 +182,15 @@ async function startViewer(): Promise<ViewerStatus> {
   }
 
   const display = process.env.DISPLAY || DEFAULT_DISPLAY;
-  const novncPort = process.env.NOVNC_PORT || DEFAULT_NOVNC_PORT;
-  const vncPort = process.env.VNC_PORT || DEFAULT_VNC_PORT;
+  const { novncHost, novncPort, vncHost, vncPort } = getViewerProxyConfig();
 
   stopViewerProcesses();
 
   logger.info("Starting challenge viewer processes", {
     display,
+    novncHost,
     novncPort,
+    vncHost,
     vncPort,
   });
 
@@ -103,10 +202,24 @@ async function startViewer(): Promise<ViewerStatus> {
   await sleep(500);
   startProcess(
     "x11vnc",
-    ["-display", display, "-forever", "-nopw", "-quiet", "-rfbport", vncPort],
+    [
+      "-display",
+      display,
+      "-forever",
+      "-nopw",
+      "-quiet",
+      "-listen",
+      vncHost,
+      "-rfbport",
+      vncPort,
+    ],
     "x11vnc",
   );
-  startProcess("sh", ["-c", buildNoVncCommand(novncPort, vncPort)], "novnc");
+  startProcess(
+    "sh",
+    ["-c", buildNoVncCommand({ novncHost, novncPort, vncHost, vncPort })],
+    "novnc",
+  );
 
   await sleep(STARTUP_DELAY_MS);
 
@@ -133,13 +246,118 @@ export async function ensureChallengeViewer(): Promise<ViewerStatus> {
   return startPromise;
 }
 
-export function buildChallengeViewerUrl(args: {
-  protocol: string;
-  hostname: string;
-}): string {
-  const configured = process.env.JOBOPS_CHALLENGE_VIEWER_URL;
-  if (configured) return configured;
+export function createChallengeViewerSession(): { token: string } {
+  pruneExpiredViewerTokens();
+  const token = randomBytes(32).toString("base64url");
+  viewerTokens.set(token, Date.now() + VIEWER_TOKEN_TTL_MS);
+  return { token };
+}
 
-  const novncPort = process.env.NOVNC_PORT || DEFAULT_NOVNC_PORT;
-  return `${args.protocol}//${args.hostname}:${novncPort}/vnc.html?autoconnect=true`;
+export function buildChallengeViewerUrl(args: { token: string }): string {
+  const viewerPath = `${CHALLENGE_VIEWER_PREFIX}${args.token}/vnc.html`;
+  const webSocketPath = `${CHALLENGE_VIEWER_PREFIX.slice(1)}${args.token}/websockify`;
+  const params = new URLSearchParams({
+    autoconnect: "true",
+    path: webSocketPath,
+  });
+  return `${viewerPath}?${params.toString()}`;
+}
+
+export async function proxyChallengeViewerRequest(
+  req: Request,
+  res: Response,
+): Promise<void> {
+  const target = getChallengeViewerProxyTarget(req.originalUrl);
+  if (!target) {
+    res.status(404).type("text/plain; charset=utf-8").send("Not found");
+    return;
+  }
+  if (!validateViewerToken(target.token)) {
+    res.status(403).type("text/plain; charset=utf-8").send("Forbidden");
+    return;
+  }
+
+  try {
+    const upstreamResponse = await fetch(target.upstreamUrl, {
+      method: req.method,
+      headers: buildProxyHeaders(req),
+      redirect: "manual",
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    res.status(upstreamResponse.status);
+    for (const [key, value] of upstreamResponse.headers.entries()) {
+      if (HOP_BY_HOP_HEADERS.has(key.toLowerCase())) continue;
+      res.setHeader(key, value);
+    }
+
+    if (req.method === "HEAD" || !upstreamResponse.body) {
+      res.end();
+      return;
+    }
+
+    for await (const chunk of upstreamResponse.body) {
+      res.write(chunk);
+    }
+    res.end();
+  } catch (error) {
+    logger.warn("Challenge viewer proxy request failed", {
+      path: req.path,
+      error: sanitizeUnknown(error),
+    });
+    res.status(502).type("text/plain; charset=utf-8").send("Upstream error");
+  }
+}
+
+export function attachChallengeViewerUpgradeProxy(server: Server): void {
+  server.on("upgrade", (req: IncomingMessage, socket: Socket, head: Buffer) => {
+    const target = getChallengeViewerProxyTarget(req.url ?? "");
+    if (!target) return;
+
+    if (!validateViewerToken(target.token)) {
+      writeUpgradeRejection(socket, 403, "Forbidden");
+      return;
+    }
+
+    const { novncHost, novncPort } = getViewerProxyConfig();
+    const upstreamSocket = connect(Number(novncPort), novncHost);
+
+    upstreamSocket.on("connect", () => {
+      const requestPath = `${target.upstreamUrl.pathname}${target.upstreamUrl.search}`;
+      const headerLines = [
+        `${req.method ?? "GET"} ${requestPath} HTTP/${req.httpVersion}`,
+      ];
+
+      for (const [key, value] of Object.entries(req.headers)) {
+        if (!value) continue;
+        if (key.toLowerCase() === "host") {
+          headerLines.push(`host: ${novncHost}:${novncPort}`);
+          continue;
+        }
+        const headerValue = Array.isArray(value) ? value.join(", ") : value;
+        headerLines.push(`${key}: ${headerValue}`);
+      }
+      if (!("host" in req.headers)) {
+        headerLines.push(`host: ${novncHost}:${novncPort}`);
+      }
+
+      upstreamSocket.write(`${headerLines.join("\r\n")}\r\n\r\n`);
+      if (head.length > 0) upstreamSocket.write(head);
+      upstreamSocket.pipe(socket);
+      socket.pipe(upstreamSocket);
+    });
+
+    upstreamSocket.on("error", (error) => {
+      logger.warn("Challenge viewer websocket proxy failed", {
+        error: sanitizeUnknown(error),
+      });
+      if (!socket.destroyed) {
+        writeUpgradeRejection(socket, 502, "Bad Gateway");
+      }
+    });
+
+    socket.on("error", () => {
+      upstreamSocket.destroy();
+    });
+  });
 }

--- a/orchestrator/src/server/services/challenge-viewer.ts
+++ b/orchestrator/src/server/services/challenge-viewer.ts
@@ -106,11 +106,12 @@ function buildNoVncCommand(args: {
 }): string {
   return `
 NOVNC_LISTEN="${args.novncHost}:${args.novncPort}"
-NOVNC_WEB=$(find /usr -type d -path "*/share/novnc" -o -type d -name novnc 2>/dev/null | head -1)
-if [ -z "$NOVNC_WEB" ]; then
+NOVNC_HTML=$(find /usr/share /usr/local/share /usr/lib -type f -name vnc.html 2>/dev/null | head -1)
+if [ -z "$NOVNC_HTML" ]; then
   echo "noVNC web root not found" >&2
   exit 1
 fi
+NOVNC_WEB=$(dirname "$NOVNC_HTML")
 exec websockify --web "$NOVNC_WEB" "$NOVNC_LISTEN" "${args.vncHost}:${args.vncPort}"
 `;
 }

--- a/orchestrator/src/server/services/challenge-viewer.ts
+++ b/orchestrator/src/server/services/challenge-viewer.ts
@@ -1,0 +1,145 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { logger } from "@infra/logger";
+
+type ViewerStatus = { available: true } | { available: false; reason: string };
+
+const STARTUP_DELAY_MS = 1_200;
+const DEFAULT_DISPLAY = ":99";
+const DEFAULT_NOVNC_PORT = "6080";
+const DEFAULT_VNC_PORT = "5900";
+
+let viewerProcesses: ChildProcess[] = [];
+let startPromise: Promise<ViewerStatus> | null = null;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isProcessAlive(process: ChildProcess): boolean {
+  return process.exitCode === null && !process.killed;
+}
+
+function isViewerRunning(): boolean {
+  return viewerProcesses.length > 0 && viewerProcesses.every(isProcessAlive);
+}
+
+function stopViewerProcesses(): void {
+  for (const process of viewerProcesses) {
+    if (isProcessAlive(process)) {
+      process.kill();
+    }
+  }
+  viewerProcesses = [];
+}
+
+function startProcess(command: string, args: string[], name: string) {
+  const child = spawn(command, args, {
+    env: process.env,
+    stdio: "ignore",
+  });
+
+  child.on("error", (error) => {
+    logger.warn("Challenge viewer process failed to start", {
+      process: name,
+      error,
+    });
+  });
+
+  child.on("exit", (code, signal) => {
+    logger.info("Challenge viewer process exited", {
+      process: name,
+      code,
+      signal,
+    });
+  });
+
+  child.unref();
+  viewerProcesses.push(child);
+  return child;
+}
+
+function buildNoVncCommand(novncPort: string, vncPort: string): string {
+  return `
+NOVNC_PATH=$(find /usr -path "*/novnc/utils/novnc_proxy" -o -path "*/novnc/utils/launch.sh" 2>/dev/null | head -1)
+if [ -n "$NOVNC_PATH" ]; then
+  exec "$NOVNC_PATH" --vnc "localhost:${vncPort}" --listen "${novncPort}"
+fi
+NOVNC_WEB=$(find /usr -type d -name novnc 2>/dev/null | head -1)
+exec websockify --web "$NOVNC_WEB" "${novncPort}" "localhost:${vncPort}"
+`;
+}
+
+async function startViewer(): Promise<ViewerStatus> {
+  if (process.env.JOBOPS_CHALLENGE_VIEWER === "disabled") {
+    return {
+      available: false,
+      reason: "Challenge viewer is disabled by JOBOPS_CHALLENGE_VIEWER.",
+    };
+  }
+
+  if (process.platform !== "linux") {
+    return {
+      available: false,
+      reason:
+        "Challenge viewer is only needed in Linux container environments.",
+    };
+  }
+
+  const display = process.env.DISPLAY || DEFAULT_DISPLAY;
+  const novncPort = process.env.NOVNC_PORT || DEFAULT_NOVNC_PORT;
+  const vncPort = process.env.VNC_PORT || DEFAULT_VNC_PORT;
+
+  stopViewerProcesses();
+
+  logger.info("Starting challenge viewer processes", {
+    display,
+    novncPort,
+    vncPort,
+  });
+
+  startProcess(
+    "Xvfb",
+    [display, "-screen", "0", "1280x720x24", "-nolisten", "tcp"],
+    "xvfb",
+  );
+  await sleep(500);
+  startProcess(
+    "x11vnc",
+    ["-display", display, "-forever", "-nopw", "-quiet", "-rfbport", vncPort],
+    "x11vnc",
+  );
+  startProcess("sh", ["-c", buildNoVncCommand(novncPort, vncPort)], "novnc");
+
+  await sleep(STARTUP_DELAY_MS);
+
+  if (!isViewerRunning()) {
+    stopViewerProcesses();
+    return {
+      available: false,
+      reason:
+        "Challenge viewer could not start. Check Xvfb/x11vnc/noVNC installation.",
+    };
+  }
+
+  process.env.DISPLAY = display;
+  return { available: true };
+}
+
+export async function ensureChallengeViewer(): Promise<ViewerStatus> {
+  if (isViewerRunning()) return { available: true };
+  if (!startPromise) {
+    startPromise = startViewer().finally(() => {
+      startPromise = null;
+    });
+  }
+  return startPromise;
+}
+
+export function buildChallengeViewerUrl(args: {
+  protocol: string;
+  hostname: string;
+}): string {
+  const configured = process.env.JOBOPS_CHALLENGE_VIEWER_URL;
+  if (configured) return configured;
+
+  const novncPort = process.env.NOVNC_PORT || DEFAULT_NOVNC_PORT;
+  return `${args.protocol}//${args.hostname}:${novncPort}/vnc.html?autoconnect=true`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,6 +100,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "extractors/browser-utils": {
+      "version": "0.0.1",
+      "license": "SEE LICENSE IN ../../LICENSE",
+      "dependencies": {
+        "camoufox-js": "^0.9.2"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "playwright": "*",
+        "typescript": "~5.9.0"
+      },
+      "peerDependencies": {
+        "playwright": "*"
+      }
+    },
+    "extractors/browser-utils/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "extractors/browser-utils/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "extractors/golangjobs": {
       "name": "golangjobs-extractor",
       "version": "0.0.1",
@@ -128,7 +160,8 @@
       "version": "0.0.1",
       "license": "SEE LICENSE IN ../../LICENSE",
       "dependencies": {
-        "camoufox-js": "^0.8.0",
+        "browser-utils": "^0.0.1",
+        "camoufox-js": "^0.9.2",
         "crawlee": "^3.0.0",
         "playwright": "*",
         "tsx": "^4.4.0"
@@ -185,7 +218,8 @@
       "name": "hiringcafe-extractor",
       "version": "0.0.1",
       "dependencies": {
-        "camoufox-js": "^0.8.0",
+        "browser-utils": "^0.0.1",
+        "camoufox-js": "^0.9.2",
         "job-ops-shared": "^1.0.0",
         "playwright": "^1.57.0",
         "tsx": "^4.4.0"
@@ -274,7 +308,8 @@
       "version": "0.0.1",
       "license": "SEE LICENSE IN ../../LICENSE",
       "dependencies": {
-        "camoufox-js": "^0.8.0",
+        "browser-utils": "^0.0.1",
+        "camoufox-js": "^0.9.2",
         "job-ops-shared": "^1.0.0",
         "playwright": "^1.57.0",
         "tsx": "^4.4.0"
@@ -11015,6 +11050,10 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-utils": {
+      "resolved": "extractors/browser-utils",
+      "link": true
+    },
     "node_modules/browserslist": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -11263,20 +11302,21 @@
       }
     },
     "node_modules/camoufox-js": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/camoufox-js/-/camoufox-js-0.8.5.tgz",
-      "integrity": "sha512-20ihPbspAcOVSUTX9Drxxp0C116DON1n8OVA1eUDglWZiHwiHwFVFOMrIEBwAHMZpU11mIEH/kawJtstRIrDPA==",
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/camoufox-js/-/camoufox-js-0.9.3.tgz",
+      "integrity": "sha512-HKdCaUudkgJBzZZ9HxDu0JVmRFKWySnQrhhsqBGnEEuGHzsCs+Bon0bCrEePZ4Ax0BlycMOr/zxKq6kSu516sw==",
       "license": "MPL-2.0",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "better-sqlite3": "^12.2.0",
+        "cli-progress": "^3.12.0",
         "commander": "^14.0.0",
         "fingerprint-generator": "^2.1.66",
         "glob": "^13.0.0",
-        "impit": "^0.7.0",
+        "impit": "^0.11.0",
         "language-tags": "^2.0.1",
         "maxmind": "^5.0.0",
-        "progress": "^2.0.3",
+        "pretty-bytes": "^7.1.0",
         "ua-parser-js": "^2.0.2",
         "xml2js": "^0.6.2"
       },
@@ -11553,6 +11593,38 @@
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-progress/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cli-progress/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -15558,28 +15630,28 @@
       "license": "MIT"
     },
     "node_modules/impit": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit/-/impit-0.7.6.tgz",
-      "integrity": "sha512-AkS6Gv63+E6GMvBrcRhMmOREKpq5oJ0J5m3xwfkHiEs97UIsbpEqFmW3sFw/sdyOTDGRF5q4EjaLxtb922Ta8g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit/-/impit-0.11.0.tgz",
+      "integrity": "sha512-968YrfzZN5CCgHs/n/yAbPgetq+bOreQOI9UQXmHK3srRs24g+m9CNGL8tRWUIZCK0tnc+baBJ0nw+8saHz0qw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "impit-darwin-arm64": "0.7.6",
-        "impit-darwin-x64": "0.7.6",
-        "impit-linux-arm64-gnu": "0.7.6",
-        "impit-linux-arm64-musl": "0.7.6",
-        "impit-linux-x64-gnu": "0.7.6",
-        "impit-linux-x64-musl": "0.7.6",
-        "impit-win32-arm64-msvc": "0.7.6",
-        "impit-win32-x64-msvc": "0.7.6"
+        "impit-darwin-arm64": "0.11.0",
+        "impit-darwin-x64": "0.11.0",
+        "impit-linux-arm64-gnu": "0.11.0",
+        "impit-linux-arm64-musl": "0.11.0",
+        "impit-linux-x64-gnu": "0.11.0",
+        "impit-linux-x64-musl": "0.11.0",
+        "impit-win32-arm64-msvc": "0.11.0",
+        "impit-win32-x64-msvc": "0.11.0"
       }
     },
     "node_modules/impit-darwin-arm64": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.7.6.tgz",
-      "integrity": "sha512-M7NQXkttyzqilWfzVkNCp7hApT69m0etyJkVpHze4bR5z1kJnHhdsb8BSdDv2dzvZL4u1JyqZNxq+qoMn84eUw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit-darwin-arm64/-/impit-darwin-arm64-0.11.0.tgz",
+      "integrity": "sha512-XZcgJQ49hVGoa+bXmXqkvSucyo99X13zggMjqg5lU1SYChpgtsmDG2OyhmKt+if07Y+HtB6EAlCBLl6HPPlbbQ==",
       "cpu": [
         "arm64"
       ],
@@ -15593,9 +15665,9 @@
       }
     },
     "node_modules/impit-darwin-x64": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.7.6.tgz",
-      "integrity": "sha512-kikTesWirAwJp9JPxzGLoGVc+heBlEabWS5AhTkQedACU153vmuL90OBQikVr3ul2N0LPImvnuB+51wV0zDE6g==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit-darwin-x64/-/impit-darwin-x64-0.11.0.tgz",
+      "integrity": "sha512-lyz/HnElBkr/e13pTrBWDocfjVVR6eKrOZmnVeCEPxYlNuPCOslhHp2p+1BdgIQO/8s2X2MVeS0zVSXq3hNp+w==",
       "cpu": [
         "x64"
       ],
@@ -15609,9 +15681,9 @@
       }
     },
     "node_modules/impit-linux-arm64-gnu": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit-linux-arm64-gnu/-/impit-linux-arm64-gnu-0.7.6.tgz",
-      "integrity": "sha512-H6GHjVr/0lG9VEJr6IHF8YLq+YkSIOF4k7Dfue2ygzUAj1+jZ5ZwnouhG/XrZHYW6EWsZmEAjjRfWE56Q0wDRQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-gnu/-/impit-linux-arm64-gnu-0.11.0.tgz",
+      "integrity": "sha512-xdvbpoPnrAHDtetZjfD6/zqswhg9CRAd7f3YyBFzzNg3aoBRhgMFrdD2BLEWAvaq1PZkj+/emCaPZfJZJfPuJg==",
       "cpu": [
         "arm64"
       ],
@@ -15625,9 +15697,9 @@
       }
     },
     "node_modules/impit-linux-arm64-musl": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit-linux-arm64-musl/-/impit-linux-arm64-musl-0.7.6.tgz",
-      "integrity": "sha512-1sCB/UBVXLZTpGJsXRdNNSvhN9xmmQcYLMWAAB4Itb7w684RHX1pLoCb6ichv7bfAf6tgaupcFIFZNBp3ghmQA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-arm64-musl/-/impit-linux-arm64-musl-0.11.0.tgz",
+      "integrity": "sha512-w7isVF4RfVynopjGSP+a3/6KJmL7MzdEw2niIi9YjRnCRDPi4XEmxDm9XScB7vUE8E4s7LT8QKa/SIb3MEpvFQ==",
       "cpu": [
         "arm64"
       ],
@@ -15657,9 +15729,9 @@
       }
     },
     "node_modules/impit-linux-x64-musl": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.7.6.tgz",
-      "integrity": "sha512-sdGWyu+PCLmaOXy7Mzo4WP61ZLl5qpZ1L+VeXW+Ycazgu0e7ox0NZLdiLRunIrEzD+h0S+e4CyzNwaiP3yIolg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-musl/-/impit-linux-x64-musl-0.11.0.tgz",
+      "integrity": "sha512-UmahyHiqcNTCYnAgW+SjQwfyqfALYxXeN3Likuf/aS/tzlTP/CPmtNu1O+Vl7G8dZaWRlBNtAwvLeKlkUKBL5A==",
       "cpu": [
         "x64"
       ],
@@ -15673,9 +15745,9 @@
       }
     },
     "node_modules/impit-win32-arm64-msvc": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.7.6.tgz",
-      "integrity": "sha512-sM5deBqo0EuXg5GACBUMKEua9jIau/i34bwNlfrf/Amnw1n0GB4/RkuUh+sKiUcbNAntrRq+YhCq8qDP8IW19w==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit-win32-arm64-msvc/-/impit-win32-arm64-msvc-0.11.0.tgz",
+      "integrity": "sha512-LppsL30N+EgVx1tsBNsYz2vf8aM+RXpin/9Szzs8G82PD5QmOnrhJE6JTpzyfVYebjn/UdJcIqFzfcZRCciLOg==",
       "cpu": [
         "arm64"
       ],
@@ -15689,9 +15761,9 @@
       }
     },
     "node_modules/impit-win32-x64-msvc": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.7.6.tgz",
-      "integrity": "sha512-ry63ADGLCB/PU/vNB1VioRt2V+klDJ34frJUXUZBEv1kA96HEAg9AxUk+604o+UHS3ttGH2rkLmrbwHOdAct5Q==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit-win32-x64-msvc/-/impit-win32-x64-msvc-0.11.0.tgz",
+      "integrity": "sha512-fXIrgD8EdxDBic90DvcJ350lbeHYTQGybNEQNW7zQrSMEht0A/r7mm9yI1VhhSOiT7glCl96CAvG3mTSGqAipA==",
       "cpu": [
         "x64"
       ],
@@ -15705,9 +15777,9 @@
       }
     },
     "node_modules/impit/node_modules/impit-linux-x64-gnu": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.7.6.tgz",
-      "integrity": "sha512-yYhlRnZ4fhKt8kuGe0JK2WSHc8TkR6BEH0wn+guevmu8EOn9Xu43OuRvkeOyVAkRqvFnlZtMyySUo/GuSLz9Gw==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/impit-linux-x64-gnu/-/impit-linux-x64-gnu-0.11.0.tgz",
+      "integrity": "sha512-Y0NBSiFn79G2CXUx2J+a8W2e53ZS7smohsZX18XY8i9LxLf2FQ6pt7e1eWVDHEdo298r5w4EFPc46Gdg6npw+A==",
       "cpu": [
         "x64"
       ],
@@ -21480,6 +21552,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/pretty-bytes": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
+      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pretty-error": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-4.0.0.tgz",
@@ -21526,15 +21610,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26419,6 +26419,7 @@
         "@tiptap/starter-kit": "^3.22.2",
         "@umami/node": "^0.4.0",
         "better-sqlite3": "^11.6.0",
+        "browser-utils": "^0.0.1",
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",

--- a/shared/src/types/extractors.ts
+++ b/shared/src/types/extractors.ts
@@ -36,6 +36,10 @@ export interface ExtractorRunResult {
   success: boolean;
   jobs: CreateJobInput[];
   error?: string;
+  /** When set, the extractor failed because a Cloudflare challenge couldn't be
+   *  solved headless. The value is the URL that needs a human to solve it in a
+   *  headed browser. The pipeline should pause and prompt the user. */
+  challengeRequired?: string;
 }
 
 export interface ExtractorManifest {

--- a/shared/src/types/pipeline.ts
+++ b/shared/src/types/pipeline.ts
@@ -122,6 +122,7 @@ export interface PipelineStatusResponse {
 export type PipelineProgressStep =
   | "idle"
   | "crawling"
+  | "challenge_required"
   | "importing"
   | "scoring"
   | "processing"
@@ -135,10 +136,18 @@ export interface PipelineProgressCurrentJob {
   employer: string;
 }
 
+export interface PipelinePendingChallenge {
+  extractorId: string;
+  extractorName: string;
+  url: string;
+  sources: ExtractorSourceId[];
+}
+
 export interface PipelineProgressState {
   step: PipelineProgressStep;
   message: string;
   detail?: string;
+  pendingChallenges?: PipelinePendingChallenge[];
   crawlingSource: string | null;
   crawlingSourcesCompleted: number;
   crawlingSourcesTotal: number;


### PR DESCRIPTION
Per #264

If Cloudflare challenge fails, a manual 'Solve' button shows up: 
<img width="789" height="291" alt="Screenshot_20260319_162955" src="https://github.com/user-attachments/assets/6ca0be0a-8a02-49b9-b3ca-6000b42946b4" />

Clicking 'Solve' opens the challenge to be solved: 
<img width="1255" height="639" alt="Screenshot_20260319_163027" src="https://github.com/user-attachments/assets/ee47f933-8bd8-428e-872f-af7696cb616b" />

Once the challenge is solved, the cookies file is saved for the extractor. Fetches should work until it times out. In that case the challenge needs to be solved manually again  

## Summary

Adds a shared `browser-utils` package and pipeline integration so Playwright-based extractors (gradcracker, hiringcafe, ukvisajobs) can detect, retry, and recover from Cloudflare challenges:

- **`extractors/browser-utils/`** — CF challenge detection, retry with backoff, cookie persistence, Camoufox launch config, headed solver for human challenge solving
- **Extractor integration** — all three Playwright extractors use browser-utils for navigation, cookie loading, and challenge signaling
- **Pipeline pause/resume** — new `challenge_required` step: pipeline pauses when extractors hit CF walls, UI shows challenge cards, user solves via headed browser, pipeline auto-resumes and retries affected extractors
- **API endpoints** — `GET /api/pipeline/challenges` and `POST /api/pipeline/solve-challenge`
- **Cookie + UA persistence** — solver saves `cf_clearance` + User-Agent to disk; extractors reuse both on next headless run (CF ties clearance to UA/TLS fingerprint)

## Design decisions

- **Pause = in-memory Promise block** — no state serialization. Server restart kills paused pipeline (same as running pipeline). Acceptable since challenges happen at most once/day and user is present.
- **Batch challenges** — all extractors finish before pausing. User sees every challenged site at once, solves in one batch.
- **One retry** — after challenges solved, re-run only failed extractors. If retry also hits challenges, continue with partial results (don't loop).
- **Dynamic import** — `browser-utils` imported dynamically in solve-challenge route to avoid loading Playwright on every server startup.
- **Camoufox fingerprints only** — Crawlee's built-in fingerprinting disabled to avoid conflicts with Camoufox's C++-level spoofing.

## Out of scope

- Glassdoor/JobSpy 403s (inside python-jobspy's HTTP client, needs library fork) 
- Proxy rotation (no free solution)
- Remote challenge solving (noVNC/browser streaming)

## Test plan

- [x] Run pipeline with gradcracker, hiringcafe, ukvisajobs — verify cookie loading/saving
- [x] Trigger a CF challenge (clear cookies, use challenged site) — verify pipeline pauses and shows challenge cards
- [x] Solve challenge via UI button — verify pipeline resumes and retries
- [x] Run `npm --workspace orchestrator run test:run` — 840/840 passing
- [x] Run full CI checks (biome, types, build) — all green