### PR TITLE
Add previously applied duplicate warnings to job views

### DIFF
--- a/docs-site/docs/features/orchestrator.md
+++ b/docs-site/docs/features/orchestrator.md
@@ -36,6 +36,7 @@ It exists to ensure:
 - a consistent path from discovery to tailored output
 - clear status transitions across manual and automated workflows
 - predictable regeneration behavior when job data changes
+- visibility when a reposted role looks like a job you already applied to, even if the URL changed
 - faster external research from the Ready tab with prebuilt search links for LinkedIn, GitHub, and broader web results
 - one place to filter and sort jobs across every orchestrator tab
 
@@ -66,6 +67,8 @@ What the panel includes:
 - salary filters
 - date filters
 - sorting controls
+
+Job rows and the detail header can also show a `Previously Applied` warning when JobOps finds a high-confidence fuzzy match against one of your past applied or in-progress jobs using title and company, not just URL dedupe.
 
 Date filters work on every jobs tab:
 

--- a/docs-site/docs/features/orchestrator.md
+++ b/docs-site/docs/features/orchestrator.md
@@ -68,7 +68,7 @@ What the panel includes:
 - date filters
 - sorting controls
 
-Job rows and the detail header can also show a `Previously Applied` warning when JobOps finds a high-confidence fuzzy match against one of your past applied or in-progress jobs using title and company, not just URL dedupe.
+Job rows and the detail header can also show a `Previously Applied` warning when JobOps finds a high-confidence fuzzy match against one of your past applied or in-progress jobs using title and company, not just URL dedupe. To avoid flagging genuinely new openings, JobOps only shows this warning when the matched historical application falls within 30 days of the current job's discovery date.
 
 Date filters work on every jobs tab:
 

--- a/orchestrator/src/client/components/JobHeader.test.tsx
+++ b/orchestrator/src/client/components/JobHeader.test.tsx
@@ -123,6 +123,28 @@ describe("JobHeader", () => {
     expect(screen.getByText("Sponsor Not Found")).toBeInTheDocument();
   });
 
+  it("shows a previously applied badge with match details", () => {
+    const jobWithAppliedDuplicate = {
+      ...mockJob,
+      appliedDuplicateMatch: {
+        jobId: "job-2",
+        title: "Software Engineer",
+        employer: "Tech Corp",
+        appliedAt: "2026-04-01T10:00:00.000Z",
+        score: 97,
+        titleScore: 98,
+        employerScore: 96,
+      },
+    };
+
+    renderWithRouter(<JobHeader job={jobWithAppliedDuplicate} />);
+
+    expect(screen.getByText("Previously Applied")).toBeInTheDocument();
+    expect(
+      screen.getByText("Applied 1 Apr 2026 · 97% match"),
+    ).toBeInTheDocument();
+  });
+
   it("hides sponsor info when showSponsorInfo is false", () => {
     (useSettings as any).mockReturnValue({
       showSponsorInfo: false,

--- a/orchestrator/src/client/components/JobHeader.test.tsx
+++ b/orchestrator/src/client/components/JobHeader.test.tsx
@@ -123,7 +123,7 @@ describe("JobHeader", () => {
     expect(screen.getByText("Sponsor Not Found")).toBeInTheDocument();
   });
 
-  it("shows a previously applied badge with match details", () => {
+  it("shows a previously applied status indicator with match details", () => {
     const jobWithAppliedDuplicate = {
       ...mockJob,
       appliedDuplicateMatch: {

--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -1,4 +1,4 @@
-import type { Job } from "@shared/types.js";
+import type { AppliedDuplicateMatch, Job } from "@shared/types.js";
 import {
   ArrowUpRight,
   Calendar,
@@ -23,6 +23,7 @@ import { useSettings } from "../hooks/useSettings";
 import {
   getJobStatusIndicator,
   getTracerStatusIndicator,
+  StatusBadgeIndicator,
   StatusIndicator,
 } from "./StatusIndicator";
 
@@ -157,6 +158,35 @@ const SponsorPill: React.FC<SponsorPillProps> = ({ score, names, onCheck }) => {
   );
 };
 
+const AppliedDuplicatePill: React.FC<{
+  match: AppliedDuplicateMatch | null;
+}> = ({ match }) => {
+  if (!match) {
+    return null;
+  }
+
+  const appliedDate = formatDate(match.appliedAt) ?? "Unknown date";
+  const tooltip = (
+    <div className="space-y-1">
+      <p className="text-xs font-medium">{match.title}</p>
+      <p className="text-xs opacity-80">{match.employer}</p>
+      <p className="text-[10px] opacity-80">
+        Applied {appliedDate} · {match.score}% match
+      </p>
+    </div>
+  );
+
+  return (
+    <StatusBadgeIndicator
+      label="Previously Applied"
+      variant="amber"
+      className="cursor-help text-[10px]"
+      tooltip={tooltip}
+      tooltipClassName="max-w-xs"
+    />
+  );
+};
+
 export const JobHeader: React.FC<JobHeaderProps> = ({
   job,
   className,
@@ -248,6 +278,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
             dotColor={tracerStatus.dotColor}
             label={tracerStatus.label}
           />
+          <AppliedDuplicatePill match={job.appliedDuplicateMatch} />
           {showSponsorInfo && (
             <SponsorPill
               score={job.sponsorMatchScore}

--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -20,10 +20,10 @@ import {
 } from "@/components/ui/tooltip";
 import { cn, formatDate, sourceLabel } from "@/lib/utils";
 import { useSettings } from "../hooks/useSettings";
+import { appliedDuplicateIndicator } from "../pages/orchestrator/constants";
 import {
   getJobStatusIndicator,
   getTracerStatusIndicator,
-  StatusBadgeIndicator,
   StatusIndicator,
 } from "./StatusIndicator";
 
@@ -177,10 +177,10 @@ const AppliedDuplicatePill: React.FC<{
   );
 
   return (
-    <StatusBadgeIndicator
-      label="Previously Applied"
-      variant="amber"
-      className="cursor-help text-[10px]"
+    <StatusIndicator
+      dotColor={appliedDuplicateIndicator.dot}
+      label={appliedDuplicateIndicator.label}
+      className="cursor-help"
       tooltip={tooltip}
       tooltipClassName="max-w-xs"
     />

--- a/orchestrator/src/client/pages/InProgressBoardPage.test.tsx
+++ b/orchestrator/src/client/pages/InProgressBoardPage.test.tsx
@@ -39,6 +39,7 @@ const makeJob = (overrides: Partial<JobListItem>): JobListItem => ({
   closedAt: null,
   suitabilityScore: null,
   sponsorMatchScore: null,
+  appliedDuplicateMatch: null,
   jobType: null,
   jobFunction: null,
   salaryMinAmount: null,

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -288,11 +288,16 @@ vi.mock("./orchestrator/OrchestratorFilters", () => ({
 }));
 
 vi.mock("./orchestrator/JobDetailPanel", () => ({
-  JobDetailPanel: () => <div data-testid="detail-panel" />,
+  JobDetailPanel: ({ selectedJob }: { selectedJob: Job | null }) => (
+    <div data-testid="detail-panel">
+      {selectedJob?.appliedDuplicateMatch ? "Previously Applied" : "No match"}
+    </div>
+  ),
 }));
 
 vi.mock("./orchestrator/JobListPanel", () => ({
   JobListPanel: ({
+    activeJobs,
     onSelectJob,
     onToggleSelectJob,
     onToggleSelectAll,
@@ -302,12 +307,16 @@ vi.mock("./orchestrator/JobListPanel", () => ({
     onToggleSelectJob: (id: string) => void;
     onToggleSelectAll: (checked: boolean) => void;
     selectedJobId: string | null;
+    activeJobs: Job[];
   }) => (
     <div>
       <div data-job-id="job-1" />
       <div data-job-id="job-2" />
       <div data-job-id="job-3" />
       <div data-testid="selected-job">{selectedJobId ?? "none"}</div>
+      <div data-testid="duplicate-count">
+        {activeJobs.filter((job) => job.appliedDuplicateMatch).length}
+      </div>
       <button
         data-testid="toggle-select-all-on"
         type="button"
@@ -504,6 +513,46 @@ describe("OrchestratorPage", () => {
     await waitFor(() => {
       expect(locationText()).toContain("/all/job-2");
     });
+  });
+
+  it("surfaces applied duplicate warnings for reposted jobs in the orchestrator flow", () => {
+    const appliedJob = createJob({
+      id: "job-applied",
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+    const repostedJob = createJob({
+      id: "job-1",
+      status: "ready",
+      appliedDuplicateMatch: {
+        jobId: "job-applied",
+        title: appliedJob.title,
+        employer: appliedJob.employer,
+        appliedAt: "2026-04-01T10:00:00.000Z",
+        score: 96,
+        titleScore: 97,
+        employerScore: 95,
+      },
+    });
+    mockJobs = [repostedJob, appliedJob, processingJob];
+    mockSelectedJob = repostedJob;
+    window.matchMedia = createMatchMedia(
+      true,
+    ) as unknown as typeof window.matchMedia;
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/ready/job-1"]}>
+        <Routes>
+          <Route path="/jobs/:tab" element={<OrchestratorPage />} />
+          <Route path="/jobs/:tab/:jobId" element={<OrchestratorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("duplicate-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("detail-panel")).toHaveTextContent(
+      "Previously Applied",
+    );
   });
 
   it("preserves the selected job id when a refresh temporarily excludes it", async () => {

--- a/orchestrator/src/client/pages/orchestrator/JobListPanel.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobListPanel.test.tsx
@@ -148,7 +148,7 @@ describe("JobListPanel", () => {
     expect(onSelectJob).toHaveBeenCalledWith("job-2");
   });
 
-  it("shows a previously applied badge for flagged reposts", () => {
+  it("shows a yellow status dot for flagged reposts without an inline badge", () => {
     const jobs = [
       createJob({
         id: "job-1",
@@ -179,7 +179,10 @@ describe("JobListPanel", () => {
       />,
     );
 
-    expect(screen.getByText("Previously Applied")).toBeInTheDocument();
+    expect(screen.queryByText("Previously Applied")).not.toBeInTheDocument();
+    expect(screen.getByTitle("Previously Applied")).toHaveClass(
+      "bg-yellow-400",
+    );
   });
 
   it("toggles row selection and select-all", () => {

--- a/orchestrator/src/client/pages/orchestrator/JobListPanel.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobListPanel.test.tsx
@@ -148,6 +148,40 @@ describe("JobListPanel", () => {
     expect(onSelectJob).toHaveBeenCalledWith("job-2");
   });
 
+  it("shows a previously applied badge for flagged reposts", () => {
+    const jobs = [
+      createJob({
+        id: "job-1",
+        title: "Backend Engineer",
+        appliedDuplicateMatch: {
+          jobId: "job-applied",
+          title: "Backend Engineer",
+          employer: "Acme Labs",
+          appliedAt: "2026-04-01T10:00:00.000Z",
+          score: 96,
+          titleScore: 97,
+          employerScore: 95,
+        },
+      }),
+    ];
+
+    render(
+      <JobListPanel
+        isLoading={false}
+        jobs={jobs}
+        activeJobs={jobs}
+        selectedJobId={null}
+        selectedJobIds={new Set()}
+        activeTab="ready"
+        onSelectJob={vi.fn()}
+        onToggleSelectJob={vi.fn()}
+        onToggleSelectAll={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Previously Applied")).toBeInTheDocument();
+  });
+
   it("toggles row selection and select-all", () => {
     const onToggleSelectJob = vi.fn();
     const onToggleSelectAll = vi.fn();

--- a/orchestrator/src/client/pages/orchestrator/JobListPanel.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobListPanel.tsx
@@ -5,7 +5,12 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import type { FilterTab } from "./constants";
-import { defaultStatusToken, emptyStateCopy, statusTokens } from "./constants";
+import {
+  appliedDuplicateIndicator,
+  defaultStatusToken,
+  emptyStateCopy,
+  statusTokens,
+} from "./constants";
 import { JobRowContent } from "./JobRowContent";
 
 interface EmptyStateAction {
@@ -104,6 +109,12 @@ export const JobListPanel: React.FC<JobListPanelProps> = ({
           const isSelected = job.id === selectedJobId;
           const isChecked = selectedJobIds.has(job.id);
           const statusToken = statusTokens[job.status] ?? defaultStatusToken;
+          const statusDotClassName = job.appliedDuplicateMatch
+            ? appliedDuplicateIndicator.dot
+            : statusToken.dot;
+          const statusDotTitle = job.appliedDuplicateMatch
+            ? appliedDuplicateIndicator.label
+            : statusToken.label;
           return (
             <div
               key={job.id}
@@ -123,12 +134,12 @@ export const JobListPanel: React.FC<JobListPanelProps> = ({
                 <span
                   className={cn(
                     "absolute inset-0 m-auto h-2 w-2 rounded-full transition-opacity duration-150 ease-out",
-                    statusToken.dot,
+                    statusDotClassName,
                     isChecked || isSelected
                       ? "opacity-0"
                       : "opacity-100 group-hover:opacity-0",
                   )}
-                  title={statusToken.label}
+                  title={statusDotTitle}
                 />
                 <Checkbox
                   checked={isChecked}

--- a/orchestrator/src/client/pages/orchestrator/JobRowContent.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobRowContent.tsx
@@ -1,5 +1,4 @@
 import type { JobListItem } from "@shared/types.js";
-import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { defaultStatusToken, statusTokens } from "./constants";
 
@@ -56,13 +55,6 @@ export const JobRowContent = ({
             <span className="before:content-['_in_']">{job.location}</span>
           )}
         </div>
-        {job.appliedDuplicateMatch && (
-          <div className="mt-1">
-            <Badge className="border-amber-500/30 bg-amber-500/10 text-amber-200">
-              Previously Applied
-            </Badge>
-          </div>
-        )}
         {job.salary?.trim() && (
           <div className="truncate text-xs text-muted-foreground mt-0.5">
             {job.salary}

--- a/orchestrator/src/client/pages/orchestrator/JobRowContent.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobRowContent.tsx
@@ -1,4 +1,5 @@
 import type { JobListItem } from "@shared/types.js";
+import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { defaultStatusToken, statusTokens } from "./constants";
 
@@ -55,6 +56,13 @@ export const JobRowContent = ({
             <span className="before:content-['_in_']">{job.location}</span>
           )}
         </div>
+        {job.appliedDuplicateMatch && (
+          <div className="mt-1">
+            <Badge className="border-amber-500/30 bg-amber-500/10 text-amber-200">
+              Previously Applied
+            </Badge>
+          </div>
+        )}
         {job.salary?.trim() && (
           <div className="truncate text-xs text-muted-foreground mt-0.5">
             {job.salary}

--- a/orchestrator/src/client/pages/orchestrator/constants.ts
+++ b/orchestrator/src/client/pages/orchestrator/constants.ts
@@ -73,6 +73,11 @@ export const defaultStatusToken = {
   dot: "bg-muted-foreground",
 };
 
+export const appliedDuplicateIndicator = {
+  label: "Previously Applied",
+  dot: "bg-yellow-400",
+};
+
 export type FilterTab = "ready" | "discovered" | "applied" | "all";
 export type DateFilterPreset = "7" | "14" | "30" | "90" | "custom";
 export type DateFilterDimension = "ready" | "applied" | "closed" | "discovered";

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -77,6 +77,59 @@ describe.sequential("Jobs API routes", () => {
     expect(typeof defaultBody.data.revision).toBe("string");
   });
 
+  it("adds applied duplicate match metadata to list and detail responses", async () => {
+    const { createJob, updateJob } = await import("@server/repositories/jobs");
+    const appliedJob = await createJob({
+      source: "manual",
+      title: "Backend Engineer",
+      employer: "Acme Ltd",
+      jobUrl: "https://example.com/job/applied-original",
+      jobDescription: "Original description",
+    });
+    const repostedJob = await createJob({
+      source: "manual",
+      title: "Backend Engineer",
+      employer: "Acme Limited",
+      jobUrl: "https://example.com/job/reposted",
+      jobDescription: "Reposted description",
+    });
+
+    await updateJob(appliedJob.id, {
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+    await updateJob(repostedJob.id, { status: "ready" });
+
+    const listRes = await fetch(`${baseUrl}/api/jobs?view=list`);
+    const listBody = await listRes.json();
+    const repostedListItem = listBody.data.jobs.find(
+      (job: { id: string }) => job.id === repostedJob.id,
+    );
+    const appliedListItem = listBody.data.jobs.find(
+      (job: { id: string }) => job.id === appliedJob.id,
+    );
+
+    expect(listRes.status).toBe(200);
+    expect(repostedListItem.appliedDuplicateMatch).toEqual({
+      jobId: appliedJob.id,
+      title: "Backend Engineer",
+      employer: "Acme Ltd",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+      score: 100,
+      titleScore: 100,
+      employerScore: 100,
+    });
+    expect(appliedListItem.appliedDuplicateMatch).toBeNull();
+
+    const detailRes = await fetch(`${baseUrl}/api/jobs/${repostedJob.id}`);
+    const detailBody = await detailRes.json();
+
+    expect(detailRes.status).toBe(200);
+    expect(detailBody.ok).toBe(true);
+    expect(detailBody.data.appliedDuplicateMatch?.jobId).toBe(appliedJob.id);
+    expect(detailBody.data.appliedDuplicateMatch?.score).toBe(100);
+  });
+
   it("returns jobs revision and supports status filtering", async () => {
     const { createJob, updateJob } = await import("@server/repositories/jobs");
     const readyJob = await createJob({

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -130,6 +130,56 @@ describe.sequential("Jobs API routes", () => {
     expect(detailBody.data.appliedDuplicateMatch?.score).toBe(100);
   });
 
+  it("skips applied duplicate candidate fetching when the list only contains historical jobs", async () => {
+    const jobsRepo = await import("@server/repositories/jobs");
+    const candidateSpy = vi.spyOn(
+      jobsRepo,
+      "getAppliedDuplicateMatchCandidates",
+    );
+    const { createJob, updateJob } = jobsRepo;
+    const appliedJob = await createJob({
+      source: "manual",
+      title: "Applied Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/applied-only",
+      jobDescription: "Applied description",
+    });
+    const inProgressJob = await createJob({
+      source: "manual",
+      title: "In Progress Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/in-progress-only",
+      jobDescription: "In progress description",
+    });
+
+    await updateJob(appliedJob.id, {
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+    await updateJob(inProgressJob.id, {
+      status: "in_progress",
+      appliedAt: "2026-04-02T10:00:00.000Z",
+    });
+
+    const listRes = await fetch(
+      `${baseUrl}/api/jobs?view=list&status=applied,in_progress`,
+    );
+    const listBody = await listRes.json();
+
+    expect(listRes.status).toBe(200);
+    expect(listBody.ok).toBe(true);
+    expect(candidateSpy).not.toHaveBeenCalled();
+    expect(listBody.data.jobs).toHaveLength(2);
+    expect(
+      listBody.data.jobs.every(
+        (job: { appliedDuplicateMatch: unknown }) =>
+          job.appliedDuplicateMatch === null,
+      ),
+    ).toBe(true);
+
+    candidateSpy.mockRestore();
+  });
+
   it("returns jobs revision and supports status filtering", async () => {
     const { createJob, updateJob } = await import("@server/repositories/jobs");
     const readyJob = await createJob({

--- a/orchestrator/src/server/api/routes/jobs.ts
+++ b/orchestrator/src/server/api/routes/jobs.ts
@@ -28,6 +28,7 @@ import {
   transitionStage,
   updateStageEvent,
 } from "@server/services/applicationTracking";
+import { attachAppliedDuplicateMatches } from "@server/services/applied-duplicate-matching";
 import {
   simulateApplyJob,
   simulateGeneratePdf,
@@ -534,12 +535,18 @@ jobsRouter.get("/", async (req: Request, res: Response) => {
       view === "list"
         ? await jobsRepo.getJobListItems(statuses)
         : await jobsRepo.getAllJobs(statuses);
+    const appliedDuplicateCandidates =
+      await jobsRepo.getAppliedDuplicateMatchCandidates();
+    const jobsWithAppliedDuplicateMatches = attachAppliedDuplicateMatches(
+      jobs,
+      appliedDuplicateCandidates,
+    );
     const stats = await jobsRepo.getJobStats();
     const revision = await jobsRepo.getJobsRevision(statuses);
 
     const response: JobsListResponse<Job | JobListItem> = {
-      jobs,
-      total: jobs.length,
+      jobs: jobsWithAppliedDuplicateMatches,
+      total: jobsWithAppliedDuplicateMatches.length,
       byStatus: stats,
       revision: revision.revision,
     };
@@ -549,7 +556,7 @@ jobsRouter.get("/", async (req: Request, res: Response) => {
       view,
       statusFilter: statusFilter ?? null,
       revision: revision.revision,
-      returnedCount: jobs.length,
+      returnedCount: jobsWithAppliedDuplicateMatches.length,
     });
 
     ok(res, response);
@@ -903,7 +910,11 @@ jobsRouter.get("/:id", async (req: Request, res: Response) => {
     if (!job) {
       return fail(res, notFound("Job not found"));
     }
-    ok(res, job);
+    const [jobWithAppliedDuplicateMatch] = attachAppliedDuplicateMatches(
+      [job],
+      await jobsRepo.getAppliedDuplicateMatchCandidates(),
+    );
+    ok(res, jobWithAppliedDuplicateMatch);
   } catch (error) {
     fail(res, toAppError(error));
   }

--- a/orchestrator/src/server/api/routes/jobs.ts
+++ b/orchestrator/src/server/api/routes/jobs.ts
@@ -28,7 +28,10 @@ import {
   transitionStage,
   updateStageEvent,
 } from "@server/services/applicationTracking";
-import { attachAppliedDuplicateMatches } from "@server/services/applied-duplicate-matching";
+import {
+  attachAppliedDuplicateMatches,
+  isHistoricalAppliedJob,
+} from "@server/services/applied-duplicate-matching";
 import {
   simulateApplyJob,
   simulateGeneratePdf,
@@ -535,12 +538,15 @@ jobsRouter.get("/", async (req: Request, res: Response) => {
       view === "list"
         ? await jobsRepo.getJobListItems(statuses)
         : await jobsRepo.getAllJobs(statuses);
-    const appliedDuplicateCandidates =
-      await jobsRepo.getAppliedDuplicateMatchCandidates();
-    const jobsWithAppliedDuplicateMatches = attachAppliedDuplicateMatches(
-      jobs,
-      appliedDuplicateCandidates,
+    const shouldAttachAppliedDuplicateMatches = jobs.some(
+      (job) => !isHistoricalAppliedJob(job),
     );
+    const jobsWithAppliedDuplicateMatches = shouldAttachAppliedDuplicateMatches
+      ? attachAppliedDuplicateMatches(
+          jobs,
+          await jobsRepo.getAppliedDuplicateMatchCandidates(),
+        )
+      : jobs;
     const stats = await jobsRepo.getJobStats();
     const revision = await jobsRepo.getJobsRevision(statuses);
 

--- a/orchestrator/src/server/repositories/jobs.ts
+++ b/orchestrator/src/server/repositories/jobs.ts
@@ -16,6 +16,15 @@ import { db, schema } from "../db/index";
 
 const { jobs } = schema;
 
+type AppliedDuplicateMatchCandidate = {
+  id: string;
+  title: string;
+  employer: string;
+  status: Extract<JobStatus, "applied" | "in_progress">;
+  appliedAt: string;
+  discoveredAt: string;
+};
+
 function normalizeStatusFilter(statuses?: JobStatus[]): string | null {
   if (!statuses || statuses.length === 0) return null;
   return Array.from(new Set(statuses)).sort().join(",");
@@ -90,12 +99,7 @@ export async function getJobListItems(
 }
 
 export async function getAppliedDuplicateMatchCandidates(): Promise<
-  Array<
-    Pick<
-      Job,
-      "id" | "title" | "employer" | "status" | "appliedAt" | "discoveredAt"
-    >
-  >
+  AppliedDuplicateMatchCandidate[]
 > {
   const rows = await db
     .select({
@@ -107,15 +111,20 @@ export async function getAppliedDuplicateMatchCandidates(): Promise<
       discoveredAt: jobs.discoveredAt,
     })
     .from(jobs)
-    .where(inArray(jobs.status, ["applied", "in_progress"]))
+    .where(
+      and(
+        inArray(jobs.status, ["applied", "in_progress"]),
+        sql`${jobs.appliedAt} IS NOT NULL`,
+      ),
+    )
     .orderBy(desc(jobs.appliedAt));
 
   return rows.map((row) => ({
     id: row.id,
     title: row.title,
     employer: row.employer,
-    status: row.status as JobStatus,
-    appliedAt: row.appliedAt,
+    status: row.status as AppliedDuplicateMatchCandidate["status"],
+    appliedAt: row.appliedAt as string,
     discoveredAt: row.discoveredAt,
   }));
 }

--- a/orchestrator/src/server/repositories/jobs.ts
+++ b/orchestrator/src/server/repositories/jobs.ts
@@ -90,7 +90,12 @@ export async function getJobListItems(
 }
 
 export async function getAppliedDuplicateMatchCandidates(): Promise<
-  Array<Pick<Job, "id" | "title" | "employer" | "status" | "appliedAt">>
+  Array<
+    Pick<
+      Job,
+      "id" | "title" | "employer" | "status" | "appliedAt" | "discoveredAt"
+    >
+  >
 > {
   const rows = await db
     .select({
@@ -99,6 +104,7 @@ export async function getAppliedDuplicateMatchCandidates(): Promise<
       employer: jobs.employer,
       status: jobs.status,
       appliedAt: jobs.appliedAt,
+      discoveredAt: jobs.discoveredAt,
     })
     .from(jobs)
     .where(inArray(jobs.status, ["applied", "in_progress"]))
@@ -110,6 +116,7 @@ export async function getAppliedDuplicateMatchCandidates(): Promise<
     employer: row.employer,
     status: row.status as JobStatus,
     appliedAt: row.appliedAt,
+    discoveredAt: row.discoveredAt,
   }));
 }
 

--- a/orchestrator/src/server/repositories/jobs.ts
+++ b/orchestrator/src/server/repositories/jobs.ts
@@ -85,6 +85,31 @@ export async function getJobListItems(
     ...row,
     source: row.source as JobListItem["source"],
     status: row.status as JobStatus,
+    appliedDuplicateMatch: null,
+  }));
+}
+
+export async function getAppliedDuplicateMatchCandidates(): Promise<
+  Array<Pick<Job, "id" | "title" | "employer" | "status" | "appliedAt">>
+> {
+  const rows = await db
+    .select({
+      id: jobs.id,
+      title: jobs.title,
+      employer: jobs.employer,
+      status: jobs.status,
+      appliedAt: jobs.appliedAt,
+    })
+    .from(jobs)
+    .where(inArray(jobs.status, ["applied", "in_progress"]))
+    .orderBy(desc(jobs.appliedAt));
+
+  return rows.map((row) => ({
+    id: row.id,
+    title: row.title,
+    employer: row.employer,
+    status: row.status as JobStatus,
+    appliedAt: row.appliedAt,
   }));
 }
 
@@ -471,6 +496,7 @@ function mapRowToJob(row: typeof jobs.$inferSelect): Job {
     tracerLinksEnabled: row.tracerLinksEnabled ?? false,
     sponsorMatchScore: row.sponsorMatchScore ?? null,
     sponsorMatchNames: row.sponsorMatchNames ?? null,
+    appliedDuplicateMatch: null,
     jobType: row.jobType ?? null,
     salarySource: row.salarySource ?? null,
     salaryInterval: row.salaryInterval ?? null,

--- a/orchestrator/src/server/services/applied-duplicate-matching.test.ts
+++ b/orchestrator/src/server/services/applied-duplicate-matching.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   attachAppliedDuplicateMatches,
   findAppliedDuplicateMatch,
+  isHistoricalAppliedJob,
 } from "./applied-duplicate-matching";
 
 describe("applied duplicate matching", () => {
@@ -154,6 +155,15 @@ describe("applied duplicate matching", () => {
     );
 
     expect(annotatedJob.appliedDuplicateMatch).toBeNull();
+  });
+
+  it("treats in-progress jobs without an applied timestamp as non-historical", () => {
+    expect(
+      isHistoricalAppliedJob({
+        status: "in_progress",
+        appliedAt: null,
+      }),
+    ).toBe(false);
   });
 
   it("does not match when the historical application is older than 30 days", () => {

--- a/orchestrator/src/server/services/applied-duplicate-matching.test.ts
+++ b/orchestrator/src/server/services/applied-duplicate-matching.test.ts
@@ -12,6 +12,7 @@ describe("applied duplicate matching", () => {
       title: "Backend Engineer",
       employer: "Acme Labs",
       status: "ready",
+      discoveredAt: "2026-04-15T10:00:00.000Z",
     });
     const appliedJob = createJob({
       id: "applied-job",
@@ -38,6 +39,7 @@ describe("applied duplicate matching", () => {
       title: "Platform Engineer",
       employer: "Acme Ltd",
       status: "discovered",
+      discoveredAt: "2026-04-15T10:00:00.000Z",
     });
     const appliedJob = createJob({
       id: "applied-job",
@@ -58,6 +60,7 @@ describe("applied duplicate matching", () => {
       title: "Backend Engineer",
       employer: "Acme Labs",
       status: "ready",
+      discoveredAt: "2026-04-15T10:00:00.000Z",
     });
     const appliedJob = createJob({
       id: "applied-job",
@@ -76,6 +79,7 @@ describe("applied duplicate matching", () => {
       title: "Backend Engineer",
       employer: "Acme Labs",
       status: "ready",
+      discoveredAt: "2026-04-15T10:00:00.000Z",
     });
     const appliedJob = createJob({
       id: "applied-job",
@@ -94,6 +98,7 @@ describe("applied duplicate matching", () => {
       title: "Senior Backend Engineer",
       employer: "Acme Labs",
       status: "ready",
+      discoveredAt: "2026-04-15T10:00:00.000Z",
     });
     const olderPerfectMatch = createJob({
       id: "older-perfect",
@@ -149,5 +154,24 @@ describe("applied duplicate matching", () => {
     );
 
     expect(annotatedJob.appliedDuplicateMatch).toBeNull();
+  });
+
+  it("does not match when the historical application is older than 30 days", () => {
+    const repostedJob = createJob({
+      id: "new-job",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "ready",
+      discoveredAt: "2026-05-15T10:00:00.000Z",
+    });
+    const oldAppliedJob = createJob({
+      id: "applied-job",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+
+    expect(findAppliedDuplicateMatch(repostedJob, [oldAppliedJob])).toBeNull();
   });
 });

--- a/orchestrator/src/server/services/applied-duplicate-matching.test.ts
+++ b/orchestrator/src/server/services/applied-duplicate-matching.test.ts
@@ -1,0 +1,153 @@
+import { createJob } from "@shared/testing/factories.js";
+import { describe, expect, it } from "vitest";
+import {
+  attachAppliedDuplicateMatches,
+  findAppliedDuplicateMatch,
+} from "./applied-duplicate-matching";
+
+describe("applied duplicate matching", () => {
+  it("matches reposted jobs with the same title and company", () => {
+    const repostedJob = createJob({
+      id: "new-job",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "ready",
+    });
+    const appliedJob = createJob({
+      id: "applied-job",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+
+    expect(findAppliedDuplicateMatch(repostedJob, [appliedJob])).toEqual({
+      jobId: "applied-job",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+      score: 100,
+      titleScore: 100,
+      employerScore: 100,
+    });
+  });
+
+  it("treats employer suffix variants as the same company", () => {
+    const repostedJob = createJob({
+      id: "new-job",
+      title: "Platform Engineer",
+      employer: "Acme Ltd",
+      status: "discovered",
+    });
+    const appliedJob = createJob({
+      id: "applied-job",
+      title: "Platform Engineer",
+      employer: "Acme Limited",
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+
+    const match = findAppliedDuplicateMatch(repostedJob, [appliedJob]);
+    expect(match?.jobId).toBe("applied-job");
+    expect(match?.employerScore).toBe(100);
+  });
+
+  it("does not match when the company differs", () => {
+    const repostedJob = createJob({
+      id: "new-job",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "ready",
+    });
+    const appliedJob = createJob({
+      id: "applied-job",
+      title: "Backend Engineer",
+      employer: "Globex",
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+
+    expect(findAppliedDuplicateMatch(repostedJob, [appliedJob])).toBeNull();
+  });
+
+  it("does not match when the title differs meaningfully", () => {
+    const repostedJob = createJob({
+      id: "new-job",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "ready",
+    });
+    const appliedJob = createJob({
+      id: "applied-job",
+      title: "Product Designer",
+      employer: "Acme Labs",
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+
+    expect(findAppliedDuplicateMatch(repostedJob, [appliedJob])).toBeNull();
+  });
+
+  it("prefers the strongest match and breaks ties by most recent application", () => {
+    const repostedJob = createJob({
+      id: "new-job",
+      title: "Senior Backend Engineer",
+      employer: "Acme Labs",
+      status: "ready",
+    });
+    const olderPerfectMatch = createJob({
+      id: "older-perfect",
+      title: "Senior Backend Engineer",
+      employer: "Acme Labs",
+      status: "applied",
+      appliedAt: "2026-03-01T10:00:00.000Z",
+    });
+    const newerPerfectMatch = createJob({
+      id: "newer-perfect",
+      title: "Senior Backend Engineer",
+      employer: "Acme Labs",
+      status: "in_progress",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+    const weakerMatch = createJob({
+      id: "weaker-match",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "applied",
+      appliedAt: "2026-04-10T10:00:00.000Z",
+    });
+
+    const match = findAppliedDuplicateMatch(repostedJob, [
+      weakerMatch,
+      olderPerfectMatch,
+      newerPerfectMatch,
+    ]);
+
+    expect(match?.jobId).toBe("newer-perfect");
+    expect(match?.score).toBe(100);
+  });
+
+  it("does not surface a duplicate badge on already applied jobs", () => {
+    const firstAppliedJob = createJob({
+      id: "applied-job-1",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "applied",
+      appliedAt: "2026-03-01T10:00:00.000Z",
+    });
+    const secondAppliedJob = createJob({
+      id: "applied-job-2",
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      status: "applied",
+      appliedAt: "2026-04-01T10:00:00.000Z",
+    });
+
+    const [annotatedJob] = attachAppliedDuplicateMatches(
+      [firstAppliedJob],
+      [firstAppliedJob, secondAppliedJob],
+    );
+
+    expect(annotatedJob.appliedDuplicateMatch).toBeNull();
+  });
+});

--- a/orchestrator/src/server/services/applied-duplicate-matching.ts
+++ b/orchestrator/src/server/services/applied-duplicate-matching.ts
@@ -11,6 +11,7 @@ import type {
 } from "@shared/types";
 
 const APPLIED_DUPLICATE_THRESHOLD = 90;
+const APPLIED_DUPLICATE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 const HISTORICAL_JOB_STATUSES: ReadonlySet<JobStatus> = new Set([
   "applied",
   "in_progress",
@@ -18,11 +19,23 @@ const HISTORICAL_JOB_STATUSES: ReadonlySet<JobStatus> = new Set([
 
 type MatchableJob = Pick<
   Job,
-  "id" | "title" | "employer" | "status" | "appliedAt"
+  "id" | "title" | "employer" | "status" | "appliedAt" | "discoveredAt"
 >;
 
 function isHistoricalJob(job: MatchableJob): boolean {
   return HISTORICAL_JOB_STATUSES.has(job.status) && Boolean(job.appliedAt);
+}
+
+function isWithinDuplicateWindow(job: MatchableJob, candidate: MatchableJob) {
+  const discoveredAt = Date.parse(job.discoveredAt);
+  const appliedAt = Date.parse(candidate.appliedAt as string);
+
+  if (!Number.isFinite(discoveredAt) || !Number.isFinite(appliedAt)) {
+    return false;
+  }
+
+  const ageMs = discoveredAt - appliedAt;
+  return ageMs >= 0 && ageMs <= APPLIED_DUPLICATE_WINDOW_MS;
 }
 
 export function findAppliedDuplicateMatch(
@@ -43,6 +56,10 @@ export function findAppliedDuplicateMatch(
 
   for (const candidate of candidates) {
     if (!isHistoricalJob(candidate) || candidate.id === job.id) {
+      continue;
+    }
+
+    if (!isWithinDuplicateWindow(job, candidate)) {
       continue;
     }
 

--- a/orchestrator/src/server/services/applied-duplicate-matching.ts
+++ b/orchestrator/src/server/services/applied-duplicate-matching.ts
@@ -1,0 +1,100 @@
+import {
+  calculateSimilarity,
+  normalizeCompanyName,
+  normalizeJobTitle,
+} from "@shared/job-matching";
+import type {
+  AppliedDuplicateMatch,
+  Job,
+  JobListItem,
+  JobStatus,
+} from "@shared/types";
+
+const APPLIED_DUPLICATE_THRESHOLD = 90;
+const HISTORICAL_JOB_STATUSES: ReadonlySet<JobStatus> = new Set([
+  "applied",
+  "in_progress",
+]);
+
+type MatchableJob = Pick<
+  Job,
+  "id" | "title" | "employer" | "status" | "appliedAt"
+>;
+
+function isHistoricalJob(job: MatchableJob): boolean {
+  return HISTORICAL_JOB_STATUSES.has(job.status) && Boolean(job.appliedAt);
+}
+
+export function findAppliedDuplicateMatch(
+  job: MatchableJob,
+  candidates: MatchableJob[],
+): AppliedDuplicateMatch | null {
+  if (isHistoricalJob(job)) {
+    return null;
+  }
+
+  const normalizedTitle = normalizeJobTitle(job.title);
+  const normalizedEmployer = normalizeCompanyName(job.employer);
+  if (!normalizedTitle || !normalizedEmployer) {
+    return null;
+  }
+
+  let bestMatch: AppliedDuplicateMatch | null = null;
+
+  for (const candidate of candidates) {
+    if (!isHistoricalJob(candidate) || candidate.id === job.id) {
+      continue;
+    }
+
+    const titleScore = calculateSimilarity(
+      normalizedTitle,
+      normalizeJobTitle(candidate.title),
+    );
+    const employerScore = calculateSimilarity(
+      normalizedEmployer,
+      normalizeCompanyName(candidate.employer),
+    );
+
+    if (
+      titleScore <= APPLIED_DUPLICATE_THRESHOLD ||
+      employerScore <= APPLIED_DUPLICATE_THRESHOLD
+    ) {
+      continue;
+    }
+
+    const score = Math.round((titleScore + employerScore) / 2);
+    const candidateMatch: AppliedDuplicateMatch = {
+      jobId: candidate.id,
+      title: candidate.title,
+      employer: candidate.employer,
+      appliedAt: candidate.appliedAt as string,
+      score,
+      titleScore,
+      employerScore,
+    };
+
+    const currentAppliedAt = Date.parse(candidateMatch.appliedAt);
+    const bestAppliedAt = bestMatch ? Date.parse(bestMatch.appliedAt) : 0;
+
+    if (
+      !bestMatch ||
+      candidateMatch.score > bestMatch.score ||
+      (candidateMatch.score === bestMatch.score &&
+        currentAppliedAt > bestAppliedAt)
+    ) {
+      bestMatch = candidateMatch;
+    }
+  }
+
+  return bestMatch;
+}
+
+export function attachAppliedDuplicateMatches<T extends Job | JobListItem>(
+  jobs: T[],
+  candidates: MatchableJob[],
+): T[] {
+  return jobs.map((job) => ({
+    ...job,
+    appliedDuplicateMatch: findAppliedDuplicateMatch(job, candidates),
+  }));
+}

--- a/orchestrator/src/server/services/applied-duplicate-matching.ts
+++ b/orchestrator/src/server/services/applied-duplicate-matching.ts
@@ -22,7 +22,9 @@ type MatchableJob = Pick<
   "id" | "title" | "employer" | "status" | "appliedAt" | "discoveredAt"
 >;
 
-function isHistoricalJob(job: MatchableJob): boolean {
+export function isHistoricalAppliedJob(
+  job: Pick<Job, "status" | "appliedAt">,
+): boolean {
   return HISTORICAL_JOB_STATUSES.has(job.status) && Boolean(job.appliedAt);
 }
 
@@ -42,7 +44,7 @@ export function findAppliedDuplicateMatch(
   job: MatchableJob,
   candidates: MatchableJob[],
 ): AppliedDuplicateMatch | null {
-  if (isHistoricalJob(job)) {
+  if (isHistoricalAppliedJob(job)) {
     return null;
   }
 
@@ -55,7 +57,7 @@ export function findAppliedDuplicateMatch(
   let bestMatch: AppliedDuplicateMatch | null = null;
 
   for (const candidate of candidates) {
-    if (!isHistoricalJob(candidate) || candidate.id === job.id) {
+    if (!isHistoricalAppliedJob(candidate) || candidate.id === job.id) {
       continue;
     }
 

--- a/orchestrator/src/server/services/visa-sponsors/index.ts
+++ b/orchestrator/src/server/services/visa-sponsors/index.ts
@@ -12,6 +12,10 @@ import fs from "node:fs";
 import path from "node:path";
 import { getDataDir } from "@server/config/dataDir";
 import { createScheduler } from "@server/utils/scheduler";
+import {
+  calculateSimilarity,
+  normalizeCompanyName,
+} from "@shared/job-matching";
 import type {
   VisaSponsor,
   VisaSponsorProviderManifest,
@@ -19,7 +23,6 @@ import type {
   VisaSponsorSearchResult,
   VisaSponsorStatusResponse,
 } from "@shared/types";
-import { normalizeWhitespace } from "@shared/utils/string";
 import { isVisaSponsorProviderId } from "@shared/visa-sponsor-providers";
 import { parseVisaSponsorsCsv } from "@shared/visa-sponsors/csv";
 import {
@@ -62,72 +65,6 @@ function getOrCreateProviderState(providerId: string): ProviderState {
 // ============================================================================
 // Company name normalization and similarity (shared across all providers)
 // ============================================================================
-
-const COMPANY_SUFFIXES = [
-  "limited",
-  "ltd",
-  "llp",
-  "plc",
-  "inc",
-  "incorporated",
-  "corporation",
-  "corp",
-  "company",
-  "co",
-  "llc",
-  "uk",
-  "international",
-  "intl",
-  "group",
-  "holdings",
-  "t/a",
-  "trading as",
-  "&",
-  "the",
-];
-
-export function normalizeCompanyName(name: string): string {
-  let normalized = name.toLowerCase().trim();
-  normalized = normalized.replace(/[.,'"()[\]{}!?@#$%^&*+=|\\/<>:;`~]/g, " ");
-  for (const suffix of COMPANY_SUFFIXES) {
-    const regex = new RegExp(`\\b${suffix}\\b`, "gi");
-    normalized = normalized.replace(regex, "");
-  }
-  return normalizeWhitespace(normalized);
-}
-
-export function calculateSimilarity(str1: string, str2: string): number {
-  const s1 = str1.toLowerCase();
-  const s2 = str2.toLowerCase();
-
-  if (s1 === s2) return 100;
-  if (s1.length === 0 || s2.length === 0) return 0;
-
-  if (s1.includes(s2) || s2.includes(s1)) {
-    const longerLen = Math.max(s1.length, s2.length);
-    const shorterLen = Math.min(s1.length, s2.length);
-    return Math.round((shorterLen / longerLen) * 100);
-  }
-
-  const matrix: number[][] = [];
-  for (let i = 0; i <= s1.length; i++) matrix[i] = [i];
-  for (let j = 0; j <= s2.length; j++) matrix[0][j] = j;
-
-  for (let i = 1; i <= s1.length; i++) {
-    for (let j = 1; j <= s2.length; j++) {
-      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
-      matrix[i][j] = Math.min(
-        matrix[i - 1][j] + 1,
-        matrix[i][j - 1] + 1,
-        matrix[i - 1][j - 1] + cost,
-      );
-    }
-  }
-
-  const distance = matrix[s1.length][s2.length];
-  const maxLen = Math.max(s1.length, s2.length);
-  return Math.round(((maxLen - distance) / maxLen) * 100);
-}
 
 // ============================================================================
 // CSV parsing (generic 5-column format used for stored files)

--- a/shared/src/job-matching.ts
+++ b/shared/src/job-matching.ts
@@ -1,0 +1,77 @@
+import { normalizeWhitespace } from "./utils/string";
+
+const COMPANY_SUFFIXES = [
+  "limited",
+  "ltd",
+  "llp",
+  "plc",
+  "inc",
+  "incorporated",
+  "corporation",
+  "corp",
+  "company",
+  "co",
+  "llc",
+  "uk",
+  "international",
+  "intl",
+  "group",
+  "holdings",
+  "t/a",
+  "trading as",
+  "&",
+  "the",
+];
+
+function normalizeMatchText(value: string): string {
+  const normalized = value.toLowerCase().trim();
+  return normalizeWhitespace(
+    normalized.replace(/[.,'"()[\]{}!?@#$%^&*+=|\\/<>:;`~_-]/g, " "),
+  );
+}
+
+export function normalizeCompanyName(name: string): string {
+  let normalized = normalizeMatchText(name);
+  for (const suffix of COMPANY_SUFFIXES) {
+    const regex = new RegExp(`\\b${suffix}\\b`, "gi");
+    normalized = normalized.replace(regex, " ");
+  }
+  return normalizeWhitespace(normalized);
+}
+
+export function normalizeJobTitle(title: string): string {
+  return normalizeMatchText(title);
+}
+
+export function calculateSimilarity(str1: string, str2: string): number {
+  const s1 = str1.toLowerCase();
+  const s2 = str2.toLowerCase();
+
+  if (s1 === s2) return 100;
+  if (s1.length === 0 || s2.length === 0) return 0;
+
+  if (s1.includes(s2) || s2.includes(s1)) {
+    const longerLen = Math.max(s1.length, s2.length);
+    const shorterLen = Math.min(s1.length, s2.length);
+    return Math.round((shorterLen / longerLen) * 100);
+  }
+
+  const matrix: number[][] = [];
+  for (let i = 0; i <= s1.length; i++) matrix[i] = [i];
+  for (let j = 0; j <= s2.length; j++) matrix[0][j] = j;
+
+  for (let i = 1; i <= s1.length; i++) {
+    for (let j = 1; j <= s2.length; j++) {
+      const cost = s1[i - 1] === s2[j - 1] ? 0 : 1;
+      matrix[i][j] = Math.min(
+        matrix[i - 1][j] + 1,
+        matrix[i][j - 1] + 1,
+        matrix[i - 1][j - 1] + cost,
+      );
+    }
+  }
+
+  const distance = matrix[s1.length][s2.length];
+  const maxLen = Math.max(s1.length, s2.length);
+  return Math.round(((maxLen - distance) / maxLen) * 100);
+}

--- a/shared/src/testing/factories.ts
+++ b/shared/src/testing/factories.ts
@@ -39,6 +39,7 @@ export const createJob = (overrides: Partial<Job> = {}): Job => ({
   tracerLinksEnabled: false,
   sponsorMatchScore: null,
   sponsorMatchNames: null,
+  appliedDuplicateMatch: null,
   jobType: null,
   salarySource: null,
   salaryInterval: null,

--- a/shared/src/types/jobs.ts
+++ b/shared/src/types/jobs.ts
@@ -119,6 +119,16 @@ export interface Interview {
 
 export type JobSource = ExtractorSourceId;
 
+export interface AppliedDuplicateMatch {
+  jobId: string;
+  title: string;
+  employer: string;
+  appliedAt: string;
+  score: number;
+  titleScore: number;
+  employerScore: number;
+}
+
 export interface Job {
   id: string;
 
@@ -156,6 +166,7 @@ export interface Job {
   tracerLinksEnabled: boolean; // Rewrite outbound resume links to tracer links on next PDF generation
   sponsorMatchScore: number | null; // 0-100 fuzzy match score with visa sponsors
   sponsorMatchNames: string | null; // JSON array of matched sponsor names (when 100% matches or top match)
+  appliedDuplicateMatch: AppliedDuplicateMatch | null; // Prior applied/in-progress job with highly similar title + employer
 
   // JobSpy fields (nullable for non-JobSpy sources)
   jobType: string | null;
@@ -209,6 +220,7 @@ export type JobListItem = Pick<
   | "closedAt"
   | "suitabilityScore"
   | "sponsorMatchScore"
+  | "appliedDuplicateMatch"
   | "jobType"
   | "jobFunction"
   | "salaryMinAmount"


### PR DESCRIPTION
## Summary
- add shared fuzzy-matching helpers for company names, job titles, and similarity scoring
- derive `appliedDuplicateMatch` on job list/detail API responses by comparing jobs against past `applied` and `in_progress` roles
- show a `Previously Applied` badge in orchestrator job rows and the detail header with match context
- document the new warning behavior in the Orchestrator docs

## Testing
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`