### PR TITLE
Fix mobile scrolling for the log event modal

### DIFF
--- a/orchestrator/src/client/components/LogEventModal.test.tsx
+++ b/orchestrator/src/client/components/LogEventModal.test.tsx
@@ -8,9 +8,10 @@ vi.mock("@/components/ui/alert-dialog", () => ({
   AlertDialog: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
-  AlertDialogContent: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
+  AlertDialogContent: ({
+    children,
+    ...props
+  }: React.HTMLAttributes<HTMLDivElement>) => <div {...props}>{children}</div>,
   AlertDialogDescription: ({ children }: { children: React.ReactNode }) => (
     <div>{children}</div>
   ),
@@ -109,5 +110,14 @@ describe("LogEventModal", () => {
 
     expect(await screen.findByText("Title is required")).toBeInTheDocument();
     expect(onLog).not.toHaveBeenCalled();
+  });
+
+  it("keeps the modal scrollable on small screens", () => {
+    render(<LogEventModal isOpen onClose={vi.fn()} onLog={vi.fn()} />);
+
+    expect(screen.getByTestId("log-event-modal")).toHaveClass(
+      "max-h-[calc(100vh-2rem)]",
+      "overflow-y-auto",
+    );
   });
 });

--- a/orchestrator/src/client/components/LogEventModal.tsx
+++ b/orchestrator/src/client/components/LogEventModal.tsx
@@ -137,7 +137,10 @@ export const LogEventModal: React.FC<LogEventModalProps> = ({
 
   return (
     <AlertDialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <AlertDialogContent className="max-w-md">
+      <AlertDialogContent
+        data-testid="log-event-modal"
+        className="max-h-[calc(100vh-2rem)] max-w-md overflow-y-auto"
+      >
         <AlertDialogHeader>
           <AlertDialogTitle>
             {editingEvent ? "Edit Event" : "Log Event"}


### PR DESCRIPTION
## Summary
- constrain the log event modal height to the viewport and enable vertical scrolling on small screens
- add a stable test id to the modal content for targeted assertions
- extend the modal test to verify the mobile scroll behavior while preserving existing form coverage

## Testing
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator rebuild better-sqlite3`
- `npm --workspace orchestrator run test:run`