### PR TITLE
Add job-level notes with split-pane editing on the job page

### DIFF
--- a/docs-site/docs/features/orchestrator.md
+++ b/docs-site/docs/features/orchestrator.md
@@ -16,6 +16,7 @@ It controls:
 - job lifecycle states
 - manual and automatic ready flow
 - PDF generation and regeneration
+- job-level titled markdown notes on the dedicated job page
 - handoff to post-application tracking
 
 Job states:
@@ -36,6 +37,7 @@ It exists to ensure:
 - a consistent path from discovery to tailored output
 - clear status transitions across manual and automated workflows
 - predictable regeneration behavior when job data changes
+- a place to keep application-specific answers, interview contacts, and general reminders close to the job
 - visibility when a reposted role looks like a job you already applied to, even if the URL changed
 - faster external research from the Ready tab with prebuilt search links for LinkedIn, GitHub, and broader web results
 - one place to filter and sort jobs across every orchestrator tab
@@ -115,6 +117,28 @@ Ghostwriter is available in `discovered` and `ready` job views.
 
 For details, see [Ghostwriter](/docs/next/features/ghostwriter).
 
+### Job notes
+
+The dedicated job page includes a full-width `Notes` section below the stage timeline and job details area.
+
+Use it for things like:
+
+- answers to application questions, such as why you want the role or how your experience fits
+- notes about recruiters, hiring managers, and interviewers
+- reminders, follow-ups, and other job-specific context you want to keep with the application
+
+Each note has a title and a markdown body. The section shows a notes list on the left and a full TipTap editor on the right when you click **Edit** or **Add note**.
+
+To use it:
+
+1. Open a job in the dedicated job page.
+2. Scroll below the stage timeline and application details cards to the `Notes` section.
+3. Click **Add note** or **Edit** on an existing note.
+4. Use the TipTap editor on the right to enter a title and write the note body.
+5. Save the note, then edit or delete it later from the same section if needed.
+
+The saved view renders markdown by default, so links, lists, headings, and emphasis stay readable without leaving the job page.
+
 ### Ready tab search links
 
 In the `ready` view, JobOps can show prebuilt search links based on the current job's employer, title, and skills.
@@ -186,6 +210,12 @@ curl -X POST "http://localhost:3001/api/jobs/<jobId>/generate-pdf"
 - Run summarize with `force=true` after changing the JD/tailoring.
 - Regenerate PDF after summarize completes.
 
+### Notes do not appear as expected
+
+- Make sure you are on the dedicated job page, not the orchestrator detail panel.
+- Confirm the note was saved after entering both a title and note content.
+- If markdown looks plain, check for unsupported formatting or paste the note into the saved view again after editing.
+
 ### Reopen skipped/applied jobs
 
 - Patch `status` back to `discovered` to return the job to the active queue.
@@ -198,8 +228,8 @@ curl -X POST "http://localhost:3001/api/jobs/<jobId>/generate-pdf"
 
 ## Related pages
 
+- [Job Search Bar](/docs/next/features/job-search-bar)
 - [Pipeline Run](/docs/next/features/pipeline-run)
 - [Ghostwriter](/docs/next/features/ghostwriter)
 - [Reactive Resume](/docs/next/features/reactive-resume)
 - [Post-Application Tracking](/docs/next/features/post-application-tracking)
-- [Job Search Bar](/docs/next/features/job-search-bar)

--- a/orchestrator/src/client/api/client.notes.test.ts
+++ b/orchestrator/src/client/api/client.notes.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "./client";
+
+function createJsonResponse(status: number, payload: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(payload),
+    json: async () => payload,
+  } as Response;
+}
+
+describe("job notes API client", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    api.__resetApiClientAuthForTests();
+  });
+
+  it("fetches job notes with a cache-busting query param", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: [
+          {
+            id: "note-1",
+            jobId: "job-1",
+            title: "Why applied",
+            content: "Because it fits.",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        meta: { requestId: "req-1" },
+      }),
+    );
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+    await expect(api.getJobNotes("job-1")).resolves.toEqual([
+      {
+        id: "note-1",
+        jobId: "job-1",
+        title: "Why applied",
+        content: "Because it fits.",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/jobs/job-1/notes?t=1700000000000",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("creates a job note with the provided markdown content", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: {
+          id: "note-2",
+          jobId: "job-1",
+          title: "Recruiter contact",
+          content: "- Alex\n- alex@example.com",
+          createdAt: "2026-01-02T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+        },
+        meta: { requestId: "req-2" },
+      }),
+    );
+
+    await expect(
+      api.createJobNote("job-1", {
+        title: "Recruiter contact",
+        content: "- Alex\n- alex@example.com",
+      }),
+    ).resolves.toEqual({
+      id: "note-2",
+      jobId: "job-1",
+      title: "Recruiter contact",
+      content: "- Alex\n- alex@example.com",
+      createdAt: "2026-01-02T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/jobs/job-1/notes",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          title: "Recruiter contact",
+          content: "- Alex\n- alex@example.com",
+        }),
+      }),
+    );
+  });
+
+  it("updates a job note", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: {
+          id: "note-2",
+          jobId: "job-1",
+          title: "Recruiter contact",
+          content: "Updated note",
+          createdAt: "2026-01-02T00:00:00.000Z",
+          updatedAt: "2026-01-03T00:00:00.000Z",
+        },
+        meta: { requestId: "req-3" },
+      }),
+    );
+
+    await expect(
+      api.updateJobNote("job-1", "note-2", {
+        title: "Recruiter contact",
+        content: "Updated note",
+      }),
+    ).resolves.toEqual({
+      id: "note-2",
+      jobId: "job-1",
+      title: "Recruiter contact",
+      content: "Updated note",
+      createdAt: "2026-01-02T00:00:00.000Z",
+      updatedAt: "2026-01-03T00:00:00.000Z",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/jobs/job-1/notes/note-2",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({
+          title: "Recruiter contact",
+          content: "Updated note",
+        }),
+      }),
+    );
+  });
+
+  it("deletes a job note", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: null,
+        meta: { requestId: "req-4" },
+      }),
+    );
+
+    await expect(api.deleteJobNote("job-1", "note-2")).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/jobs/job-1/notes/note-2",
+      expect.objectContaining({
+        method: "DELETE",
+      }),
+    );
+  });
+});

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -11,6 +11,7 @@ import type {
   AppSettings,
   BackupInfo,
   BranchInfo,
+  CreateJobNoteInput,
   DemoInfoResponse,
   DesignResumeDocument,
   DesignResumeExportResponse,
@@ -26,6 +27,7 @@ import type {
   JobChatStreamEvent,
   JobChatThread,
   JobListItem,
+  JobNote,
   JobOutcome,
   JobSource,
   JobsListResponse,
@@ -51,6 +53,7 @@ import type {
   StageTransitionTarget,
   TracerAnalyticsResponse,
   TracerReadinessResponse,
+  UpdateJobNoteInput,
   ValidationResult,
   VisaSponsor,
   VisaSponsorSearchResponse,
@@ -577,6 +580,40 @@ export async function updateJob(
   return fetchApi<Job>(`/jobs/${id}`, {
     method: "PATCH",
     body: JSON.stringify(update),
+  });
+}
+
+export async function getJobNotes(id: string): Promise<JobNote[]> {
+  return fetchApi<JobNote[]>(`/jobs/${id}/notes?t=${Date.now()}`);
+}
+
+export async function createJobNote(
+  jobId: string,
+  input: CreateJobNoteInput,
+): Promise<JobNote> {
+  return fetchApi<JobNote>(`/jobs/${jobId}/notes`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updateJobNote(
+  jobId: string,
+  noteId: string,
+  input: UpdateJobNoteInput,
+): Promise<JobNote> {
+  return fetchApi<JobNote>(`/jobs/${jobId}/notes/${noteId}`, {
+    method: "PATCH",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function deleteJobNote(
+  jobId: string,
+  noteId: string,
+): Promise<void> {
+  await fetchApi<void>(`/jobs/${jobId}/notes/${noteId}`, {
+    method: "DELETE",
   });
 }
 

--- a/orchestrator/src/client/components/design-resume/RichTextEditor.test.tsx
+++ b/orchestrator/src/client/components/design-resume/RichTextEditor.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RichTextEditor } from "./RichTextEditor";
+
+describe("RichTextEditor", () => {
+  it("renders heading content and exposes heading controls", async () => {
+    const { container } = render(
+      <RichTextEditor
+        value="<h2>Why this role</h2><p>Because the team and mission fit.</p>"
+        onChange={vi.fn()}
+        formatLabel={null}
+      />,
+    );
+
+    expect(
+      screen.getByRole("button", { name: /heading 1/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /heading 2/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /heading 3/i }),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(container.querySelector("h2")).toHaveTextContent("Why this role");
+    });
+  });
+});

--- a/orchestrator/src/client/components/design-resume/RichTextEditor.tsx
+++ b/orchestrator/src/client/components/design-resume/RichTextEditor.tsx
@@ -1,4 +1,3 @@
-import Link from "@tiptap/extension-link";
 import { EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { Bold, Italic, Link2, List, ListOrdered, Unlink } from "lucide-react";
@@ -12,6 +11,8 @@ type RichTextEditorProps = {
   onChange: (value: string) => void;
   placeholder?: string;
   className?: string;
+  editorClassName?: string;
+  formatLabel?: string | null;
 };
 
 export function RichTextEditor({
@@ -19,23 +20,28 @@ export function RichTextEditor({
   onChange,
   placeholder = "Write something useful...",
   className,
+  editorClassName,
+  formatLabel = "HTML",
 }: RichTextEditorProps) {
   const editor = useEditor({
     extensions: [
-      StarterKit,
-      Link.configure({
-        openOnClick: false,
-        HTMLAttributes: {
-          rel: "noreferrer noopener",
-          target: "_blank",
+      StarterKit.configure({
+        link: {
+          openOnClick: false,
+          HTMLAttributes: {
+            rel: "noreferrer noopener",
+            target: "_blank",
+          },
         },
       }),
     ],
     content: value,
     editorProps: {
       attributes: {
-        class:
-          "min-h-[160px] rounded-b-xl border border-t-0 border-border/60 bg-background/60 px-4 py-3 text-sm leading-6 text-foreground outline-none focus-visible:ring-0",
+        class: cn(
+          "min-h-[160px] rounded-b-xl border border-t-0 border-border/60 bg-background/60 px-4 py-3 text-sm leading-6 text-foreground outline-none focus-visible:ring-0 [&>*:first-child]:mt-0 [&_h1]:mt-6 [&_h1]:text-3xl [&_h1]:font-semibold [&_h1]:tracking-tight [&_h2]:mt-5 [&_h2]:text-2xl [&_h2]:font-semibold [&_h2]:tracking-tight [&_h3]:mt-4 [&_h3]:text-xl [&_h3]:font-semibold [&_p]:my-3 [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-6 [&_blockquote]:my-4 [&_blockquote]:border-l-2 [&_blockquote]:border-border/70 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-muted [&_pre]:p-3 [&_code]:rounded [&_code]:bg-muted/80 [&_code]:px-1 [&_code]:py-0.5",
+          editorClassName,
+        ),
       },
     },
     onUpdate: ({ editor: current }) => {
@@ -92,6 +98,24 @@ export function RichTextEditor({
     >
       <div className="flex flex-wrap items-center gap-1 rounded-t-xl border-b border-border/60 bg-muted/20 px-2 py-2">
         {toolbarButton(
+          editor.isActive("heading", { level: 1 }),
+          "Heading 1",
+          <span className="text-[11px] font-semibold">H1</span>,
+          () => editor.chain().focus().toggleHeading({ level: 1 }).run(),
+        )}
+        {toolbarButton(
+          editor.isActive("heading", { level: 2 }),
+          "Heading 2",
+          <span className="text-[11px] font-semibold">H2</span>,
+          () => editor.chain().focus().toggleHeading({ level: 2 }).run(),
+        )}
+        {toolbarButton(
+          editor.isActive("heading", { level: 3 }),
+          "Heading 3",
+          <span className="text-[11px] font-semibold">H3</span>,
+          () => editor.chain().focus().toggleHeading({ level: 3 }).run(),
+        )}
+        {toolbarButton(
           editor.isActive("bold"),
           "Bold",
           <Bold className="h-4 w-4" />,
@@ -127,9 +151,11 @@ export function RichTextEditor({
           <Unlink className="h-4 w-4" />,
           () => editor.chain().focus().unsetLink().run(),
         )}
-        <div className="ml-auto px-2 text-[11px] uppercase tracking-[0.24em] text-muted-foreground">
-          HTML
-        </div>
+        {formatLabel ? (
+          <div className="ml-auto px-2 text-[11px] uppercase tracking-[0.24em] text-muted-foreground">
+            {formatLabel}
+          </div>
+        ) : null}
       </div>
       <div className="relative">
         {!value && (

--- a/orchestrator/src/client/hooks/queries/useJobMutations.notes.test.ts
+++ b/orchestrator/src/client/hooks/queries/useJobMutations.notes.test.ts
@@ -1,0 +1,54 @@
+import * as api from "@client/api";
+import type { JobNote } from "@shared/types";
+import { act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryKeys } from "@/client/lib/queryKeys";
+import { renderHookWithQueryClient } from "@/client/test/renderWithQueryClient";
+import { useCreateJobNoteMutation } from "./useJobMutations";
+
+vi.mock("@client/api", () => ({
+  createJobNote: vi.fn(),
+}));
+
+describe("job note mutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("invalidates the job notes query after creating a note", async () => {
+    const note: JobNote = {
+      id: "note-1",
+      jobId: "job-1",
+      title: "Why applied",
+      content: "Because it fits.",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    vi.mocked(api.createJobNote).mockResolvedValue(note);
+
+    const { result, queryClient } = renderHookWithQueryClient(() =>
+      useCreateJobNoteMutation(),
+    );
+    const invalidateSpy = vi
+      .spyOn(queryClient, "invalidateQueries")
+      .mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        jobId: "job-1",
+        input: {
+          title: "Why applied",
+          content: "Because it fits.",
+        },
+      });
+    });
+
+    expect(api.createJobNote).toHaveBeenCalledWith("job-1", {
+      title: "Why applied",
+      content: "Because it fits.",
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: queryKeys.jobs.notes("job-1"),
+    });
+  });
+});

--- a/orchestrator/src/client/hooks/queries/useJobMutations.ts
+++ b/orchestrator/src/client/hooks/queries/useJobMutations.ts
@@ -1,8 +1,22 @@
 import * as api from "@client/api";
-import type { Job } from "@shared/types";
+import type {
+  CreateJobNoteInput,
+  Job,
+  UpdateJobNoteInput,
+} from "@shared/types";
+import type { QueryClient } from "@tanstack/react-query";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/client/lib/queryKeys";
 import { invalidateJobData } from "./invalidate";
+
+export async function invalidateJobNotesData(
+  queryClient: QueryClient,
+  jobId: string,
+): Promise<void> {
+  await queryClient.invalidateQueries({
+    queryKey: queryKeys.jobs.notes(jobId),
+  });
+}
 
 export function useUpdateJobMutation() {
   const queryClient = useQueryClient();
@@ -97,6 +111,51 @@ export function useCheckSponsorMutation() {
     mutationFn: (id: string) => api.checkSponsor(id),
     onSuccess: async (_data, id) => {
       await invalidateJobData(queryClient, id);
+    },
+  });
+}
+
+export function useCreateJobNoteMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      jobId,
+      input,
+    }: {
+      jobId: string;
+      input: CreateJobNoteInput;
+    }) => api.createJobNote(jobId, input),
+    onSuccess: async (_data, variables) => {
+      await invalidateJobNotesData(queryClient, variables.jobId);
+    },
+  });
+}
+
+export function useUpdateJobNoteMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      jobId,
+      noteId,
+      input,
+    }: {
+      jobId: string;
+      noteId: string;
+      input: UpdateJobNoteInput;
+    }) => api.updateJobNote(jobId, noteId, input),
+    onSuccess: async (_data, variables) => {
+      await invalidateJobNotesData(queryClient, variables.jobId);
+    },
+  });
+}
+
+export function useDeleteJobNoteMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ jobId, noteId }: { jobId: string; noteId: string }) =>
+      api.deleteJobNote(jobId, noteId),
+    onSuccess: async (_data, variables) => {
+      await invalidateJobNotesData(queryClient, variables.jobId);
     },
   });
 }

--- a/orchestrator/src/client/lib/jobNoteContent.test.ts
+++ b/orchestrator/src/client/lib/jobNoteContent.test.ts
@@ -26,4 +26,24 @@ describe("job note content bridge", () => {
     expect(markdown).toContain("- mission");
     expect(markdown).toContain("- team");
   });
+
+  it("preserves backslashes without double escaping them", () => {
+    const markdown = editorHtmlToMarkdown(`<p>C:\\temp\\notes\\draft.md</p>`);
+
+    expect(markdown).toBe(String.raw`C:\\temp\\notes\\draft.md`);
+  });
+
+  it("serializes balanced parentheses in link urls safely", () => {
+    const markdown = editorHtmlToMarkdown(
+      `<p><a href="https://example.com/foo(bar)">Docs</a></p>`,
+    );
+
+    expect(markdown).toBe("[Docs](https://example.com/foo%28bar%29)");
+  });
+
+  it("keeps br tags as hard breaks instead of collapsing them to spaces", () => {
+    const markdown = editorHtmlToMarkdown(`<p>line one<br>line two</p>`);
+
+    expect(markdown).toBe("line one  \nline two");
+  });
 });

--- a/orchestrator/src/client/lib/jobNoteContent.test.ts
+++ b/orchestrator/src/client/lib/jobNoteContent.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { editorHtmlToMarkdown, markdownToEditorHtml } from "./jobNoteContent";
+
+describe("job note content bridge", () => {
+  it("renders markdown into TipTap-friendly html", () => {
+    const html = markdownToEditorHtml(
+      "## Fit\n\n- mission\n- team\n\n[site](https://example.com)",
+    );
+
+    expect(html).toContain("<h2>Fit</h2>");
+    expect(html).toContain("<ul>");
+    expect(html).toContain('<a href="https://example.com">site</a>');
+  });
+
+  it("serializes TipTap html back to markdown", () => {
+    const markdown = editorHtmlToMarkdown(
+      `<h2>Fit</h2>
+       <p>Because <strong>yes</strong> and <a href="https://example.com/docs">docs</a>.</p>
+       <ul><li>mission</li><li>team</li></ul>`,
+    );
+
+    expect(markdown).toContain("## Fit");
+    expect(markdown).toContain(
+      "Because **yes** and [docs](https://example.com/docs).",
+    );
+    expect(markdown).toContain("- mission");
+    expect(markdown).toContain("- team");
+  });
+});

--- a/orchestrator/src/client/lib/jobNoteContent.ts
+++ b/orchestrator/src/client/lib/jobNoteContent.ts
@@ -1,0 +1,159 @@
+import MarkdownIt from "markdown-it";
+
+const markdownIt = new MarkdownIt({
+  html: false,
+  linkify: true,
+  breaks: false,
+});
+
+const ESCAPE_RE = /([\\`*_{}()[\]#+>])/g;
+
+const escapeMarkdownText = (value: string) =>
+  value.replaceAll("\\", "\\\\").replace(ESCAPE_RE, "\\$1");
+
+const escapeLinkTarget = (value: string) =>
+  encodeURI(value.trim()).replaceAll(")", "%29");
+
+const normalizeWhitespace = (value: string) => value.replace(/\s+/g, " ");
+
+const isElement = (node: Node): node is HTMLElement =>
+  node.nodeType === Node.ELEMENT_NODE;
+
+function serializeInlineNode(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) {
+    return escapeMarkdownText(normalizeWhitespace(node.textContent ?? ""));
+  }
+
+  if (!isElement(node)) return "";
+
+  const tag = node.tagName.toLowerCase();
+  switch (tag) {
+    case "strong":
+    case "b":
+      return `**${serializeInlineChildren(node)}**`;
+    case "em":
+    case "i":
+      return `*${serializeInlineChildren(node)}*`;
+    case "code":
+      return `\`${escapeMarkdownText(node.textContent ?? "")}\``;
+    case "a": {
+      const href = node.getAttribute("href")?.trim();
+      const label = serializeInlineChildren(node).trim();
+      if (!href) return label;
+      return `[${label || escapeMarkdownText(href)}](${escapeLinkTarget(href)})`;
+    }
+    case "br":
+      return "  \n";
+    case "span":
+    case "div":
+    case "body":
+      return serializeInlineChildren(node);
+    default:
+      return serializeInlineChildren(node);
+  }
+}
+
+function serializeInlineChildren(node: ParentNode): string {
+  return Array.from(node.childNodes)
+    .map((child) => serializeInlineNode(child))
+    .join("")
+    .replace(/\s{2,}/g, " ");
+}
+
+function serializeBlockNode(node: Node): string {
+  if (node.nodeType === Node.TEXT_NODE) {
+    const text = normalizeWhitespace(node.textContent ?? "").trim();
+    return text ? escapeMarkdownText(text) : "";
+  }
+
+  if (!isElement(node)) return "";
+
+  const tag = node.tagName.toLowerCase();
+  switch (tag) {
+    case "p":
+      return serializeInlineChildren(node).trim();
+    case "h1":
+    case "h2":
+    case "h3":
+    case "h4":
+    case "h5":
+    case "h6":
+      return `${"#".repeat(Number(tag.slice(1)))} ${serializeInlineChildren(node).trim()}`;
+    case "ul":
+      return serializeList(node, false);
+    case "ol":
+      return serializeList(node, true);
+    case "blockquote": {
+      const body = serializeBlockChildren(node).trim();
+      return body
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+    }
+    case "pre": {
+      const code = node.querySelector("code")?.textContent ?? node.textContent;
+      return `\`\`\`\n${(code ?? "").replace(/\n$/, "")}\n\`\`\``;
+    }
+    case "li":
+      return serializeListItem(node);
+    case "hr":
+      return "---";
+    case "div":
+    case "section":
+    case "article":
+    case "body":
+      return serializeBlockChildren(node);
+    default:
+      return serializeInlineChildren(node).trim();
+  }
+}
+
+function serializeBlockChildren(node: ParentNode): string {
+  return Array.from(node.childNodes)
+    .map((child) => serializeBlockNode(child))
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .join("\n\n")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+function serializeList(node: HTMLElement, ordered: boolean): string {
+  const items = Array.from(node.children).filter(
+    (child): child is HTMLLIElement => child.tagName.toLowerCase() === "li",
+  );
+
+  return items
+    .map((item, index) => {
+      const content = serializeListItem(item);
+      const prefix = ordered ? `${index + 1}. ` : "- ";
+      return prefix + content.replaceAll("\n", "\n  ");
+    })
+    .join("\n");
+}
+
+function serializeListItem(node: HTMLElement): string {
+  const parts = Array.from(node.childNodes)
+    .map((child) => {
+      if (child.nodeType === Node.ELEMENT_NODE) {
+        const tag = (child as HTMLElement).tagName.toLowerCase();
+        if (tag === "ul" || tag === "ol" || tag === "blockquote") {
+          return serializeBlockNode(child);
+        }
+      }
+      return serializeInlineNode(child);
+    })
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  return parts.join(" ").trim();
+}
+
+export function markdownToEditorHtml(markdown: string): string {
+  return markdownIt.render(markdown ?? "");
+}
+
+export function editorHtmlToMarkdown(html: string): string {
+  const template = document.createElement("template");
+  template.innerHTML = html;
+  return serializeBlockChildren(template.content).trim();
+}

--- a/orchestrator/src/client/lib/jobNoteContent.ts
+++ b/orchestrator/src/client/lib/jobNoteContent.ts
@@ -6,13 +6,13 @@ const markdownIt = new MarkdownIt({
   breaks: false,
 });
 
-const ESCAPE_RE = /([\\`*_{}()[\]#+>])/g;
+const ESCAPE_RE = /([`*_{}()[\]#+>])/g;
 
 const escapeMarkdownText = (value: string) =>
   value.replaceAll("\\", "\\\\").replace(ESCAPE_RE, "\\$1");
 
 const escapeLinkTarget = (value: string) =>
-  encodeURI(value.trim()).replaceAll(")", "%29");
+  encodeURI(value.trim()).replaceAll("(", "%28").replaceAll(")", "%29");
 
 const normalizeWhitespace = (value: string) => value.replace(/\s+/g, " ");
 
@@ -56,8 +56,7 @@ function serializeInlineNode(node: Node): string {
 function serializeInlineChildren(node: ParentNode): string {
   return Array.from(node.childNodes)
     .map((child) => serializeInlineNode(child))
-    .join("")
-    .replace(/\s{2,}/g, " ");
+    .join("");
 }
 
 function serializeBlockNode(node: Node): string {

--- a/orchestrator/src/client/lib/queryKeys.test.ts
+++ b/orchestrator/src/client/lib/queryKeys.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { queryKeys } from "./queryKeys";
+
+describe("queryKeys", () => {
+  it("builds the job notes key from the job id", () => {
+    expect(queryKeys.jobs.notes("job-1")).toEqual(["jobs", "notes", "job-1"]);
+  });
+});

--- a/orchestrator/src/client/lib/queryKeys.ts
+++ b/orchestrator/src/client/lib/queryKeys.ts
@@ -45,6 +45,7 @@ export const queryKeys = {
     stageEvents: (id: string) =>
       [...queryKeys.jobs.all, "stage-events", id] as const,
     tasks: (id: string) => [...queryKeys.jobs.all, "tasks", id] as const,
+    notes: (id: string) => [...queryKeys.jobs.all, "notes", id] as const,
   },
   pipeline: {
     all: ["pipeline"] as const,

--- a/orchestrator/src/client/pages/JobPage.test.tsx
+++ b/orchestrator/src/client/pages/JobPage.test.tsx
@@ -1,0 +1,368 @@
+import { createJob } from "@shared/testing/factories.js";
+import type { Job, JobNote } from "@shared/types.js";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { editorHtmlToMarkdown } from "@/client/lib/jobNoteContent";
+import * as api from "../api";
+import { renderWithQueryClient } from "../test/renderWithQueryClient";
+import { JobPage } from "./JobPage";
+
+const TIPTAP_HTML =
+  `<h2>Fit</h2><p>Because <strong>this team</strong> and <a href="https://example.com/docs">docs</a>.</p>` +
+  `<ul><li>mission</li><li>team</li></ul>`;
+
+const render = (ui: Parameters<typeof renderWithQueryClient>[0]) =>
+  renderWithQueryClient(ui);
+
+let notesStore: JobNote[] = [];
+
+const makeNote = (overrides: Partial<JobNote>): JobNote => ({
+  id: "note-1",
+  jobId: "job-1",
+  title: "Application answer",
+  content: "Write the answer here.",
+  createdAt: "2026-01-01T09:00:00.000Z",
+  updatedAt: "2026-01-01T09:00:00.000Z",
+  ...overrides,
+});
+
+vi.mock("@/client/components/design-resume/RichTextEditor", () => ({
+  RichTextEditor: ({
+    value,
+    onChange,
+    placeholder,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+  }) => (
+    <div data-testid="tiptap-editor">
+      <div data-testid="tiptap-editor-value">{value}</div>
+      <div>{placeholder}</div>
+      <button type="button" onClick={() => onChange(TIPTAP_HTML)}>
+        Emit editor content
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+vi.mock("../api", () => ({
+  getJob: vi.fn(),
+  getJobStageEvents: vi.fn(),
+  getJobTasks: vi.fn(),
+  getJobNotes: vi.fn(),
+  createJobNote: vi.fn(),
+  updateJobNote: vi.fn(),
+  deleteJobNote: vi.fn(),
+  updateJobStageEvent: vi.fn(),
+  deleteJobStageEvent: vi.fn(),
+  transitionJobStage: vi.fn(),
+  markAsApplied: vi.fn(),
+  skipJob: vi.fn(),
+  rescoreJob: vi.fn(),
+  generateJobPdf: vi.fn(),
+  checkSponsor: vi.fn(),
+}));
+
+vi.mock("../components/JobHeader", () => ({
+  JobHeader: ({ job }: { job: Job }) => (
+    <div data-testid="job-header">{job.title}</div>
+  ),
+}));
+
+vi.mock("../components/ghostwriter/GhostwriterDrawer", () => ({
+  GhostwriterDrawer: () => <div data-testid="ghostwriter-drawer" />,
+}));
+
+vi.mock("../components/JobDetailsEditDrawer", () => ({
+  JobDetailsEditDrawer: () => null,
+}));
+
+vi.mock("../components/LogEventModal", () => ({
+  LogEventModal: () => null,
+}));
+
+vi.mock("../components/ConfirmDelete", () => ({
+  ConfirmDelete: ({
+    isOpen,
+    onClose,
+    onConfirm,
+    title,
+    description,
+  }: {
+    isOpen: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    title?: string;
+    description?: string;
+  }) =>
+    isOpen ? (
+      <div role="alertdialog">
+        <div>{title}</div>
+        <div>{description}</div>
+        <button type="button" onClick={onConfirm}>
+          Delete
+        </button>
+        <button type="button" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("./job/Timeline", () => ({
+  JobTimeline: () => <div data-testid="job-timeline" />,
+}));
+
+vi.mock("@client/hooks/useQueryErrorToast", () => ({
+  useQueryErrorToast: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    message: vi.fn(),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  notesStore = [];
+
+  vi.mocked(api.getJob).mockResolvedValue(createJob() as Job);
+  vi.mocked(api.getJobStageEvents).mockResolvedValue([]);
+  vi.mocked(api.getJobTasks).mockResolvedValue([
+    {
+      id: "task-1",
+      applicationId: "job-1",
+      type: "todo",
+      title: "Prepare follow-up questions",
+      dueDate: 1_704_060_000,
+      isCompleted: false,
+      notes: "Bring questions about the team.",
+    },
+  ]);
+  vi.mocked(api.getJobNotes).mockImplementation(async () => notesStore);
+  vi.mocked(api.createJobNote).mockImplementation(async (jobId, input) => {
+    const created = makeNote({
+      id: `note-${notesStore.length + 1}`,
+      jobId,
+      title: input.title,
+      content: input.content,
+      createdAt: "2026-01-01T10:00:00.000Z",
+      updatedAt: "2026-01-01T10:00:00.000Z",
+    });
+    notesStore = [created, ...notesStore];
+    return created;
+  });
+  vi.mocked(api.updateJobNote).mockImplementation(
+    async (_jobId, noteId, input) => {
+      const current = notesStore.find((note) => note.id === noteId);
+      if (!current) {
+        throw new Error("Note not found");
+      }
+
+      const updated = {
+        ...current,
+        title: input.title,
+        content: input.content,
+        updatedAt: "2026-01-01T11:00:00.000Z",
+      };
+      notesStore = notesStore.map((note) =>
+        note.id === noteId ? updated : note,
+      );
+      return updated;
+    },
+  );
+  vi.mocked(api.deleteJobNote).mockImplementation(async (_jobId, noteId) => {
+    notesStore = notesStore.filter((note) => note.id !== noteId);
+  });
+});
+
+const renderJobPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/job/job-1"]}>
+      <Routes>
+        <Route path="/job/:id" element={<JobPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("JobPage notes", () => {
+  it("renders the full-width notes section and defaults to markdown preview", async () => {
+    notesStore = [
+      makeNote({
+        id: "note-older",
+        title: "Recruiter contact",
+        content: "Reach out to Jane.",
+        updatedAt: "2026-01-01T09:00:00.000Z",
+      }),
+      makeNote({
+        id: "note-newer",
+        title: "Why this company",
+        content:
+          "# Strong fit\n\n- Great mission\n- Good team\n\n[Team](https://example.com)",
+        updatedAt: "2026-01-01T12:00:00.000Z",
+      }),
+    ];
+
+    renderJobPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("job-header")).toHaveTextContent(
+        "Backend Engineer",
+      );
+    });
+
+    expect(screen.getByTestId("job-notes-section")).toHaveClass("w-full");
+    expect(screen.getByTestId("job-notes-list")).toBeInTheDocument();
+    expect(screen.getByTestId("job-notes-detail")).toBeInTheDocument();
+
+    const applicationDetails = screen.getByText("Application details");
+    const notesHeading = screen.getByText("Notes");
+    const upcomingTasks = screen.getByText("Upcoming tasks");
+
+    expect(
+      applicationDetails.compareDocumentPosition(notesHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      upcomingTasks.compareDocumentPosition(notesHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+
+    expect(
+      await screen.findByRole("heading", { name: "Strong fit" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Team" })).toHaveAttribute(
+      "href",
+      "https://example.com",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Recruiter contact/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText("Reach out to Jane.")).toBeInTheDocument(),
+    );
+  });
+
+  it("switches between markdown view and TipTap edit mode inline", async () => {
+    notesStore = [];
+
+    renderJobPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "No notes yet. Capture reminders, interview prep, or links in markdown.",
+        ),
+      ).toBeInTheDocument(),
+    );
+
+    fireEvent.click(
+      within(screen.getByTestId("job-notes-detail")).getByRole("button", {
+        name: /add note/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tiptap-editor")).toBeInTheDocument(),
+    );
+
+    fireEvent.change(screen.getByLabelText("Title"), {
+      target: { value: "Why this company" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: "Emit editor content" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save note/i }));
+
+    const expectedMarkdown = editorHtmlToMarkdown(TIPTAP_HTML);
+
+    await waitFor(() =>
+      expect(api.createJobNote).toHaveBeenCalledWith("job-1", {
+        title: "Why this company",
+        content: expectedMarkdown,
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith("Note saved");
+    expect(
+      await screen.findByRole("heading", { name: "Fit" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "docs" })).toHaveAttribute(
+      "href",
+      "https://example.com/docs",
+    );
+
+    fireEvent.click(
+      within(screen.getByTestId("job-notes-detail")).getByRole("button", {
+        name: "Edit note",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("tiptap-editor")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("tiptap-editor-value")).toHaveTextContent(
+      "<h2>Fit</h2>",
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Emit editor content" }),
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save note/i }));
+
+    await waitFor(() =>
+      expect(api.updateJobNote).toHaveBeenCalledWith("job-1", "note-1", {
+        title: "Why this company",
+        content: expectedMarkdown,
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith("Note saved");
+
+    fireEvent.click(
+      within(screen.getByTestId("job-notes-detail")).getByRole("button", {
+        name: "Delete note",
+      }),
+    );
+    fireEvent.click(
+      within(screen.getByRole("alertdialog")).getByRole("button", {
+        name: /^delete$/i,
+      }),
+    );
+
+    await waitFor(() =>
+      expect(api.deleteJobNote).toHaveBeenCalledWith("job-1", "note-1"),
+    );
+    expect(toast.success).toHaveBeenCalledWith("Note deleted");
+    await waitFor(() =>
+      expect(screen.queryByText("Why this company")).toBeNull(),
+    );
+  });
+});

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -2,6 +2,7 @@ import {
   type ApplicationStage,
   type ApplicationTask,
   type Job,
+  type JobNote,
   type JobOutcome,
   STAGE_LABELS,
   type StageEvent,
@@ -22,23 +23,34 @@ import {
   PlusCircle,
   RefreshCcw,
   Sparkles,
+  Trash2,
   Upload,
   XCircle,
 } from "lucide-react";
 import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
+import { RichTextEditor } from "@/client/components/design-resume/RichTextEditor";
+import { JobDescriptionMarkdown } from "@/client/components/JobDescriptionMarkdown";
 import { invalidateJobData } from "@/client/hooks/queries/invalidate";
 import {
   useCheckSponsorMutation,
+  useCreateJobNoteMutation,
+  useDeleteJobNoteMutation,
   useGenerateJobPdfMutation,
   useMarkAsAppliedMutation,
   useRescoreJobMutation,
   useSkipJobMutation,
   useUpdateJobMutation,
+  useUpdateJobNoteMutation,
 } from "@/client/hooks/queries/useJobMutations";
 import { useQueryErrorToast } from "@/client/hooks/useQueryErrorToast";
 import { uploadJobPdfFromFile } from "@/client/lib/job-pdf-upload";
+import { getRenderableJobDescription } from "@/client/lib/jobDescription";
+import {
+  markdownToEditorHtml as markdownToTipTapHtml,
+  editorHtmlToMarkdown as tipTapHtmlToMarkdown,
+} from "@/client/lib/jobNoteContent";
 import { queryKeys } from "@/client/lib/queryKeys";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -50,9 +62,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
 import { trackProductEvent } from "@/lib/analytics";
 import {
+  cn,
   copyTextToClipboard,
+  formatDateTime,
   formatJobForWebhook,
   formatTimestamp,
 } from "@/lib/utils";
@@ -66,6 +81,445 @@ import {
   LogEventModal,
 } from "../components/LogEventModal";
 import { JobTimeline } from "./job/Timeline";
+
+const sortNotesByUpdatedAtDesc = (notes: JobNote[]) =>
+  [...notes].sort(
+    (left, right) =>
+      new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
+  );
+
+const JobNotesCard: React.FC<{ jobId: string }> = ({ jobId }) => {
+  const [editorState, setEditorState] = React.useState<
+    { mode: "create" } | { mode: "edit"; noteId: string } | null
+  >(null);
+  const [selectedNoteId, setSelectedNoteId] = React.useState<string | null>(
+    null,
+  );
+  const [draftTitle, setDraftTitle] = React.useState("");
+  const [draftContent, setDraftContent] = React.useState("");
+  const [editorError, setEditorError] = React.useState<string | null>(null);
+  const [noteToDelete, setNoteToDelete] = React.useState<JobNote | null>(null);
+
+  const notesQuery = useQuery<JobNote[]>({
+    queryKey: queryKeys.jobs.notes(jobId),
+    queryFn: () => api.getJobNotes(jobId),
+    enabled: Boolean(jobId),
+  });
+  const createNoteMutation = useCreateJobNoteMutation();
+  const updateNoteMutation = useUpdateJobNoteMutation();
+  const deleteNoteMutation = useDeleteJobNoteMutation();
+
+  useQueryErrorToast(
+    notesQuery.error,
+    "Failed to load notes. Please try again.",
+  );
+
+  const notes = React.useMemo(
+    () => sortNotesByUpdatedAtDesc(notesQuery.data ?? []),
+    [notesQuery.data],
+  );
+  const selectedNote = React.useMemo(
+    () => notes.find((note) => note.id === selectedNoteId) ?? notes[0] ?? null,
+    [notes, selectedNoteId],
+  );
+  const isSaving = createNoteMutation.isPending || updateNoteMutation.isPending;
+  const isDeleting = deleteNoteMutation.isPending;
+
+  const resetEditor = React.useCallback(() => {
+    setEditorState(null);
+    setDraftTitle("");
+    setDraftContent("");
+    setEditorError(null);
+  }, []);
+
+  const openCreateEditor = React.useCallback(() => {
+    setEditorState({ mode: "create" });
+    setSelectedNoteId(null);
+    setDraftTitle("");
+    setDraftContent("");
+    setEditorError(null);
+  }, []);
+
+  const openEditEditor = React.useCallback((note: JobNote) => {
+    setEditorState({ mode: "edit", noteId: note.id });
+    setDraftTitle(note.title);
+    setDraftContent(markdownToTipTapHtml(note.content));
+    setEditorError(null);
+    setSelectedNoteId(note.id);
+  }, []);
+
+  const confirmDeleteNote = React.useCallback((note: JobNote) => {
+    setNoteToDelete(note);
+  }, []);
+
+  const saveNote = React.useCallback(async () => {
+    const title = draftTitle.trim();
+    const content = tipTapHtmlToMarkdown(draftContent).trim();
+
+    if (!title || !content) {
+      setEditorError("Title and note content are required.");
+      return;
+    }
+
+    try {
+      const savedNote =
+        editorState?.mode === "edit"
+          ? await updateNoteMutation.mutateAsync({
+              jobId,
+              noteId: editorState.noteId,
+              input: { title, content },
+            })
+          : await createNoteMutation.mutateAsync({
+              jobId,
+              input: { title, content },
+            });
+
+      toast.success("Note saved");
+      setSelectedNoteId(savedNote.id);
+      resetEditor();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to save note";
+      toast.error(message);
+    }
+  }, [
+    createNoteMutation,
+    draftContent,
+    draftTitle,
+    editorState,
+    jobId,
+    resetEditor,
+    updateNoteMutation,
+  ]);
+
+  const handleDeleteNote = React.useCallback(async () => {
+    if (!noteToDelete) return;
+
+    try {
+      await deleteNoteMutation.mutateAsync({
+        jobId,
+        noteId: noteToDelete.id,
+      });
+      toast.success("Note deleted");
+      if (selectedNoteId === noteToDelete.id) {
+        const nextNote = notes.find((note) => note.id !== noteToDelete.id);
+        setSelectedNoteId(nextNote?.id ?? null);
+      }
+      if (
+        editorState?.mode === "edit" &&
+        editorState.noteId === noteToDelete.id
+      ) {
+        resetEditor();
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to delete note";
+      toast.error(message);
+    } finally {
+      setNoteToDelete(null);
+    }
+  }, [
+    deleteNoteMutation,
+    editorState,
+    jobId,
+    noteToDelete,
+    notes,
+    resetEditor,
+    selectedNoteId,
+  ]);
+
+  const canEditOtherNotes = editorState === null;
+
+  React.useEffect(() => {
+    if (editorState) return;
+    if (notes.length === 0) {
+      setSelectedNoteId(null);
+      return;
+    }
+
+    if (!selectedNoteId || !notes.some((note) => note.id === selectedNoteId)) {
+      setSelectedNoteId(notes[0]?.id ?? null);
+    }
+  }, [editorState, notes, selectedNoteId]);
+
+  const startViewingNote = React.useCallback(
+    (note: JobNote) => {
+      if (editorState) return;
+      setSelectedNoteId(note.id);
+    },
+    [editorState],
+  );
+
+  const selectedTimestamp = selectedNote
+    ? (formatDateTime(selectedNote.updatedAt) ?? selectedNote.updatedAt)
+    : null;
+
+  return (
+    <section data-testid="job-notes-section" className="w-full">
+      <Card className="border-border/50">
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <FileText className="h-4 w-4" />
+              Notes
+            </CardTitle>
+            {!editorState && (
+              <Button size="sm" variant="outline" onClick={openCreateEditor}>
+                <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
+                Add note
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 lg:grid-cols-[minmax(14rem,0.7fr)_minmax(0,1.3fr)]">
+            <aside data-testid="job-notes-list" className="space-y-3">
+              {!editorState && notesQuery.isLoading && notes.length === 0 && (
+                <div className="rounded-xl border border-dashed border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
+                  Loading notes...
+                </div>
+              )}
+
+              {!editorState && !notesQuery.isLoading && notes.length === 0 && (
+                <div className="rounded-xl border border-dashed border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
+                  No notes yet. Capture reminders, interview prep, or links in
+                  markdown.
+                </div>
+              )}
+
+              {notes.length > 0 && (
+                <div className="space-y-2">
+                  {notes.map((note) => {
+                    const noteTimestamp =
+                      formatDateTime(note.updatedAt) ?? note.updatedAt;
+                    const isSelected = note.id === selectedNoteId;
+                    return (
+                      <button
+                        key={note.id}
+                        type="button"
+                        className={cn(
+                          "w-full rounded-xl border px-4 py-3 text-left transition",
+                          isSelected
+                            ? "border-primary/40 bg-primary/5 shadow-sm"
+                            : "border-border/60 bg-background/70 hover:border-border hover:bg-muted/40",
+                          editorState && "cursor-default opacity-70",
+                        )}
+                        onClick={() => startViewingNote(note)}
+                        disabled={Boolean(editorState)}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-semibold">
+                              {note.title}
+                            </div>
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              Updated {noteTimestamp}
+                            </div>
+                          </div>
+                          {isSelected && !editorState && (
+                            <Badge variant="secondary" className="text-[10px]">
+                              Selected
+                            </Badge>
+                          )}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </aside>
+
+            <div
+              data-testid="job-notes-detail"
+              className="min-w-0 rounded-2xl border border-border/60 bg-muted/10 p-4 shadow-sm"
+            >
+              {editorState ? (
+                <form
+                  className="space-y-4"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void saveNote();
+                  }}
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
+                        {editorState.mode === "create"
+                          ? "New note"
+                          : "Editing note"}
+                      </div>
+                      <div className="mt-1 text-lg font-semibold">
+                        {editorState.mode === "create"
+                          ? "Draft a note"
+                          : draftTitle || selectedNote?.title || "Edit note"}
+                      </div>
+                    </div>
+                    {editorState.mode === "edit" && selectedNote && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        Updated {selectedTimestamp}
+                      </Badge>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="job-note-title"
+                      className="text-[10px] uppercase tracking-wide text-muted-foreground"
+                    >
+                      Title
+                    </label>
+                    <Input
+                      id="job-note-title"
+                      autoFocus
+                      value={draftTitle}
+                      onChange={(event) => {
+                        setDraftTitle(event.target.value);
+                        setEditorError(null);
+                      }}
+                      placeholder="Why I am applying"
+                      disabled={isSaving || isDeleting}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                        Content
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        TipTap editor
+                      </div>
+                    </div>
+                    <RichTextEditor
+                      key={
+                        editorState.mode === "edit"
+                          ? editorState.noteId
+                          : "create-note"
+                      }
+                      value={draftContent}
+                      onChange={(next) => {
+                        setDraftContent(next);
+                        setEditorError(null);
+                      }}
+                      placeholder="Capture answers, reminders, interview notes, and useful links."
+                      className="bg-background/20"
+                    />
+                  </div>
+
+                  {editorError && (
+                    <div className="text-sm text-destructive">
+                      {editorError}
+                    </div>
+                  )}
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="submit" disabled={isSaving || isDeleting}>
+                      {isSaving ? "Saving..." : "Save note"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={resetEditor}
+                      disabled={isSaving || isDeleting}
+                    >
+                      Cancel
+                    </Button>
+                    {editorState.mode === "edit" && selectedNote && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => confirmDeleteNote(selectedNote)}
+                        disabled={isSaving || isDeleting}
+                      >
+                        Delete note
+                      </Button>
+                    )}
+                  </div>
+                </form>
+              ) : selectedNote ? (
+                <div className="space-y-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-lg font-semibold">
+                        {selectedNote.title}
+                      </div>
+                      <div className="mt-1 text-sm text-muted-foreground">
+                        Updated {selectedTimestamp}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button
+                        size="icon"
+                        variant="outline"
+                        onClick={() => openEditEditor(selectedNote)}
+                        disabled={!canEditOtherNotes}
+                        aria-label="Edit note"
+                        title="Edit note"
+                      >
+                        <Edit2 className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => confirmDeleteNote(selectedNote)}
+                        disabled={!canEditOtherNotes}
+                        aria-label="Delete note"
+                        title="Delete note"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-border/60 bg-card/70 p-4">
+                    <JobDescriptionMarkdown
+                      description={getRenderableJobDescription(
+                        selectedNote.content,
+                      )}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="flex min-h-[280px] flex-col items-start justify-between gap-4 rounded-xl border border-dashed border-border/60 bg-background/60 p-5">
+                  <div className="space-y-2">
+                    <div className="text-lg font-semibold">
+                      No note selected
+                    </div>
+                    <div className="max-w-xl text-sm text-muted-foreground">
+                      Notes you add here can hold interview answers, contact
+                      details, and application-specific reminders. Select a note
+                      on the left or create a new one to get started.
+                    </div>
+                  </div>
+                  {!editorState && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={openCreateEditor}
+                    >
+                      <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
+                      Add note
+                    </Button>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <ConfirmDelete
+        isOpen={noteToDelete !== null}
+        onClose={() => setNoteToDelete(null)}
+        onConfirm={() => void handleDeleteNote()}
+        title="Delete note?"
+        description="This will permanently delete this note from the job."
+      />
+    </section>
+  );
+};
 
 export const JobPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -136,6 +590,7 @@ export const JobPage: React.FC = () => {
         queryKey: queryKeys.jobs.stageEvents(id),
       }),
       queryClient.invalidateQueries({ queryKey: queryKeys.jobs.tasks(id) }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.jobs.notes(id) }),
     ]);
   }, [id, queryClient]);
 
@@ -721,6 +1176,8 @@ export const JobPage: React.FC = () => {
           )}
         </div>
       </div>
+
+      {job?.id && <JobNotesCard jobId={job.id} />}
 
       <LogEventModal
         isOpen={isLogModalOpen}

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -237,6 +237,286 @@ describe.sequential("Jobs API routes", () => {
     expect(res.status).toBe(404);
   });
 
+  describe("job notes", () => {
+    it("creates, lists, updates, and deletes notes for a job", async () => {
+      const { createJob } = await import("@server/repositories/jobs");
+      const job = await createJob({
+        source: "manual",
+        title: "Notes Role",
+        employer: "Acme",
+        jobUrl: "https://example.com/job/notes-flow",
+        jobDescription: "Test description",
+      });
+
+      const createRes = await fetch(`${baseUrl}/api/jobs/${job.id}/notes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Why this company",
+          content: "Strong mission, team, and growth opportunities.",
+        }),
+      });
+      const createBody = await createRes.json();
+
+      expect(createRes.status).toBe(201);
+      expect(createBody.ok).toBe(true);
+      expect(createBody.data.title).toBe("Why this company");
+      expect(createBody.data.content).toBe(
+        "Strong mission, team, and growth opportunities.",
+      );
+      expect(createBody.data.jobId).toBe(job.id);
+      expect(createBody.data.createdAt).toBeTruthy();
+      expect(createBody.data.updatedAt).toBeTruthy();
+      expect(typeof createBody.meta.requestId).toBe("string");
+      expect(createRes.headers.get("x-request-id")).toBe(
+        createBody.meta.requestId,
+      );
+
+      const listRes = await fetch(`${baseUrl}/api/jobs/${job.id}/notes`);
+      const listBody = await listRes.json();
+
+      expect(listRes.status).toBe(200);
+      expect(listBody.ok).toBe(true);
+      expect(Array.isArray(listBody.data)).toBe(true);
+      expect(listBody.data).toHaveLength(1);
+      expect(listBody.data[0].id).toBe(createBody.data.id);
+      expect(listBody.data[0].title).toBe("Why this company");
+      expect(typeof listBody.meta.requestId).toBe("string");
+
+      const updateRes = await fetch(
+        `${baseUrl}/api/jobs/${job.id}/notes/${createBody.data.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "Recruiter contact",
+            content: "Jamie Lee at Acme. Follow up next week.",
+          }),
+        },
+      );
+      const updateBody = await updateRes.json();
+
+      expect(updateRes.status).toBe(200);
+      expect(updateBody.ok).toBe(true);
+      expect(updateBody.data.title).toBe("Recruiter contact");
+      expect(updateBody.data.content).toBe(
+        "Jamie Lee at Acme. Follow up next week.",
+      );
+      expect(updateBody.data.updatedAt).toBeTruthy();
+      expect(typeof updateBody.meta.requestId).toBe("string");
+
+      const deleteRes = await fetch(
+        `${baseUrl}/api/jobs/${job.id}/notes/${createBody.data.id}`,
+        {
+          method: "DELETE",
+        },
+      );
+      const deleteBody = await deleteRes.json();
+
+      expect(deleteRes.status).toBe(200);
+      expect(deleteBody.ok).toBe(true);
+      expect(deleteBody.data).toBeNull();
+      expect(typeof deleteBody.meta.requestId).toBe("string");
+
+      const emptyRes = await fetch(`${baseUrl}/api/jobs/${job.id}/notes`);
+      const emptyBody = await emptyRes.json();
+      expect(emptyRes.status).toBe(200);
+      expect(emptyBody.ok).toBe(true);
+      expect(emptyBody.data).toHaveLength(0);
+    });
+
+    it("validates note payloads", async () => {
+      const { createJob } = await import("@server/repositories/jobs");
+      const job = await createJob({
+        source: "manual",
+        title: "Validation Role",
+        employer: "Acme",
+        jobUrl: "https://example.com/job/notes-validation",
+        jobDescription: "Test description",
+      });
+
+      const invalidCreateRes = await fetch(
+        `${baseUrl}/api/jobs/${job.id}/notes`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "   ",
+            content: "x".repeat(20001),
+          }),
+        },
+      );
+      const invalidCreateBody = await invalidCreateRes.json();
+
+      expect(invalidCreateRes.status).toBe(400);
+      expect(invalidCreateBody.ok).toBe(false);
+      expect(invalidCreateBody.error.code).toBe("INVALID_REQUEST");
+      expect(typeof invalidCreateBody.meta.requestId).toBe("string");
+
+      const createRes = await fetch(`${baseUrl}/api/jobs/${job.id}/notes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Interview prep",
+          content: "Focus on systems design and behavioral stories.",
+        }),
+      });
+      const createBody = await createRes.json();
+
+      expect(createRes.status).toBe(201);
+      expect(createBody.ok).toBe(true);
+
+      const invalidUpdateRes = await fetch(
+        `${baseUrl}/api/jobs/${job.id}/notes/${createBody.data.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: " ".repeat(2),
+            content: " ",
+          }),
+        },
+      );
+      const invalidUpdateBody = await invalidUpdateRes.json();
+
+      expect(invalidUpdateRes.status).toBe(400);
+      expect(invalidUpdateBody.ok).toBe(false);
+      expect(invalidUpdateBody.error.code).toBe("INVALID_REQUEST");
+      expect(typeof invalidUpdateBody.meta.requestId).toBe("string");
+    });
+
+    it("returns 404s for missing jobs and notes", async () => {
+      const { createJob } = await import("@server/repositories/jobs");
+      const job = await createJob({
+        source: "manual",
+        title: "Missing Note Role",
+        employer: "Acme",
+        jobUrl: "https://example.com/job/notes-missing",
+        jobDescription: "Test description",
+      });
+
+      const missingJobListRes = await fetch(
+        `${baseUrl}/api/jobs/missing-id/notes`,
+      );
+      const missingJobListBody = await missingJobListRes.json();
+
+      expect(missingJobListRes.status).toBe(404);
+      expect(missingJobListBody.ok).toBe(false);
+      expect(missingJobListBody.error.code).toBe("NOT_FOUND");
+      expect(typeof missingJobListBody.meta.requestId).toBe("string");
+
+      const missingJobCreateRes = await fetch(
+        `${baseUrl}/api/jobs/missing-id/notes`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "Question",
+            content: "Answer",
+          }),
+        },
+      );
+      const missingJobCreateBody = await missingJobCreateRes.json();
+
+      expect(missingJobCreateRes.status).toBe(404);
+      expect(missingJobCreateBody.ok).toBe(false);
+      expect(missingJobCreateBody.error.code).toBe("NOT_FOUND");
+
+      const missingNotePatchRes = await fetch(
+        `${baseUrl}/api/jobs/${job.id}/notes/missing-note-id`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "Updated",
+            content: "Updated answer",
+          }),
+        },
+      );
+      const missingNotePatchBody = await missingNotePatchRes.json();
+
+      expect(missingNotePatchRes.status).toBe(404);
+      expect(missingNotePatchBody.ok).toBe(false);
+      expect(missingNotePatchBody.error.code).toBe("NOT_FOUND");
+
+      const missingNoteDeleteRes = await fetch(
+        `${baseUrl}/api/jobs/${job.id}/notes/missing-note-id`,
+        {
+          method: "DELETE",
+        },
+      );
+      const missingNoteDeleteBody = await missingNoteDeleteRes.json();
+
+      expect(missingNoteDeleteRes.status).toBe(404);
+      expect(missingNoteDeleteBody.ok).toBe(false);
+      expect(missingNoteDeleteBody.error.code).toBe("NOT_FOUND");
+      expect(typeof missingNoteDeleteBody.meta.requestId).toBe("string");
+    });
+
+    it("orders notes by most recently updated first", async () => {
+      const { createJob } = await import("@server/repositories/jobs");
+      const job = await createJob({
+        source: "manual",
+        title: "Ordering Role",
+        employer: "Acme",
+        jobUrl: "https://example.com/job/notes-ordering",
+        jobDescription: "Test description",
+      });
+
+      const firstRes = await fetch(`${baseUrl}/api/jobs/${job.id}/notes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Company research",
+          content: "Read the latest product launch post.",
+        }),
+      });
+      const firstBody = await firstRes.json();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const secondRes = await fetch(`${baseUrl}/api/jobs/${job.id}/notes`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: "Interview contacts",
+          content: "Met with Sara from recruiting.",
+        }),
+      });
+      const secondBody = await secondRes.json();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      const updateRes = await fetch(
+        `${baseUrl}/api/jobs/${job.id}/notes/${firstBody.data.id}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            title: "Company research",
+            content: "Read the latest product launch post and team blog.",
+          }),
+        },
+      );
+      const updateBody = await updateRes.json();
+
+      expect(updateRes.status).toBe(200);
+      expect(updateBody.ok).toBe(true);
+
+      const listRes = await fetch(`${baseUrl}/api/jobs/${job.id}/notes`);
+      const listBody = await listRes.json();
+
+      expect(listRes.status).toBe(200);
+      expect(listBody.ok).toBe(true);
+      expect(listBody.data).toHaveLength(2);
+      expect(listBody.data[0].id).toBe(firstBody.data.id);
+      expect(listBody.data[1].id).toBe(secondBody.data.id);
+      expect(listBody.data[0].updatedAt >= listBody.data[1].updatedAt).toBe(
+        true,
+      );
+    });
+  });
+
   it("uploads a PDF resume for a job and stores it in data/pdfs", async () => {
     const { createJob } = await import("@server/repositories/jobs");
     const job = await createJob({

--- a/orchestrator/src/server/api/routes/jobs.ts
+++ b/orchestrator/src/server/api/routes/jobs.ts
@@ -71,6 +71,11 @@ const tailoredSkillsPayloadSchema = z.array(
   }),
 );
 
+const jobNoteSchema = z.object({
+  title: z.string().trim().min(1).max(120),
+  content: z.string().trim().min(1).max(20000),
+});
+
 async function notifyJobCompleteWebhook(job: Job) {
   const overrideWebhookUrl = await settingsRepo.getSetting(
     "jobCompleteWebhookUrl",
@@ -935,6 +940,240 @@ jobsRouter.get("/:id/events", async (req: Request, res: Response) => {
     ok(res, events);
   } catch (error) {
     fail(res, toAppError(error));
+  }
+});
+
+/**
+ * GET /api/jobs/:id/notes - Get notes for a job
+ */
+jobsRouter.get("/:id/notes", async (req: Request, res: Response) => {
+  const requestId = String(res.getHeader("x-request-id") || "unknown");
+
+  try {
+    const job = await jobsRepo.getJobById(req.params.id);
+    if (!job) {
+      const err = notFound("Job not found");
+      logger.warn("Job notes fetch failed", {
+        route: "GET /api/jobs/:id/notes",
+        jobId: req.params.id,
+        requestId,
+        status: err.status,
+        code: err.code,
+      });
+      return fail(res, err);
+    }
+
+    const notes = await jobsRepo.listJobNotes(job.id);
+
+    logger.info("Job notes fetched", {
+      route: "GET /api/jobs/:id/notes",
+      jobId: job.id,
+      requestId,
+      returnedCount: notes.length,
+    });
+
+    ok(res, notes);
+  } catch (error) {
+    const err = toAppError(error);
+    logger.error("Job notes fetch failed", {
+      route: "GET /api/jobs/:id/notes",
+      jobId: req.params.id,
+      requestId,
+      status: err.status,
+      code: err.code,
+      details: err.details,
+      errorMessage: error instanceof Error ? error.message : undefined,
+    });
+    fail(res, err);
+  }
+});
+
+/**
+ * POST /api/jobs/:id/notes - Create a note for a job
+ */
+jobsRouter.post("/:id/notes", async (req: Request, res: Response) => {
+  const requestId = String(res.getHeader("x-request-id") || "unknown");
+
+  try {
+    const input = jobNoteSchema.safeParse(req.body);
+    if (!input.success) {
+      return fail(
+        res,
+        badRequest("Invalid job note request", input.error.flatten()),
+      );
+    }
+
+    const job = await jobsRepo.getJobById(req.params.id);
+    if (!job) {
+      const err = notFound("Job not found");
+      logger.warn("Job note create failed", {
+        route: "POST /api/jobs/:id/notes",
+        jobId: req.params.id,
+        requestId,
+        status: err.status,
+        code: err.code,
+      });
+      return fail(res, err);
+    }
+
+    const note = await jobsRepo.createJobNote({
+      jobId: job.id,
+      ...input.data,
+    });
+
+    logger.info("Job note created", {
+      route: "POST /api/jobs/:id/notes",
+      jobId: job.id,
+      noteId: note.id,
+      requestId,
+    });
+
+    ok(res, note, 201);
+  } catch (error) {
+    const err = toAppError(error);
+    logger.error("Job note create failed", {
+      route: "POST /api/jobs/:id/notes",
+      jobId: req.params.id,
+      requestId,
+      status: err.status,
+      code: err.code,
+      details: err.details,
+      errorMessage: error instanceof Error ? error.message : undefined,
+    });
+    fail(res, err);
+  }
+});
+
+/**
+ * PATCH /api/jobs/:id/notes/:noteId - Update a job note
+ */
+jobsRouter.patch("/:id/notes/:noteId", async (req: Request, res: Response) => {
+  const requestId = String(res.getHeader("x-request-id") || "unknown");
+
+  try {
+    const input = jobNoteSchema.safeParse(req.body);
+    if (!input.success) {
+      return fail(
+        res,
+        badRequest("Invalid job note request", input.error.flatten()),
+      );
+    }
+
+    const job = await jobsRepo.getJobById(req.params.id);
+    if (!job) {
+      const err = notFound("Job not found");
+      logger.warn("Job note update failed", {
+        route: "PATCH /api/jobs/:id/notes/:noteId",
+        jobId: req.params.id,
+        noteId: req.params.noteId,
+        requestId,
+        status: err.status,
+        code: err.code,
+      });
+      return fail(res, err);
+    }
+
+    const note = await jobsRepo.updateJobNote({
+      jobId: job.id,
+      noteId: req.params.noteId,
+      ...input.data,
+    });
+    if (!note) {
+      const err = notFound("Job note not found");
+      logger.warn("Job note update failed", {
+        route: "PATCH /api/jobs/:id/notes/:noteId",
+        jobId: job.id,
+        noteId: req.params.noteId,
+        requestId,
+        status: err.status,
+        code: err.code,
+      });
+      return fail(res, err);
+    }
+
+    logger.info("Job note updated", {
+      route: "PATCH /api/jobs/:id/notes/:noteId",
+      jobId: job.id,
+      noteId: note.id,
+      requestId,
+    });
+
+    ok(res, note);
+  } catch (error) {
+    const err = toAppError(error);
+    logger.error("Job note update failed", {
+      route: "PATCH /api/jobs/:id/notes/:noteId",
+      jobId: req.params.id,
+      noteId: req.params.noteId,
+      requestId,
+      status: err.status,
+      code: err.code,
+      details: err.details,
+      errorMessage: error instanceof Error ? error.message : undefined,
+    });
+    fail(res, err);
+  }
+});
+
+/**
+ * DELETE /api/jobs/:id/notes/:noteId - Delete a job note
+ */
+jobsRouter.delete("/:id/notes/:noteId", async (req: Request, res: Response) => {
+  const requestId = String(res.getHeader("x-request-id") || "unknown");
+
+  try {
+    const job = await jobsRepo.getJobById(req.params.id);
+    if (!job) {
+      const err = notFound("Job not found");
+      logger.warn("Job note delete failed", {
+        route: "DELETE /api/jobs/:id/notes/:noteId",
+        jobId: req.params.id,
+        noteId: req.params.noteId,
+        requestId,
+        status: err.status,
+        code: err.code,
+      });
+      return fail(res, err);
+    }
+
+    const deletedCount = await jobsRepo.deleteJobNote({
+      jobId: job.id,
+      noteId: req.params.noteId,
+    });
+    if (deletedCount === 0) {
+      const err = notFound("Job note not found");
+      logger.warn("Job note delete failed", {
+        route: "DELETE /api/jobs/:id/notes/:noteId",
+        jobId: job.id,
+        noteId: req.params.noteId,
+        requestId,
+        status: err.status,
+        code: err.code,
+      });
+      return fail(res, err);
+    }
+
+    logger.info("Job note deleted", {
+      route: "DELETE /api/jobs/:id/notes/:noteId",
+      jobId: job.id,
+      noteId: req.params.noteId,
+      requestId,
+    });
+
+    ok(res, null);
+  } catch (error) {
+    const err = toAppError(error);
+    logger.error("Job note delete failed", {
+      route: "DELETE /api/jobs/:id/notes/:noteId",
+      jobId: req.params.id,
+      noteId: req.params.noteId,
+      requestId,
+      status: err.status,
+      code: err.code,
+      details: err.details,
+      errorMessage: error instanceof Error ? error.message : undefined,
+    });
+    fail(res, err);
   }
 });
 

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -212,6 +212,19 @@ const migrations = [
     FOREIGN KEY (application_id) REFERENCES jobs(id) ON DELETE CASCADE
   )`,
 
+  `CREATE TABLE IF NOT EXISTS job_notes (
+    id TEXT PRIMARY KEY,
+    job_id TEXT NOT NULL,
+    title TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+  )`,
+
+  `CREATE INDEX IF NOT EXISTS idx_job_notes_job_updated
+    ON job_notes(job_id, updated_at)`,
+
   `CREATE TABLE IF NOT EXISTS interviews (
     id TEXT PRIMARY KEY,
     application_id TEXT NOT NULL,

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -141,6 +141,26 @@ export const tasks = sqliteTable("tasks", {
   notes: text("notes"),
 });
 
+export const jobNotes = sqliteTable(
+  "job_notes",
+  {
+    id: text("id").primaryKey(),
+    jobId: text("job_id")
+      .notNull()
+      .references(() => jobs.id, { onDelete: "cascade" }),
+    title: text("title").notNull(),
+    content: text("content").notNull(),
+    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => ({
+    jobUpdatedIndex: index("idx_job_notes_job_updated").on(
+      table.jobId,
+      table.updatedAt,
+    ),
+  }),
+);
+
 export const interviews = sqliteTable("interviews", {
   id: text("id").primaryKey(),
   applicationId: text("application_id")
@@ -497,6 +517,8 @@ export type StageEventRow = typeof stageEvents.$inferSelect;
 export type NewStageEventRow = typeof stageEvents.$inferInsert;
 export type TaskRow = typeof tasks.$inferSelect;
 export type NewTaskRow = typeof tasks.$inferInsert;
+export type JobNoteRow = typeof jobNotes.$inferSelect;
+export type NewJobNoteRow = typeof jobNotes.$inferInsert;
 export type InterviewRow = typeof interviews.$inferSelect;
 export type NewInterviewRow = typeof interviews.$inferInsert;
 export type PipelineRunRow = typeof pipelineRuns.$inferSelect;

--- a/orchestrator/src/server/repositories/jobs.notes.test.ts
+++ b/orchestrator/src/server/repositories/jobs.notes.test.ts
@@ -1,0 +1,96 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe.sequential("jobs repository job notes", () => {
+  let tempDir: string;
+  let db: Awaited<typeof import("../db/index")>["db"];
+  let schema: Awaited<typeof import("../db/index")>["schema"];
+  let jobsRepo: Awaited<typeof import("./jobs")>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-job-notes-repo-"));
+    process.env.DATA_DIR = tempDir;
+    process.env.NODE_ENV = "test";
+
+    await import("../db/migrate");
+    ({ db, schema } = await import("../db/index"));
+    jobsRepo = await import("./jobs");
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import("../db/index");
+    closeDb();
+    await rm(tempDir, { recursive: true, force: true });
+    vi.clearAllMocks();
+  });
+
+  it("persists notes and orders them by updatedAt desc", async () => {
+    const job = await jobsRepo.createJob({
+      source: "manual",
+      title: "Backend Engineer",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/repo-notes",
+    });
+
+    const first = await jobsRepo.createJobNote({
+      jobId: job.id,
+      title: "Why this company",
+      content: "Mission and product fit.",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const second = await jobsRepo.createJobNote({
+      jobId: job.id,
+      title: "Interview contacts",
+      content: "Recruiter: Jamie Lee",
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const updatedFirst = await jobsRepo.updateJobNote({
+      jobId: job.id,
+      noteId: first.id,
+      title: "Why this company",
+      content: "Mission, product fit, and growth opportunity.",
+    });
+
+    expect(updatedFirst).not.toBeNull();
+    expect(updatedFirst?.updatedAt).not.toBe(first.updatedAt);
+
+    const notes = await jobsRepo.listJobNotes(job.id);
+
+    expect(notes.map((note) => note.id)).toEqual([first.id, second.id]);
+    expect(notes[0]?.content).toContain("growth opportunity");
+  });
+
+  it("cascades note deletion when the parent job is removed", async () => {
+    const job = await jobsRepo.createJob({
+      source: "manual",
+      title: "Platform Engineer",
+      employer: "Beta",
+      jobUrl: "https://example.com/job/repo-cascade",
+    });
+
+    await jobsRepo.createJobNote({
+      jobId: job.id,
+      title: "Recruiter contact",
+      content: "alex@example.com",
+    });
+
+    const notesBeforeDelete = await jobsRepo.listJobNotes(job.id);
+    expect(notesBeforeDelete).toHaveLength(1);
+
+    await db.delete(schema.jobs).where(eq(schema.jobs.id, job.id)).run();
+
+    const notesAfterDelete = await jobsRepo.listJobNotes(job.id);
+    expect(notesAfterDelete).toHaveLength(0);
+
+    const remainingRows = await db.select().from(schema.jobNotes);
+    expect(remainingRows).toHaveLength(0);
+  });
+});

--- a/orchestrator/src/server/repositories/jobs.ts
+++ b/orchestrator/src/server/repositories/jobs.ts
@@ -5,16 +5,19 @@
 import { randomUUID } from "node:crypto";
 import type {
   CreateJobInput,
+  CreateJobNoteInput,
   Job,
   JobListItem,
+  JobNote,
   JobStatus,
   JobsRevisionResponse,
   UpdateJobInput,
+  UpdateJobNoteInput,
 } from "@shared/types";
 import { and, desc, eq, inArray, isNull, lt, ne, sql } from "drizzle-orm";
 import { db, schema } from "../db/index";
 
-const { jobs } = schema;
+const { jobNotes, jobs } = schema;
 
 type AppliedDuplicateMatchCandidate = {
   id: string;
@@ -169,6 +172,86 @@ export async function getJobsRevision(
 export async function getJobById(id: string): Promise<Job | null> {
   const [row] = await db.select().from(jobs).where(eq(jobs.id, id));
   return row ? mapRowToJob(row) : null;
+}
+
+export async function listJobNotes(jobId: string): Promise<JobNote[]> {
+  const rows = await db
+    .select()
+    .from(jobNotes)
+    .where(eq(jobNotes.jobId, jobId))
+    .orderBy(
+      desc(jobNotes.updatedAt),
+      desc(jobNotes.createdAt),
+      desc(jobNotes.id),
+    );
+
+  return rows.map(mapRowToJobNote);
+}
+
+export async function getJobNoteById(noteId: string): Promise<JobNote | null> {
+  const [row] = await db.select().from(jobNotes).where(eq(jobNotes.id, noteId));
+  return row ? mapRowToJobNote(row) : null;
+}
+
+export async function getJobNoteForJob(
+  jobId: string,
+  noteId: string,
+): Promise<JobNote | null> {
+  const [row] = await db
+    .select()
+    .from(jobNotes)
+    .where(and(eq(jobNotes.id, noteId), eq(jobNotes.jobId, jobId)));
+  return row ? mapRowToJobNote(row) : null;
+}
+
+export async function createJobNote(
+  input: CreateJobNoteInput & { jobId: string },
+): Promise<JobNote> {
+  const id = randomUUID();
+  const now = new Date().toISOString();
+
+  await db.insert(jobNotes).values({
+    id,
+    jobId: input.jobId,
+    title: input.title,
+    content: input.content,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const note = await getJobNoteById(id);
+  if (!note) {
+    throw new Error(`Failed to retrieve newly created job note with ID ${id}`);
+  }
+  return note;
+}
+
+export async function updateJobNote(
+  input: { jobId: string; noteId: string } & UpdateJobNoteInput,
+): Promise<JobNote | null> {
+  const now = new Date().toISOString();
+
+  await db
+    .update(jobNotes)
+    .set({
+      title: input.title,
+      content: input.content,
+      updatedAt: now,
+    })
+    .where(and(eq(jobNotes.id, input.noteId), eq(jobNotes.jobId, input.jobId)));
+
+  return getJobNoteForJob(input.jobId, input.noteId);
+}
+
+export async function deleteJobNote(input: {
+  jobId: string;
+  noteId: string;
+}): Promise<number> {
+  const result = await db
+    .delete(jobNotes)
+    .where(and(eq(jobNotes.id, input.noteId), eq(jobNotes.jobId, input.jobId)));
+
+  return result.changes;
 }
 
 export async function listJobSummariesByIds(jobIds: string[]): Promise<
@@ -541,6 +624,17 @@ function mapRowToJob(row: typeof jobs.$inferSelect): Job {
     processedAt: row.processedAt,
     readyAt: row.readyAt,
     appliedAt: row.appliedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function mapRowToJobNote(row: typeof jobNotes.$inferSelect): JobNote {
+  return {
+    id: row.id,
+    jobId: row.jobId,
+    title: row.title,
+    content: row.content,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/shared/src/types/jobs.ts
+++ b/shared/src/types/jobs.ts
@@ -117,6 +117,15 @@ export interface Interview {
   outcome: InterviewOutcome | null;
 }
 
+export interface JobNote {
+  id: string;
+  jobId: string;
+  title: string;
+  content: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export type JobSource = ExtractorSourceId;
 
 export interface AppliedDuplicateMatch {
@@ -328,4 +337,14 @@ export interface UpdateJobInput {
   appliedAt?: string;
   sponsorMatchScore?: number;
   sponsorMatchNames?: string;
+}
+
+export interface CreateJobNoteInput {
+  title: string;
+  content: string;
+}
+
+export interface UpdateJobNoteInput {
+  title: string;
+  content: string;
 }


### PR DESCRIPTION

<img width="2032" height="1161" alt="image" src="https://github.com/user-attachments/assets/eb130841-b041-4d6b-bfcd-784d0e27fdf3" />


## Summary
- add job-level `job_notes` support across shared types, schema, migrations, repository helpers, and job note API routes
- add client note queries and mutations, plus a markdown-to-TipTap bridge for editing while keeping markdown as the stored format
- update the job page to show a full-width notes section with a note list, markdown preview, inline TipTap editing, and icon-only note actions
- document the new notes workflow in the orchestrator feature docs

## Testing
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`