### PR TITLE
Remove eager duplicate matching from jobs list responses

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -17,6 +17,7 @@
     "format:fix": "biome format --write",
     "build:client": "vite build",
     "start": "tsx src/server/index.ts",
+    "benchmark:jobs": "tsx scripts/benchmark-jobs.ts",
     "db:migrate": "tsx src/server/db/migrate.ts",
     "db:migrate:prod": "tsx src/server/db/migrate.ts",
     "db:clear": "tsx src/server/db/clear.ts",

--- a/orchestrator/scripts/benchmark-jobs.ts
+++ b/orchestrator/scripts/benchmark-jobs.ts
@@ -1,0 +1,456 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join, resolve } from "node:path";
+import { format } from "node:util";
+import Database from "better-sqlite3";
+
+type Scenario = {
+  label: string;
+  path: string;
+};
+
+type RouteBenchmarkMeta = {
+  route: string;
+  view: "list" | "full";
+  statusFilter: string | null;
+  returnedCount: number;
+  duplicateMatchingEnabled: boolean;
+  candidateCount: number;
+  totalMs: number;
+  queryParseMs: number;
+  primaryQueryMs: number;
+  duplicateCandidatesQueryMs: number;
+  duplicateMatchCpuMs: number;
+  statsAggregateMs: number;
+  revisionAggregateMs: number;
+  internalRouteMs: number;
+};
+
+type ParsedLogLine = {
+  msg?: string;
+  requestId?: string;
+  meta?: Record<string, unknown>;
+};
+
+type RequestMetrics = RouteBenchmarkMeta & {
+  requestId: string;
+  scenario: string;
+  httpDurationMs: number;
+  serializeAndWriteMs: number;
+};
+
+type MetricSummary = {
+  mean: number;
+  p50: number;
+  p95: number;
+};
+
+type ScenarioSummary = {
+  scenario: string;
+  requests: number;
+  totals: MetricSummary;
+  internalRoute: MetricSummary;
+  queryParse: MetricSummary;
+  primaryQuery: MetricSummary;
+  duplicateCandidates: MetricSummary;
+  duplicateMatchCpu: MetricSummary;
+  stats: MetricSummary;
+  revision: MetricSummary;
+  serializeAndWrite: MetricSummary;
+  slowestPhase: string;
+  phasePercentOfTotal: Record<string, number>;
+};
+
+const WARMUP_REQUESTS = Number.parseInt(
+  process.env.JOBS_BENCH_WARMUP_REQUESTS ?? "3",
+  10,
+);
+const MEASURED_REQUESTS = Number.parseInt(
+  process.env.JOBS_BENCH_REQUESTS ?? "10",
+  10,
+);
+const scenarios: Scenario[] = [
+  { label: "list", path: "/api/jobs?view=list" },
+  { label: "full", path: "/api/jobs?view=full" },
+  {
+    label: "list_status_applied_in_progress",
+    path: "/api/jobs?view=list&status=applied,in_progress",
+  },
+];
+
+function resolveSourceDataDir(cwd: string): string {
+  const fromEnv = (process.env.DATA_DIR || "").trim();
+  if (fromEnv) return resolve(fromEnv);
+
+  const cwdBase = basename(cwd);
+  const parentDir = resolve(cwd, "..");
+  const candidates =
+    cwdBase === "orchestrator"
+      ? [join(parentDir, "data"), join(cwd, "data")]
+      : [join(cwd, "data"), join(parentDir, "data")];
+
+  return resolve(candidates[0]);
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((p / 100) * sorted.length) - 1),
+  );
+  return sorted[index] ?? 0;
+}
+
+function summarize(values: number[]): MetricSummary {
+  if (values.length === 0) {
+    return { mean: 0, p50: 0, p95: 0 };
+  }
+
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return {
+    mean: total / values.length,
+    p50: percentile(values, 50),
+    p95: percentile(values, 95),
+  };
+}
+
+function formatMs(value: number): string {
+  return `${value.toFixed(2)}ms`;
+}
+
+function toJsonLine(args: unknown[]): string {
+  return format(...args);
+}
+
+function parseLogLines(lines: string[]): ParsedLogLine[] {
+  return lines.flatMap((line) => {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return [];
+
+    try {
+      return [JSON.parse(trimmed) as ParsedLogLine];
+    } catch {
+      return [];
+    }
+  });
+}
+
+async function createDbSnapshot(
+  sourceDbPath: string,
+  destinationDbPath: string,
+) {
+  const sourceDb = new Database(sourceDbPath, {
+    fileMustExist: true,
+    readonly: true,
+  });
+
+  try {
+    await sourceDb.backup(destinationDbPath);
+  } finally {
+    sourceDb.close();
+  }
+}
+
+function installConsoleCapture() {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  const originalWarn = console.warn;
+  const originalError = console.error;
+
+  console.log = (...args: unknown[]) => {
+    lines.push(toJsonLine(args));
+  };
+  console.warn = (...args: unknown[]) => {
+    lines.push(toJsonLine(args));
+  };
+  console.error = (...args: unknown[]) => {
+    lines.push(toJsonLine(args));
+  };
+
+  return {
+    lines,
+    restore() {
+      console.log = originalLog;
+      console.warn = originalWarn;
+      console.error = originalError;
+    },
+  };
+}
+
+function findRequestMetrics(
+  parsedLogs: ParsedLogLine[],
+  requestIdToScenario: Map<string, string>,
+): RequestMetrics[] {
+  const routeLogs = new Map<string, RouteBenchmarkMeta>();
+  const httpLogs = new Map<string, number>();
+
+  for (const line of parsedLogs) {
+    if (!line.requestId) continue;
+
+    if (line.msg === "Jobs list benchmark" && line.meta) {
+      routeLogs.set(line.requestId, line.meta as unknown as RouteBenchmarkMeta);
+    }
+
+    if (line.msg === "HTTP request completed" && line.meta) {
+      const durationMs = Number(line.meta.durationMs ?? 0);
+      if (Number.isFinite(durationMs)) {
+        httpLogs.set(line.requestId, durationMs);
+      }
+    }
+  }
+
+  return Array.from(requestIdToScenario.entries()).map(
+    ([requestId, scenario]) => {
+      const routeMeta = routeLogs.get(requestId);
+      const httpDurationMs = httpLogs.get(requestId);
+
+      if (!routeMeta) {
+        throw new Error(`Missing benchmark log for request ${requestId}`);
+      }
+
+      if (httpDurationMs === undefined) {
+        throw new Error(`Missing HTTP duration log for request ${requestId}`);
+      }
+
+      return {
+        ...routeMeta,
+        requestId,
+        scenario,
+        httpDurationMs,
+        serializeAndWriteMs: Math.max(
+          0,
+          httpDurationMs - routeMeta.internalRouteMs,
+        ),
+      };
+    },
+  );
+}
+
+function summarizeScenario(metrics: RequestMetrics[]): ScenarioSummary {
+  const phaseMeans = {
+    queryParse: summarize(metrics.map((entry) => entry.queryParseMs)).mean,
+    primaryQuery: summarize(metrics.map((entry) => entry.primaryQueryMs)).mean,
+    duplicateCandidates: summarize(
+      metrics.map((entry) => entry.duplicateCandidatesQueryMs),
+    ).mean,
+    duplicateMatchCpu: summarize(
+      metrics.map((entry) => entry.duplicateMatchCpuMs),
+    ).mean,
+    stats: summarize(metrics.map((entry) => entry.statsAggregateMs)).mean,
+    revision: summarize(metrics.map((entry) => entry.revisionAggregateMs)).mean,
+    serializeAndWrite: summarize(
+      metrics.map((entry) => entry.serializeAndWriteMs),
+    ).mean,
+  };
+  const slowestPhase =
+    Object.entries(phaseMeans).sort(
+      (left, right) => right[1] - left[1],
+    )[0]?.[0] ?? "unknown";
+  const totalMean = summarize(
+    metrics.map((entry) => entry.httpDurationMs),
+  ).mean;
+
+  return {
+    scenario: metrics[0]?.scenario ?? "unknown",
+    requests: metrics.length,
+    totals: summarize(metrics.map((entry) => entry.httpDurationMs)),
+    internalRoute: summarize(metrics.map((entry) => entry.internalRouteMs)),
+    queryParse: summarize(metrics.map((entry) => entry.queryParseMs)),
+    primaryQuery: summarize(metrics.map((entry) => entry.primaryQueryMs)),
+    duplicateCandidates: summarize(
+      metrics.map((entry) => entry.duplicateCandidatesQueryMs),
+    ),
+    duplicateMatchCpu: summarize(
+      metrics.map((entry) => entry.duplicateMatchCpuMs),
+    ),
+    stats: summarize(metrics.map((entry) => entry.statsAggregateMs)),
+    revision: summarize(metrics.map((entry) => entry.revisionAggregateMs)),
+    serializeAndWrite: summarize(
+      metrics.map((entry) => entry.serializeAndWriteMs),
+    ),
+    slowestPhase,
+    phasePercentOfTotal: Object.fromEntries(
+      Object.entries(phaseMeans).map(([phase, mean]) => [
+        phase,
+        totalMean > 0 ? Number(((mean / totalMean) * 100).toFixed(2)) : 0,
+      ]),
+    ),
+  };
+}
+
+function renderTable(summaries: ScenarioSummary[]): string {
+  const rows = summaries.map((summary) => ({
+    scenario: summary.scenario,
+    requests: String(summary.requests),
+    "total mean": formatMs(summary.totals.mean),
+    "total p95": formatMs(summary.totals.p95),
+    "primary query": formatMs(summary.primaryQuery.mean),
+    "dup candidates": formatMs(summary.duplicateCandidates.mean),
+    "dup match cpu": formatMs(summary.duplicateMatchCpu.mean),
+    stats: formatMs(summary.stats.mean),
+    revision: formatMs(summary.revision.mean),
+    "serialize/write": formatMs(summary.serializeAndWrite.mean),
+    "slowest phase": summary.slowestPhase,
+  }));
+  const headers = Object.keys(
+    rows[0] ?? {
+      scenario: "",
+      requests: "",
+      "total mean": "",
+      "total p95": "",
+      "primary query": "",
+      "dup candidates": "",
+      "dup match cpu": "",
+      stats: "",
+      revision: "",
+      "serialize/write": "",
+      "slowest phase": "",
+    },
+  );
+  const widths = headers.map((header) =>
+    Math.max(
+      header.length,
+      ...rows.map((row) => row[header as keyof typeof row].length),
+    ),
+  );
+  const formatRow = (values: string[]) =>
+    values
+      .map((value, index) => value.padEnd(widths[index] ?? value.length))
+      .join("  ");
+  const divider = widths.map((width) => "-".repeat(width)).join("  ");
+
+  return [
+    formatRow(headers),
+    divider,
+    ...rows.map((row) =>
+      formatRow(headers.map((header) => row[header as keyof typeof row])),
+    ),
+  ].join("\n");
+}
+
+async function main() {
+  const cwd = process.cwd();
+  const liveDataDir = resolveSourceDataDir(cwd);
+  const liveDbPath = join(liveDataDir, "jobs.db");
+  const tempDataDir = await mkdtemp(join(tmpdir(), "job-ops-bench-"));
+  const tempDbPath = join(tempDataDir, "jobs.db");
+
+  let restoreConsole: (() => void) | null = null;
+  let closeDb: (() => void) | null = null;
+  let server: import("node:http").Server | null = null;
+
+  try {
+    await createDbSnapshot(liveDbPath, tempDbPath);
+
+    process.env.DATA_DIR = tempDataDir;
+    process.env.BENCHMARK_JOBS_TIMING = "1";
+
+    await import("@server/db/migrate");
+    const { applyStoredEnvOverrides } = await import(
+      "@server/services/envSettings"
+    );
+    await applyStoredEnvOverrides();
+    const { createApp } = await import("@server/app");
+    ({ closeDb } = await import("@server/db/index"));
+
+    const app = createApp();
+    server = await new Promise<import("node:http").Server>((resolveServer) => {
+      const nextServer = app.listen(0, () => resolveServer(nextServer));
+    });
+
+    const capture = installConsoleCapture();
+    restoreConsole = capture.restore;
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Failed to resolve benchmark server port");
+    }
+
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+    const requestIdToScenario = new Map<string, string>();
+
+    for (const scenario of scenarios) {
+      for (let index = 0; index < WARMUP_REQUESTS; index += 1) {
+        const requestId = `jobs-bench-warmup-${scenario.label}-${index}`;
+        const response = await fetch(`${baseUrl}${scenario.path}`, {
+          headers: { "x-request-id": requestId },
+        });
+        if (!response.ok) {
+          throw new Error(
+            `Warmup request failed for ${scenario.label}: ${response.status}`,
+          );
+        }
+        await response.text();
+      }
+
+      for (let index = 0; index < MEASURED_REQUESTS; index += 1) {
+        const requestId = `jobs-bench-${scenario.label}-${index}`;
+        requestIdToScenario.set(requestId, scenario.label);
+        const response = await fetch(`${baseUrl}${scenario.path}`, {
+          headers: { "x-request-id": requestId },
+        });
+        if (!response.ok) {
+          throw new Error(
+            `Benchmark request failed for ${scenario.label}: ${response.status}`,
+          );
+        }
+        await response.text();
+      }
+    }
+
+    await new Promise((resolveTick) => setTimeout(resolveTick, 0));
+
+    restoreConsole();
+    restoreConsole = null;
+
+    const parsedLogs = parseLogLines(capture.lines);
+    const metrics = findRequestMetrics(parsedLogs, requestIdToScenario);
+    const summaries = Array.from(
+      metrics.reduce((map, metric) => {
+        const bucket = map.get(metric.scenario) ?? [];
+        bucket.push(metric);
+        map.set(metric.scenario, bucket);
+        return map;
+      }, new Map<string, RequestMetrics[]>()),
+    )
+      .map(([, scenarioMetrics]) => summarizeScenario(scenarioMetrics))
+      .sort((left, right) => left.scenario.localeCompare(right.scenario));
+
+    console.log(`Source DB: ${liveDbPath}`);
+    console.log(`Snapshot DB: ${tempDbPath}`);
+    console.log(
+      `Warmup requests: ${WARMUP_REQUESTS}, measured requests: ${MEASURED_REQUESTS}`,
+    );
+    console.log("");
+    console.log(renderTable(summaries));
+    console.log("");
+    console.log(
+      JSON.stringify(
+        {
+          sourceDbPath: liveDbPath,
+          snapshotDbPath: tempDbPath,
+          warmupRequests: WARMUP_REQUESTS,
+          measuredRequests: MEASURED_REQUESTS,
+          summaries,
+        },
+        null,
+        2,
+      ),
+    );
+  } finally {
+    if (restoreConsole) restoreConsole();
+
+    if (server) {
+      await new Promise<void>((resolveClose) =>
+        server?.close(() => resolveClose()),
+      );
+    }
+    closeDb?.();
+    await rm(tempDataDir, { recursive: true, force: true });
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -159,7 +159,7 @@ const SponsorPill: React.FC<SponsorPillProps> = ({ score, names, onCheck }) => {
 };
 
 const AppliedDuplicatePill: React.FC<{
-  match: AppliedDuplicateMatch | null;
+  match: AppliedDuplicateMatch | null | undefined;
 }> = ({ match }) => {
   if (!match) {
     return null;

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -59,6 +59,7 @@ describe.sequential("Jobs API routes", () => {
     expect(listBody.data.jobs[0].id).toBeTruthy();
     expect(listBody.data.jobs[0].title).toBe("List View Role");
     expect(listBody.data.jobs[0]).not.toHaveProperty("jobDescription");
+    expect(listBody.data.jobs[0]).not.toHaveProperty("appliedDuplicateMatch");
     expect(typeof listBody.data.revision).toBe("string");
 
     const fullRes = await fetch(`${baseUrl}/api/jobs?view=full`);
@@ -67,6 +68,7 @@ describe.sequential("Jobs API routes", () => {
     expect(fullBody.ok).toBe(true);
     expect(fullBody.data.jobs[0].title).toBe("List View Role");
     expect(fullBody.data.jobs[0]).toHaveProperty("jobDescription");
+    expect(fullBody.data.jobs[0]).not.toHaveProperty("appliedDuplicateMatch");
     expect(typeof fullBody.data.revision).toBe("string");
 
     const defaultRes = await fetch(`${baseUrl}/api/jobs`);
@@ -74,10 +76,98 @@ describe.sequential("Jobs API routes", () => {
     expect(defaultRes.status).toBe(200);
     expect(defaultBody.ok).toBe(true);
     expect(defaultBody.data.jobs[0]).not.toHaveProperty("jobDescription");
+    expect(defaultBody.data.jobs[0]).not.toHaveProperty("appliedDuplicateMatch");
     expect(typeof defaultBody.data.revision).toBe("string");
   });
 
-  it("adds applied duplicate match metadata to list and detail responses", async () => {
+  it("keeps the jobs list response contract unchanged in benchmark mode", async () => {
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: { BENCHMARK_JOBS_TIMING: "1" },
+    }));
+
+    const { createJob } = await import("@server/repositories/jobs");
+    await createJob({
+      source: "manual",
+      title: "Bench Mode Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/bench-mode",
+      jobDescription: "Bench mode description",
+    });
+
+    const res = await fetch(`${baseUrl}/api/jobs?view=list`);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data).toHaveProperty("jobs");
+    expect(body.data).toHaveProperty("total");
+    expect(body.data).toHaveProperty("byStatus");
+    expect(body.data).toHaveProperty("revision");
+    expect(body.data).not.toHaveProperty("totalMs");
+    expect(body.data).not.toHaveProperty("internalRouteMs");
+    expect(typeof body.meta.requestId).toBe("string");
+  });
+
+  it("emits the benchmark log only when benchmark mode is enabled", async () => {
+    const { logger } = await import("@infra/logger");
+    const infoSpy = vi.spyOn(logger, "info");
+    const { createJob } = await import("@server/repositories/jobs");
+
+    await createJob({
+      source: "manual",
+      title: "No Benchmark Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/no-benchmark-log",
+      jobDescription: "No benchmark log description",
+    });
+
+    await fetch(`${baseUrl}/api/jobs?view=list`);
+
+    expect(
+      infoSpy.mock.calls.filter(
+        ([message]) => message === "Jobs list benchmark",
+      ),
+    ).toHaveLength(0);
+
+    infoSpy.mockClear();
+    infoSpy.mockRestore();
+
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: { BENCHMARK_JOBS_TIMING: "1" },
+    }));
+
+    const { logger: enabledLogger } = await import("@infra/logger");
+    const enabledInfoSpy = vi.spyOn(enabledLogger, "info");
+    const enabledRepo = await import("@server/repositories/jobs");
+    await enabledRepo.createJob({
+      source: "manual",
+      title: "Benchmark Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/benchmark-log",
+      jobDescription: "Benchmark log description",
+    });
+
+    await fetch(`${baseUrl}/api/jobs?view=list`);
+
+    const benchmarkCalls = enabledInfoSpy.mock.calls.filter(
+      ([message]) => message === "Jobs list benchmark",
+    );
+
+    expect(benchmarkCalls).toHaveLength(1);
+    expect(benchmarkCalls[0]?.[1]).toMatchObject({
+      route: "GET /api/jobs",
+      view: "list",
+      duplicateMatchingEnabled: false,
+      returnedCount: 1,
+      candidateCount: 0,
+    });
+
+    enabledInfoSpy.mockRestore();
+  });
+
+  it("omits applied duplicate match metadata from list responses and keeps it in detail responses", async () => {
     const { createJob, updateJob } = await import("@server/repositories/jobs");
     const appliedJob = await createJob({
       source: "manual",
@@ -110,22 +200,15 @@ describe.sequential("Jobs API routes", () => {
     );
 
     expect(listRes.status).toBe(200);
-    expect(repostedListItem.appliedDuplicateMatch).toEqual({
-      jobId: appliedJob.id,
-      title: "Backend Engineer",
-      employer: "Acme Ltd",
-      appliedAt: "2026-04-01T10:00:00.000Z",
-      score: 100,
-      titleScore: 100,
-      employerScore: 100,
-    });
-    expect(appliedListItem.appliedDuplicateMatch).toBeNull();
+    expect(repostedListItem).not.toHaveProperty("appliedDuplicateMatch");
+    expect(appliedListItem).not.toHaveProperty("appliedDuplicateMatch");
 
     const detailRes = await fetch(`${baseUrl}/api/jobs/${repostedJob.id}`);
     const detailBody = await detailRes.json();
 
     expect(detailRes.status).toBe(200);
     expect(detailBody.ok).toBe(true);
+    expect(detailBody.data).toHaveProperty("appliedDuplicateMatch");
     expect(detailBody.data.appliedDuplicateMatch?.jobId).toBe(appliedJob.id);
     expect(detailBody.data.appliedDuplicateMatch?.score).toBe(100);
   });
@@ -172,8 +255,8 @@ describe.sequential("Jobs API routes", () => {
     expect(listBody.data.jobs).toHaveLength(2);
     expect(
       listBody.data.jobs.every(
-        (job: { appliedDuplicateMatch: unknown }) =>
-          job.appliedDuplicateMatch === null,
+        (job: { appliedDuplicateMatch?: unknown }) =>
+          !Object.hasOwn(job, "appliedDuplicateMatch"),
       ),
     ).toBe(true);
 

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -76,7 +76,9 @@ describe.sequential("Jobs API routes", () => {
     expect(defaultRes.status).toBe(200);
     expect(defaultBody.ok).toBe(true);
     expect(defaultBody.data.jobs[0]).not.toHaveProperty("jobDescription");
-    expect(defaultBody.data.jobs[0]).not.toHaveProperty("appliedDuplicateMatch");
+    expect(defaultBody.data.jobs[0]).not.toHaveProperty(
+      "appliedDuplicateMatch",
+    );
     expect(typeof defaultBody.data.revision).toBe("string");
   });
 

--- a/orchestrator/src/server/api/routes/jobs.ts
+++ b/orchestrator/src/server/api/routes/jobs.ts
@@ -28,10 +28,7 @@ import {
   transitionStage,
   updateStageEvent,
 } from "@server/services/applicationTracking";
-import {
-  attachAppliedDuplicateMatches,
-  isHistoricalAppliedJob,
-} from "@server/services/applied-duplicate-matching";
+import { attachAppliedDuplicateMatches } from "@server/services/applied-duplicate-matching";
 import {
   simulateApplyJob,
   simulateGeneratePdf,
@@ -248,6 +245,9 @@ const SKIPPABLE_STATUSES: ReadonlySet<JobStatus> = new Set([
   "discovered",
   "ready",
 ]);
+const JOBS_BENCHMARK_ENABLED =
+  process.env.BENCHMARK_JOBS_TIMING === "1" ||
+  process.env.BENCHMARK_JOBS_TIMING === "true";
 
 function parseStatusFilter(statusFilter?: string): JobStatus[] | undefined {
   const parsed = statusFilter?.split(",").filter(Boolean) as
@@ -519,7 +519,17 @@ function mapJobActionFailure(
  */
 jobsRouter.get("/", async (req: Request, res: Response) => {
   try {
+    const benchmarkStart = performance.now();
+    let queryParseMs = 0;
+    let primaryQueryMs = 0;
+    const duplicateCandidatesQueryMs = 0;
+    const duplicateMatchCpuMs = 0;
+    let statsAggregateMs = 0;
+    let revisionAggregateMs = 0;
+
+    const queryParseStart = performance.now();
     const parsedQuery = listJobsQuerySchema.safeParse(req.query);
+    queryParseMs = performance.now() - queryParseStart;
     if (!parsedQuery.success) {
       return fail(
         res,
@@ -534,35 +544,61 @@ jobsRouter.get("/", async (req: Request, res: Response) => {
     const statuses = parseStatusFilter(statusFilter);
     const view = parsedQuery.data.view ?? "list";
 
+    const primaryQueryStart = performance.now();
     const jobs: Array<Job | JobListItem> =
       view === "list"
         ? await jobsRepo.getJobListItems(statuses)
         : await jobsRepo.getAllJobs(statuses);
-    const shouldAttachAppliedDuplicateMatches = jobs.some(
-      (job) => !isHistoricalAppliedJob(job),
-    );
-    const jobsWithAppliedDuplicateMatches = shouldAttachAppliedDuplicateMatches
-      ? attachAppliedDuplicateMatches(
-          jobs,
-          await jobsRepo.getAppliedDuplicateMatchCandidates(),
-        )
-      : jobs;
+    primaryQueryMs = performance.now() - primaryQueryStart;
+    const candidateCount = 0;
+    const duplicateMatchingEnabled = false;
+    const statsAggregateStart = performance.now();
     const stats = await jobsRepo.getJobStats();
+    statsAggregateMs = performance.now() - statsAggregateStart;
+    const revisionAggregateStart = performance.now();
     const revision = await jobsRepo.getJobsRevision(statuses);
+    revisionAggregateMs = performance.now() - revisionAggregateStart;
 
     const response: JobsListResponse<Job | JobListItem> = {
-      jobs: jobsWithAppliedDuplicateMatches,
-      total: jobsWithAppliedDuplicateMatches.length,
+      jobs,
+      total: jobs.length,
       byStatus: stats,
       revision: revision.revision,
     };
+    const internalRouteMs =
+      queryParseMs +
+      primaryQueryMs +
+      duplicateCandidatesQueryMs +
+      duplicateMatchCpuMs +
+      statsAggregateMs +
+      revisionAggregateMs;
+    const totalMs = performance.now() - benchmarkStart;
+
+    if (JOBS_BENCHMARK_ENABLED) {
+      logger.info("Jobs list benchmark", {
+        route: "GET /api/jobs",
+        view,
+        statusFilter: statusFilter ?? null,
+        returnedCount: jobs.length,
+        duplicateMatchingEnabled,
+        candidateCount,
+        totalMs,
+        queryParseMs,
+        primaryQueryMs,
+        duplicateCandidatesQueryMs,
+        duplicateMatchCpuMs,
+        statsAggregateMs,
+        revisionAggregateMs,
+        internalRouteMs,
+      });
+    }
 
     logger.info("Jobs list fetched", {
       route: "GET /api/jobs",
       view,
       statusFilter: statusFilter ?? null,
       revision: revision.revision,
-      returnedCount: jobsWithAppliedDuplicateMatches.length,
+      returnedCount: jobs.length,
     });
 
     ok(res, response);

--- a/orchestrator/src/server/repositories/jobs.ts
+++ b/orchestrator/src/server/repositories/jobs.ts
@@ -94,7 +94,6 @@ export async function getJobListItems(
     ...row,
     source: row.source as JobListItem["source"],
     status: row.status as JobStatus,
-    appliedDuplicateMatch: null,
   }));
 }
 
@@ -512,7 +511,6 @@ function mapRowToJob(row: typeof jobs.$inferSelect): Job {
     tracerLinksEnabled: row.tracerLinksEnabled ?? false,
     sponsorMatchScore: row.sponsorMatchScore ?? null,
     sponsorMatchNames: row.sponsorMatchNames ?? null,
-    appliedDuplicateMatch: null,
     jobType: row.jobType ?? null,
     salarySource: row.salarySource ?? null,
     salaryInterval: row.salaryInterval ?? null,

--- a/orchestrator/src/server/services/applied-duplicate-matching.ts
+++ b/orchestrator/src/server/services/applied-duplicate-matching.ts
@@ -22,42 +22,62 @@ type MatchableJob = Pick<
   "id" | "title" | "employer" | "status" | "appliedAt" | "discoveredAt"
 >;
 
+type PreparedMatchableJob = MatchableJob & {
+  normalizedTitle: string;
+  normalizedEmployer: string;
+  discoveredAtMs: number | null;
+  appliedAtMs: number | null;
+};
+
 export function isHistoricalAppliedJob(
   job: Pick<Job, "status" | "appliedAt">,
 ): boolean {
   return HISTORICAL_JOB_STATUSES.has(job.status) && Boolean(job.appliedAt);
 }
 
-function isWithinDuplicateWindow(job: MatchableJob, candidate: MatchableJob) {
-  const discoveredAt = Date.parse(job.discoveredAt);
-  const appliedAt = Date.parse(candidate.appliedAt as string);
+function prepareMatchableJob(job: MatchableJob): PreparedMatchableJob {
+  const discoveredAtMs = Date.parse(job.discoveredAt);
+  const appliedAtMs = job.appliedAt ? Date.parse(job.appliedAt) : null;
 
-  if (!Number.isFinite(discoveredAt) || !Number.isFinite(appliedAt)) {
+  return {
+    ...job,
+    normalizedTitle: normalizeJobTitle(job.title),
+    normalizedEmployer: normalizeCompanyName(job.employer),
+    discoveredAtMs: Number.isFinite(discoveredAtMs) ? discoveredAtMs : null,
+    appliedAtMs:
+      appliedAtMs !== null && Number.isFinite(appliedAtMs) ? appliedAtMs : null,
+  };
+}
+
+function isWithinDuplicateWindow(
+  job: PreparedMatchableJob,
+  candidate: PreparedMatchableJob,
+) {
+  if (job.discoveredAtMs === null || candidate.appliedAtMs === null) {
     return false;
   }
 
-  const ageMs = discoveredAt - appliedAt;
+  const ageMs = job.discoveredAtMs - candidate.appliedAtMs;
   return ageMs >= 0 && ageMs <= APPLIED_DUPLICATE_WINDOW_MS;
 }
 
-export function findAppliedDuplicateMatch(
-  job: MatchableJob,
-  candidates: MatchableJob[],
+function findAppliedDuplicateMatchFromPreparedJobs(
+  job: PreparedMatchableJob,
+  candidates: PreparedMatchableJob[],
 ): AppliedDuplicateMatch | null {
-  if (isHistoricalAppliedJob(job)) {
-    return null;
-  }
-
-  const normalizedTitle = normalizeJobTitle(job.title);
-  const normalizedEmployer = normalizeCompanyName(job.employer);
-  if (!normalizedTitle || !normalizedEmployer) {
+  if (!job.normalizedTitle || !job.normalizedEmployer) {
     return null;
   }
 
   let bestMatch: AppliedDuplicateMatch | null = null;
+  let bestAppliedAtMs = 0;
 
   for (const candidate of candidates) {
-    if (!isHistoricalAppliedJob(candidate) || candidate.id === job.id) {
+    if (candidate.id === job.id || !isHistoricalAppliedJob(candidate)) {
+      continue;
+    }
+
+    if (!candidate.normalizedTitle || !candidate.normalizedEmployer) {
       continue;
     }
 
@@ -66,12 +86,12 @@ export function findAppliedDuplicateMatch(
     }
 
     const titleScore = calculateSimilarity(
-      normalizedTitle,
-      normalizeJobTitle(candidate.title),
+      job.normalizedTitle,
+      candidate.normalizedTitle,
     );
     const employerScore = calculateSimilarity(
-      normalizedEmployer,
-      normalizeCompanyName(candidate.employer),
+      job.normalizedEmployer,
+      candidate.normalizedEmployer,
     );
 
     if (
@@ -92,28 +112,63 @@ export function findAppliedDuplicateMatch(
       employerScore,
     };
 
-    const currentAppliedAt = Date.parse(candidateMatch.appliedAt);
-    const bestAppliedAt = bestMatch ? Date.parse(bestMatch.appliedAt) : 0;
+    const currentAppliedAt = candidate.appliedAtMs ?? 0;
 
     if (
       !bestMatch ||
       candidateMatch.score > bestMatch.score ||
       (candidateMatch.score === bestMatch.score &&
-        currentAppliedAt > bestAppliedAt)
+        currentAppliedAt > bestAppliedAtMs)
     ) {
       bestMatch = candidateMatch;
+      bestAppliedAtMs = currentAppliedAt;
     }
   }
 
   return bestMatch;
 }
 
+export function findAppliedDuplicateMatch(
+  job: MatchableJob,
+  candidates: MatchableJob[],
+): AppliedDuplicateMatch | null {
+  if (isHistoricalAppliedJob(job)) {
+    return null;
+  }
+
+  const preparedJob = prepareMatchableJob(job);
+  if (!preparedJob.normalizedTitle || !preparedJob.normalizedEmployer) {
+    return null;
+  }
+
+  return findAppliedDuplicateMatchFromPreparedJobs(
+    preparedJob,
+    candidates.map(prepareMatchableJob),
+  );
+}
+
 export function attachAppliedDuplicateMatches<T extends Job | JobListItem>(
   jobs: T[],
   candidates: MatchableJob[],
 ): T[] {
-  return jobs.map((job) => ({
-    ...job,
-    appliedDuplicateMatch: findAppliedDuplicateMatch(job, candidates),
-  }));
+  const preparedCandidates = candidates.map(prepareMatchableJob);
+
+  return jobs.map((job) => {
+    if (isHistoricalAppliedJob(job)) {
+      return {
+        ...job,
+        appliedDuplicateMatch: null,
+      };
+    }
+
+    const preparedJob = prepareMatchableJob(job);
+
+    return {
+      ...job,
+      appliedDuplicateMatch: findAppliedDuplicateMatchFromPreparedJobs(
+        preparedJob,
+        preparedCandidates,
+      ),
+    };
+  });
 }

--- a/orchestrator/tsconfig.json
+++ b/orchestrator/tsconfig.json
@@ -19,6 +19,6 @@
       "@shared/*": ["../shared/src/*"]
     }
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "scripts/**/*"],
   "exclude": ["node_modules", "dist"]
 }

--- a/shared/src/types/jobs.ts
+++ b/shared/src/types/jobs.ts
@@ -166,7 +166,7 @@ export interface Job {
   tracerLinksEnabled: boolean; // Rewrite outbound resume links to tracer links on next PDF generation
   sponsorMatchScore: number | null; // 0-100 fuzzy match score with visa sponsors
   sponsorMatchNames: string | null; // JSON array of matched sponsor names (when 100% matches or top match)
-  appliedDuplicateMatch: AppliedDuplicateMatch | null; // Prior applied/in-progress job with highly similar title + employer
+  appliedDuplicateMatch?: AppliedDuplicateMatch | null; // Included on detail responses and may be omitted on list responses
 
   // JobSpy fields (nullable for non-JobSpy sources)
   jobType: string | null;


### PR DESCRIPTION
## Summary
- stop attaching `appliedDuplicateMatch` on `GET /api/jobs` list and full responses to remove the hot-path CPU bottleneck
- keep duplicate match hydration on job detail responses and make the client/shared types tolerate omitted list metadata
- add benchmark logging plus a dedicated `benchmark:jobs` script to measure route phases against a DB snapshot
- precompute normalized duplicate-match inputs so remaining detail-path matching work is cheaper

## Testing
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`
- `npm --workspace orchestrator run benchmark:jobs`