### PR TITLE
Refactor backend Umami analytics to use @umami/node

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -49,6 +49,7 @@
     "@tiptap/extension-link": "^3.22.2",
     "@tiptap/react": "^3.22.2",
     "@tiptap/starter-kit": "^3.22.2",
+    "@umami/node": "^0.4.0",
     "better-sqlite3": "^11.6.0",
     "canvas-confetti": "^1.9.4",
     "class-variance-authority": "^0.7.1",

--- a/orchestrator/src/server/infra/product-analytics.test.ts
+++ b/orchestrator/src/server/infra/product-analytics.test.ts
@@ -1,4 +1,20 @@
+import umami from "@umami/node";
+
+import { logger } from "./logger";
 import { trackServerProductEvent } from "./product-analytics";
+
+vi.mock("@umami/node", () => ({
+  default: {
+    init: vi.fn(),
+    track: vi.fn(),
+  },
+}));
+
+vi.mock("./logger", () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}));
 
 describe("server product analytics", () => {
   const originalNodeEnv = process.env.NODE_ENV;
@@ -7,9 +23,9 @@ describe("server product analytics", () => {
   beforeEach(() => {
     process.env.NODE_ENV = "development";
     process.env.JOBOPS_PUBLIC_BASE_URL = "https://jobops.example";
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockResolvedValue(new Response(null, { status: 202 })),
+    vi.clearAllMocks();
+    vi.mocked(umami.track).mockResolvedValue(
+      new Response(null, { status: 202 }),
     );
   });
 
@@ -20,7 +36,6 @@ describe("server product analytics", () => {
     } else {
       process.env.JOBOPS_PUBLIC_BASE_URL = originalBaseUrl;
     }
-    vi.unstubAllGlobals();
   });
 
   it("sends Umami-compatible event payloads with sanitized data", async () => {
@@ -38,40 +53,21 @@ describe("server product analytics", () => {
       },
     );
 
-    expect(fetch).toHaveBeenCalledTimes(1);
-    const [url, init] = vi.mocked(fetch).mock.calls[0] ?? [];
-
-    expect(url).toBe("https://umami.dakheera47.com/api/send");
-    expect(init?.method).toBe("POST");
-    expect(init?.headers).toEqual({
-      "content-type": "application/json",
-      "user-agent": "job-ops-server-analytics/1.0",
+    expect(umami.init).toHaveBeenCalledWith({
+      websiteId: "0dc42ed1-87c3-4ac0-9409-5a9b9588fe66",
+      hostUrl: "https://umami.dakheera47.com",
+      userAgent: "job-ops-server-analytics/1.0",
     });
-
-    const payload = JSON.parse(String(init?.body)) as {
-      type: string;
-      payload: {
-        website: string;
-        hostname: string;
-        url: string;
-        name: string;
-        data?: Record<string, unknown>;
-      };
-    };
-
-    expect(payload).toEqual({
-      type: "event",
-      payload: {
-        website: "0dc42ed1-87c3-4ac0-9409-5a9b9588fe66",
-        hostname: "jobops.example",
-        url: "/applications/in-progress",
-        name: "application_offer_detected",
-        data: {
-          source: "tracking_inbox_auto",
-          stage: "offer",
-        },
+    expect(umami.track).toHaveBeenCalledWith({
+      hostname: "jobops.example",
+      url: "/applications/in-progress",
+      name: "application_offer_detected",
+      data: {
+        source: "tracking_inbox_auto",
+        stage: "offer",
       },
     });
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 
   it("does not emit analytics during test runs", async () => {
@@ -81,6 +77,34 @@ describe("server product analytics", () => {
       origin: "move_to_ready",
     });
 
-    expect(fetch).not.toHaveBeenCalled();
+    expect(umami.init).not.toHaveBeenCalled();
+    expect(umami.track).not.toHaveBeenCalled();
+  });
+
+  it("logs a warning when Umami returns a non-ok response", async () => {
+    vi.mocked(umami.track).mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+
+    await trackServerProductEvent(
+      "resume_generated",
+      {
+        origin: "move_to_ready",
+      },
+      {
+        requestOrigin: "https://app.jobops.example",
+        urlPath: "/jobs",
+      },
+    );
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Server product analytics request failed",
+      {
+        event: "resume_generated",
+        status: 500,
+        requestOrigin: "https://app.jobops.example",
+        urlPath: "/jobs",
+      },
+    );
   });
 });

--- a/orchestrator/src/server/infra/product-analytics.ts
+++ b/orchestrator/src/server/infra/product-analytics.ts
@@ -1,9 +1,10 @@
+import umami from "@umami/node";
+
 import { logger } from "./logger";
 import { sanitizeUnknown } from "./sanitize";
 
-const UMAMI_EVENT_ENDPOINT = "https://umami.dakheera47.com/api/send";
+const UMAMI_HOST_URL = "https://umami.dakheera47.com";
 const UMAMI_WEBSITE_ID = "0dc42ed1-87c3-4ac0-9409-5a9b9588fe66";
-const ANALYTICS_TIMEOUT_MS = 5_000;
 const UMAMI_USER_AGENT = "job-ops-server-analytics/1.0";
 const DISALLOWED_KEY_PARTS = [
   "query",
@@ -98,23 +99,16 @@ export async function trackServerProductEvent(
   });
 
   try {
-    const response = await fetch(UMAMI_EVENT_ENDPOINT, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        "user-agent": UMAMI_USER_AGENT,
-      },
-      body: JSON.stringify({
-        type: "event",
-        payload: {
-          website: UMAMI_WEBSITE_ID,
-          hostname: page.hostname,
-          url: page.url,
-          name: event,
-          ...(sanitized ? { data: sanitized } : {}),
-        },
-      }),
-      signal: AbortSignal.timeout(ANALYTICS_TIMEOUT_MS),
+    umami.init({
+      websiteId: UMAMI_WEBSITE_ID,
+      hostUrl: UMAMI_HOST_URL,
+      userAgent: UMAMI_USER_AGENT,
+    });
+    const response = await umami.track({
+      hostname: page.hostname,
+      url: page.url,
+      name: event,
+      ...(sanitized ? { data: sanitized } : {}),
     });
 
     if (!response.ok) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9952,6 +9952,12 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
+    "node_modules/@umami/node": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@umami/node/-/node-0.4.0.tgz",
+      "integrity": "sha512-pyphprbiF7KiDSc+SWZ4/rVM8B5vU27zIiFfEPj2lEqczpI4xAKSp+dM3tlzyRAWJL32fcbCfAaLGhJZQV13Rg==",
+      "license": "MIT"
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -26164,6 +26170,7 @@
         "@tiptap/extension-link": "^3.22.2",
         "@tiptap/react": "^3.22.2",
         "@tiptap/starter-kit": "^3.22.2",
+        "@umami/node": "^0.4.0",
         "better-sqlite3": "^11.6.0",
         "canvas-confetti": "^1.9.4",
         "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- add `@umami/node` to the orchestrator workspace dependencies
- replace the custom server-side Umami `fetch` request in `product-analytics.ts` with the official Node client
- update analytics tests to mock `@umami/node`, assert client initialization and tracked payloads, and cover non-OK warning logging

## Testing
- `npm --workspace orchestrator run test:run -- src/server/infra/product-analytics.test.ts`
- Full CI-parity checks were attempted, but broader workspace issues unrelated to this change were already failing