### PR TITLE
Add job PDF uploads and unify onboarding completion checks

### DIFF
--- a/docs-site/docs/workflows/find-jobs-and-apply-workflow.md
+++ b/docs-site/docs/workflows/find-jobs-and-apply-workflow.md
@@ -58,9 +58,10 @@ At this stage:
 
 1. Open job details.
 2. Open the **search links** row when you want quick external research on LinkedIn, GitHub, or the wider web.
-3. Optionally enable tracer links for that specific job.
-4. Download the tailored PDF.
-5. Submit your application externally.
+3. If you wrote a resume outside JobOps, use **Upload PDF** in the job detail view to attach that file to the application instead of using the generated version.
+4. Optionally enable tracer links for that specific job.
+5. Download the PDF you want to submit.
+6. Submit your application externally.
 
 ### 5) Mark jobs as applied in JobOps
 

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -427,6 +427,20 @@ export async function updateJob(
   });
 }
 
+export async function uploadJobPdf(
+  id: string,
+  input: {
+    fileName: string;
+    mediaType?: string;
+    dataBase64: string;
+  },
+): Promise<Job> {
+  return fetchApi<Job>(`/jobs/${id}/pdf`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
 export async function getTracerAnalytics(options?: {
   jobId?: string;
   from?: number;

--- a/orchestrator/src/client/components/ReadyPanel.tsx
+++ b/orchestrator/src/client/components/ReadyPanel.tsx
@@ -20,11 +20,13 @@ import {
   Loader2,
   RefreshCcw,
   Undo2,
+  Upload,
   XCircle,
 } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { uploadJobPdfFromFile } from "@/client/lib/job-pdf-upload";
 import { Button, buttonVariants } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -74,6 +76,7 @@ export const ReadyPanel: React.FC<ReadyPanelProps> = ({
   const [mode, setMode] = useState<PanelMode>("ready");
   const [isMarkingApplied, setIsMarkingApplied] = useState(false);
   const [isRegenerating, setIsRegenerating] = useState(false);
+  const [isUploadingPdf, setIsUploadingPdf] = useState(false);
   const [isEditDetailsOpen, setIsEditDetailsOpen] = useState(false);
   const { isRescoring, rescoreJob } = useRescoreJob(onJobUpdated);
   const [catalog, setCatalog] = useState<ResumeProjectCatalogItem[]>([]);
@@ -84,6 +87,7 @@ export const ReadyPanel: React.FC<ReadyPanelProps> = ({
     timeoutId: ReturnType<typeof setTimeout>;
   } | null>(null);
   const previousJobIdRef = useRef<string | null>(null);
+  const uploadPdfInputRef = useRef<HTMLInputElement | null>(null);
   const markAsAppliedMutation = useMarkAsAppliedMutation();
   const skipJobMutation = useSkipJobMutation();
 
@@ -288,6 +292,29 @@ export const ReadyPanel: React.FC<ReadyPanelProps> = ({
       toast.error("Could not copy job info");
     }
   }, [job]);
+
+  const handleUploadPdf = useCallback(
+    async (file: File) => {
+      if (!job) return;
+
+      try {
+        setIsUploadingPdf(true);
+        await uploadJobPdfFromFile(job.id, file);
+        toast.success(job.pdfPath ? "PDF replaced" : "PDF attached");
+        await onJobUpdated();
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to upload PDF";
+        toast.error(message);
+      } finally {
+        setIsUploadingPdf(false);
+        if (uploadPdfInputRef.current) {
+          uploadPdfInputRef.current.value = "";
+        }
+      }
+    },
+    [job, onJobUpdated],
+  );
 
   // Handler for regenerating PDF after tailoring edits
   const handleTailorFinalize = useCallback(async () => {
@@ -514,6 +541,17 @@ export const ReadyPanel: React.FC<ReadyPanelProps> = ({
               <Edit2 className="mr-2 h-4 w-4" />
               Edit details
             </DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={() => uploadPdfInputRef.current?.click()}
+              disabled={isUploadingPdf}
+            >
+              <Upload className="mr-2 h-4 w-4" />
+              {isUploadingPdf
+                ? "Uploading PDF..."
+                : job.pdfPath
+                  ? "Replace PDF"
+                  : "Upload PDF"}
+            </DropdownMenuItem>
 
             <DropdownMenuItem
               onSelect={handleRegenerate}
@@ -568,6 +606,19 @@ export const ReadyPanel: React.FC<ReadyPanelProps> = ({
         onOpenChange={setIsEditDetailsOpen}
         job={job}
         onJobUpdated={onJobUpdated}
+      />
+
+      <input
+        ref={uploadPdfInputRef}
+        type="file"
+        accept="application/pdf,.pdf"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          if (file) {
+            void handleUploadPdf(file);
+          }
+        }}
       />
 
       {/* ─────────────────────────────────────────────────────────────────────

--- a/orchestrator/src/client/hooks/useOnboardingRequirement.ts
+++ b/orchestrator/src/client/hooks/useOnboardingRequirement.ts
@@ -1,6 +1,7 @@
 import * as api from "@client/api";
 import { useDemoInfo } from "@client/hooks/useDemoInfo";
 import { useSettings } from "@client/hooks/useSettings";
+import { isOnboardingComplete } from "@client/lib/onboarding";
 import { normalizeLlmProvider } from "@client/pages/settings/utils";
 import type { ValidationResult } from "@shared/types";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -125,14 +126,12 @@ export function useOnboardingRequirement() {
   ]);
 
   const complete = useMemo(() => {
-    if (demoMode) return true;
-    if (!settings) return false;
-
-    const llmComplete = llmValidation.valid;
-    const basicAuthComplete =
-      settings.basicAuthActive || settings.onboardingBasicAuthDecision !== null;
-
-    return llmComplete && baseResumeValidation.valid && basicAuthComplete;
+    return isOnboardingComplete({
+      demoMode,
+      settings,
+      llmValid: llmValidation.valid,
+      baseResumeValid: baseResumeValidation.valid,
+    });
   }, [baseResumeValidation.valid, demoMode, llmValidation.valid, settings]);
 
   const checking =

--- a/orchestrator/src/client/lib/job-pdf-upload.ts
+++ b/orchestrator/src/client/lib/job-pdf-upload.ts
@@ -1,0 +1,21 @@
+import * as api from "@client/api";
+import { fileToDataUrl } from "@client/components/design-resume/utils";
+import type { Job } from "@shared/types";
+
+export async function uploadJobPdfFromFile(
+  jobId: string,
+  file: File,
+): Promise<Job> {
+  const dataUrl = await fileToDataUrl(file);
+  const match = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl.trim());
+
+  if (!match) {
+    throw new Error("PDF file could not be encoded for upload.");
+  }
+
+  return api.uploadJobPdf(jobId, {
+    fileName: file.name,
+    mediaType: file.type || match[1],
+    dataBase64: match[2],
+  });
+}

--- a/orchestrator/src/client/lib/onboarding.test.ts
+++ b/orchestrator/src/client/lib/onboarding.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasCompletedBasicAuthOnboarding,
+  isOnboardingComplete,
+} from "./onboarding";
+
+describe("onboarding helpers", () => {
+  it("treats a skipped basic-auth decision as complete", () => {
+    expect(
+      hasCompletedBasicAuthOnboarding({
+        basicAuthActive: false,
+        onboardingBasicAuthDecision: "skipped",
+      } as any),
+    ).toBe(true);
+  });
+
+  it("requires all onboarding validations when not in demo mode", () => {
+    expect(
+      isOnboardingComplete({
+        demoMode: false,
+        settings: {
+          basicAuthActive: false,
+          onboardingBasicAuthDecision: "skipped",
+        } as any,
+        llmValid: true,
+        baseResumeValid: false,
+      }),
+    ).toBe(false);
+
+    expect(
+      isOnboardingComplete({
+        demoMode: false,
+        settings: {
+          basicAuthActive: false,
+          onboardingBasicAuthDecision: "skipped",
+        } as any,
+        llmValid: true,
+        baseResumeValid: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/orchestrator/src/client/lib/onboarding.ts
+++ b/orchestrator/src/client/lib/onboarding.ts
@@ -1,0 +1,25 @@
+import type { AppSettings } from "@shared/types";
+
+export function hasCompletedBasicAuthOnboarding(
+  settings: AppSettings | null | undefined,
+): boolean {
+  return Boolean(
+    settings?.basicAuthActive || settings?.onboardingBasicAuthDecision !== null,
+  );
+}
+
+export function isOnboardingComplete(input: {
+  demoMode: boolean;
+  settings: AppSettings | null | undefined;
+  llmValid: boolean;
+  baseResumeValid: boolean;
+}): boolean {
+  if (input.demoMode) return true;
+  if (!input.settings) return false;
+
+  return Boolean(
+    input.llmValid &&
+      input.baseResumeValid &&
+      hasCompletedBasicAuthOnboarding(input.settings),
+  );
+}

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -22,6 +22,7 @@ import {
   PlusCircle,
   RefreshCcw,
   Sparkles,
+  Upload,
   XCircle,
 } from "lucide-react";
 import React from "react";
@@ -37,6 +38,7 @@ import {
   useUpdateJobMutation,
 } from "@/client/hooks/queries/useJobMutations";
 import { useQueryErrorToast } from "@/client/hooks/useQueryErrorToast";
+import { uploadJobPdfFromFile } from "@/client/lib/job-pdf-upload";
 import { queryKeys } from "@/client/lib/queryKeys";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -72,12 +74,14 @@ export const JobPage: React.FC = () => {
   const [isLogModalOpen, setIsLogModalOpen] = React.useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
   const [isEditDetailsOpen, setIsEditDetailsOpen] = React.useState(false);
+  const [isUploadingPdf, setIsUploadingPdf] = React.useState(false);
   const [activeAction, setActiveAction] = React.useState<string | null>(null);
   const [eventToDelete, setEventToDelete] = React.useState<string | null>(null);
   const [editingEvent, setEditingEvent] = React.useState<StageEvent | null>(
     null,
   );
   const pendingEventRef = React.useRef<StageEvent | null>(null);
+  const uploadPdfInputRef = React.useRef<HTMLInputElement | null>(null);
   const openEditDetails = React.useCallback(() => {
     window.setTimeout(() => setIsEditDetailsOpen(true), 0);
   }, []);
@@ -335,6 +339,28 @@ export const JobPage: React.FC = () => {
     }
   };
 
+  const handleUploadPdf = async (file: File) => {
+    if (!job) return;
+
+    try {
+      setIsUploadingPdf(true);
+      await uploadJobPdfFromFile(job.id, file);
+      await loadData();
+      toast.success(
+        job.pdfPath ? "Resume PDF replaced" : "Resume PDF attached",
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to upload resume PDF";
+      toast.error(message);
+    } finally {
+      setIsUploadingPdf(false);
+      if (uploadPdfInputRef.current) {
+        uploadPdfInputRef.current.value = "";
+      }
+    }
+  };
+
   const currentStage = job
     ? (events.at(-1)?.toStage ??
       (job.status === "applied" || job.status === "in_progress"
@@ -497,6 +523,21 @@ export const JobPage: React.FC = () => {
                   </a>
                 </Button>
               )}
+
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-9 border-border/60 bg-background/30"
+                onClick={() => uploadPdfInputRef.current?.click()}
+                disabled={isUploadingPdf}
+              >
+                <Upload className="mr-1.5 h-3.5 w-3.5" />
+                {isUploadingPdf
+                  ? "Uploading PDF"
+                  : job?.pdfPath
+                    ? "Replace PDF"
+                    : "Upload PDF"}
+              </Button>
 
               {isReady && (
                 <Button
@@ -705,6 +746,19 @@ export const JobPage: React.FC = () => {
         onOpenChange={setIsEditDetailsOpen}
         job={job}
         onJobUpdated={loadData}
+      />
+
+      <input
+        ref={uploadPdfInputRef}
+        type="file"
+        accept="application/pdf,.pdf"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          if (file) {
+            void handleUploadPdf(file);
+          }
+        }}
       />
     </main>
   );

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -2,6 +2,7 @@ import { PageHeader, PageMain } from "@client/components/layout";
 import { ArrowLeft, ArrowRight, Sparkles } from "lucide-react";
 import type React from "react";
 import { Navigate } from "react-router-dom";
+import { useOnboardingRequirement } from "@/client/hooks/useOnboardingRequirement";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -17,8 +18,13 @@ import { useOnboardingFlow } from "./onboarding/useOnboardingFlow";
 
 export const OnboardingPage: React.FC = () => {
   const flow = useOnboardingFlow();
+  const onboardingRequirement = useOnboardingRequirement();
 
   if (flow.demoMode) {
+    return <Navigate to="/jobs/ready" replace />;
+  }
+
+  if (!onboardingRequirement.checking && onboardingRequirement.complete) {
     return <Navigate to="/jobs/ready" replace />;
   }
 

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -3,6 +3,10 @@ import { fileToDataUrl } from "@client/components/design-resume/utils";
 import { useDemoInfo } from "@client/hooks/useDemoInfo";
 import { useRxResumeConfigState } from "@client/hooks/useRxResumeConfigState";
 import { useSettings } from "@client/hooks/useSettings";
+import {
+  hasCompletedBasicAuthOnboarding,
+  isOnboardingComplete,
+} from "@client/lib/onboarding";
 import { queryKeys } from "@client/lib/queryKeys";
 import {
   getRxResumeCredentialDrafts,
@@ -19,7 +23,6 @@ import type { AppSettings, ValidationResult } from "@shared/types.js";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
-import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { EMPTY_VALIDATION_STATE, STEP_COPY } from "./content";
 import type {
@@ -32,7 +35,6 @@ import type {
 } from "./types";
 
 export function useOnboardingFlow() {
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { settings, isLoading: settingsLoading } = useSettings();
   const { storedRxResume, setBaseResumeId, syncBaseResumeId } =
@@ -126,9 +128,7 @@ export function useOnboardingFlow() {
   const llmKeyHint = settings?.llmApiKeyHint ?? null;
   const hasLlmKey = Boolean(llmKeyHint);
   const llmValidated = llmValidation.valid;
-  const basicAuthComplete = Boolean(
-    settings?.basicAuthActive || settings?.onboardingBasicAuthDecision !== null,
-  );
+  const basicAuthComplete = hasCompletedBasicAuthOnboarding(settings);
 
   const toValidationState = useCallback(
     (
@@ -320,18 +320,12 @@ export function useOnboardingFlow() {
         )
       : 0;
 
-  const complete =
-    llmValidated && baseResumeValidation.valid && basicAuthComplete;
-
-  useEffect(() => {
-    if (demoMode) {
-      navigate("/jobs/ready", { replace: true });
-      return;
-    }
-    if (!settingsLoading && complete) {
-      navigate("/jobs/ready", { replace: true });
-    }
-  }, [complete, demoMode, navigate, settingsLoading]);
+  const complete = isOnboardingComplete({
+    demoMode,
+    settings,
+    llmValid: llmValidated,
+    baseResumeValid: baseResumeValidation.valid,
+  });
 
   const handleSaveLlm = useCallback(async () => {
     const values = getValues();

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -1,4 +1,6 @@
+import { readFile } from "node:fs/promises";
 import type { Server } from "node:http";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startServer, stopServer } from "./test-utils";
 
@@ -130,6 +132,66 @@ describe.sequential("Jobs API routes", () => {
   it("returns 404 for missing jobs", async () => {
     const res = await fetch(`${baseUrl}/api/jobs/missing-id`);
     expect(res.status).toBe(404);
+  });
+
+  it("uploads a PDF resume for a job and stores it in data/pdfs", async () => {
+    const { createJob } = await import("@server/repositories/jobs");
+    const job = await createJob({
+      source: "manual",
+      title: "Upload PDF Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/upload-pdf",
+      jobDescription: "Test description",
+    });
+    const pdfContent = Buffer.from("%PDF-1.7\nUploaded resume\n");
+
+    const res = await fetch(`${baseUrl}/api/jobs/${job.id}/pdf`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fileName: "external-resume.pdf",
+        mediaType: "application/pdf",
+        dataBase64: pdfContent.toString("base64"),
+      }),
+    });
+    const body = await res.json();
+    const storedPath = join(tempDir, "pdfs", `resume_${job.id}.pdf`);
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    expect(body.data.pdfPath).toBe(storedPath);
+    expect(typeof body.meta.requestId).toBe("string");
+    await expect(readFile(storedPath, "utf8")).resolves.toContain(
+      "Uploaded resume",
+    );
+  });
+
+  it("rejects uploaded files that are not valid PDFs", async () => {
+    const { createJob } = await import("@server/repositories/jobs");
+    const job = await createJob({
+      source: "manual",
+      title: "Upload Bad PDF Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/upload-bad-pdf",
+      jobDescription: "Test description",
+    });
+
+    const res = await fetch(`${baseUrl}/api/jobs/${job.id}/pdf`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fileName: "external-resume.pdf",
+        mediaType: "application/pdf",
+        dataBase64: Buffer.from("not-a-pdf").toString("base64"),
+      }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("INVALID_REQUEST");
+    expect(body.error.message).toMatch(/valid pdf/i);
+    expect(typeof body.meta.requestId).toBe("string");
   });
 
   it("updates core job detail fields", async () => {

--- a/orchestrator/src/server/api/routes/jobs.ts
+++ b/orchestrator/src/server/api/routes/jobs.ts
@@ -1,3 +1,4 @@
+import { rm } from "node:fs/promises";
 import {
   AppError,
   type AppErrorCode,
@@ -34,6 +35,7 @@ import {
   simulateRescoreJob,
   simulateSummarizeJob,
 } from "@server/services/demo-simulator";
+import { uploadJobPdf } from "@server/services/job-pdf-upload";
 import { getProfile } from "@server/services/profile";
 import { scoreJobSuitability } from "@server/services/scorer";
 import { getTracerReadiness } from "@server/services/tracer-links";
@@ -230,6 +232,12 @@ const listJobsQuerySchema = z.object({
 
 const jobsRevisionQuerySchema = z.object({
   status: z.string().optional(),
+});
+
+const uploadJobPdfSchema = z.object({
+  fileName: z.string().trim().min(1).max(255),
+  mediaType: z.string().trim().min(1).max(200).optional(),
+  dataBase64: z.string().trim().min(1),
 });
 
 const SKIPPABLE_STATUSES: ReadonlySet<JobStatus> = new Set([
@@ -1107,6 +1115,111 @@ jobsRouter.patch("/:id", async (req: Request, res: Response) => {
       status: err.status,
       code: err.code,
       details: err.details,
+    });
+
+    fail(res, err);
+  }
+});
+
+jobsRouter.post("/:id/pdf", async (req: Request, res: Response) => {
+  let uploadedPath: string | null = null;
+
+  try {
+    const input = uploadJobPdfSchema.parse(req.body);
+    const currentJob = await jobsRepo.getJobById(req.params.id);
+
+    if (!currentJob) {
+      const err = new AppError({
+        status: 404,
+        code: "NOT_FOUND",
+        message: "Job not found",
+      });
+      logger.warn("Job PDF upload failed", {
+        route: "POST /api/jobs/:id/pdf",
+        jobId: req.params.id,
+        status: err.status,
+        code: err.code,
+      });
+      fail(res, err);
+      return;
+    }
+
+    const uploaded = await uploadJobPdf({
+      jobId: req.params.id,
+      fileName: input.fileName,
+      mediaType: input.mediaType,
+      dataBase64: input.dataBase64,
+    });
+    uploadedPath = uploaded.outputPath;
+
+    const job = await jobsRepo.updateJob(req.params.id, {
+      pdfPath: uploaded.outputPath,
+    });
+
+    if (!job) {
+      await rm(uploaded.outputPath, { force: true }).catch((cleanupError) => {
+        logger.warn("Failed to clean up uploaded PDF after missing job", {
+          route: "POST /api/jobs/:id/pdf",
+          jobId: req.params.id,
+          cleanupError,
+        });
+      });
+
+      const err = new AppError({
+        status: 404,
+        code: "NOT_FOUND",
+        message: "Job not found",
+      });
+      logger.warn("Job PDF upload failed", {
+        route: "POST /api/jobs/:id/pdf",
+        jobId: req.params.id,
+        status: err.status,
+        code: err.code,
+      });
+      fail(res, err);
+      return;
+    }
+
+    logger.info("Job PDF uploaded", {
+      route: "POST /api/jobs/:id/pdf",
+      jobId: req.params.id,
+      fileName: input.fileName,
+      byteLength: uploaded.byteLength,
+    });
+
+    ok(res, job, 201);
+  } catch (error) {
+    const err =
+      error instanceof z.ZodError
+        ? badRequest(
+            error.issues[0]?.message ?? "Invalid job PDF upload request",
+            error.flatten(),
+          )
+        : error instanceof AppError
+          ? error
+          : new AppError({
+              status: 500,
+              code: "INTERNAL_ERROR",
+              message: error instanceof Error ? error.message : "Unknown error",
+            });
+
+    if (uploadedPath) {
+      await rm(uploadedPath, { force: true }).catch((cleanupError) => {
+        logger.warn("Failed to clean up uploaded PDF after route error", {
+          route: "POST /api/jobs/:id/pdf",
+          jobId: req.params.id,
+          cleanupError,
+        });
+      });
+    }
+
+    logger.error("Job PDF upload failed", {
+      route: "POST /api/jobs/:id/pdf",
+      jobId: req.params.id,
+      status: err.status,
+      code: err.code,
+      details: err.details,
+      uploadedPath,
     });
 
     fail(res, err);

--- a/orchestrator/src/server/services/job-pdf-upload.ts
+++ b/orchestrator/src/server/services/job-pdf-upload.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { badRequest } from "@infra/errors";
+import { getDataDir } from "@server/config/dataDir";
+
+type UploadJobPdfInput = {
+  jobId: string;
+  fileName: string;
+  mediaType?: string | null;
+  dataBase64: string;
+};
+
+const MAX_UPLOAD_PDF_BYTES = 10 * 1024 * 1024;
+
+function normalizeFileName(fileName: string): string {
+  const trimmed = fileName.trim();
+  if (!trimmed) {
+    throw badRequest("Resume upload requires a file name.");
+  }
+  if (trimmed.length > 255) {
+    throw badRequest("Resume file names must be 255 characters or shorter.");
+  }
+  return trimmed;
+}
+
+function normalizePdfMediaType(input: {
+  fileName: string;
+  mediaType?: string | null;
+}): void {
+  const extension = input.fileName.toLowerCase().split(".").pop() ?? "";
+  const normalizedMediaType = input.mediaType?.trim().toLowerCase() ?? "";
+
+  if (normalizedMediaType === "application/pdf") {
+    return;
+  }
+
+  if (
+    (!normalizedMediaType ||
+      normalizedMediaType === "application/octet-stream") &&
+    extension === "pdf"
+  ) {
+    return;
+  }
+
+  throw badRequest("Only PDF resumes are supported.");
+}
+
+function normalizeBase64Payload(dataBase64: string): string {
+  const trimmed = dataBase64.trim();
+  if (!trimmed) {
+    throw badRequest("Resume upload requires file data.");
+  }
+
+  const normalized = trimmed.replace(/\s+/g, "");
+  if (!normalized) {
+    throw badRequest("Resume upload requires file data.");
+  }
+
+  if (
+    normalized.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
+  ) {
+    throw badRequest("Resume file data must be valid base64.");
+  }
+
+  const paddingLength = normalized.endsWith("==")
+    ? 2
+    : normalized.endsWith("=")
+      ? 1
+      : 0;
+  const estimatedByteLength = (normalized.length / 4) * 3 - paddingLength;
+  if (estimatedByteLength > MAX_UPLOAD_PDF_BYTES) {
+    throw badRequest("Resume PDFs must be 10 MB or smaller.");
+  }
+
+  return normalized;
+}
+
+function decodeBase64Payload(dataBase64: string): Buffer {
+  const normalized = normalizeBase64Payload(dataBase64);
+  const decoded = Buffer.from(normalized, "base64");
+
+  if (decoded.toString("base64") !== normalized) {
+    throw badRequest("Resume file data must be valid base64.");
+  }
+
+  if (decoded.byteLength === 0) {
+    throw badRequest("Resume file data must not be empty.");
+  }
+
+  if (decoded.byteLength > MAX_UPLOAD_PDF_BYTES) {
+    throw badRequest("Resume PDFs must be 10 MB or smaller.");
+  }
+
+  return decoded;
+}
+
+function assertPdfSignature(decoded: Buffer): void {
+  if (decoded.byteLength < 5 || decoded.subarray(0, 5).toString() !== "%PDF-") {
+    throw badRequest("Uploaded file must be a valid PDF.");
+  }
+}
+
+export async function uploadJobPdf(input: UploadJobPdfInput): Promise<{
+  outputPath: string;
+  byteLength: number;
+}> {
+  const fileName = normalizeFileName(input.fileName);
+  normalizePdfMediaType({
+    fileName,
+    mediaType: input.mediaType,
+  });
+
+  const decoded = decodeBase64Payload(input.dataBase64);
+  assertPdfSignature(decoded);
+
+  const pdfDir = join(getDataDir(), "pdfs");
+  const outputPath = join(pdfDir, `resume_${input.jobId}.pdf`);
+  const tempPath = join(pdfDir, `resume_${input.jobId}.${randomUUID()}.tmp`);
+
+  await mkdir(pdfDir, { recursive: true });
+
+  try {
+    await writeFile(tempPath, decoded);
+    await rename(tempPath, outputPath);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+
+  return {
+    outputPath,
+    byteLength: decoded.byteLength,
+  };
+}


### PR DESCRIPTION
## Summary
- add a `POST /api/jobs/:id/pdf` endpoint to validate, store, and attach externally authored resume PDFs
- add shared client upload helpers and UI actions in the job detail view and ready panel for uploading or replacing a job PDF
- unify onboarding completion logic behind a shared helper so the onboarding page and route guard use the same redirect criteria
- update workflow docs to explain uploading a custom PDF from the job detail view

## Testing
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`