### PR TITLE
Add Codex provider with app-server auth flows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,6 @@
 
 MODEL=google/gemini-3-flash-preview
 
-# Optional: use your host Codex login/session cache inside Docker.
-# Set this to an absolute path to your host ".codex" directory.
-# Example (macOS/Linux): CODEX_HOME_MOUNT=/Users/you/.codex
-# CODEX_HOME_MOUNT=
-
 # Optional: Authentication for protected app and API access
 # The app is fully unauthenticated if this isn't set, which is the default.
 BASIC_AUTH_USER=

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@
 
 MODEL=google/gemini-3-flash-preview
 
+# Optional: use your host Codex login/session cache inside Docker.
+# Set this to an absolute path to your host ".codex" directory.
+# Example (macOS/Linux): CODEX_HOME_MOUNT=/Users/you/.codex
+# CODEX_HOME_MOUNT=
+
 # Optional: Authentication for protected app and API access
 # The app is fully unauthenticated if this isn't set, which is the default.
 BASIC_AUTH_USER=

--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -1,0 +1,115 @@
+{
+  "name": ".opencode",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@opencode-ai/plugin": "1.4.3"
+      }
+    },
+    "node_modules/@opencode-ai/plugin": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.3.tgz",
+      "integrity": "sha512-Ob/3tVSIeuMRJBr2O23RtrnC5djRe01Lglx+TwGEmjrH9yDBJ2tftegYLnNEjRoMuzITgq9LD8168p4pzv+U/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@opencode-ai/sdk": "1.4.3",
+        "zod": "4.1.8"
+      },
+      "peerDependencies": {
+        "@opentui/core": ">=0.1.97",
+        "@opentui/solid": ">=0.1.97"
+      },
+      "peerDependenciesMeta": {
+        "@opentui/core": {
+          "optional": true
+        },
+        "@opentui/solid": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opencode-ai/sdk": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.3.tgz",
+      "integrity": "sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "7.0.6"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.8",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV DATA_DIR=/app/data
 ENV CODEX_HOME=/app/codex-home
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 ENV PATH=/root/.local/bin:${PATH}
+ARG CODEX_CLI_VERSION=0.23.0
 
 # Install runtime dependencies shared by build and production stages.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -25,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Install Codex CLI for local app-server based inference.
-RUN npm install -g @openai/codex@latest
+RUN npm install -g @openai/codex@${CODEX_CLI_VERSION}
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV DATA_DIR=/app/data
 ENV CODEX_HOME=/app/codex-home
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 ENV PATH=/root/.local/bin:${PATH}
-ARG CODEX_CLI_VERSION=0.23.0
+ARG CODEX_CLI_VERSION=0.120.0
 
 # Install runtime dependencies shared by build and production stages.
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV NODE_ENV=production
 ENV PORT=3001
 ENV PYTHON_PATH=/usr/bin/python3
 ENV DATA_DIR=/app/data
+ENV CODEX_HOME=/app/codex-home
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 ENV PATH=/root/.local/bin:${PATH}
 
@@ -22,6 +23,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libdbus-glib-1-2 libxt6 libx11-xcb1 libasound2 \
     curl && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+# Install Codex CLI for local app-server based inference.
+RUN npm install -g @openai/codex@latest
 
 WORKDIR /app
 
@@ -166,8 +170,8 @@ COPY extractors/workingnomads ./extractors/workingnomads
 COPY extractors/golangjobs ./extractors/golangjobs
 COPY extractors/ukvisajobs ./extractors/ukvisajobs
 
-# Create data directory.
-RUN mkdir -p /app/data/pdfs
+# Create runtime directories.
+RUN mkdir -p /app/data/pdfs /app/codex-home
 
 EXPOSE 3001
 

--- a/README.md
+++ b/README.md
@@ -53,25 +53,6 @@ docker compose up -d
 
 Open `http://localhost:3005` and follow the onboarding wizard. You'll be searching in under 10 minutes.
 
-If you pick the `Codex` provider, authenticate once inside the running container:
-
-```bash
-docker compose exec job-ops codex login
-```
-
-Prefer logging in once on your host and reusing it in Docker? Set this in `.env`:
-
-```bash
-CODEX_HOME_MOUNT=/absolute/path/to/your/.codex
-```
-
-Then restart and log in once on the host:
-
-```bash
-docker compose up -d
-codex login
-```
-
 ---
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -59,6 +59,19 @@ If you pick the `Codex` provider, authenticate once inside the running container
 docker compose exec job-ops codex login
 ```
 
+Prefer logging in once on your host and reusing it in Docker? Set this in `.env`:
+
+```bash
+CODEX_HOME_MOUNT=/absolute/path/to/your/.codex
+```
+
+Then restart and log in once on the host:
+
+```bash
+docker compose up -d
+codex login
+```
+
 ---
 
 ## How It Works

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ docker compose up -d
 
 Open `http://localhost:3005` and follow the onboarding wizard. You'll be searching in under 10 minutes.
 
+If you pick the `Codex` provider, authenticate once inside the running container:
+
+```bash
+docker compose exec job-ops codex login
+```
+
 ---
 
 ## How It Works
@@ -101,6 +107,7 @@ No manual updates. No spreadsheets. See the [tracking docs](https://jobops.dakhe
 
 JobOps works with the model provider you already use:
 
+- Codex (local app-server in Docker, authenticated with `codex login`)
 - OpenAI
 - Google Gemini
 - OpenRouter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     volumes:
       # Persist database and generated PDFs
       - ./data:/app/data
+      # Persist Codex login/session data for app-server provider
+      - codex-home:/app/codex-home
     environment:
       # Server config
       - NODE_ENV=production
@@ -21,6 +23,8 @@ services:
 
       # Python path (uses system python in container)
       - PYTHON_PATH=/usr/bin/python3
+      # Codex runtime home (stores auth and config)
+      - CODEX_HOME=/app/codex-home
 
     env_file:
       - path: ./.env
@@ -69,3 +73,4 @@ services:
 # Volumes for data persistence
 volumes:
   data:
+  codex-home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,10 +14,8 @@ services:
     volumes:
       # Persist database and generated PDFs
       - ./data:/app/data
-      # Persist Codex login/session data for app-server provider.
-      # Optional host mount override:
-      # CODEX_HOME_MOUNT=/absolute/path/to/.codex
-      - ${CODEX_HOME_MOUNT:-codex-home}:/app/codex-home
+      # Persist Codex login/session data for app-server provider
+      - codex-home:/app/codex-home
     environment:
       # Server config
       - NODE_ENV=production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,10 @@ services:
     volumes:
       # Persist database and generated PDFs
       - ./data:/app/data
-      # Persist Codex login/session data for app-server provider
-      - codex-home:/app/codex-home
+      # Persist Codex login/session data for app-server provider.
+      # Optional host mount override:
+      # CODEX_HOME_MOUNT=/absolute/path/to/.codex
+      - ${CODEX_HOME_MOUNT:-codex-home}:/app/codex-home
     environment:
       # Server config
       - NODE_ENV=production

--- a/docs-site/docs/getting-started/codex-auth.md
+++ b/docs-site/docs/getting-started/codex-auth.md
@@ -1,7 +1,7 @@
 ---
 id: codex-auth
 title: Codex Authentication
-description: Authenticate Codex in JobOps using either device-code sign-in or host login reuse in Docker.
+description: Authenticate Codex in JobOps with the built-in device-code sign-in flow.
 sidebar_position: 3
 ---
 
@@ -9,10 +9,7 @@ sidebar_position: 3
 
 This page explains how to authenticate the `codex` provider in JobOps.
 
-You can use either:
-
-1. Device-code sign-in from the JobOps UI
-2. Host-login reuse by mounting your host `.codex` folder into Docker
+Use the device-code sign-in flow from the JobOps UI.
 
 ## Why it exists
 
@@ -20,39 +17,17 @@ Some accounts/workspaces disable device-code authorization and show this error:
 
 `Enable device code authorization for Codex in ChatGPT Security Settings, then run "codex login --device-auth" again`
 
-When that happens, JobOps can still work with Codex by reusing host login instead of device code.
+When that happens, complete the ChatGPT security setting first, then retry sign-in.
 
 ## How to use it
 
-### Option 1) Device-code sign-in in JobOps
+### Device-code sign-in in JobOps
 
 1. In JobOps, set **Provider** to `Codex` in onboarding or settings.
 2. Click **Start Sign-In**.
 3. Open the verification URL shown in the UI.
 4. Enter the one-time code shown in the UI.
-5. Return and click **Refresh Status** (or wait for auto-refresh).
-
-### Option 2) Login once on host, reuse inside Docker
-
-1. In `.env`, set:
-
-```bash
-CODEX_HOME_MOUNT=/absolute/path/to/your/.codex
-```
-
-2. Restart JobOps:
-
-```bash
-docker compose up -d
-```
-
-3. Log in once on the host:
-
-```bash
-codex login
-```
-
-4. In JobOps, keep provider as `Codex` and click **Refresh Status**.
+5. Return and click **Check Status** (or wait for auto-refresh).
 
 ## Common problems
 
@@ -66,17 +41,6 @@ Fix:
 
 1. Enable device-code authorization in **ChatGPT Security Settings**
 2. Retry **Start Sign-In**
-
-Or use Option 2 (host-login reuse) above.
-
-### Host login completed but JobOps still says unauthenticated
-
-Checklist:
-
-1. Confirm `CODEX_HOME_MOUNT` points to the host directory that contains your Codex auth files.
-2. Restart container after changing `.env`.
-3. Run `codex login` on host again.
-4. Click **Refresh Status** in JobOps.
 
 ## Related pages
 

--- a/docs-site/docs/getting-started/codex-auth.md
+++ b/docs-site/docs/getting-started/codex-auth.md
@@ -1,0 +1,84 @@
+---
+id: codex-auth
+title: Codex Authentication
+description: Authenticate Codex in JobOps using either device-code sign-in or host login reuse in Docker.
+sidebar_position: 3
+---
+
+## What it is
+
+This page explains how to authenticate the `codex` provider in JobOps.
+
+You can use either:
+
+1. Device-code sign-in from the JobOps UI
+2. Host-login reuse by mounting your host `.codex` folder into Docker
+
+## Why it exists
+
+Some accounts/workspaces disable device-code authorization and show this error:
+
+`Enable device code authorization for Codex in ChatGPT Security Settings, then run "codex login --device-auth" again`
+
+When that happens, JobOps can still work with Codex by reusing host login instead of device code.
+
+## How to use it
+
+### Option 1) Device-code sign-in in JobOps
+
+1. In JobOps, set **Provider** to `Codex` in onboarding or settings.
+2. Click **Start Sign-In**.
+3. Open the verification URL shown in the UI.
+4. Enter the one-time code shown in the UI.
+5. Return and click **Refresh Status** (or wait for auto-refresh).
+
+### Option 2) Login once on host, reuse inside Docker
+
+1. In `.env`, set:
+
+```bash
+CODEX_HOME_MOUNT=/absolute/path/to/your/.codex
+```
+
+2. Restart JobOps:
+
+```bash
+docker compose up -d
+```
+
+3. Log in once on the host:
+
+```bash
+codex login
+```
+
+4. In JobOps, keep provider as `Codex` and click **Refresh Status**.
+
+## Common problems
+
+### Device-code auth error in UI
+
+Symptom:
+
+- `Enable device code authorization for Codex in ChatGPT Security Settings...`
+
+Fix:
+
+1. Enable device-code authorization in **ChatGPT Security Settings**
+2. Retry **Start Sign-In**
+
+Or use Option 2 (host-login reuse) above.
+
+### Host login completed but JobOps still says unauthenticated
+
+Checklist:
+
+1. Confirm `CODEX_HOME_MOUNT` points to the host directory that contains your Codex auth files.
+2. Restart container after changing `.env`.
+3. Run `codex login` on host again.
+4. Click **Refresh Status** in JobOps.
+
+## Related pages
+
+- [Self-Hosting (Docker Compose)](/docs/next/getting-started/self-hosting)
+- [Common Problems](/docs/next/troubleshooting/common-problems)

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -42,6 +42,19 @@ The onboarding wizard helps you validate and save:
 
 Settings are saved to the local database.
 
+## Codex login (host once)
+
+If you use the `Codex` provider and want to avoid logging in inside the container, mount your host `.codex` directory:
+
+1. In `.env`, set:
+   - `CODEX_HOME_MOUNT=/absolute/path/to/your/.codex`
+2. Restart:
+   - `docker compose up -d`
+3. Log in once on the host:
+   - `codex login`
+
+JobOps will reuse that session inside Docker through `/app/codex-home`.
+
 ## Gmail OAuth (Tracking Inbox)
 
 If you want Gmail integration, configure OAuth credentials.

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -42,18 +42,7 @@ The onboarding wizard helps you validate and save:
 
 Settings are saved to the local database.
 
-## Codex login (host once)
-
-If you use the `Codex` provider and want to avoid logging in inside the container, mount your host `.codex` directory:
-
-1. In `.env`, set:
-   - `CODEX_HOME_MOUNT=/absolute/path/to/your/.codex`
-2. Restart:
-   - `docker compose up -d`
-3. Log in once on the host:
-   - `codex login`
-
-JobOps will reuse that session inside Docker through `/app/codex-home`.
+## Codex sign-in
 
 For full Codex auth troubleshooting (including device-code authorization errors), see:
 

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -55,6 +55,10 @@ If you use the `Codex` provider and want to avoid logging in inside the containe
 
 JobOps will reuse that session inside Docker through `/app/codex-home`.
 
+For full Codex auth troubleshooting (including device-code authorization errors), see:
+
+- [Codex Authentication](/docs/next/getting-started/codex-auth)
+
 ## Gmail OAuth (Tracking Inbox)
 
 If you want Gmail integration, configure OAuth credentials.

--- a/docs-site/docs/troubleshooting/common-problems.md
+++ b/docs-site/docs/troubleshooting/common-problems.md
@@ -30,6 +30,16 @@ npm --workspace docs-site run build
 - Validate `LLM_API_KEY` and provider settings.
 - Check settings page and API connectivity.
 
+## Codex sign-in shows device-code authorization error
+
+- Symptom: UI shows:
+  - `Enable device code authorization for Codex in ChatGPT Security Settings, then run "codex login --device-auth" again`
+- Fix:
+  - Enable device-code authorization in ChatGPT Security Settings and retry sign-in
+  - Or use host-login reuse with `CODEX_HOME_MOUNT` and `codex login` on host
+- Full guide:
+  - [Codex Authentication](/docs/next/getting-started/codex-auth)
+
 ## Resume tailoring or scoring says the model does not exist
 
 - Root cause: the selected provider and model do not match.

--- a/docs-site/docs/troubleshooting/common-problems.md
+++ b/docs-site/docs/troubleshooting/common-problems.md
@@ -36,7 +36,6 @@ npm --workspace docs-site run build
   - `Enable device code authorization for Codex in ChatGPT Security Settings, then run "codex login --device-auth" again`
 - Fix:
   - Enable device-code authorization in ChatGPT Security Settings and retry sign-in
-  - Or use host-login reuse with `CODEX_HOME_MOUNT` and `codex login` on host
 - Full guide:
   - [Codex Authentication](/docs/next/getting-started/codex-auth)
 

--- a/docs-site/versioned_docs/version-0.3.1/getting-started/codex-auth.md
+++ b/docs-site/versioned_docs/version-0.3.1/getting-started/codex-auth.md
@@ -1,7 +1,7 @@
 ---
 id: codex-auth
 title: Codex Authentication
-description: Authenticate Codex in JobOps using either device-code sign-in or host login reuse in Docker.
+description: Authenticate Codex in JobOps with the built-in device-code sign-in flow.
 sidebar_position: 3
 ---
 
@@ -9,10 +9,7 @@ sidebar_position: 3
 
 This page explains how to authenticate the `codex` provider in JobOps.
 
-You can use either:
-
-1. Device-code sign-in from the JobOps UI
-2. Host-login reuse by mounting your host `.codex` folder into Docker
+Use the device-code sign-in flow from the JobOps UI.
 
 ## Why it exists
 
@@ -20,39 +17,17 @@ Some accounts/workspaces disable device-code authorization and show this error:
 
 `Enable device code authorization for Codex in ChatGPT Security Settings, then run "codex login --device-auth" again`
 
-When that happens, JobOps can still work with Codex by reusing host login instead of device code.
+When that happens, complete the ChatGPT security setting first, then retry sign-in.
 
 ## How to use it
 
-### Option 1) Device-code sign-in in JobOps
+### Device-code sign-in in JobOps
 
 1. In JobOps, set **Provider** to `Codex` in onboarding or settings.
 2. Click **Start Sign-In**.
 3. Open the verification URL shown in the UI.
 4. Enter the one-time code shown in the UI.
-5. Return and click **Refresh Status** (or wait for auto-refresh).
-
-### Option 2) Login once on host, reuse inside Docker
-
-1. In `.env`, set:
-
-```bash
-CODEX_HOME_MOUNT=/absolute/path/to/your/.codex
-```
-
-2. Restart JobOps:
-
-```bash
-docker compose up -d
-```
-
-3. Log in once on the host:
-
-```bash
-codex login
-```
-
-4. In JobOps, keep provider as `Codex` and click **Refresh Status**.
+5. Return and click **Check Status** (or wait for auto-refresh).
 
 ## Common problems
 
@@ -66,17 +41,6 @@ Fix:
 
 1. Enable device-code authorization in **ChatGPT Security Settings**
 2. Retry **Start Sign-In**
-
-Or use Option 2 (host-login reuse) above.
-
-### Host login completed but JobOps still says unauthenticated
-
-Checklist:
-
-1. Confirm `CODEX_HOME_MOUNT` points to the host directory that contains your Codex auth files.
-2. Restart container after changing `.env`.
-3. Run `codex login` on host again.
-4. Click **Refresh Status** in JobOps.
 
 ## Related pages
 

--- a/docs-site/versioned_docs/version-0.3.1/getting-started/codex-auth.md
+++ b/docs-site/versioned_docs/version-0.3.1/getting-started/codex-auth.md
@@ -1,0 +1,84 @@
+---
+id: codex-auth
+title: Codex Authentication
+description: Authenticate Codex in JobOps using either device-code sign-in or host login reuse in Docker.
+sidebar_position: 3
+---
+
+## What it is
+
+This page explains how to authenticate the `codex` provider in JobOps.
+
+You can use either:
+
+1. Device-code sign-in from the JobOps UI
+2. Host-login reuse by mounting your host `.codex` folder into Docker
+
+## Why it exists
+
+Some accounts/workspaces disable device-code authorization and show this error:
+
+`Enable device code authorization for Codex in ChatGPT Security Settings, then run "codex login --device-auth" again`
+
+When that happens, JobOps can still work with Codex by reusing host login instead of device code.
+
+## How to use it
+
+### Option 1) Device-code sign-in in JobOps
+
+1. In JobOps, set **Provider** to `Codex` in onboarding or settings.
+2. Click **Start Sign-In**.
+3. Open the verification URL shown in the UI.
+4. Enter the one-time code shown in the UI.
+5. Return and click **Refresh Status** (or wait for auto-refresh).
+
+### Option 2) Login once on host, reuse inside Docker
+
+1. In `.env`, set:
+
+```bash
+CODEX_HOME_MOUNT=/absolute/path/to/your/.codex
+```
+
+2. Restart JobOps:
+
+```bash
+docker compose up -d
+```
+
+3. Log in once on the host:
+
+```bash
+codex login
+```
+
+4. In JobOps, keep provider as `Codex` and click **Refresh Status**.
+
+## Common problems
+
+### Device-code auth error in UI
+
+Symptom:
+
+- `Enable device code authorization for Codex in ChatGPT Security Settings...`
+
+Fix:
+
+1. Enable device-code authorization in **ChatGPT Security Settings**
+2. Retry **Start Sign-In**
+
+Or use Option 2 (host-login reuse) above.
+
+### Host login completed but JobOps still says unauthenticated
+
+Checklist:
+
+1. Confirm `CODEX_HOME_MOUNT` points to the host directory that contains your Codex auth files.
+2. Restart container after changing `.env`.
+3. Run `codex login` on host again.
+4. Click **Refresh Status** in JobOps.
+
+## Related pages
+
+- [Self-Hosting (Docker Compose)](/docs/next/getting-started/self-hosting)
+- [Common Problems](/docs/next/troubleshooting/common-problems)

--- a/docs-site/versioned_docs/version-0.3.1/getting-started/self-hosting.md
+++ b/docs-site/versioned_docs/version-0.3.1/getting-started/self-hosting.md
@@ -42,18 +42,7 @@ The onboarding wizard helps you validate and save:
 
 Settings are saved to the local database.
 
-## Codex login (host once)
-
-If you use the `Codex` provider and want to avoid logging in inside the container, mount your host `.codex` directory:
-
-1. In `.env`, set:
-   - `CODEX_HOME_MOUNT=/absolute/path/to/your/.codex`
-2. Restart:
-   - `docker compose up -d`
-3. Log in once on the host:
-   - `codex login`
-
-JobOps will reuse that session inside Docker through `/app/codex-home`.
+## Codex sign-in
 
 For full Codex auth troubleshooting (including device-code authorization errors), see:
 

--- a/docs-site/versioned_docs/version-0.3.1/getting-started/self-hosting.md
+++ b/docs-site/versioned_docs/version-0.3.1/getting-started/self-hosting.md
@@ -42,6 +42,23 @@ The onboarding wizard helps you validate and save:
 
 Settings are saved to the local database.
 
+## Codex login (host once)
+
+If you use the `Codex` provider and want to avoid logging in inside the container, mount your host `.codex` directory:
+
+1. In `.env`, set:
+   - `CODEX_HOME_MOUNT=/absolute/path/to/your/.codex`
+2. Restart:
+   - `docker compose up -d`
+3. Log in once on the host:
+   - `codex login`
+
+JobOps will reuse that session inside Docker through `/app/codex-home`.
+
+For full Codex auth troubleshooting (including device-code authorization errors), see:
+
+- [Codex Authentication](/docs/next/getting-started/codex-auth)
+
 ## Gmail OAuth (Tracking Inbox)
 
 If you want Gmail integration, configure OAuth credentials.

--- a/docs-site/versioned_docs/version-0.3.1/troubleshooting/common-problems.md
+++ b/docs-site/versioned_docs/version-0.3.1/troubleshooting/common-problems.md
@@ -30,6 +30,16 @@ npm --workspace docs-site run build
 - Validate `LLM_API_KEY` and provider settings.
 - Check settings page and API connectivity.
 
+## Codex sign-in shows device-code authorization error
+
+- Symptom: UI shows:
+  - `Enable device code authorization for Codex in ChatGPT Security Settings, then run "codex login --device-auth" again`
+- Fix:
+  - Enable device-code authorization in ChatGPT Security Settings and retry sign-in
+  - Or use host-login reuse with `CODEX_HOME_MOUNT` and `codex login` on host
+- Full guide:
+  - [Codex Authentication](/docs/next/getting-started/codex-auth)
+
 ## Resume tailoring or scoring says the model does not exist
 
 - Root cause: the selected provider and model do not match.

--- a/docs-site/versioned_docs/version-0.3.1/troubleshooting/common-problems.md
+++ b/docs-site/versioned_docs/version-0.3.1/troubleshooting/common-problems.md
@@ -36,7 +36,6 @@ npm --workspace docs-site run build
   - `Enable device code authorization for Codex in ChatGPT Security Settings, then run "codex login --device-auth" again`
 - Fix:
   - Enable device-code authorization in ChatGPT Security Settings and retry sign-in
-  - Or use host-login reuse with `CODEX_HOME_MOUNT` and `codex login` on host
 - Full guide:
   - [Codex Authentication](/docs/next/getting-started/codex-auth)
 

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -1672,9 +1672,14 @@ export async function getCodexAuthStatus(): Promise<CodexAuthStatusResponse> {
   return fetchApi<CodexAuthStatusResponse>("/settings/codex-auth");
 }
 
-export async function startCodexAuth(): Promise<CodexAuthStatusResponse> {
+export async function startCodexAuth(input?: {
+  forceRestart?: boolean;
+}): Promise<CodexAuthStatusResponse> {
   return fetchApi<CodexAuthStatusResponse>("/settings/codex-auth/start", {
     method: "POST",
+    body: JSON.stringify({
+      forceRestart: input?.forceRestart ?? false,
+    }),
   });
 }
 

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -100,6 +100,18 @@ type StreamSseInput =
   | { content: string; stream: true }
   | { stream: true };
 
+export type CodexAuthStatusResponse = {
+  authenticated: boolean;
+  validationMessage: string | null;
+  flowStatus: string;
+  loginInProgress: boolean;
+  verificationUrl: string | null;
+  userCode: string | null;
+  startedAt: string | null;
+  expiresAt: string | null;
+  flowMessage: string | null;
+};
+
 export type AuthCredentials = {
   username: string;
   password: string;
@@ -1654,6 +1666,16 @@ export async function getLlmModels(input?: {
     body: JSON.stringify(input ?? {}),
   });
   return data.models;
+}
+
+export async function getCodexAuthStatus(): Promise<CodexAuthStatusResponse> {
+  return fetchApi<CodexAuthStatusResponse>("/settings/codex-auth");
+}
+
+export async function startCodexAuth(): Promise<CodexAuthStatusResponse> {
+  return fetchApi<CodexAuthStatusResponse>("/settings/codex-auth/start", {
+    method: "POST",
+  });
 }
 
 export async function validateRxresume(input?: {

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -102,6 +102,7 @@ type StreamSseInput =
 
 export type CodexAuthStatusResponse = {
   authenticated: boolean;
+  username: string | null;
   validationMessage: string | null;
   flowStatus: string;
   loginInProgress: boolean;
@@ -1680,6 +1681,12 @@ export async function startCodexAuth(input?: {
     body: JSON.stringify({
       forceRestart: input?.forceRestart ?? false,
     }),
+  });
+}
+
+export async function disconnectCodexAuth(): Promise<CodexAuthStatusResponse> {
+  return fetchApi<CodexAuthStatusResponse>("/settings/codex-auth/disconnect", {
+    method: "POST",
   });
 }
 

--- a/orchestrator/src/client/components/CodexAuthPanel.tsx
+++ b/orchestrator/src/client/components/CodexAuthPanel.tsx
@@ -1,0 +1,361 @@
+import * as api from "@client/api";
+import {
+  AlertCircle,
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  Loader2,
+} from "lucide-react";
+import type React from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+type CodexAuthPanelProps = {
+  isBusy: boolean;
+};
+
+type AuthMode = "device" | "host";
+
+const TWO_MINUTES_MS = 2 * 60 * 1000;
+
+function formatRemaining(ms: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
+  const [authMode, setAuthMode] = useState<AuthMode>("device");
+  const [codexAuthStatus, setCodexAuthStatus] = useState<Awaited<
+    ReturnType<typeof api.getCodexAuthStatus>
+  > | null>(null);
+  const [isLoadingCodexAuthStatus, setIsLoadingCodexAuthStatus] =
+    useState(false);
+  const [isStartingCodexAuth, setIsStartingCodexAuth] = useState(false);
+  const [codexAuthError, setCodexAuthError] = useState<string | null>(null);
+  const [hasCopiedCode, setHasCopiedCode] = useState(false);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  const refreshCodexAuthStatus = useCallback(async (showLoading = true) => {
+    if (showLoading) {
+      setIsLoadingCodexAuthStatus(true);
+    }
+    setCodexAuthError(null);
+    try {
+      const status = await api.getCodexAuthStatus();
+      setCodexAuthStatus(status);
+    } catch (error) {
+      setCodexAuthError(
+        error instanceof Error
+          ? error.message
+          : "Failed to load Codex sign-in status.",
+      );
+    } finally {
+      if (showLoading) {
+        setIsLoadingCodexAuthStatus(false);
+      }
+    }
+  }, []);
+
+  const startCodexAuth = useCallback(async () => {
+    setIsStartingCodexAuth(true);
+    setCodexAuthError(null);
+    setHasCopiedCode(false);
+    try {
+      const status = await api.startCodexAuth();
+      setCodexAuthStatus(status);
+    } catch (error) {
+      setCodexAuthError(
+        error instanceof Error
+          ? error.message
+          : "Failed to start Codex sign-in.",
+      );
+    } finally {
+      setIsStartingCodexAuth(false);
+    }
+  }, []);
+
+  const copyCode = useCallback(async () => {
+    const code = codexAuthStatus?.userCode;
+    if (!code) return;
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      setCodexAuthError("Copy is not available in this browser.");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(code);
+      setHasCopiedCode(true);
+      window.setTimeout(() => setHasCopiedCode(false), 1800);
+    } catch (error) {
+      setCodexAuthError(
+        error instanceof Error ? error.message : "Failed to copy code.",
+      );
+    }
+  }, [codexAuthStatus?.userCode]);
+
+  useEffect(() => {
+    void refreshCodexAuthStatus();
+  }, [refreshCodexAuthStatus]);
+
+  useEffect(() => {
+    if (!codexAuthStatus?.loginInProgress || codexAuthStatus.authenticated) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      void refreshCodexAuthStatus(false);
+    }, 4_000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [
+    codexAuthStatus?.authenticated,
+    codexAuthStatus?.loginInProgress,
+    refreshCodexAuthStatus,
+  ]);
+
+  const expirationMs = useMemo(() => {
+    if (!codexAuthStatus?.expiresAt) return null;
+    const parsed = Date.parse(codexAuthStatus.expiresAt);
+    return Number.isFinite(parsed) ? parsed : null;
+  }, [codexAuthStatus?.expiresAt]);
+
+  useEffect(() => {
+    if (!expirationMs || codexAuthStatus?.authenticated) return;
+    if (expirationMs - Date.now() > TWO_MINUTES_MS) return;
+
+    const timer = window.setInterval(() => {
+      setNowMs(Date.now());
+    }, 1_000);
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [codexAuthStatus?.authenticated, expirationMs]);
+
+  const remainingMs = expirationMs ? expirationMs - nowMs : null;
+  const showExpiryCountdown =
+    remainingMs !== null && remainingMs > 0 && remainingMs <= TWO_MINUTES_MS;
+
+  const hasCode = Boolean(codexAuthStatus?.userCode);
+  const hasVerificationUrl = Boolean(codexAuthStatus?.verificationUrl);
+  const hasDevicePayload = hasCode && hasVerificationUrl;
+  const isAuthenticated = Boolean(codexAuthStatus?.authenticated);
+  const isWaitingForApproval =
+    Boolean(codexAuthStatus?.loginInProgress) && !isAuthenticated;
+  const hasFailed = codexAuthStatus?.flowStatus === "failed";
+
+  const badge = isAuthenticated
+    ? {
+        icon: CheckCircle2,
+        text: "Authenticated",
+        className: "border-emerald-300 bg-emerald-500/10 text-emerald-700",
+      }
+    : hasFailed
+      ? {
+          icon: AlertCircle,
+          text: "Needs Attention",
+          className: "border-destructive/40 bg-destructive/10 text-destructive",
+        }
+      : isWaitingForApproval
+        ? {
+            icon: Loader2,
+            text: "Waiting for approval",
+            className: "border-amber-300 bg-amber-500/10 text-amber-700",
+          }
+        : {
+            icon: AlertCircle,
+            text: "Not authenticated",
+            className: "border-border bg-muted text-muted-foreground",
+          };
+  const BadgeIcon = badge.icon;
+
+  return (
+    <div className="space-y-3 rounded-md border border-border bg-muted/30 p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="text-xs font-medium">Codex Sign-In</div>
+        <Badge className={`gap-1 ${badge.className}`} variant="outline">
+          <BadgeIcon
+            className={`h-3.5 w-3.5 ${
+              isWaitingForApproval ? "animate-spin" : ""
+            }`}
+          />
+          {badge.text}
+        </Badge>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant={authMode === "device" ? "secondary" : "outline"}
+          onClick={() => setAuthMode("device")}
+          disabled={isBusy}
+        >
+          Device Code
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant={authMode === "host" ? "secondary" : "outline"}
+          onClick={() => setAuthMode("host")}
+          disabled={isBusy}
+        >
+          Use Docker Login
+        </Button>
+      </div>
+
+      {authMode === "device" ? (
+        <div className="space-y-3">
+          <div className="space-y-1 text-xs text-muted-foreground">
+            <div className="flex items-center gap-2">
+              {hasDevicePayload || isAuthenticated ? (
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+              ) : (
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
+                  1
+                </span>
+              )}
+              <span>Start sign-in</span>
+            </div>
+            <div className="flex items-center gap-2">
+              {hasCopiedCode || isAuthenticated ? (
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+              ) : (
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
+                  2
+                </span>
+              )}
+              <span>Copy code and open verification page</span>
+            </div>
+            <div className="flex items-center gap-2">
+              {isAuthenticated ? (
+                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+              ) : isWaitingForApproval ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin text-amber-700" />
+              ) : (
+                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
+                  3
+                </span>
+              )}
+              <span>Approve and return to JobOps</span>
+            </div>
+          </div>
+
+          {hasDevicePayload ? (
+            <div className="space-y-2 rounded-lg border border-border bg-background/70 p-3">
+              <div className="text-center text-[11px] uppercase tracking-wide text-muted-foreground">
+                One-time code
+              </div>
+              <div className="text-center font-mono text-2xl font-semibold tracking-widest text-foreground">
+                {codexAuthStatus?.userCode}
+              </div>
+              <div className="flex flex-wrap items-center justify-center gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => void copyCode()}
+                  disabled={isBusy}
+                >
+                  <Copy className="h-3.5 w-3.5" />
+                  {hasCopiedCode ? "Copied" : "Copy code"}
+                </Button>
+                <Button type="button" size="sm" variant="outline" asChild>
+                  <a
+                    href={codexAuthStatus?.verificationUrl ?? "#"}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                    Open verification page
+                  </a>
+                </Button>
+              </div>
+              <div className="break-all text-center text-[11px] text-muted-foreground">
+                {codexAuthStatus?.verificationUrl}
+              </div>
+              {showExpiryCountdown ? (
+                <div className="text-center text-[11px] text-amber-700">
+                  Code expires in {formatRemaining(remainingMs)}
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <div className="rounded-md border border-dashed border-border/70 bg-background/60 px-3 py-2 text-xs text-muted-foreground">
+              Click{" "}
+              <span className="font-medium text-foreground">Start Sign-In</span>{" "}
+              to generate your one-time code.
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            {hasDevicePayload && !isAuthenticated ? (
+              <>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() => void refreshCodexAuthStatus()}
+                  disabled={isBusy || isLoadingCodexAuthStatus}
+                >
+                  {isLoadingCodexAuthStatus ? "Checking..." : "Check Status"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void startCodexAuth()}
+                  disabled={isBusy || isStartingCodexAuth}
+                >
+                  {isStartingCodexAuth ? "Starting..." : "Start New Sign-In"}
+                </Button>
+              </>
+            ) : (
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void startCodexAuth()}
+                disabled={isBusy || isStartingCodexAuth}
+              >
+                {isStartingCodexAuth ? "Starting..." : "Start Sign-In"}
+              </Button>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-2 rounded-lg border border-border bg-background/70 p-3 text-xs text-muted-foreground">
+          <div className="text-foreground">
+            Reuse your host Codex session inside Docker.
+          </div>
+          <ol className="space-y-1">
+            <li>1. Set `CODEX_HOME_MOUNT` to your host `.codex` directory.</li>
+            <li>2. Run `docker compose up -d`.</li>
+            <li>3. Run `codex login` on the host once.</li>
+            <li>4. Return and click `Check Status`.</li>
+          </ol>
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            onClick={() => void refreshCodexAuthStatus()}
+            disabled={isBusy || isLoadingCodexAuthStatus}
+          >
+            {isLoadingCodexAuthStatus ? "Checking..." : "Check Status"}
+          </Button>
+        </div>
+      )}
+
+      {codexAuthError ? (
+        <p className="text-xs text-destructive">{codexAuthError}</p>
+      ) : null}
+      {codexAuthStatus?.flowMessage && !isAuthenticated ? (
+        <p className="text-xs text-muted-foreground">
+          {codexAuthStatus.flowMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+};

--- a/orchestrator/src/client/components/CodexAuthPanel.tsx
+++ b/orchestrator/src/client/components/CodexAuthPanel.tsx
@@ -1,11 +1,5 @@
 import * as api from "@client/api";
-import {
-  AlertCircle,
-  CheckCircle2,
-  Copy,
-  ExternalLink,
-  Loader2,
-} from "lucide-react";
+import { CheckCircle2, Copy, ExternalLink, Loader2 } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -31,6 +25,8 @@ export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
   const [isLoadingCodexAuthStatus, setIsLoadingCodexAuthStatus] =
     useState(false);
   const [isStartingCodexAuth, setIsStartingCodexAuth] = useState(false);
+  const [isDisconnectingCodexAuth, setIsDisconnectingCodexAuth] =
+    useState(false);
   const [codexAuthError, setCodexAuthError] = useState<string | null>(null);
   const [hasCopiedCode, setHasCopiedCode] = useState(false);
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -93,6 +89,22 @@ export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
     }
   }, [codexAuthStatus?.userCode]);
 
+  const disconnectCodex = useCallback(async () => {
+    setIsDisconnectingCodexAuth(true);
+    setCodexAuthError(null);
+    setHasCopiedCode(false);
+    try {
+      const status = await api.disconnectCodexAuth();
+      setCodexAuthStatus(status);
+    } catch (error) {
+      setCodexAuthError(
+        error instanceof Error ? error.message : "Failed to disconnect Codex.",
+      );
+    } finally {
+      setIsDisconnectingCodexAuth(false);
+    }
+  }, []);
+
   useEffect(() => {
     void refreshCodexAuthStatus();
   }, [refreshCodexAuthStatus]);
@@ -143,45 +155,54 @@ export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
   const isAuthenticated = Boolean(codexAuthStatus?.authenticated);
   const isWaitingForApproval =
     Boolean(codexAuthStatus?.loginInProgress) && !isAuthenticated;
-  const hasFailed = codexAuthStatus?.flowStatus === "failed";
+  const displayUsername = codexAuthStatus?.username?.trim() || "your account";
 
-  const badge = isAuthenticated
-    ? {
-        icon: CheckCircle2,
-        text: "Authenticated",
-        className: "border-emerald-300 bg-emerald-500/10 text-emerald-700",
-      }
-    : hasFailed
-      ? {
-          icon: AlertCircle,
-          text: "Needs Attention",
-          className: "border-destructive/40 bg-destructive/10 text-destructive",
-        }
-      : isWaitingForApproval
-        ? {
-            icon: Loader2,
-            text: "Waiting for approval",
-            className: "border-amber-300 bg-amber-500/10 text-amber-700",
-          }
-        : {
-            icon: AlertCircle,
-            text: "Not authenticated",
-            className: "border-border bg-muted text-muted-foreground",
-          };
-  const BadgeIcon = badge.icon;
+  if (isAuthenticated) {
+    return (
+      <div className="space-y-3 rounded-md border border-border bg-muted/30 p-3">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-xs font-medium">Codex Sign-In</div>
+          <Badge
+            className="gap-1 border-emerald-700 bg-emerald-700 text-white dark:border-emerald-300 dark:bg-emerald-300 dark:text-emerald-950"
+            variant="outline"
+          >
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Authenticated
+          </Badge>
+        </div>
+
+        <div className="flex items-center justify-between gap-3 rounded-md border border-emerald-300/60 bg-emerald-500/10 px-3 py-2">
+          <p className="text-sm text-foreground">
+            <span className="font-medium">Connected as </span>
+            <span className="font-mono">{displayUsername}</span>
+          </p>
+          <button
+            type="button"
+            className="text-xs font-medium text-destructive underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+            onClick={() => void disconnectCodex()}
+            disabled={isBusy || isDisconnectingCodexAuth}
+          >
+            {isDisconnectingCodexAuth ? "Disconnecting..." : "Disconnect"}
+          </button>
+        </div>
+
+        {codexAuthError ? (
+          <p className="text-xs text-destructive">{codexAuthError}</p>
+        ) : null}
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-3 rounded-md border border-border bg-muted/30 p-3">
       <div className="flex items-center justify-between gap-2">
         <div className="text-xs font-medium">Codex Sign-In</div>
-        <Badge className={`gap-1 ${badge.className}`} variant="outline">
-          <BadgeIcon
-            className={`h-3.5 w-3.5 ${
-              isWaitingForApproval ? "animate-spin" : ""
-            }`}
-          />
-          {badge.text}
-        </Badge>
+        {isWaitingForApproval ? (
+          <div className="inline-flex items-center gap-1 text-xs text-amber-700">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Waiting for approval
+          </div>
+        ) : null}
       </div>
 
       <div className="rounded-md border border-dashed border-border/70 bg-background/60 px-3 py-2 text-xs text-muted-foreground">

--- a/orchestrator/src/client/components/CodexAuthPanel.tsx
+++ b/orchestrator/src/client/components/CodexAuthPanel.tsx
@@ -56,12 +56,12 @@ export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
     }
   }, []);
 
-  const startCodexAuth = useCallback(async () => {
+  const startCodexAuth = useCallback(async (forceRestart = false) => {
     setIsStartingCodexAuth(true);
     setCodexAuthError(null);
     setHasCopiedCode(false);
     try {
-      const status = await api.startCodexAuth();
+      const status = await api.startCodexAuth({ forceRestart });
       setCodexAuthStatus(status);
     } catch (error) {
       setCodexAuthError(
@@ -123,7 +123,7 @@ export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
 
   useEffect(() => {
     if (!expirationMs || codexAuthStatus?.authenticated) return;
-    if (expirationMs - Date.now() > TWO_MINUTES_MS) return;
+    setNowMs(Date.now());
 
     const timer = window.setInterval(() => {
       setNowMs(Date.now());
@@ -278,7 +278,7 @@ export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
               type="button"
               size="sm"
               variant="outline"
-              onClick={() => void startCodexAuth()}
+              onClick={() => void startCodexAuth(true)}
               disabled={isBusy || isStartingCodexAuth}
             >
               {isStartingCodexAuth ? "Starting..." : "Start New Sign-In"}

--- a/orchestrator/src/client/components/CodexAuthPanel.tsx
+++ b/orchestrator/src/client/components/CodexAuthPanel.tsx
@@ -15,8 +15,6 @@ type CodexAuthPanelProps = {
   isBusy: boolean;
 };
 
-type AuthMode = "device" | "host";
-
 const TWO_MINUTES_MS = 2 * 60 * 1000;
 
 function formatRemaining(ms: number): string {
@@ -27,7 +25,6 @@ function formatRemaining(ms: number): string {
 }
 
 export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
-  const [authMode, setAuthMode] = useState<AuthMode>("device");
   const [codexAuthStatus, setCodexAuthStatus] = useState<Awaited<
     ReturnType<typeof api.getCodexAuthStatus>
   > | null>(null);
@@ -187,166 +184,117 @@ export const CodexAuthPanel: React.FC<CodexAuthPanelProps> = ({ isBusy }) => {
         </Badge>
       </div>
 
-      <div className="grid grid-cols-2 gap-2">
-        <Button
-          type="button"
-          size="sm"
-          variant={authMode === "device" ? "secondary" : "outline"}
-          onClick={() => setAuthMode("device")}
-          disabled={isBusy}
-        >
-          Device Code
-        </Button>
-        <Button
-          type="button"
-          size="sm"
-          variant={authMode === "host" ? "secondary" : "outline"}
-          onClick={() => setAuthMode("host")}
-          disabled={isBusy}
-        >
-          Use Docker Login
-        </Button>
+      <div className="rounded-md border border-dashed border-border/70 bg-background/60 px-3 py-2 text-xs text-muted-foreground">
+        Start sign-in to generate a one-time code. After approval in your
+        browser, click{" "}
+        <span className="font-medium text-foreground">Check Status</span>.
       </div>
 
-      {authMode === "device" ? (
-        <div className="space-y-3">
-          <div className="space-y-1 text-xs text-muted-foreground">
-            <div className="flex items-center gap-2">
-              {hasDevicePayload || isAuthenticated ? (
-                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
-              ) : (
-                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
-                  1
-                </span>
-              )}
-              <span>Start sign-in</span>
-            </div>
-            <div className="flex items-center gap-2">
-              {hasCopiedCode || isAuthenticated ? (
-                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
-              ) : (
-                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
-                  2
-                </span>
-              )}
-              <span>Copy code and open verification page</span>
-            </div>
-            <div className="flex items-center gap-2">
-              {isAuthenticated ? (
-                <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
-              ) : isWaitingForApproval ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin text-amber-700" />
-              ) : (
-                <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
-                  3
-                </span>
-              )}
-              <span>Approve and return to JobOps</span>
-            </div>
-          </div>
-
-          {hasDevicePayload ? (
-            <div className="space-y-2 rounded-lg border border-border bg-background/70 p-3">
-              <div className="text-center text-[11px] uppercase tracking-wide text-muted-foreground">
-                One-time code
-              </div>
-              <div className="text-center font-mono text-2xl font-semibold tracking-widest text-foreground">
-                {codexAuthStatus?.userCode}
-              </div>
-              <div className="flex flex-wrap items-center justify-center gap-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="secondary"
-                  onClick={() => void copyCode()}
-                  disabled={isBusy}
-                >
-                  <Copy className="h-3.5 w-3.5" />
-                  {hasCopiedCode ? "Copied" : "Copy code"}
-                </Button>
-                <Button type="button" size="sm" variant="outline" asChild>
-                  <a
-                    href={codexAuthStatus?.verificationUrl ?? "#"}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <ExternalLink className="h-3.5 w-3.5" />
-                    Open verification page
-                  </a>
-                </Button>
-              </div>
-              <div className="break-all text-center text-[11px] text-muted-foreground">
-                {codexAuthStatus?.verificationUrl}
-              </div>
-              {showExpiryCountdown ? (
-                <div className="text-center text-[11px] text-amber-700">
-                  Code expires in {formatRemaining(remainingMs)}
-                </div>
-              ) : null}
-            </div>
+      <div className="space-y-1 text-xs text-muted-foreground">
+        <div className="flex items-center gap-2">
+          {hasDevicePayload || isAuthenticated ? (
+            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
           ) : (
-            <div className="rounded-md border border-dashed border-border/70 bg-background/60 px-3 py-2 text-xs text-muted-foreground">
-              Click{" "}
-              <span className="font-medium text-foreground">Start Sign-In</span>{" "}
-              to generate your one-time code.
-            </div>
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
+              1
+            </span>
           )}
-
-          <div className="flex flex-wrap gap-2">
-            {hasDevicePayload && !isAuthenticated ? (
-              <>
-                <Button
-                  type="button"
-                  size="sm"
-                  onClick={() => void refreshCodexAuthStatus()}
-                  disabled={isBusy || isLoadingCodexAuthStatus}
-                >
-                  {isLoadingCodexAuthStatus ? "Checking..." : "Check Status"}
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void startCodexAuth()}
-                  disabled={isBusy || isStartingCodexAuth}
-                >
-                  {isStartingCodexAuth ? "Starting..." : "Start New Sign-In"}
-                </Button>
-              </>
-            ) : (
-              <Button
-                type="button"
-                size="sm"
-                onClick={() => void startCodexAuth()}
-                disabled={isBusy || isStartingCodexAuth}
-              >
-                {isStartingCodexAuth ? "Starting..." : "Start Sign-In"}
-              </Button>
-            )}
-          </div>
+          <span>Start sign-in</span>
         </div>
-      ) : (
-        <div className="space-y-2 rounded-lg border border-border bg-background/70 p-3 text-xs text-muted-foreground">
-          <div className="text-foreground">
-            Reuse your host Codex session inside Docker.
+        <div className="flex items-center gap-2">
+          {hasCopiedCode || isAuthenticated ? (
+            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+          ) : (
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
+              2
+            </span>
+          )}
+          <span>Copy code and open verification page</span>
+        </div>
+        <div className="flex items-center gap-2">
+          {isAuthenticated ? (
+            <CheckCircle2 className="h-3.5 w-3.5 text-emerald-600" />
+          ) : isWaitingForApproval ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin text-amber-700" />
+          ) : (
+            <span className="inline-flex h-4 w-4 items-center justify-center rounded-full border text-[10px]">
+              3
+            </span>
+          )}
+          <span>Approve and return to JobOps</span>
+        </div>
+      </div>
+
+      {hasDevicePayload ? (
+        <div className="space-y-2 rounded-lg border border-border bg-background/70 p-3">
+          <div className="text-center text-[11px] uppercase tracking-wide text-muted-foreground">
+            One-time code
           </div>
-          <ol className="space-y-1">
-            <li>1. Set `CODEX_HOME_MOUNT` to your host `.codex` directory.</li>
-            <li>2. Run `docker compose up -d`.</li>
-            <li>3. Run `codex login` on the host once.</li>
-            <li>4. Return and click `Check Status`.</li>
-          </ol>
+          <div className="text-center font-mono text-2xl font-semibold tracking-widest text-foreground">
+            {codexAuthStatus?.userCode}
+          </div>
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <Button
+              type="button"
+              size="sm"
+              variant="secondary"
+              onClick={() => void copyCode()}
+              disabled={isBusy}
+            >
+              <Copy className="h-3.5 w-3.5" />
+              {hasCopiedCode ? "Copied" : "Copy code"}
+            </Button>
+            <Button type="button" size="sm" variant="outline" asChild>
+              <a
+                href={codexAuthStatus?.verificationUrl ?? "#"}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                Open verification page
+              </a>
+            </Button>
+          </div>
+          {showExpiryCountdown ? (
+            <div className="text-center text-[11px] text-amber-700">
+              Code expires in {formatRemaining(remainingMs)}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap gap-2">
+        {hasDevicePayload && !isAuthenticated ? (
+          <>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => void refreshCodexAuthStatus()}
+              disabled={isBusy || isLoadingCodexAuthStatus}
+            >
+              {isLoadingCodexAuthStatus ? "Checking..." : "Check Status"}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() => void startCodexAuth()}
+              disabled={isBusy || isStartingCodexAuth}
+            >
+              {isStartingCodexAuth ? "Starting..." : "Start New Sign-In"}
+            </Button>
+          </>
+        ) : (
           <Button
             type="button"
             size="sm"
-            variant="secondary"
-            onClick={() => void refreshCodexAuthStatus()}
-            disabled={isBusy || isLoadingCodexAuthStatus}
+            onClick={() => void startCodexAuth()}
+            disabled={isBusy || isStartingCodexAuth}
           >
-            {isLoadingCodexAuthStatus ? "Checking..." : "Check Status"}
+            {isStartingCodexAuth ? "Starting..." : "Start Sign-In"}
           </Button>
-        </div>
-      )}
+        )}
+      </div>
 
       {codexAuthError ? (
         <p className="text-xs text-destructive">{codexAuthError}</p>

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -13,6 +13,8 @@ import { OnboardingPage } from "./OnboardingPage";
 vi.mock("@client/api", () => ({
   importDesignResumeFromFile: vi.fn(),
   suggestOnboardingSearchTerms: vi.fn(),
+  getCodexAuthStatus: vi.fn(),
+  startCodexAuth: vi.fn(),
   validateLlm: vi.fn(),
   validateRxresume: vi.fn(),
   validateResumeConfig: vi.fn(),
@@ -155,6 +157,31 @@ describe("OnboardingPage", () => {
       terms: ["Platform Engineer", "Backend Engineer"],
       source: "ai",
     });
+    vi.mocked(api.getCodexAuthStatus).mockResolvedValue({
+      authenticated: false,
+      validationMessage:
+        "Codex is not authenticated in this container. Run `codex login` and try again.",
+      flowStatus: "idle",
+      loginInProgress: false,
+      verificationUrl: null,
+      userCode: null,
+      startedAt: null,
+      expiresAt: null,
+      flowMessage: null,
+    });
+    vi.mocked(api.startCodexAuth).mockResolvedValue({
+      authenticated: false,
+      validationMessage:
+        "Codex is not authenticated in this container. Run `codex login` and try again.",
+      flowStatus: "running",
+      loginInProgress: true,
+      verificationUrl: "https://auth.openai.com/codex/device",
+      userCode: "ABCD-EFGH",
+      startedAt: "2026-04-14T16:00:00.000Z",
+      expiresAt: "2026-04-14T16:15:00.000Z",
+      flowMessage:
+        "Open the verification URL and enter the one-time code to finish login.",
+    });
   });
 
   it("keeps the LLM step visible even when a key hint already exists", async () => {
@@ -180,6 +207,39 @@ describe("OnboardingPage", () => {
     expect(screen.getByLabelText("API key")).toBeInTheDocument();
     expect(
       screen.getByText(/leave blank to keep the saved key/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows Codex sign-in controls in onboarding when provider is codex", async () => {
+    currentSettings = {
+      ...baseSettings,
+      llmProvider: { value: "codex", default: "codex", override: null },
+      llmApiKeyHint: null,
+    };
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: false,
+      message: "Codex is not authenticated in this container.",
+    });
+    vi.mocked(api.validateRxresume).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateResumeConfig).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(api.getCodexAuthStatus).toHaveBeenCalled());
+    expect(screen.getByText("Codex Sign-In")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /start sign-in/i }));
+
+    await waitFor(() => expect(api.startCodexAuth).toHaveBeenCalled());
+    expect(await screen.findByText(/ABCD-EFGH/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/https:\/\/auth\.openai\.com\/codex\/device/i),
     ).toBeInTheDocument();
   });
 

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -238,9 +238,13 @@ describe("OnboardingPage", () => {
 
     await waitFor(() => expect(api.startCodexAuth).toHaveBeenCalled());
     expect(await screen.findByText(/ABCD-EFGH/)).toBeInTheDocument();
-    expect(
-      await screen.findByText(/https:\/\/auth\.openai\.com\/codex\/device/i),
-    ).toBeInTheDocument();
+    const openVerificationLink = await screen.findByRole("link", {
+      name: /open verification page/i,
+    });
+    expect(openVerificationLink).toHaveAttribute(
+      "href",
+      "https://auth.openai.com/codex/device",
+    );
   });
 
   it("does not treat local providers as validated before the connection check passes", async () => {

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@client/api", () => ({
   suggestOnboardingSearchTerms: vi.fn(),
   getCodexAuthStatus: vi.fn(),
   startCodexAuth: vi.fn(),
+  disconnectCodexAuth: vi.fn(),
   validateLlm: vi.fn(),
   validateRxresume: vi.fn(),
   validateResumeConfig: vi.fn(),
@@ -159,6 +160,7 @@ describe("OnboardingPage", () => {
     });
     vi.mocked(api.getCodexAuthStatus).mockResolvedValue({
       authenticated: false,
+      username: null,
       validationMessage:
         "Codex is not authenticated in this container. Run `codex login` and try again.",
       flowStatus: "idle",
@@ -171,6 +173,7 @@ describe("OnboardingPage", () => {
     });
     vi.mocked(api.startCodexAuth).mockResolvedValue({
       authenticated: false,
+      username: null,
       validationMessage:
         "Codex is not authenticated in this container. Run `codex login` and try again.",
       flowStatus: "running",

--- a/orchestrator/src/client/pages/SettingsPage.test.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../api", () => ({
   getLlmModels: vi.fn().mockResolvedValue([]),
   getCodexAuthStatus: vi.fn().mockResolvedValue({
     authenticated: false,
+    username: null,
     validationMessage:
       "Codex is not authenticated in this container. Run `codex login` and try again.",
     flowStatus: "idle",
@@ -31,6 +32,7 @@ vi.mock("../api", () => ({
   }),
   startCodexAuth: vi.fn().mockResolvedValue({
     authenticated: false,
+    username: null,
     validationMessage:
       "Codex is not authenticated in this container. Run `codex login` and try again.",
     flowStatus: "running",
@@ -42,6 +44,7 @@ vi.mock("../api", () => ({
     flowMessage:
       "Open the verification URL and enter the one-time code to finish login.",
   }),
+  disconnectCodexAuth: vi.fn(),
   updateSettings: vi.fn(),
   validateRxresume: vi.fn(),
   getRxResumeProjects: vi.fn(),

--- a/orchestrator/src/client/pages/SettingsPage.test.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.test.tsx
@@ -17,6 +17,31 @@ const render = (ui: Parameters<typeof renderWithQueryClient>[0]) =>
 vi.mock("../api", () => ({
   getSettings: vi.fn(),
   getLlmModels: vi.fn().mockResolvedValue([]),
+  getCodexAuthStatus: vi.fn().mockResolvedValue({
+    authenticated: false,
+    validationMessage:
+      "Codex is not authenticated in this container. Run `codex login` and try again.",
+    flowStatus: "idle",
+    loginInProgress: false,
+    verificationUrl: null,
+    userCode: null,
+    startedAt: null,
+    expiresAt: null,
+    flowMessage: null,
+  }),
+  startCodexAuth: vi.fn().mockResolvedValue({
+    authenticated: false,
+    validationMessage:
+      "Codex is not authenticated in this container. Run `codex login` and try again.",
+    flowStatus: "running",
+    loginInProgress: true,
+    verificationUrl: "https://auth.openai.com/codex/device",
+    userCode: "ABCD-EFGH",
+    startedAt: "2026-04-14T16:00:00.000Z",
+    expiresAt: "2026-04-14T16:15:00.000Z",
+    flowMessage:
+      "Open the verification URL and enter the one-time code to finish login.",
+  }),
   updateSettings: vi.fn(),
   validateRxresume: vi.fn(),
   getRxResumeProjects: vi.fn(),
@@ -179,6 +204,34 @@ describe("SettingsPage", () => {
       }),
     );
     expect(toast.success).toHaveBeenCalledWith("Settings saved");
+  });
+
+  it("starts codex sign-in from model settings", async () => {
+    vi.mocked(api.getSettings).mockResolvedValue(
+      createAppSettings({
+        llmProvider: {
+          value: "codex",
+          default: "codex",
+          override: "codex",
+        },
+      }),
+    );
+
+    renderPage();
+    await openModelSection();
+
+    await waitFor(() => expect(api.getCodexAuthStatus).toHaveBeenCalled());
+
+    const startButton = await screen.findByRole("button", {
+      name: /start sign-in/i,
+    });
+    fireEvent.click(startButton);
+
+    await waitFor(() => expect(api.startCodexAuth).toHaveBeenCalled());
+    expect(await screen.findByText(/ABCD-EFGH/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/https:\/\/auth\.openai\.com\/codex\/device/i),
+    ).toBeInTheDocument();
   });
 
   it("shows validation error for too long model override", async () => {

--- a/orchestrator/src/client/pages/SettingsPage.test.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.test.tsx
@@ -229,9 +229,13 @@ describe("SettingsPage", () => {
 
     await waitFor(() => expect(api.startCodexAuth).toHaveBeenCalled());
     expect(await screen.findByText(/ABCD-EFGH/)).toBeInTheDocument();
-    expect(
-      await screen.findByText(/https:\/\/auth\.openai\.com\/codex\/device/i),
-    ).toBeInTheDocument();
+    const openVerificationLink = await screen.findByRole("link", {
+      name: /open verification page/i,
+    });
+    expect(openVerificationLink).toHaveAttribute(
+      "href",
+      "https://auth.openai.com/codex/device",
+    );
   });
 
   it("shows validation error for too long model override", async () => {

--- a/orchestrator/src/client/pages/SettingsPage.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.tsx
@@ -168,7 +168,7 @@ const SETTINGS_NAV_GROUPS: SettingsNavGroup[] = [
         id: "model",
         label: "Models",
         description: "Provider, API credentials, and task-specific overrides.",
-        searchTerms: ["llm", "provider", "openai", "gemini", "ollama"],
+        searchTerms: ["llm", "provider", "openai", "gemini", "ollama", "codex"],
       },
       {
         id: "chat",

--- a/orchestrator/src/client/pages/onboarding/components/LlmConnectionStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/LlmConnectionStep.tsx
@@ -173,6 +173,20 @@ export const LlmConnectionStep: React.FC<{
           {isCodexProvider ? (
             <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
               <div className="text-xs font-medium">Codex Sign-In</div>
+              <div className="space-y-1 text-xs text-muted-foreground">
+                <p>Option 1: Start sign-in here with a one-time device code.</p>
+                <p>
+                  Option 2: Reuse host login (Docker) by setting{" "}
+                  <span className="font-mono text-foreground">
+                    CODEX_HOME_MOUNT
+                  </span>{" "}
+                  to your host{" "}
+                  <span className="font-mono text-foreground">.codex</span>{" "}
+                  path, then running{" "}
+                  <span className="font-mono text-foreground">codex login</span>{" "}
+                  on the host once.
+                </p>
+              </div>
               <p className="text-xs text-muted-foreground">
                 {codexAuthStatus?.authenticated
                   ? "Codex is authenticated and ready."

--- a/orchestrator/src/client/pages/onboarding/components/LlmConnectionStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/LlmConnectionStep.tsx
@@ -1,3 +1,4 @@
+import * as api from "@client/api";
 import { SettingsInput } from "@client/pages/settings/components/SettingsInput";
 import {
   getLlmProviderConfig,
@@ -6,7 +7,9 @@ import {
   type LlmProviderId,
 } from "@client/pages/settings/utils";
 import type React from "react";
+import { useCallback, useEffect, useState } from "react";
 import { type Control, Controller } from "react-hook-form";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -50,6 +53,90 @@ export const LlmConnectionStep: React.FC<{
 }> = ({ control, isBusy, llmKeyHint, selectedProvider, validation }) => {
   const providerConfig = getLlmProviderConfig(selectedProvider);
   const { showApiKey, showBaseUrl } = providerConfig;
+  const isCodexProvider = providerConfig.normalizedProvider === "codex";
+  const [codexAuthStatus, setCodexAuthStatus] = useState<Awaited<
+    ReturnType<typeof api.getCodexAuthStatus>
+  > | null>(null);
+  const [isLoadingCodexAuthStatus, setIsLoadingCodexAuthStatus] =
+    useState(false);
+  const [isStartingCodexAuth, setIsStartingCodexAuth] = useState(false);
+  const [codexAuthError, setCodexAuthError] = useState<string | null>(null);
+
+  const refreshCodexAuthStatus = useCallback(
+    async (showLoading = true) => {
+      if (!isCodexProvider) return;
+      if (showLoading) {
+        setIsLoadingCodexAuthStatus(true);
+      }
+      setCodexAuthError(null);
+      try {
+        const status = await api.getCodexAuthStatus();
+        setCodexAuthStatus(status);
+      } catch (error) {
+        setCodexAuthError(
+          error instanceof Error
+            ? error.message
+            : "Failed to load Codex sign-in status.",
+        );
+      } finally {
+        if (showLoading) {
+          setIsLoadingCodexAuthStatus(false);
+        }
+      }
+    },
+    [isCodexProvider],
+  );
+
+  const startCodexAuth = useCallback(async () => {
+    setIsStartingCodexAuth(true);
+    setCodexAuthError(null);
+    try {
+      const status = await api.startCodexAuth();
+      setCodexAuthStatus(status);
+    } catch (error) {
+      setCodexAuthError(
+        error instanceof Error
+          ? error.message
+          : "Failed to start Codex sign-in.",
+      );
+    } finally {
+      setIsStartingCodexAuth(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isCodexProvider) {
+      setCodexAuthStatus(null);
+      setCodexAuthError(null);
+      setIsLoadingCodexAuthStatus(false);
+      setIsStartingCodexAuth(false);
+      return;
+    }
+
+    void refreshCodexAuthStatus();
+  }, [isCodexProvider, refreshCodexAuthStatus]);
+
+  useEffect(() => {
+    if (!isCodexProvider || !codexAuthStatus?.loginInProgress) {
+      return;
+    }
+    if (codexAuthStatus.authenticated) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      void refreshCodexAuthStatus(false);
+    }, 4_000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [
+    codexAuthStatus?.authenticated,
+    codexAuthStatus?.loginInProgress,
+    isCodexProvider,
+    refreshCodexAuthStatus,
+  ]);
 
   return (
     <div className="space-y-6">
@@ -83,6 +170,81 @@ export const LlmConnectionStep: React.FC<{
           <p className="text-sm text-muted-foreground">
             {providerConfig.providerHint}
           </p>
+          {isCodexProvider ? (
+            <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
+              <div className="text-xs font-medium">Codex Sign-In</div>
+              <p className="text-xs text-muted-foreground">
+                {codexAuthStatus?.authenticated
+                  ? "Codex is authenticated and ready."
+                  : "Start sign-in to get a device code, then complete it in your browser."}
+              </p>
+              {codexAuthStatus?.verificationUrl && codexAuthStatus?.userCode ? (
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  <div>
+                    Code:{" "}
+                    <span className="font-mono text-foreground">
+                      {codexAuthStatus.userCode}
+                    </span>
+                  </div>
+                  <div className="break-all">
+                    URL:{" "}
+                    <a
+                      href={codexAuthStatus.verificationUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
+                    >
+                      {codexAuthStatus.verificationUrl}
+                    </a>
+                  </div>
+                  {codexAuthStatus.expiresAt ? (
+                    <div>
+                      Expires at:{" "}
+                      {new Date(codexAuthStatus.expiresAt).toLocaleString()}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+              {codexAuthStatus?.validationMessage ? (
+                <p className="text-xs text-muted-foreground">
+                  Status: {codexAuthStatus.validationMessage}
+                </p>
+              ) : null}
+              {codexAuthStatus?.flowMessage &&
+              !codexAuthStatus.authenticated ? (
+                <p className="text-xs text-muted-foreground">
+                  {codexAuthStatus.flowMessage}
+                </p>
+              ) : null}
+              {codexAuthError ? (
+                <p className="text-xs text-destructive">{codexAuthError}</p>
+              ) : null}
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void startCodexAuth()}
+                  disabled={isBusy || isStartingCodexAuth}
+                >
+                  {isStartingCodexAuth
+                    ? "Starting..."
+                    : codexAuthStatus?.authenticated
+                      ? "Start New Sign-In"
+                      : "Start Sign-In"}
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="secondary"
+                  onClick={() => void refreshCodexAuthStatus()}
+                  disabled={isBusy || isLoadingCodexAuthStatus}
+                >
+                  {isLoadingCodexAuthStatus ? "Checking..." : "Refresh Status"}
+                </Button>
+              </div>
+            </div>
+          ) : null}
         </div>
 
         {showBaseUrl ? (
@@ -132,8 +294,7 @@ export const LlmConnectionStep: React.FC<{
           />
         ) : (
           <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 px-4 py-4 text-sm text-muted-foreground">
-            No API key is required for this provider. Job Ops will only validate
-            the local endpoint details.
+            No API key is required for this provider.
           </div>
         )}
       </div>

--- a/orchestrator/src/client/pages/onboarding/components/LlmConnectionStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/LlmConnectionStep.tsx
@@ -1,4 +1,4 @@
-import * as api from "@client/api";
+import { CodexAuthPanel } from "@client/components/CodexAuthPanel";
 import { SettingsInput } from "@client/pages/settings/components/SettingsInput";
 import {
   getLlmProviderConfig,
@@ -7,9 +7,7 @@ import {
   type LlmProviderId,
 } from "@client/pages/settings/utils";
 import type React from "react";
-import { useCallback, useEffect, useState } from "react";
 import { type Control, Controller } from "react-hook-form";
-import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -54,89 +52,6 @@ export const LlmConnectionStep: React.FC<{
   const providerConfig = getLlmProviderConfig(selectedProvider);
   const { showApiKey, showBaseUrl } = providerConfig;
   const isCodexProvider = providerConfig.normalizedProvider === "codex";
-  const [codexAuthStatus, setCodexAuthStatus] = useState<Awaited<
-    ReturnType<typeof api.getCodexAuthStatus>
-  > | null>(null);
-  const [isLoadingCodexAuthStatus, setIsLoadingCodexAuthStatus] =
-    useState(false);
-  const [isStartingCodexAuth, setIsStartingCodexAuth] = useState(false);
-  const [codexAuthError, setCodexAuthError] = useState<string | null>(null);
-
-  const refreshCodexAuthStatus = useCallback(
-    async (showLoading = true) => {
-      if (!isCodexProvider) return;
-      if (showLoading) {
-        setIsLoadingCodexAuthStatus(true);
-      }
-      setCodexAuthError(null);
-      try {
-        const status = await api.getCodexAuthStatus();
-        setCodexAuthStatus(status);
-      } catch (error) {
-        setCodexAuthError(
-          error instanceof Error
-            ? error.message
-            : "Failed to load Codex sign-in status.",
-        );
-      } finally {
-        if (showLoading) {
-          setIsLoadingCodexAuthStatus(false);
-        }
-      }
-    },
-    [isCodexProvider],
-  );
-
-  const startCodexAuth = useCallback(async () => {
-    setIsStartingCodexAuth(true);
-    setCodexAuthError(null);
-    try {
-      const status = await api.startCodexAuth();
-      setCodexAuthStatus(status);
-    } catch (error) {
-      setCodexAuthError(
-        error instanceof Error
-          ? error.message
-          : "Failed to start Codex sign-in.",
-      );
-    } finally {
-      setIsStartingCodexAuth(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!isCodexProvider) {
-      setCodexAuthStatus(null);
-      setCodexAuthError(null);
-      setIsLoadingCodexAuthStatus(false);
-      setIsStartingCodexAuth(false);
-      return;
-    }
-
-    void refreshCodexAuthStatus();
-  }, [isCodexProvider, refreshCodexAuthStatus]);
-
-  useEffect(() => {
-    if (!isCodexProvider || !codexAuthStatus?.loginInProgress) {
-      return;
-    }
-    if (codexAuthStatus.authenticated) {
-      return;
-    }
-
-    const timer = window.setInterval(() => {
-      void refreshCodexAuthStatus(false);
-    }, 4_000);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [
-    codexAuthStatus?.authenticated,
-    codexAuthStatus?.loginInProgress,
-    isCodexProvider,
-    refreshCodexAuthStatus,
-  ]);
 
   return (
     <div className="space-y-6">
@@ -170,95 +85,7 @@ export const LlmConnectionStep: React.FC<{
           <p className="text-sm text-muted-foreground">
             {providerConfig.providerHint}
           </p>
-          {isCodexProvider ? (
-            <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
-              <div className="text-xs font-medium">Codex Sign-In</div>
-              <div className="space-y-1 text-xs text-muted-foreground">
-                <p>Option 1: Start sign-in here with a one-time device code.</p>
-                <p>
-                  Option 2: Reuse host login (Docker) by setting{" "}
-                  <span className="font-mono text-foreground">
-                    CODEX_HOME_MOUNT
-                  </span>{" "}
-                  to your host{" "}
-                  <span className="font-mono text-foreground">.codex</span>{" "}
-                  path, then running{" "}
-                  <span className="font-mono text-foreground">codex login</span>{" "}
-                  on the host once.
-                </p>
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {codexAuthStatus?.authenticated
-                  ? "Codex is authenticated and ready."
-                  : "Start sign-in to get a device code, then complete it in your browser."}
-              </p>
-              {codexAuthStatus?.verificationUrl && codexAuthStatus?.userCode ? (
-                <div className="space-y-1 text-xs text-muted-foreground">
-                  <div>
-                    Code:{" "}
-                    <span className="font-mono text-foreground">
-                      {codexAuthStatus.userCode}
-                    </span>
-                  </div>
-                  <div className="break-all">
-                    URL:{" "}
-                    <a
-                      href={codexAuthStatus.verificationUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
-                    >
-                      {codexAuthStatus.verificationUrl}
-                    </a>
-                  </div>
-                  {codexAuthStatus.expiresAt ? (
-                    <div>
-                      Expires at:{" "}
-                      {new Date(codexAuthStatus.expiresAt).toLocaleString()}
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
-              {codexAuthStatus?.validationMessage ? (
-                <p className="text-xs text-muted-foreground">
-                  Status: {codexAuthStatus.validationMessage}
-                </p>
-              ) : null}
-              {codexAuthStatus?.flowMessage &&
-              !codexAuthStatus.authenticated ? (
-                <p className="text-xs text-muted-foreground">
-                  {codexAuthStatus.flowMessage}
-                </p>
-              ) : null}
-              {codexAuthError ? (
-                <p className="text-xs text-destructive">{codexAuthError}</p>
-              ) : null}
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  onClick={() => void startCodexAuth()}
-                  disabled={isBusy || isStartingCodexAuth}
-                >
-                  {isStartingCodexAuth
-                    ? "Starting..."
-                    : codexAuthStatus?.authenticated
-                      ? "Start New Sign-In"
-                      : "Start Sign-In"}
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="secondary"
-                  onClick={() => void refreshCodexAuthStatus()}
-                  disabled={isBusy || isLoadingCodexAuthStatus}
-                >
-                  {isLoadingCodexAuthStatus ? "Checking..." : "Refresh Status"}
-                </Button>
-              </div>
-            </div>
-          ) : null}
+          {isCodexProvider ? <CodexAuthPanel isBusy={isBusy} /> : null}
         </div>
 
         {showBaseUrl ? (

--- a/orchestrator/src/client/pages/settings/components/ModelSettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/ModelSettingsSection.tsx
@@ -12,8 +12,15 @@ import {
 import { getDefaultModelForProvider } from "@shared/settings-registry";
 import type { UpdateSettingsInput } from "@shared/settings-schema.js";
 import type React from "react";
-import { useDeferredValue, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Controller, useFormContext } from "react-hook-form";
+import { Button } from "@/components/ui/button";
 import { SearchableDropdown } from "@/components/ui/searchable-dropdown";
 import {
   Select,
@@ -64,6 +71,13 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
   const [modelsError, setModelsError] = useState<string | null>(null);
+  const [codexAuthStatus, setCodexAuthStatus] = useState<Awaited<
+    ReturnType<typeof api.getCodexAuthStatus>
+  > | null>(null);
+  const [isLoadingCodexAuthStatus, setIsLoadingCodexAuthStatus] =
+    useState(false);
+  const [isStartingCodexAuth, setIsStartingCodexAuth] = useState(false);
+  const [codexAuthError, setCodexAuthError] = useState<string | null>(null);
   const {
     effective,
     default: defaultModel,
@@ -83,6 +97,7 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
   const previousProviderRef = useRef(selectedProvider);
   const providerConfig = getLlmProviderConfig(selectedProvider);
   const { showApiKey, showBaseUrl } = providerConfig;
+  const isCodexProvider = providerConfig.normalizedProvider === "codex";
 
   const llmBaseUrlValue = watch("llmBaseUrl");
   const llmApiKeyValue = watch("llmApiKey") ?? "";
@@ -102,6 +117,48 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
   const hasAvailableApiKey = showApiKey
     ? Boolean(deferredApiKey.trim() || llmApiKeyHint)
     : true;
+
+  const refreshCodexAuthStatus = useCallback(
+    async (showLoading = true) => {
+      if (!isCodexProvider) return;
+      if (showLoading) {
+        setIsLoadingCodexAuthStatus(true);
+      }
+      setCodexAuthError(null);
+      try {
+        const status = await api.getCodexAuthStatus();
+        setCodexAuthStatus(status);
+      } catch (error) {
+        setCodexAuthError(
+          error instanceof Error
+            ? error.message
+            : "Failed to load Codex sign-in status.",
+        );
+      } finally {
+        if (showLoading) {
+          setIsLoadingCodexAuthStatus(false);
+        }
+      }
+    },
+    [isCodexProvider],
+  );
+
+  const startCodexAuth = useCallback(async () => {
+    setIsStartingCodexAuth(true);
+    setCodexAuthError(null);
+    try {
+      const status = await api.startCodexAuth();
+      setCodexAuthStatus(status);
+    } catch (error) {
+      setCodexAuthError(
+        error instanceof Error
+          ? error.message
+          : "Failed to start Codex sign-in.",
+      );
+    } finally {
+      setIsStartingCodexAuth(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (showBaseUrl) return;
@@ -179,6 +236,40 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
     showApiKey,
     showBaseUrl,
     supportsModelSuggestions,
+  ]);
+
+  useEffect(() => {
+    if (!isCodexProvider) {
+      setCodexAuthStatus(null);
+      setCodexAuthError(null);
+      setIsLoadingCodexAuthStatus(false);
+      setIsStartingCodexAuth(false);
+      return;
+    }
+
+    void refreshCodexAuthStatus();
+  }, [isCodexProvider, refreshCodexAuthStatus]);
+
+  useEffect(() => {
+    if (!isCodexProvider || !codexAuthStatus?.loginInProgress) {
+      return;
+    }
+    if (codexAuthStatus.authenticated) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      void refreshCodexAuthStatus(false);
+    }, 4_000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [
+    codexAuthStatus?.authenticated,
+    codexAuthStatus?.loginInProgress,
+    isCodexProvider,
+    refreshCodexAuthStatus,
   ]);
 
   const keyHint = formatSecretHint(llmApiKeyHint);
@@ -273,6 +364,88 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
               <p className="text-xs text-muted-foreground">
                 {providerConfig.providerHint}
               </p>
+              {isCodexProvider && (
+                <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
+                  <div className="text-xs font-medium">Codex Sign-In</div>
+                  <p className="text-xs text-muted-foreground">
+                    {codexAuthStatus?.authenticated
+                      ? "Codex is authenticated and ready."
+                      : "Start sign-in to get a device code, then complete it in your browser."}
+                  </p>
+                  {codexAuthStatus?.verificationUrl &&
+                    codexAuthStatus?.userCode && (
+                      <div className="space-y-1 text-xs text-muted-foreground">
+                        <div>
+                          Code:{" "}
+                          <span className="font-mono text-foreground">
+                            {codexAuthStatus.userCode}
+                          </span>
+                        </div>
+                        <div className="break-all">
+                          URL:{" "}
+                          <a
+                            href={codexAuthStatus.verificationUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
+                          >
+                            {codexAuthStatus.verificationUrl}
+                          </a>
+                        </div>
+                        {codexAuthStatus.expiresAt && (
+                          <div>
+                            Expires at:{" "}
+                            {new Date(
+                              codexAuthStatus.expiresAt,
+                            ).toLocaleString()}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  {codexAuthStatus?.validationMessage && (
+                    <p className="text-xs text-muted-foreground">
+                      Status: {codexAuthStatus.validationMessage}
+                    </p>
+                  )}
+                  {codexAuthStatus?.flowMessage &&
+                    !codexAuthStatus.authenticated && (
+                      <p className="text-xs text-muted-foreground">
+                        {codexAuthStatus.flowMessage}
+                      </p>
+                    )}
+                  {codexAuthError && (
+                    <p className="text-xs text-destructive">{codexAuthError}</p>
+                  )}
+                  <div className="flex flex-wrap gap-2">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void startCodexAuth()}
+                      disabled={isLoading || isSaving || isStartingCodexAuth}
+                    >
+                      {isStartingCodexAuth
+                        ? "Starting..."
+                        : codexAuthStatus?.authenticated
+                          ? "Start New Sign-In"
+                          : "Start Sign-In"}
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      onClick={() => void refreshCodexAuthStatus()}
+                      disabled={
+                        isLoading || isSaving || isLoadingCodexAuthStatus
+                      }
+                    >
+                      {isLoadingCodexAuthStatus
+                        ? "Checking..."
+                        : "Refresh Status"}
+                    </Button>
+                  </div>
+                </div>
+              )}
             </div>
             {showBaseUrl && (
               <SettingsInput

--- a/orchestrator/src/client/pages/settings/components/ModelSettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/ModelSettingsSection.tsx
@@ -1,4 +1,5 @@
 import * as api from "@client/api";
+import { CodexAuthPanel } from "@client/components/CodexAuthPanel";
 import { SettingsInput } from "@client/pages/settings/components/SettingsInput";
 import { SettingsSectionFrame } from "@client/pages/settings/components/SettingsSectionFrame";
 import type { ModelValues } from "@client/pages/settings/types";
@@ -12,15 +13,8 @@ import {
 import { getDefaultModelForProvider } from "@shared/settings-registry";
 import type { UpdateSettingsInput } from "@shared/settings-schema.js";
 import type React from "react";
-import {
-  useCallback,
-  useDeferredValue,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
+import { useDeferredValue, useEffect, useRef, useState } from "react";
 import { Controller, useFormContext } from "react-hook-form";
-import { Button } from "@/components/ui/button";
 import { SearchableDropdown } from "@/components/ui/searchable-dropdown";
 import {
   Select,
@@ -71,13 +65,6 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
   const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [isLoadingModels, setIsLoadingModels] = useState(false);
   const [modelsError, setModelsError] = useState<string | null>(null);
-  const [codexAuthStatus, setCodexAuthStatus] = useState<Awaited<
-    ReturnType<typeof api.getCodexAuthStatus>
-  > | null>(null);
-  const [isLoadingCodexAuthStatus, setIsLoadingCodexAuthStatus] =
-    useState(false);
-  const [isStartingCodexAuth, setIsStartingCodexAuth] = useState(false);
-  const [codexAuthError, setCodexAuthError] = useState<string | null>(null);
   const {
     effective,
     default: defaultModel,
@@ -117,48 +104,6 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
   const hasAvailableApiKey = showApiKey
     ? Boolean(deferredApiKey.trim() || llmApiKeyHint)
     : true;
-
-  const refreshCodexAuthStatus = useCallback(
-    async (showLoading = true) => {
-      if (!isCodexProvider) return;
-      if (showLoading) {
-        setIsLoadingCodexAuthStatus(true);
-      }
-      setCodexAuthError(null);
-      try {
-        const status = await api.getCodexAuthStatus();
-        setCodexAuthStatus(status);
-      } catch (error) {
-        setCodexAuthError(
-          error instanceof Error
-            ? error.message
-            : "Failed to load Codex sign-in status.",
-        );
-      } finally {
-        if (showLoading) {
-          setIsLoadingCodexAuthStatus(false);
-        }
-      }
-    },
-    [isCodexProvider],
-  );
-
-  const startCodexAuth = useCallback(async () => {
-    setIsStartingCodexAuth(true);
-    setCodexAuthError(null);
-    try {
-      const status = await api.startCodexAuth();
-      setCodexAuthStatus(status);
-    } catch (error) {
-      setCodexAuthError(
-        error instanceof Error
-          ? error.message
-          : "Failed to start Codex sign-in.",
-      );
-    } finally {
-      setIsStartingCodexAuth(false);
-    }
-  }, []);
 
   useEffect(() => {
     if (showBaseUrl) return;
@@ -236,40 +181,6 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
     showApiKey,
     showBaseUrl,
     supportsModelSuggestions,
-  ]);
-
-  useEffect(() => {
-    if (!isCodexProvider) {
-      setCodexAuthStatus(null);
-      setCodexAuthError(null);
-      setIsLoadingCodexAuthStatus(false);
-      setIsStartingCodexAuth(false);
-      return;
-    }
-
-    void refreshCodexAuthStatus();
-  }, [isCodexProvider, refreshCodexAuthStatus]);
-
-  useEffect(() => {
-    if (!isCodexProvider || !codexAuthStatus?.loginInProgress) {
-      return;
-    }
-    if (codexAuthStatus.authenticated) {
-      return;
-    }
-
-    const timer = window.setInterval(() => {
-      void refreshCodexAuthStatus(false);
-    }, 4_000);
-
-    return () => {
-      window.clearInterval(timer);
-    };
-  }, [
-    codexAuthStatus?.authenticated,
-    codexAuthStatus?.loginInProgress,
-    isCodexProvider,
-    refreshCodexAuthStatus,
   ]);
 
   const keyHint = formatSecretHint(llmApiKeyHint);
@@ -364,106 +275,9 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
               <p className="text-xs text-muted-foreground">
                 {providerConfig.providerHint}
               </p>
-              {isCodexProvider && (
-                <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
-                  <div className="text-xs font-medium">Codex Sign-In</div>
-                  <div className="space-y-1 text-xs text-muted-foreground">
-                    <p>
-                      Option 1: Start sign-in here with a one-time device code.
-                    </p>
-                    <p>
-                      Option 2: Reuse host login (Docker) by setting{" "}
-                      <span className="font-mono text-foreground">
-                        CODEX_HOME_MOUNT
-                      </span>{" "}
-                      to your host{" "}
-                      <span className="font-mono text-foreground">.codex</span>{" "}
-                      path, then running{" "}
-                      <span className="font-mono text-foreground">
-                        codex login
-                      </span>{" "}
-                      on the host once.
-                    </p>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    {codexAuthStatus?.authenticated
-                      ? "Codex is authenticated and ready."
-                      : "Start sign-in to get a device code, then complete it in your browser."}
-                  </p>
-                  {codexAuthStatus?.verificationUrl &&
-                    codexAuthStatus?.userCode && (
-                      <div className="space-y-1 text-xs text-muted-foreground">
-                        <div>
-                          Code:{" "}
-                          <span className="font-mono text-foreground">
-                            {codexAuthStatus.userCode}
-                          </span>
-                        </div>
-                        <div className="break-all">
-                          URL:{" "}
-                          <a
-                            href={codexAuthStatus.verificationUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
-                          >
-                            {codexAuthStatus.verificationUrl}
-                          </a>
-                        </div>
-                        {codexAuthStatus.expiresAt && (
-                          <div>
-                            Expires at:{" "}
-                            {new Date(
-                              codexAuthStatus.expiresAt,
-                            ).toLocaleString()}
-                          </div>
-                        )}
-                      </div>
-                    )}
-                  {codexAuthStatus?.validationMessage && (
-                    <p className="text-xs text-muted-foreground">
-                      Status: {codexAuthStatus.validationMessage}
-                    </p>
-                  )}
-                  {codexAuthStatus?.flowMessage &&
-                    !codexAuthStatus.authenticated && (
-                      <p className="text-xs text-muted-foreground">
-                        {codexAuthStatus.flowMessage}
-                      </p>
-                    )}
-                  {codexAuthError && (
-                    <p className="text-xs text-destructive">{codexAuthError}</p>
-                  )}
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      onClick={() => void startCodexAuth()}
-                      disabled={isLoading || isSaving || isStartingCodexAuth}
-                    >
-                      {isStartingCodexAuth
-                        ? "Starting..."
-                        : codexAuthStatus?.authenticated
-                          ? "Start New Sign-In"
-                          : "Start Sign-In"}
-                    </Button>
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="secondary"
-                      onClick={() => void refreshCodexAuthStatus()}
-                      disabled={
-                        isLoading || isSaving || isLoadingCodexAuthStatus
-                      }
-                    >
-                      {isLoadingCodexAuthStatus
-                        ? "Checking..."
-                        : "Refresh Status"}
-                    </Button>
-                  </div>
-                </div>
-              )}
+              {isCodexProvider ? (
+                <CodexAuthPanel isBusy={isLoading || isSaving} />
+              ) : null}
             </div>
             {showBaseUrl && (
               <SettingsInput

--- a/orchestrator/src/client/pages/settings/components/ModelSettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/ModelSettingsSection.tsx
@@ -367,6 +367,24 @@ export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
               {isCodexProvider && (
                 <div className="space-y-2 rounded-md border border-border bg-muted/30 p-3">
                   <div className="text-xs font-medium">Codex Sign-In</div>
+                  <div className="space-y-1 text-xs text-muted-foreground">
+                    <p>
+                      Option 1: Start sign-in here with a one-time device code.
+                    </p>
+                    <p>
+                      Option 2: Reuse host login (Docker) by setting{" "}
+                      <span className="font-mono text-foreground">
+                        CODEX_HOME_MOUNT
+                      </span>{" "}
+                      to your host{" "}
+                      <span className="font-mono text-foreground">.codex</span>{" "}
+                      path, then running{" "}
+                      <span className="font-mono text-foreground">
+                        codex login
+                      </span>{" "}
+                      on the host once.
+                    </p>
+                  </div>
                   <p className="text-xs text-muted-foreground">
                     {codexAuthStatus?.authenticated
                       ? "Codex is authenticated and ready."

--- a/orchestrator/src/client/pages/settings/utils.test.ts
+++ b/orchestrator/src/client/pages/settings/utils.test.ts
@@ -28,6 +28,13 @@ describe("settings utils", () => {
       "https://aistudio.google.com/app/apikey",
     );
     expect(getLlmProviderConfig("ollama").keyHelperHref).toBeNull();
+    expect(getLlmProviderConfig("codex").keyHelperHref).toBeNull();
+  });
+
+  it("treats codex as a local provider without API key and base URL inputs", () => {
+    const config = getLlmProviderConfig("codex");
+    expect(config.showApiKey).toBe(false);
+    expect(config.showBaseUrl).toBe(false);
   });
 
   it("normalizes the hyphenated openai-compatible alias", () => {

--- a/orchestrator/src/client/pages/settings/utils.ts
+++ b/orchestrator/src/client/pages/settings/utils.ts
@@ -26,6 +26,7 @@ export const LLM_PROVIDERS = [
   "openai",
   "openai_compatible",
   "gemini",
+  "codex",
 ] as const;
 
 export type LlmProviderId = (typeof LLM_PROVIDERS)[number];
@@ -42,6 +43,7 @@ export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
   openai: "OpenAI",
   openai_compatible: "OpenAI-compatible",
   gemini: "Gemini",
+  codex: "Codex",
 };
 
 const PROVIDERS_WITH_API_KEY = new Set<LlmProviderId>([
@@ -66,6 +68,8 @@ const PROVIDER_HINTS: Record<LlmProviderId, string> = {
   openai_compatible:
     "Use a bearer token with any chat-completions-compatible endpoint.",
   gemini: "Gemini uses the native AI Studio API and requires a key.",
+  codex:
+    "Codex runs through a local app-server process and uses your Codex login session.",
 };
 
 const PROVIDER_KEY_HELPERS: Record<
@@ -89,6 +93,7 @@ const PROVIDER_KEY_HELPERS: Record<
     text: "Create a key at aistudio.google.com/api-keys",
     href: "https://aistudio.google.com/app/apikey",
   },
+  codex: { text: "No API key required when Codex is authenticated locally" },
 };
 
 const BASE_URL_PROVIDERS = ["lmstudio", "ollama", "openai_compatible"] as const;

--- a/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
+++ b/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
@@ -73,6 +73,25 @@ describe.sequential("Settings codex auth routes", () => {
     expect(body.data.validationMessage).toBe("Codex not authenticated");
   });
 
+  it("caches codex validation briefly while device auth is in progress", async () => {
+    getCodexDeviceAuthSnapshotMock.mockReturnValue({
+      status: "running",
+      loginInProgress: true,
+      verificationUrl: "https://auth.openai.com/codex/device",
+      userCode: "ABCD-EFGH",
+      startedAt: "2026-04-14T16:00:00.000Z",
+      expiresAt: "2026-04-14T16:15:00.000Z",
+      message: "Open the verification URL and enter the one-time code.",
+    });
+
+    const first = await fetch(`${baseUrl}/api/settings/codex-auth`);
+    const second = await fetch(`${baseUrl}/api/settings/codex-auth`);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(validateCredentialsMock).toHaveBeenCalledTimes(1);
+  });
+
   it("starts codex device auth and returns flow details", async () => {
     startCodexDeviceAuthMock.mockResolvedValueOnce({
       status: "running",

--- a/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
+++ b/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
@@ -121,7 +121,20 @@ describe.sequential("Settings codex auth routes", () => {
     expect(body.ok).toBe(true);
     expect(body.data.flowStatus).toBe("running");
     expect(body.data.userCode).toBe("ABCD-EFGH");
-    expect(startCodexDeviceAuthMock).toHaveBeenCalledOnce();
+    expect(startCodexDeviceAuthMock).toHaveBeenCalledWith(false);
+  });
+
+  it("forces codex device auth restart when requested", async () => {
+    const res = await fetch(`${baseUrl}/api/settings/codex-auth/start`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ forceRestart: true }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(startCodexDeviceAuthMock).toHaveBeenCalledWith(true);
   });
 
   it("returns SERVICE_UNAVAILABLE when codex auth start fails", async () => {

--- a/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
+++ b/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
@@ -1,0 +1,124 @@
+import type { Server } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  startCodexDeviceAuthMock,
+  getCodexDeviceAuthSnapshotMock,
+  validateCredentialsMock,
+} = vi.hoisted(() => ({
+  startCodexDeviceAuthMock: vi.fn(),
+  getCodexDeviceAuthSnapshotMock: vi.fn(),
+  validateCredentialsMock: vi.fn(),
+}));
+
+vi.mock("@server/services/llm/codex/login", () => ({
+  startCodexDeviceAuth: startCodexDeviceAuthMock,
+  getCodexDeviceAuthSnapshot: getCodexDeviceAuthSnapshotMock,
+}));
+
+vi.mock("@server/services/llm/service", () => ({
+  LlmService: vi.fn(function MockLlmService() {
+    return {
+      validateCredentials: validateCredentialsMock,
+      listModels: vi.fn().mockResolvedValue([]),
+    };
+  }),
+}));
+
+import { startServer, stopServer } from "./test-utils";
+
+describe.sequential("Settings codex auth routes", () => {
+  let server: Server;
+  let baseUrl: string;
+  let closeDb: () => void;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    getCodexDeviceAuthSnapshotMock.mockReturnValue({
+      status: "idle",
+      loginInProgress: false,
+      verificationUrl: null,
+      userCode: null,
+      startedAt: null,
+      expiresAt: null,
+      message: null,
+    });
+    validateCredentialsMock.mockResolvedValue({
+      valid: false,
+      message: "Codex not authenticated",
+    });
+    startCodexDeviceAuthMock.mockResolvedValue(undefined);
+
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: {
+        LLM_API_KEY: "secret-key",
+      },
+    }));
+  });
+
+  afterEach(async () => {
+    await stopServer({ server, closeDb, tempDir });
+  });
+
+  it("returns codex auth status in the standard API wrapper", async () => {
+    const res = await fetch(`${baseUrl}/api/settings/codex-auth`);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.authenticated).toBe(false);
+    expect(body.data.flowStatus).toBe("idle");
+    expect(body.data.validationMessage).toBe("Codex not authenticated");
+  });
+
+  it("starts codex device auth and returns flow details", async () => {
+    startCodexDeviceAuthMock.mockResolvedValueOnce({
+      status: "running",
+      loginInProgress: true,
+      verificationUrl: "https://auth.openai.com/codex/device",
+      userCode: "ABCD-EFGH",
+      startedAt: "2026-04-14T16:00:00.000Z",
+      expiresAt: "2026-04-14T16:15:00.000Z",
+      message: "Open the verification URL and enter the one-time code.",
+    });
+    getCodexDeviceAuthSnapshotMock.mockReturnValueOnce({
+      status: "running",
+      loginInProgress: true,
+      verificationUrl: "https://auth.openai.com/codex/device",
+      userCode: "ABCD-EFGH",
+      startedAt: "2026-04-14T16:00:00.000Z",
+      expiresAt: "2026-04-14T16:15:00.000Z",
+      message: "Open the verification URL and enter the one-time code.",
+    });
+
+    const res = await fetch(`${baseUrl}/api/settings/codex-auth/start`, {
+      method: "POST",
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.flowStatus).toBe("running");
+    expect(body.data.userCode).toBe("ABCD-EFGH");
+    expect(startCodexDeviceAuthMock).toHaveBeenCalledOnce();
+  });
+
+  it("returns SERVICE_UNAVAILABLE when codex auth start fails", async () => {
+    startCodexDeviceAuthMock.mockRejectedValueOnce(
+      new Error("Codex CLI is not installed in this runtime."),
+    );
+
+    const res = await fetch(`${baseUrl}/api/settings/codex-auth/start`, {
+      method: "POST",
+      headers: { "x-request-id": "req-codex-auth-fail" },
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    expect(body.meta.requestId).toBe("req-codex-auth-fail");
+  });
+});

--- a/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
+++ b/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
@@ -3,16 +3,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const {
   startCodexDeviceAuthMock,
+  disconnectCodexAuthMock,
   getCodexDeviceAuthSnapshotMock,
   validateCredentialsMock,
 } = vi.hoisted(() => ({
   startCodexDeviceAuthMock: vi.fn(),
+  disconnectCodexAuthMock: vi.fn(),
   getCodexDeviceAuthSnapshotMock: vi.fn(),
   validateCredentialsMock: vi.fn(),
 }));
 
 vi.mock("@server/services/llm/codex/login", () => ({
   startCodexDeviceAuth: startCodexDeviceAuthMock,
+  disconnectCodexAuth: disconnectCodexAuthMock,
   getCodexDeviceAuthSnapshot: getCodexDeviceAuthSnapshotMock,
 }));
 
@@ -50,6 +53,7 @@ describe.sequential("Settings codex auth routes", () => {
       message: "Codex not authenticated",
     });
     startCodexDeviceAuthMock.mockResolvedValue(undefined);
+    disconnectCodexAuthMock.mockResolvedValue(undefined);
 
     ({ server, baseUrl, closeDb, tempDir } = await startServer({
       env: {
@@ -152,5 +156,17 @@ describe.sequential("Settings codex auth routes", () => {
     expect(body.ok).toBe(false);
     expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
     expect(body.meta.requestId).toBe("req-codex-auth-fail");
+  });
+
+  it("disconnects codex auth and returns status", async () => {
+    const res = await fetch(`${baseUrl}/api/settings/codex-auth/disconnect`, {
+      method: "POST",
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.authenticated).toBe(false);
+    expect(disconnectCodexAuthMock).toHaveBeenCalledOnce();
   });
 });

--- a/orchestrator/src/server/api/routes/settings.ts
+++ b/orchestrator/src/server/api/routes/settings.ts
@@ -13,6 +13,7 @@ import { isDemoMode, sendDemoBlocked } from "@server/config/demo";
 import { getSetting } from "@server/repositories/settings";
 import { setBackupSettings } from "@server/services/backup/index";
 import {
+  disconnectCodexAuth,
   getCodexDeviceAuthSnapshot,
   startCodexDeviceAuth,
 } from "@server/services/llm/codex/login";
@@ -113,12 +114,13 @@ function getDefaultValidationBaseUrl(
 
 const CODEX_AUTH_VALIDATION_TTL_MS = 5_000;
 let codexValidationCache: {
-  value: { valid: boolean; message: string | null };
+  value: { valid: boolean; message: string | null; username?: string | null };
   expiresAtMs: number;
 } | null = null;
 let codexValidationInFlight: Promise<{
   valid: boolean;
   message: string | null;
+  username?: string | null;
 }> | null = null;
 
 function clearCodexValidationCache(): void {
@@ -129,6 +131,7 @@ function clearCodexValidationCache(): void {
 async function validateCodexCredentials(): Promise<{
   valid: boolean;
   message: string | null;
+  username?: string | null;
 }> {
   return await new LlmService({ provider: "codex" }).validateCredentials();
 }
@@ -136,6 +139,7 @@ async function validateCodexCredentials(): Promise<{
 async function getCachedCodexValidation(): Promise<{
   valid: boolean;
   message: string | null;
+  username?: string | null;
 }> {
   const now = Date.now();
   if (codexValidationCache && codexValidationCache.expiresAtMs > now) {
@@ -201,6 +205,7 @@ async function resolveLlmConfig(input: {
 
 async function getCodexAuthResponseData(): Promise<{
   authenticated: boolean;
+  username: string | null;
   validationMessage: string | null;
   flowStatus: string;
   loginInProgress: boolean;
@@ -220,6 +225,7 @@ async function getCodexAuthResponseData(): Promise<{
 
   return {
     authenticated: validation.valid,
+    username: validation.username ?? null,
     validationMessage: validation.message,
     flowStatus: flow.status,
     loginInProgress: flow.loginInProgress,
@@ -396,6 +402,37 @@ settingsRouter.post(
       logger.warn("Codex sign-in flow failed to start", {
         requestId: getRequestId() ?? null,
         route: "POST /api/settings/codex-auth/start",
+        message,
+      });
+      fail(res, serviceUnavailable(message));
+    }
+  }),
+);
+
+settingsRouter.post(
+  "/codex-auth/disconnect",
+  asyncRoute(async (_req: Request, res: Response) => {
+    if (isDemoMode()) {
+      return sendDemoBlocked(
+        res,
+        "Codex sign-out is disabled in the public demo.",
+        { route: "POST /api/settings/codex-auth/disconnect" },
+      );
+    }
+
+    try {
+      await disconnectCodexAuth();
+      clearCodexValidationCache();
+      const data = await getCodexAuthResponseData();
+      ok(res, data);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to disconnect Codex right now.";
+      logger.warn("Codex sign-out failed", {
+        requestId: getRequestId(),
+        route: "POST /api/settings/codex-auth/disconnect",
         message,
       });
       fail(res, serviceUnavailable(message));

--- a/orchestrator/src/server/api/routes/settings.ts
+++ b/orchestrator/src/server/api/routes/settings.ts
@@ -372,7 +372,7 @@ settingsRouter.get(
 
 settingsRouter.post(
   "/codex-auth/start",
-  asyncRoute(async (_req: Request, res: Response) => {
+  asyncRoute(async (req: Request, res: Response) => {
     if (isDemoMode()) {
       fail(
         res,
@@ -381,9 +381,11 @@ settingsRouter.post(
       return;
     }
 
+    const forceRestart = req.body?.forceRestart === true;
+
     try {
       clearCodexValidationCache();
-      await startCodexDeviceAuth();
+      await startCodexDeviceAuth(forceRestart);
       const data = await getCodexAuthResponseData();
       ok(res, data);
     } catch (error) {

--- a/orchestrator/src/server/api/routes/settings.ts
+++ b/orchestrator/src/server/api/routes/settings.ts
@@ -12,6 +12,10 @@ import { getRequestId } from "@infra/request-context";
 import { isDemoMode, sendDemoBlocked } from "@server/config/demo";
 import { getSetting } from "@server/repositories/settings";
 import { setBackupSettings } from "@server/services/backup/index";
+import {
+  getCodexDeviceAuthSnapshot,
+  startCodexDeviceAuth,
+} from "@server/services/llm/codex/login";
 import { LlmService } from "@server/services/llm/service";
 import { clearProfileCache } from "@server/services/profile";
 import {
@@ -144,6 +148,35 @@ async function resolveLlmConfig(input: {
   };
 }
 
+async function getCodexAuthResponseData(): Promise<{
+  authenticated: boolean;
+  validationMessage: string | null;
+  flowStatus: string;
+  loginInProgress: boolean;
+  verificationUrl: string | null;
+  userCode: string | null;
+  startedAt: string | null;
+  expiresAt: string | null;
+  flowMessage: string | null;
+}> {
+  const [validation, flow] = await Promise.all([
+    new LlmService({ provider: "codex" }).validateCredentials(),
+    Promise.resolve(getCodexDeviceAuthSnapshot()),
+  ]);
+
+  return {
+    authenticated: validation.valid,
+    validationMessage: validation.message,
+    flowStatus: flow.status,
+    loginInProgress: flow.loginInProgress,
+    verificationUrl: flow.verificationUrl,
+    userCode: flow.userCode,
+    startedAt: flow.startedAt,
+    expiresAt: flow.expiresAt,
+    flowMessage: flow.message,
+  };
+}
+
 /**
  * GET /api/settings - Get app settings (effective + defaults)
  */
@@ -271,6 +304,44 @@ settingsRouter.post(
           ? badRequest(message)
           : upstreamError(message),
       );
+    }
+  }),
+);
+
+settingsRouter.get(
+  "/codex-auth",
+  asyncRoute(async (_req: Request, res: Response) => {
+    const data = await getCodexAuthResponseData();
+    ok(res, data);
+  }),
+);
+
+settingsRouter.post(
+  "/codex-auth/start",
+  asyncRoute(async (_req: Request, res: Response) => {
+    if (isDemoMode()) {
+      fail(
+        res,
+        serviceUnavailable("Codex sign-in is disabled in the public demo."),
+      );
+      return;
+    }
+
+    try {
+      await startCodexDeviceAuth();
+      const data = await getCodexAuthResponseData();
+      ok(res, data);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Failed to start Codex sign-in.";
+      logger.warn("Codex sign-in flow failed to start", {
+        requestId: getRequestId() ?? null,
+        route: "POST /api/settings/codex-auth/start",
+        message,
+      });
+      fail(res, serviceUnavailable(message));
     }
   }),
 );

--- a/orchestrator/src/server/api/routes/settings.ts
+++ b/orchestrator/src/server/api/routes/settings.ts
@@ -111,6 +111,57 @@ function getDefaultValidationBaseUrl(
   return undefined;
 }
 
+const CODEX_AUTH_VALIDATION_TTL_MS = 5_000;
+let codexValidationCache: {
+  value: { valid: boolean; message: string | null };
+  expiresAtMs: number;
+} | null = null;
+let codexValidationInFlight: Promise<{
+  valid: boolean;
+  message: string | null;
+}> | null = null;
+
+function clearCodexValidationCache(): void {
+  codexValidationCache = null;
+  codexValidationInFlight = null;
+}
+
+async function validateCodexCredentials(): Promise<{
+  valid: boolean;
+  message: string | null;
+}> {
+  return await new LlmService({ provider: "codex" }).validateCredentials();
+}
+
+async function getCachedCodexValidation(): Promise<{
+  valid: boolean;
+  message: string | null;
+}> {
+  const now = Date.now();
+  if (codexValidationCache && codexValidationCache.expiresAtMs > now) {
+    return codexValidationCache.value;
+  }
+
+  if (codexValidationInFlight) {
+    return await codexValidationInFlight;
+  }
+
+  codexValidationInFlight = (async () => {
+    const validation = await validateCodexCredentials();
+    codexValidationCache = {
+      value: validation,
+      expiresAtMs: Date.now() + CODEX_AUTH_VALIDATION_TTL_MS,
+    };
+    return validation;
+  })();
+
+  try {
+    return await codexValidationInFlight;
+  } finally {
+    codexValidationInFlight = null;
+  }
+}
+
 async function resolveLlmConfig(input: {
   provider?: string | null;
   apiKey?: string | null;
@@ -159,10 +210,13 @@ async function getCodexAuthResponseData(): Promise<{
   expiresAt: string | null;
   flowMessage: string | null;
 }> {
-  const [validation, flow] = await Promise.all([
-    new LlmService({ provider: "codex" }).validateCredentials(),
-    Promise.resolve(getCodexDeviceAuthSnapshot()),
-  ]);
+  const flow = getCodexDeviceAuthSnapshot();
+  const validation = flow.loginInProgress
+    ? await getCachedCodexValidation()
+    : await validateCodexCredentials();
+  if (!flow.loginInProgress) {
+    clearCodexValidationCache();
+  }
 
   return {
     authenticated: validation.valid,
@@ -328,6 +382,7 @@ settingsRouter.post(
     }
 
     try {
+      clearCodexValidationCache();
       await startCodexDeviceAuth();
       const data = await getCodexAuthResponseData();
       ok(res, data);

--- a/orchestrator/src/server/services/llm/codex/client.test.ts
+++ b/orchestrator/src/server/services/llm/codex/client.test.ts
@@ -203,6 +203,36 @@ describe("CodexClient", () => {
     expect(result.message).toMatch(/codex login/i);
   });
 
+  it("returns username when codex auth status includes identity data", async () => {
+    mockSpawn((request, helpers) => {
+      if (request.method === "initialize") {
+        helpers.respond({
+          userAgent: "test",
+          codexHome: "/tmp/codex",
+          platformFamily: "unix",
+          platformOs: "linux",
+        });
+        return;
+      }
+      if (request.method === "getAuthStatus") {
+        helpers.respond({
+          authMethod: "openai",
+          requiresOpenaiAuth: false,
+          user: {
+            email: "dev@example.com",
+          },
+        });
+        return;
+      }
+      helpers.respond({});
+    });
+
+    const client = new CodexClient();
+    const result = await client.validateCredentials();
+    expect(result.valid).toBe(true);
+    expect(result.username).toBe("dev@example.com");
+  });
+
   it("paginates model/list and deduplicates model names", async () => {
     let modelListCalls = 0;
 

--- a/orchestrator/src/server/services/llm/codex/client.test.ts
+++ b/orchestrator/src/server/services/llm/codex/client.test.ts
@@ -5,7 +5,7 @@ import { createInterface } from "node:readline";
 import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LlmRequestOptions } from "../types";
-import { CodexClient } from "./client";
+import { __resetCodexSharedSessionForTests, CodexClient } from "./client";
 
 const { spawnMock } = vi.hoisted(() => ({
   spawnMock: vi.fn(),
@@ -92,7 +92,8 @@ function mockSpawn(
 }
 
 describe("CodexClient", () => {
-  afterEach(() => {
+  afterEach(async () => {
+    await __resetCodexSharedSessionForTests();
     vi.restoreAllMocks();
   });
 
@@ -237,5 +238,53 @@ describe("CodexClient", () => {
     const client = new CodexClient();
     const models = await client.listModels();
     expect(models).toEqual(["gpt-5", "gpt-5-mini", "o4-mini"]);
+  });
+
+  it("reuses a shared app-server session across sequential calls", async () => {
+    const spawnCallsBefore = vi.mocked(spawn).mock.calls.length;
+    let initializeCalls = 0;
+    let authCalls = 0;
+    let modelListCalls = 0;
+
+    mockSpawn((request, helpers) => {
+      if (request.method === "initialize") {
+        initializeCalls += 1;
+        helpers.respond({
+          userAgent: "test",
+          codexHome: "/tmp/codex",
+          platformFamily: "unix",
+          platformOs: "linux",
+        });
+        return;
+      }
+      if (request.method === "getAuthStatus") {
+        authCalls += 1;
+        helpers.respond({
+          authMethod: "openai",
+          requiresOpenaiAuth: false,
+        });
+        return;
+      }
+      if (request.method === "model/list") {
+        modelListCalls += 1;
+        helpers.respond({
+          data: [{ model: "gpt-5" }],
+          nextCursor: null,
+        });
+        return;
+      }
+      helpers.respond({});
+    });
+
+    const client = new CodexClient();
+    const auth = await client.validateCredentials();
+    const models = await client.listModels();
+
+    expect(auth.valid).toBe(true);
+    expect(models).toEqual(["gpt-5"]);
+    expect(initializeCalls).toBe(1);
+    expect(authCalls).toBe(1);
+    expect(modelListCalls).toBe(1);
+    expect(vi.mocked(spawn).mock.calls.length - spawnCallsBefore).toBe(1);
   });
 });

--- a/orchestrator/src/server/services/llm/codex/client.test.ts
+++ b/orchestrator/src/server/services/llm/codex/client.test.ts
@@ -1,0 +1,241 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { createInterface } from "node:readline";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LlmRequestOptions } from "../types";
+import { CodexClient } from "./client";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+  default: {
+    spawn: spawnMock,
+  },
+}));
+
+type JsonRpcRequest = {
+  id: number | string;
+  method: string;
+  params?: unknown;
+};
+
+function mockSpawn(
+  onRequest: (
+    request: JsonRpcRequest,
+    helpers: {
+      respond: (result: unknown) => void;
+      reject: (message: string, code?: number) => void;
+      notify: (method: string, params: unknown) => void;
+    },
+  ) => void,
+): void {
+  vi.mocked(spawn).mockImplementation(() => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+
+    const proc = new EventEmitter() as ChildProcessWithoutNullStreams & {
+      killed: boolean;
+    };
+    proc.stdin = stdin;
+    proc.stdout = stdout;
+    proc.stderr = stderr;
+    proc.killed = false;
+    proc.kill = vi.fn((signal?: NodeJS.Signals) => {
+      proc.killed = true;
+      setImmediate(() => {
+        proc.emit("exit", 0, signal ?? null);
+      });
+      return true;
+    });
+
+    const reader = createInterface({
+      input: stdin,
+      crlfDelay: Number.POSITIVE_INFINITY,
+    });
+
+    reader.on("line", (line) => {
+      const message = JSON.parse(line) as Partial<JsonRpcRequest>;
+      if (
+        typeof message.method !== "string" ||
+        (typeof message.id !== "string" && typeof message.id !== "number")
+      ) {
+        return;
+      }
+
+      const request = message as JsonRpcRequest;
+      const respond = (result: unknown) => {
+        stdout.write(`${JSON.stringify({ id: request.id, result })}\n`);
+      };
+      const reject = (message: string, code = -32000) => {
+        stdout.write(
+          `${JSON.stringify({
+            id: request.id,
+            error: { code, message },
+          })}\n`,
+        );
+      };
+      const notify = (method: string, params: unknown) => {
+        stdout.write(`${JSON.stringify({ method, params })}\n`);
+      };
+
+      onRequest(request, { respond, reject, notify });
+    });
+
+    return proc;
+  });
+}
+
+describe("CodexClient", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("creates an ephemeral thread, waits for completion, and returns assistant text", async () => {
+    let threadReadCalls = 0;
+
+    mockSpawn((request, helpers) => {
+      if (request.method === "initialize") {
+        helpers.respond({
+          userAgent: "test",
+          codexHome: "/tmp/codex",
+          platformFamily: "unix",
+          platformOs: "linux",
+        });
+        return;
+      }
+      if (request.method === "thread/start") {
+        helpers.respond({
+          thread: { id: "thread-1" },
+        });
+        return;
+      }
+      if (request.method === "turn/start") {
+        helpers.respond({
+          turn: { id: "turn-1" },
+        });
+        helpers.notify("item/completed", {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          item: {
+            type: "agentMessage",
+            id: "msg-1",
+            phase: "final_answer",
+            text: '{"score":99,"reason":"Strong fit"}',
+          },
+        });
+        helpers.notify("turn/completed", {
+          threadId: "thread-1",
+          turn: {
+            id: "turn-1",
+            status: "completed",
+            error: null,
+            items: [],
+            startedAt: null,
+            completedAt: null,
+            durationMs: null,
+          },
+        });
+        return;
+      }
+      if (request.method === "thread/read") {
+        threadReadCalls += 1;
+        helpers.reject("ephemeral threads do not support includeTurns", -32600);
+        return;
+      }
+
+      helpers.respond({});
+    });
+
+    const client = new CodexClient();
+    const response = await client.callJson({
+      model: "",
+      messages: [{ role: "user", content: "Score this job." }],
+      jsonSchema: {
+        name: "score_result",
+        schema: {
+          type: "object",
+          properties: {
+            score: { type: "number" },
+            reason: { type: "string" },
+          },
+          required: ["score", "reason"],
+          additionalProperties: false,
+        },
+      },
+    } as LlmRequestOptions<unknown>);
+
+    expect(response.text).toContain('"score":99');
+    expect(response.turnId).toBe("turn-1");
+    expect(threadReadCalls).toBe(0);
+  });
+
+  it("reports missing auth as an invalid credential state", async () => {
+    mockSpawn((request, helpers) => {
+      if (request.method === "initialize") {
+        helpers.respond({
+          userAgent: "test",
+          codexHome: "/tmp/codex",
+          platformFamily: "unix",
+          platformOs: "linux",
+        });
+        return;
+      }
+      if (request.method === "getAuthStatus") {
+        helpers.respond({
+          authMethod: null,
+          requiresOpenaiAuth: true,
+        });
+        return;
+      }
+      helpers.respond({});
+    });
+
+    const client = new CodexClient();
+    const result = await client.validateCredentials();
+    expect(result.valid).toBe(false);
+    expect(result.message).toMatch(/codex login/i);
+  });
+
+  it("paginates model/list and deduplicates model names", async () => {
+    let modelListCalls = 0;
+
+    mockSpawn((request, helpers) => {
+      if (request.method === "initialize") {
+        helpers.respond({
+          userAgent: "test",
+          codexHome: "/tmp/codex",
+          platformFamily: "unix",
+          platformOs: "linux",
+        });
+        return;
+      }
+      if (request.method === "model/list") {
+        modelListCalls += 1;
+        if (modelListCalls === 1) {
+          helpers.respond({
+            data: [{ model: "gpt-5" }, { id: "gpt-5-mini" }],
+            nextCursor: "page-2",
+          });
+          return;
+        }
+
+        helpers.respond({
+          data: [{ model: "gpt-5" }, { model: "o4-mini" }],
+          nextCursor: null,
+        });
+        return;
+      }
+      helpers.respond({});
+    });
+
+    const client = new CodexClient();
+    const models = await client.listModels();
+    expect(models).toEqual(["gpt-5", "gpt-5-mini", "o4-mini"]);
+  });
+});

--- a/orchestrator/src/server/services/llm/codex/client.ts
+++ b/orchestrator/src/server/services/llm/codex/client.ts
@@ -9,6 +9,7 @@ import { truncate } from "../utils/string";
 const DEFAULT_STARTUP_TIMEOUT_MS = 15_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
+const DEFAULT_IDLE_TIMEOUT_MS = 30_000;
 const MAX_STDERR_LINES = 40;
 const FALLBACK_CLIENT_VERSION = "dev";
 
@@ -77,6 +78,17 @@ function buildCodexErrorMessage(error: unknown): string {
 function isAbortError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return error.name === "AbortError" || error.message.includes("aborted");
+}
+
+function isSessionInfrastructureError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("app-server exited unexpectedly") ||
+    message.includes("broken pipe") ||
+    message.includes("epipe") ||
+    message.includes("stream was destroyed")
+  );
 }
 
 function toNonEmptyString(value: unknown): string | null {
@@ -353,7 +365,7 @@ class CodexAppServerSession {
       pending.timer = setTimeout(() => {
         this.pending.delete(id);
         pending.reject(
-          new Error(`Codex app-server request timed out (${method}).`),
+          new Error(`Codex app-server request timeout (${method}).`),
         );
       }, timeoutMs);
 
@@ -416,6 +428,10 @@ class CodexAppServerSession {
     }
   }
 
+  clearBufferedNotifications(): void {
+    this.notificationQueue.length = 0;
+  }
+
   private waitForNextNotification(options?: {
     signal?: AbortSignal;
     timeoutMs?: number;
@@ -444,7 +460,7 @@ class CodexAppServerSession {
       if (timeoutMs && timeoutMs > 0) {
         waiter.timer = setTimeout(() => {
           this.removeWaiter(waiter);
-          waiter.reject(new Error("Timed out waiting for Codex notification."));
+          waiter.reject(new Error("Codex notification wait timeout."));
         }, timeoutMs);
       }
 
@@ -578,33 +594,125 @@ class CodexAppServerSession {
   }
 }
 
+let sharedSession: CodexAppServerSession | null = null;
+let startupPromise: Promise<CodexAppServerSession> | null = null;
+let idleTimer: NodeJS.Timeout | null = null;
+let operationTail: Promise<void> = Promise.resolve();
+
+function clearIdleTimer(): void {
+  if (idleTimer) {
+    clearTimeout(idleTimer);
+    idleTimer = null;
+  }
+}
+
+async function resetSharedSession(): Promise<void> {
+  clearIdleTimer();
+  const session = sharedSession;
+  sharedSession = null;
+  if (session) {
+    await session.close();
+  }
+}
+
+function scheduleIdleClose(): void {
+  clearIdleTimer();
+  const idleTimeoutMs = getPositiveIntEnv(
+    "CODEX_APP_SERVER_IDLE_TIMEOUT_MS",
+    DEFAULT_IDLE_TIMEOUT_MS,
+  );
+  if (idleTimeoutMs <= 0) return;
+
+  idleTimer = setTimeout(() => {
+    void enqueueSessionOperation(async () => {
+      await resetSharedSession();
+    });
+  }, idleTimeoutMs);
+}
+
+async function getOrStartSession(
+  signal?: AbortSignal,
+): Promise<CodexAppServerSession> {
+  if (sharedSession) {
+    return sharedSession;
+  }
+  if (startupPromise) {
+    return await startupPromise;
+  }
+
+  startupPromise = CodexAppServerSession.start({ signal });
+  try {
+    const session = await startupPromise;
+    sharedSession = session;
+    return session;
+  } finally {
+    startupPromise = null;
+  }
+}
+
+function enqueueSessionOperation<T>(task: () => Promise<T>): Promise<T> {
+  const run = operationTail.then(task, task);
+  operationTail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+async function withCodexSession<T>(args: {
+  signal?: AbortSignal;
+  task: (session: CodexAppServerSession) => Promise<T>;
+}): Promise<T> {
+  return await enqueueSessionOperation(async () => {
+    clearIdleTimer();
+    const session = await getOrStartSession(args.signal);
+    session.clearBufferedNotifications();
+    try {
+      return await args.task(session);
+    } catch (error) {
+      if (isSessionInfrastructureError(error)) {
+        await resetSharedSession();
+      }
+      throw error;
+    } finally {
+      scheduleIdleClose();
+    }
+  });
+}
+
+async function closeCodexSessionForTests(): Promise<void> {
+  await enqueueSessionOperation(async () => {
+    await resetSharedSession();
+  });
+}
+
 export class CodexClient {
   async validateCredentials(
     signal?: AbortSignal,
   ): Promise<{ valid: boolean; message: string | null }> {
     try {
-      const session = await CodexAppServerSession.start({ signal });
-      try {
-        const auth = (await session.request("getAuthStatus", {
-          includeToken: false,
-          refreshToken: false,
-        })) as {
-          authMethod?: string | null;
-          requiresOpenaiAuth?: boolean | null;
-        };
-
-        if (!auth?.authMethod && auth?.requiresOpenaiAuth !== false) {
-          return {
-            valid: false,
-            message:
-              "Codex is not authenticated in this container. Run `codex login` and try again.",
+      return await withCodexSession({
+        signal,
+        task: async (session) => {
+          const auth = (await session.request("getAuthStatus", {
+            includeToken: false,
+            refreshToken: false,
+          })) as {
+            authMethod?: string | null;
+            requiresOpenaiAuth?: boolean | null;
           };
-        }
 
-        return { valid: true, message: null };
-      } finally {
-        await session.close();
-      }
+          if (!auth?.authMethod && auth?.requiresOpenaiAuth !== false) {
+            return {
+              valid: false,
+              message:
+                "Codex is not authenticated in this container. Run `codex login` and try again.",
+            };
+          }
+
+          return { valid: true, message: null };
+        },
+      });
     } catch (error) {
       if (isAbortError(error)) {
         return {
@@ -620,252 +728,259 @@ export class CodexClient {
   }
 
   async listModels(signal?: AbortSignal): Promise<string[]> {
-    const session = await CodexAppServerSession.start({ signal });
-    try {
-      const models: string[] = [];
-      let cursor: string | null = null;
+    return await withCodexSession({
+      signal,
+      task: async (session) => {
+        const models: string[] = [];
+        let cursor: string | null = null;
 
-      while (true) {
-        const result = (await session.request("model/list", {
-          cursor,
-          limit: 100,
-          includeHidden: false,
-        })) as {
-          data?: Array<{ model?: string | null; id?: string | null }>;
-          nextCursor?: string | null;
-        };
+        while (true) {
+          const result = (await session.request("model/list", {
+            cursor,
+            limit: 100,
+            includeHidden: false,
+          })) as {
+            data?: Array<{ model?: string | null; id?: string | null }>;
+            nextCursor?: string | null;
+          };
 
-        for (const model of result.data ?? []) {
-          const value = (model.model || model.id || "").trim();
-          if (value) {
-            models.push(value);
+          for (const model of result.data ?? []) {
+            const value = (model.model || model.id || "").trim();
+            if (value) {
+              models.push(value);
+            }
           }
+
+          if (!result.nextCursor) {
+            break;
+          }
+          cursor = result.nextCursor;
         }
 
-        if (!result.nextCursor) {
-          break;
-        }
-        cursor = result.nextCursor;
-      }
-
-      return Array.from(new Set(models)).sort((left, right) =>
-        left.localeCompare(right),
-      );
-    } finally {
-      await session.close();
-    }
+        return Array.from(new Set(models)).sort((left, right) =>
+          left.localeCompare(right),
+        );
+      },
+    });
   }
 
   async callJson(
     options: LlmRequestOptions<unknown>,
   ): Promise<{ text: string; turnId: string }> {
-    const session = await CodexAppServerSession.start({
+    return await withCodexSession({
       signal: options.signal,
-    });
-    try {
-      const threadStart = (await session.request("thread/start", {
-        model: options.model.trim() || null,
-        ephemeral: true,
-        approvalPolicy: "never",
-        sandbox: "read-only",
-        experimentalRawEvents: false,
-        persistExtendedHistory: false,
-      })) as {
-        thread?: { id?: string };
-      };
-
-      const threadId = threadStart.thread?.id;
-      if (!threadId) {
-        throw new Error("Codex thread/start did not return a thread id.");
-      }
-
-      const turnStart = (await session.request(
-        "turn/start",
-        {
-          threadId,
+      task: async (session) => {
+        const threadStart = (await session.request("thread/start", {
           model: options.model.trim() || null,
-          input: [
-            {
-              type: "text",
-              text: formatPrompt({
-                messages: options.messages,
-                jsonSchema: options.jsonSchema,
-              }),
-              text_elements: [],
-            },
-          ],
-          outputSchema: options.jsonSchema.schema,
-        },
-        {
-          signal: options.signal,
-          timeoutMs: getPositiveIntEnv(
-            "CODEX_APP_SERVER_REQUEST_TIMEOUT_MS",
-            DEFAULT_REQUEST_TIMEOUT_MS,
-          ),
-        },
-      )) as {
-        turn?: { id?: string };
-      };
+          ephemeral: true,
+          approvalPolicy: "never",
+          sandbox: "read-only",
+          experimentalRawEvents: false,
+          persistExtendedHistory: false,
+        })) as {
+          thread?: { id?: string };
+        };
 
-      const turnId = turnStart.turn?.id;
-      if (!turnId) {
-        throw new Error("Codex turn/start did not return a turn id.");
-      }
+        const threadId = threadStart.thread?.id;
+        if (!threadId) {
+          throw new Error("Codex thread/start did not return a thread id.");
+        }
 
-      const timeoutMs = getPositiveIntEnv(
-        "CODEX_APP_SERVER_TURN_TIMEOUT_MS",
-        DEFAULT_TURN_TIMEOUT_MS,
-      );
-      const capturedMessages = new Map<
-        string,
-        { text: string; phase: string | null }
-      >();
-      let turnCompleted: JsonRpcNotification | null = null;
-
-      while (!turnCompleted) {
-        const notification = await session.waitForNotification(
-          (candidate) => {
-            if (candidate.method === "turn/completed") {
-              const params = candidate.params as
-                | { turn?: { id?: string } }
-                | undefined;
-              return params?.turn?.id === turnId;
-            }
-
-            if (candidate.method === "item/agentMessage/delta") {
-              const params = candidate.params as
-                | { threadId?: string; turnId?: string; itemId?: string }
-                | undefined;
-              return (
-                params?.threadId === threadId &&
-                params?.turnId === turnId &&
-                typeof params.itemId === "string"
-              );
-            }
-
-            if (candidate.method === "item/completed") {
-              const params = candidate.params as
-                | { threadId?: string; turnId?: string; item?: unknown }
-                | undefined;
-              return (
-                params?.threadId === threadId &&
-                params?.turnId === turnId &&
-                typeof params.item === "object" &&
-                params.item !== null
-              );
-            }
-
-            return false;
+        const turnStart = (await session.request(
+          "turn/start",
+          {
+            threadId,
+            model: options.model.trim() || null,
+            input: [
+              {
+                type: "text",
+                text: formatPrompt({
+                  messages: options.messages,
+                  jsonSchema: options.jsonSchema,
+                }),
+                text_elements: [],
+              },
+            ],
+            outputSchema: options.jsonSchema.schema,
           },
           {
             signal: options.signal,
-            timeoutMs,
+            timeoutMs: getPositiveIntEnv(
+              "CODEX_APP_SERVER_REQUEST_TIMEOUT_MS",
+              DEFAULT_REQUEST_TIMEOUT_MS,
+            ),
           },
-        );
-
-        if (notification.method === "item/agentMessage/delta") {
-          const params = notification.params as
-            | { itemId?: string; delta?: string }
-            | undefined;
-          const itemId = params?.itemId;
-          if (typeof itemId === "string" && typeof params?.delta === "string") {
-            const existing = capturedMessages.get(itemId) ?? {
-              text: "",
-              phase: null,
-            };
-            capturedMessages.set(itemId, {
-              text: `${existing.text}${params.delta}`,
-              phase: existing.phase,
-            });
-          }
-          continue;
-        }
-
-        if (notification.method === "item/completed") {
-          const params = notification.params as { item?: unknown } | undefined;
-          const item =
-            params && typeof params.item === "object" && params.item !== null
-              ? (params.item as Record<string, unknown>)
-              : null;
-          if (item?.type === "agentMessage") {
-            const itemId =
-              typeof item.id === "string"
-                ? item.id
-                : `agent-message-${capturedMessages.size + 1}`;
-            const text = typeof item.text === "string" ? item.text : "";
-            const phase = typeof item.phase === "string" ? item.phase : null;
-            const existing = capturedMessages.get(itemId);
-            capturedMessages.set(itemId, {
-              text: text || existing?.text || "",
-              phase: phase ?? existing?.phase ?? null,
-            });
-          }
-          continue;
-        }
-
-        turnCompleted = notification;
-      }
-
-      const completedParams = turnCompleted.params as
-        | {
-            turn?: {
-              id?: string;
-              status?: string;
-              error?: { message?: string | null } | null;
-            };
-          }
-        | undefined;
-      const status = completedParams?.turn?.status;
-      if (status === "failed") {
-        const errorMessage =
-          completedParams?.turn?.error?.message?.trim() ||
-          "Codex turn failed with no error message.";
-        throw new Error(errorMessage);
-      }
-      if (status === "interrupted") {
-        throw new Error("Codex turn was interrupted.");
-      }
-
-      const textFromEvents = pickBestAgentMessageText(
-        Array.from(capturedMessages.values()),
-      );
-      if (textFromEvents) {
-        return { text: textFromEvents, turnId };
-      }
-
-      let text: string | null = null;
-      try {
-        const threadRead = (await session.request("thread/read", {
-          threadId,
-          includeTurns: true,
-        })) as {
-          thread?: {
-            turns?: Array<{
-              id?: string;
-              items?: unknown[];
-            }>;
-          };
+        )) as {
+          turn?: { id?: string };
         };
 
-        const turn = (threadRead.thread?.turns ?? []).find(
-          (candidate) => candidate.id === turnId,
-        );
-        text = extractAgentMessageText(turn ?? null);
-      } catch (error) {
-        logger.debug("Codex thread/read fallback unavailable", {
-          message: buildCodexErrorMessage(error),
-        });
-      }
+        const turnId = turnStart.turn?.id;
+        if (!turnId) {
+          throw new Error("Codex turn/start did not return a turn id.");
+        }
 
-      if (!text) {
-        throw new Error(
-          "Codex turn completed but no assistant message text was returned.",
+        const timeoutMs = getPositiveIntEnv(
+          "CODEX_APP_SERVER_TURN_TIMEOUT_MS",
+          DEFAULT_TURN_TIMEOUT_MS,
         );
-      }
+        const capturedMessages = new Map<
+          string,
+          { text: string; phase: string | null }
+        >();
+        let turnCompleted: JsonRpcNotification | null = null;
 
-      return { text, turnId };
-    } finally {
-      await session.close();
-    }
+        while (!turnCompleted) {
+          const notification = await session.waitForNotification(
+            (candidate) => {
+              if (candidate.method === "turn/completed") {
+                const params = candidate.params as
+                  | { turn?: { id?: string } }
+                  | undefined;
+                return params?.turn?.id === turnId;
+              }
+
+              if (candidate.method === "item/agentMessage/delta") {
+                const params = candidate.params as
+                  | { threadId?: string; turnId?: string; itemId?: string }
+                  | undefined;
+                return (
+                  params?.threadId === threadId &&
+                  params?.turnId === turnId &&
+                  typeof params.itemId === "string"
+                );
+              }
+
+              if (candidate.method === "item/completed") {
+                const params = candidate.params as
+                  | { threadId?: string; turnId?: string; item?: unknown }
+                  | undefined;
+                return (
+                  params?.threadId === threadId &&
+                  params?.turnId === turnId &&
+                  typeof params.item === "object" &&
+                  params.item !== null
+                );
+              }
+
+              return false;
+            },
+            {
+              signal: options.signal,
+              timeoutMs,
+            },
+          );
+
+          if (notification.method === "item/agentMessage/delta") {
+            const params = notification.params as
+              | { itemId?: string; delta?: string }
+              | undefined;
+            const itemId = params?.itemId;
+            if (
+              typeof itemId === "string" &&
+              typeof params?.delta === "string"
+            ) {
+              const existing = capturedMessages.get(itemId) ?? {
+                text: "",
+                phase: null,
+              };
+              capturedMessages.set(itemId, {
+                text: `${existing.text}${params.delta}`,
+                phase: existing.phase,
+              });
+            }
+            continue;
+          }
+
+          if (notification.method === "item/completed") {
+            const params = notification.params as
+              | { item?: unknown }
+              | undefined;
+            const item =
+              params && typeof params.item === "object" && params.item !== null
+                ? (params.item as Record<string, unknown>)
+                : null;
+            if (item?.type === "agentMessage") {
+              const itemId =
+                typeof item.id === "string"
+                  ? item.id
+                  : `agent-message-${capturedMessages.size + 1}`;
+              const text = typeof item.text === "string" ? item.text : "";
+              const phase = typeof item.phase === "string" ? item.phase : null;
+              const existing = capturedMessages.get(itemId);
+              capturedMessages.set(itemId, {
+                text: text || existing?.text || "",
+                phase: phase ?? existing?.phase ?? null,
+              });
+            }
+            continue;
+          }
+
+          turnCompleted = notification;
+        }
+
+        const completedParams = turnCompleted.params as
+          | {
+              turn?: {
+                id?: string;
+                status?: string;
+                error?: { message?: string | null } | null;
+              };
+            }
+          | undefined;
+        const status = completedParams?.turn?.status;
+        if (status === "failed") {
+          const errorMessage =
+            completedParams?.turn?.error?.message?.trim() ||
+            "Codex turn failed with no error message.";
+          throw new Error(errorMessage);
+        }
+        if (status === "interrupted") {
+          throw new Error("Codex turn was interrupted.");
+        }
+
+        const textFromEvents = pickBestAgentMessageText(
+          Array.from(capturedMessages.values()),
+        );
+        if (textFromEvents) {
+          return { text: textFromEvents, turnId };
+        }
+
+        let text: string | null = null;
+        try {
+          const threadRead = (await session.request("thread/read", {
+            threadId,
+            includeTurns: true,
+          })) as {
+            thread?: {
+              turns?: Array<{
+                id?: string;
+                items?: unknown[];
+              }>;
+            };
+          };
+
+          const turn = (threadRead.thread?.turns ?? []).find(
+            (candidate) => candidate.id === turnId,
+          );
+          text = extractAgentMessageText(turn ?? null);
+        } catch (error) {
+          logger.debug("Codex thread/read fallback unavailable", {
+            message: buildCodexErrorMessage(error),
+          });
+        }
+
+        if (!text) {
+          throw new Error(
+            "Codex turn completed but no assistant message text was returned.",
+          );
+        }
+
+        return { text, turnId };
+      },
+    });
   }
+}
+
+export async function __resetCodexSharedSessionForTests(): Promise<void> {
+  await closeCodexSessionForTests();
 }

--- a/orchestrator/src/server/services/llm/codex/client.ts
+++ b/orchestrator/src/server/services/llm/codex/client.ts
@@ -1,0 +1,824 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { createInterface, type Interface } from "node:readline";
+import { logger } from "@infra/logger";
+import type { JsonSchemaDefinition, LlmRequestOptions } from "../types";
+import { truncate } from "../utils/string";
+
+const DEFAULT_STARTUP_TIMEOUT_MS = 15_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_TURN_TIMEOUT_MS = 120_000;
+const MAX_STDERR_LINES = 40;
+
+type JsonRpcId = number | string;
+
+type JsonRpcRequest = {
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+};
+
+type JsonRpcErrorResponse = {
+  id: JsonRpcId;
+  error: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+};
+
+type JsonRpcResponse = {
+  id: JsonRpcId;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+};
+
+type JsonRpcNotification = {
+  method: string;
+  params?: unknown;
+};
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout | null;
+  abortCleanup: (() => void) | null;
+};
+
+type NotificationWaiter = {
+  resolve: (value: JsonRpcNotification) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout | null;
+  abortCleanup: (() => void) | null;
+};
+
+function getPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function buildCodexErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("ENOENT")) {
+    return "Codex CLI was not found in PATH. Install Codex inside the container and try again.";
+  }
+  return truncate(message, 500);
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.name === "AbortError" || error.message.includes("aborted");
+}
+
+function formatPrompt(args: {
+  messages: LlmRequestOptions<unknown>["messages"];
+  jsonSchema: JsonSchemaDefinition;
+}): string {
+  const transcript = args.messages
+    .map((message, index) => {
+      return `Message ${index + 1} (${message.role.toUpperCase()}):\n${message.content.trim()}`;
+    })
+    .join("\n\n");
+
+  return [
+    "You are generating a structured JSON response for JobOps.",
+    "Do not run commands or tools. Answer directly.",
+    "Return only valid JSON with no markdown fences or extra text.",
+    "The response must follow this schema exactly:",
+    JSON.stringify(args.jsonSchema.schema, null, 2),
+    "Conversation:",
+    transcript,
+  ].join("\n\n");
+}
+
+function extractAgentMessageText(
+  turn: { items?: unknown[] } | null,
+): string | null {
+  const items = Array.isArray(turn?.items) ? turn.items : [];
+  let fallback: string | null = null;
+
+  for (const item of items) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    if (record.type !== "agentMessage") continue;
+
+    const text = typeof record.text === "string" ? record.text.trim() : "";
+    if (!text) continue;
+
+    const phase = record.phase;
+    if (phase === "final_answer") {
+      return text;
+    }
+    fallback = text;
+  }
+
+  return fallback;
+}
+
+function pickBestAgentMessageText(
+  messages: Array<{ text: string; phase: string | null }>,
+): string | null {
+  let finalAnswer: string | null = null;
+  let fallback: string | null = null;
+
+  for (const message of messages) {
+    const text = message.text.trim();
+    if (!text) continue;
+    fallback = text;
+    if (message.phase === "final_answer") {
+      finalAnswer = text;
+    }
+  }
+
+  return finalAnswer ?? fallback;
+}
+
+class CodexAppServerSession {
+  private readonly proc: ChildProcessWithoutNullStreams;
+  private readonly stdoutReader: Interface;
+  private readonly pending = new Map<JsonRpcId, PendingRequest>();
+  private readonly notificationQueue: JsonRpcNotification[] = [];
+  private readonly notificationWaiters: NotificationWaiter[] = [];
+  private readonly stderrLines: string[] = [];
+  private closedError: Error | null = null;
+  private nextId = 1;
+
+  private constructor(proc: ChildProcessWithoutNullStreams) {
+    this.proc = proc;
+    this.stdoutReader = createInterface({
+      input: proc.stdout,
+      crlfDelay: Number.POSITIVE_INFINITY,
+    });
+
+    this.stdoutReader.on("line", (line) => {
+      this.handleStdoutLine(line);
+    });
+
+    this.proc.stderr.on("data", (chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      for (const line of text.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        this.stderrLines.push(trimmed);
+        if (this.stderrLines.length > MAX_STDERR_LINES) {
+          this.stderrLines.shift();
+        }
+      }
+    });
+
+    this.proc.on("error", (error) => {
+      this.shutdownWithError(error);
+    });
+
+    this.proc.on("exit", (code, signal) => {
+      if (this.closedError) return;
+      const details = [
+        `code=${code ?? "null"}`,
+        `signal=${signal ?? "null"}`,
+        this.stderrLines.length ? `stderr=${this.stderrLines.join(" | ")}` : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+      this.shutdownWithError(
+        new Error(
+          `Codex app-server exited unexpectedly${details ? ` (${details})` : ""}.`,
+        ),
+      );
+    });
+  }
+
+  static async start(args: {
+    signal?: AbortSignal;
+    startupTimeoutMs?: number;
+  }): Promise<CodexAppServerSession> {
+    const command = process.env.CODEX_APP_SERVER_BIN?.trim() || "codex";
+    const proc = spawn(command, ["app-server", "--listen", "stdio://"], {
+      stdio: "pipe",
+      cwd: process.cwd(),
+      env: process.env,
+    });
+    const session = new CodexAppServerSession(proc);
+
+    const startupTimeoutMs =
+      args.startupTimeoutMs ??
+      getPositiveIntEnv(
+        "CODEX_APP_SERVER_STARTUP_TIMEOUT_MS",
+        DEFAULT_STARTUP_TIMEOUT_MS,
+      );
+
+    try {
+      await session.request(
+        "initialize",
+        {
+          clientInfo: {
+            name: "job-ops",
+            title: "JobOps",
+            version: "0.3.1",
+          },
+          capabilities: {
+            experimentalApi: false,
+            optOutNotificationMethods: null,
+          },
+        },
+        {
+          signal: args.signal,
+          timeoutMs: startupTimeoutMs,
+        },
+      );
+      session.notify("initialized");
+      return session;
+    } catch (error) {
+      await session.close();
+      throw new Error(buildCodexErrorMessage(error));
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.proc.killed) return;
+
+    this.stdoutReader.close();
+    this.proc.kill("SIGTERM");
+
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        if (!this.proc.killed) {
+          this.proc.kill("SIGKILL");
+        }
+        resolve();
+      }, 1_500);
+
+      this.proc.once("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.writeJson({
+      method,
+      ...(params === undefined ? {} : { params }),
+    });
+  }
+
+  async request(
+    method: string,
+    params: unknown,
+    options?: {
+      signal?: AbortSignal;
+      timeoutMs?: number;
+    },
+  ): Promise<unknown> {
+    if (this.closedError) {
+      throw this.closedError;
+    }
+
+    const id = this.nextId++;
+    const timeoutMs =
+      options?.timeoutMs ??
+      getPositiveIntEnv(
+        "CODEX_APP_SERVER_REQUEST_TIMEOUT_MS",
+        DEFAULT_REQUEST_TIMEOUT_MS,
+      );
+
+    return await new Promise<unknown>((resolve, reject) => {
+      const pending: PendingRequest = {
+        resolve: (value) => {
+          if (pending.timer) clearTimeout(pending.timer);
+          if (pending.abortCleanup) pending.abortCleanup();
+          resolve(value);
+        },
+        reject: (error) => {
+          if (pending.timer) clearTimeout(pending.timer);
+          if (pending.abortCleanup) pending.abortCleanup();
+          reject(error);
+        },
+        timer: null,
+        abortCleanup: null,
+      };
+
+      pending.timer = setTimeout(() => {
+        this.pending.delete(id);
+        pending.reject(
+          new Error(`Codex app-server request timed out (${method}).`),
+        );
+      }, timeoutMs);
+
+      if (options?.signal) {
+        if (options.signal.aborted) {
+          this.pending.delete(id);
+          pending.reject(new Error(`Codex request aborted (${method}).`));
+          return;
+        }
+        const onAbort = () => {
+          this.pending.delete(id);
+          pending.reject(new Error(`Codex request aborted (${method}).`));
+        };
+        options.signal.addEventListener("abort", onAbort, { once: true });
+        pending.abortCleanup = () => {
+          options.signal?.removeEventListener("abort", onAbort);
+        };
+      }
+
+      this.pending.set(id, pending);
+      const request: JsonRpcRequest = { id, method, params };
+      this.writeJson(request);
+    });
+  }
+
+  async waitForNotification(
+    predicate: (notification: JsonRpcNotification) => boolean,
+    options?: {
+      signal?: AbortSignal;
+      timeoutMs?: number;
+    },
+  ): Promise<JsonRpcNotification> {
+    const timeoutMs =
+      options?.timeoutMs ??
+      getPositiveIntEnv(
+        "CODEX_APP_SERVER_TURN_TIMEOUT_MS",
+        DEFAULT_TURN_TIMEOUT_MS,
+      );
+
+    while (true) {
+      const fromQueue = this.notificationQueue.find((notification) =>
+        predicate(notification),
+      );
+      if (fromQueue) {
+        const index = this.notificationQueue.indexOf(fromQueue);
+        this.notificationQueue.splice(index, 1);
+        return fromQueue;
+      }
+
+      const next = await this.waitForNextNotification({
+        signal: options?.signal,
+        timeoutMs,
+      });
+
+      if (predicate(next)) {
+        return next;
+      }
+
+      this.notificationQueue.push(next);
+    }
+  }
+
+  private waitForNextNotification(options?: {
+    signal?: AbortSignal;
+    timeoutMs?: number;
+  }): Promise<JsonRpcNotification> {
+    if (this.closedError) {
+      return Promise.reject(this.closedError);
+    }
+
+    return new Promise<JsonRpcNotification>((resolve, reject) => {
+      const waiter: NotificationWaiter = {
+        resolve: (notification) => {
+          if (waiter.timer) clearTimeout(waiter.timer);
+          if (waiter.abortCleanup) waiter.abortCleanup();
+          resolve(notification);
+        },
+        reject: (error) => {
+          if (waiter.timer) clearTimeout(waiter.timer);
+          if (waiter.abortCleanup) waiter.abortCleanup();
+          reject(error);
+        },
+        timer: null,
+        abortCleanup: null,
+      };
+
+      const timeoutMs = options?.timeoutMs;
+      if (timeoutMs && timeoutMs > 0) {
+        waiter.timer = setTimeout(() => {
+          this.removeWaiter(waiter);
+          waiter.reject(new Error("Timed out waiting for Codex notification."));
+        }, timeoutMs);
+      }
+
+      if (options?.signal) {
+        if (options.signal.aborted) {
+          waiter.reject(new Error("Codex notification wait aborted."));
+          return;
+        }
+        const onAbort = () => {
+          this.removeWaiter(waiter);
+          waiter.reject(new Error("Codex notification wait aborted."));
+        };
+        options.signal.addEventListener("abort", onAbort, { once: true });
+        waiter.abortCleanup = () => {
+          options.signal?.removeEventListener("abort", onAbort);
+        };
+      }
+
+      this.notificationWaiters.push(waiter);
+    });
+  }
+
+  private removeWaiter(target: NotificationWaiter): void {
+    const index = this.notificationWaiters.indexOf(target);
+    if (index >= 0) {
+      this.notificationWaiters.splice(index, 1);
+    }
+  }
+
+  private handleStdoutLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+
+    let message: unknown;
+    try {
+      message = JSON.parse(trimmed) as unknown;
+    } catch {
+      logger.warn("Codex app-server emitted non-JSON output", {
+        line: truncate(trimmed, 400),
+      });
+      return;
+    }
+
+    if (!message || typeof message !== "object") return;
+    const record = message as Record<string, unknown>;
+
+    if ("id" in record && "method" in record) {
+      this.handleServerRequest(record);
+      return;
+    }
+
+    if ("id" in record && ("result" in record || "error" in record)) {
+      this.handleResponse(record as JsonRpcResponse);
+      return;
+    }
+
+    if ("method" in record && typeof record.method === "string") {
+      this.handleNotification({
+        method: record.method,
+        ...(Object.hasOwn(record, "params") ? { params: record.params } : {}),
+      });
+      return;
+    }
+  }
+
+  private handleResponse(response: JsonRpcResponse): void {
+    const pending = this.pending.get(response.id);
+    if (!pending) return;
+    this.pending.delete(response.id);
+
+    if (response.error) {
+      const message =
+        response.error.message || "Unknown Codex app-server request error.";
+      pending.reject(new Error(truncate(message, 500)));
+      return;
+    }
+    pending.resolve(response.result);
+  }
+
+  private handleServerRequest(request: Record<string, unknown>): void {
+    const id = request.id;
+    if (typeof id !== "string" && typeof id !== "number") {
+      return;
+    }
+    const method =
+      typeof request.method === "string" ? request.method : "unknown-method";
+
+    logger.warn("Codex app-server sent unsupported server request", {
+      method,
+    });
+
+    const response: JsonRpcErrorResponse = {
+      id,
+      error: {
+        code: -32601,
+        message: `Unsupported server request: ${method}`,
+      },
+    };
+    this.writeJson(response);
+  }
+
+  private handleNotification(notification: JsonRpcNotification): void {
+    const waiter = this.notificationWaiters.shift();
+    if (waiter) {
+      waiter.resolve(notification);
+      return;
+    }
+    this.notificationQueue.push(notification);
+  }
+
+  private writeJson(payload: unknown): void {
+    if (this.closedError) {
+      throw this.closedError;
+    }
+    this.proc.stdin.write(`${JSON.stringify(payload)}\n`);
+  }
+
+  private shutdownWithError(error: unknown): void {
+    if (this.closedError) return;
+    this.closedError = new Error(buildCodexErrorMessage(error));
+
+    for (const [id, pending] of this.pending.entries()) {
+      this.pending.delete(id);
+      pending.reject(this.closedError);
+    }
+
+    while (this.notificationWaiters.length > 0) {
+      const waiter = this.notificationWaiters.shift();
+      waiter?.reject(this.closedError);
+    }
+  }
+}
+
+export class CodexClient {
+  async validateCredentials(
+    signal?: AbortSignal,
+  ): Promise<{ valid: boolean; message: string | null }> {
+    try {
+      const session = await CodexAppServerSession.start({ signal });
+      try {
+        const auth = (await session.request("getAuthStatus", {
+          includeToken: false,
+          refreshToken: false,
+        })) as {
+          authMethod?: string | null;
+          requiresOpenaiAuth?: boolean | null;
+        };
+
+        if (!auth?.authMethod && auth?.requiresOpenaiAuth !== false) {
+          return {
+            valid: false,
+            message:
+              "Codex is not authenticated in this container. Run `codex login` and try again.",
+          };
+        }
+
+        return { valid: true, message: null };
+      } finally {
+        await session.close();
+      }
+    } catch (error) {
+      if (isAbortError(error)) {
+        return {
+          valid: false,
+          message: "Codex validation was cancelled.",
+        };
+      }
+      return {
+        valid: false,
+        message: buildCodexErrorMessage(error),
+      };
+    }
+  }
+
+  async listModels(signal?: AbortSignal): Promise<string[]> {
+    const session = await CodexAppServerSession.start({ signal });
+    try {
+      const models: string[] = [];
+      let cursor: string | null = null;
+
+      while (true) {
+        const result = (await session.request("model/list", {
+          cursor,
+          limit: 100,
+          includeHidden: false,
+        })) as {
+          data?: Array<{ model?: string | null; id?: string | null }>;
+          nextCursor?: string | null;
+        };
+
+        for (const model of result.data ?? []) {
+          const value = (model.model || model.id || "").trim();
+          if (value) {
+            models.push(value);
+          }
+        }
+
+        if (!result.nextCursor) {
+          break;
+        }
+        cursor = result.nextCursor;
+      }
+
+      return Array.from(new Set(models)).sort((left, right) =>
+        left.localeCompare(right),
+      );
+    } finally {
+      await session.close();
+    }
+  }
+
+  async callJson(
+    options: LlmRequestOptions<unknown>,
+  ): Promise<{ text: string; turnId: string }> {
+    const session = await CodexAppServerSession.start({
+      signal: options.signal,
+    });
+    try {
+      const threadStart = (await session.request("thread/start", {
+        model: options.model.trim() || null,
+        ephemeral: true,
+        approvalPolicy: "never",
+        sandbox: "read-only",
+        experimentalRawEvents: false,
+        persistExtendedHistory: false,
+      })) as {
+        thread?: { id?: string };
+      };
+
+      const threadId = threadStart.thread?.id;
+      if (!threadId) {
+        throw new Error("Codex thread/start did not return a thread id.");
+      }
+
+      const turnStart = (await session.request(
+        "turn/start",
+        {
+          threadId,
+          model: options.model.trim() || null,
+          input: [
+            {
+              type: "text",
+              text: formatPrompt({
+                messages: options.messages,
+                jsonSchema: options.jsonSchema,
+              }),
+              text_elements: [],
+            },
+          ],
+          outputSchema: options.jsonSchema.schema,
+        },
+        {
+          signal: options.signal,
+          timeoutMs: getPositiveIntEnv(
+            "CODEX_APP_SERVER_REQUEST_TIMEOUT_MS",
+            DEFAULT_REQUEST_TIMEOUT_MS,
+          ),
+        },
+      )) as {
+        turn?: { id?: string };
+      };
+
+      const turnId = turnStart.turn?.id;
+      if (!turnId) {
+        throw new Error("Codex turn/start did not return a turn id.");
+      }
+
+      const timeoutMs = getPositiveIntEnv(
+        "CODEX_APP_SERVER_TURN_TIMEOUT_MS",
+        DEFAULT_TURN_TIMEOUT_MS,
+      );
+      const capturedMessages = new Map<
+        string,
+        { text: string; phase: string | null }
+      >();
+      let turnCompleted: JsonRpcNotification | null = null;
+
+      while (!turnCompleted) {
+        const notification = await session.waitForNotification(
+          (candidate) => {
+            if (candidate.method === "turn/completed") {
+              const params = candidate.params as
+                | { turn?: { id?: string } }
+                | undefined;
+              return params?.turn?.id === turnId;
+            }
+
+            if (candidate.method === "item/agentMessage/delta") {
+              const params = candidate.params as
+                | { threadId?: string; turnId?: string; itemId?: string }
+                | undefined;
+              return (
+                params?.threadId === threadId &&
+                params?.turnId === turnId &&
+                typeof params.itemId === "string"
+              );
+            }
+
+            if (candidate.method === "item/completed") {
+              const params = candidate.params as
+                | { threadId?: string; turnId?: string; item?: unknown }
+                | undefined;
+              return (
+                params?.threadId === threadId &&
+                params?.turnId === turnId &&
+                typeof params.item === "object" &&
+                params.item !== null
+              );
+            }
+
+            return false;
+          },
+          {
+            signal: options.signal,
+            timeoutMs,
+          },
+        );
+
+        if (notification.method === "item/agentMessage/delta") {
+          const params = notification.params as
+            | { itemId?: string; delta?: string }
+            | undefined;
+          const itemId = params?.itemId;
+          if (typeof itemId === "string" && typeof params?.delta === "string") {
+            const existing = capturedMessages.get(itemId) ?? {
+              text: "",
+              phase: null,
+            };
+            capturedMessages.set(itemId, {
+              text: `${existing.text}${params.delta}`,
+              phase: existing.phase,
+            });
+          }
+          continue;
+        }
+
+        if (notification.method === "item/completed") {
+          const params = notification.params as { item?: unknown } | undefined;
+          const item =
+            params && typeof params.item === "object" && params.item !== null
+              ? (params.item as Record<string, unknown>)
+              : null;
+          if (item?.type === "agentMessage") {
+            const itemId =
+              typeof item.id === "string"
+                ? item.id
+                : `agent-message-${capturedMessages.size + 1}`;
+            const text = typeof item.text === "string" ? item.text : "";
+            const phase = typeof item.phase === "string" ? item.phase : null;
+            const existing = capturedMessages.get(itemId);
+            capturedMessages.set(itemId, {
+              text: text || existing?.text || "",
+              phase: phase ?? existing?.phase ?? null,
+            });
+          }
+          continue;
+        }
+
+        turnCompleted = notification;
+      }
+
+      const completedParams = turnCompleted.params as
+        | {
+            turn?: {
+              id?: string;
+              status?: string;
+              error?: { message?: string | null } | null;
+            };
+          }
+        | undefined;
+      const status = completedParams?.turn?.status;
+      if (status === "failed") {
+        const errorMessage =
+          completedParams?.turn?.error?.message?.trim() ||
+          "Codex turn failed with no error message.";
+        throw new Error(errorMessage);
+      }
+      if (status === "interrupted") {
+        throw new Error("Codex turn was interrupted.");
+      }
+
+      const textFromEvents = pickBestAgentMessageText(
+        Array.from(capturedMessages.values()),
+      );
+      if (textFromEvents) {
+        return { text: textFromEvents, turnId };
+      }
+
+      let text: string | null = null;
+      try {
+        const threadRead = (await session.request("thread/read", {
+          threadId,
+          includeTurns: true,
+        })) as {
+          thread?: {
+            turns?: Array<{
+              id?: string;
+              items?: unknown[];
+            }>;
+          };
+        };
+
+        const turn = (threadRead.thread?.turns ?? []).find(
+          (candidate) => candidate.id === turnId,
+        );
+        text = extractAgentMessageText(turn ?? null);
+      } catch (error) {
+        logger.debug("Codex thread/read fallback unavailable", {
+          message: buildCodexErrorMessage(error),
+        });
+      }
+
+      if (!text) {
+        throw new Error(
+          "Codex turn completed but no assistant message text was returned.",
+        );
+      }
+
+      return { text, turnId };
+    } finally {
+      await session.close();
+    }
+  }
+}

--- a/orchestrator/src/server/services/llm/codex/client.ts
+++ b/orchestrator/src/server/services/llm/codex/client.ts
@@ -1,4 +1,6 @@
 import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { createInterface, type Interface } from "node:readline";
 import { logger } from "@infra/logger";
 import type { JsonSchemaDefinition, LlmRequestOptions } from "../types";
@@ -8,6 +10,7 @@ const DEFAULT_STARTUP_TIMEOUT_MS = 15_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_TURN_TIMEOUT_MS = 120_000;
 const MAX_STDERR_LINES = 40;
+const FALLBACK_CLIENT_VERSION = "dev";
 
 type JsonRpcId = number | string;
 
@@ -74,6 +77,50 @@ function buildCodexErrorMessage(error: unknown): string {
 function isAbortError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   return error.name === "AbortError" || error.message.includes("aborted");
+}
+
+function toNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function readVersionFromPackage(filePath: string): string | null {
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    return toNonEmptyString(parsed.version);
+  } catch {
+    return null;
+  }
+}
+
+let cachedClientVersion: string | null = null;
+
+function resolveClientVersion(): string {
+  if (cachedClientVersion) {
+    return cachedClientVersion;
+  }
+
+  const envVersion =
+    toNonEmptyString(process.env.JOBOPS_VERSION) ||
+    toNonEmptyString(process.env.npm_package_version);
+  if (envVersion) {
+    cachedClientVersion = envVersion;
+    return cachedClientVersion;
+  }
+
+  const packageVersion =
+    readVersionFromPackage(
+      join(process.cwd(), "orchestrator", "package.json"),
+    ) || readVersionFromPackage(join(process.cwd(), "package.json"));
+  if (packageVersion) {
+    cachedClientVersion = packageVersion;
+    return cachedClientVersion;
+  }
+
+  cachedClientVersion = FALLBACK_CLIENT_VERSION;
+  return cachedClientVersion;
 }
 
 function formatPrompt(args: {
@@ -219,7 +266,7 @@ class CodexAppServerSession {
           clientInfo: {
             name: "job-ops",
             title: "JobOps",
-            version: "0.3.1",
+            version: resolveClientVersion(),
           },
           capabilities: {
             experimentalApi: false,

--- a/orchestrator/src/server/services/llm/codex/client.ts
+++ b/orchestrator/src/server/services/llm/codex/client.ts
@@ -59,6 +59,17 @@ type NotificationWaiter = {
   abortCleanup: (() => void) | null;
 };
 
+type CodexAuthStatusResponse = {
+  authMethod?: string | null;
+  requiresOpenaiAuth?: boolean | null;
+  username?: string | null;
+  userName?: string | null;
+  login?: string | null;
+  email?: string | null;
+  account?: Record<string, unknown> | null;
+  user?: Record<string, unknown> | null;
+};
+
 function getPositiveIntEnv(name: string, fallback: number): number {
   const raw = process.env[name]?.trim();
   if (!raw) return fallback;
@@ -95,6 +106,42 @@ function toNonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
     : null;
+}
+
+function getRecordString(
+  record: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  if (!record) return null;
+  return toNonEmptyString(record[key]);
+}
+
+function extractCodexUsername(raw: unknown): string | null {
+  if (!raw || typeof raw !== "object") return null;
+  const auth = raw as CodexAuthStatusResponse;
+
+  const direct =
+    toNonEmptyString(auth.username) ||
+    toNonEmptyString(auth.userName) ||
+    toNonEmptyString(auth.login) ||
+    toNonEmptyString(auth.email);
+  if (direct) return direct;
+
+  const fromUser =
+    getRecordString(auth.user ?? null, "username") ||
+    getRecordString(auth.user ?? null, "userName") ||
+    getRecordString(auth.user ?? null, "login") ||
+    getRecordString(auth.user ?? null, "email") ||
+    getRecordString(auth.user ?? null, "name");
+  if (fromUser) return fromUser;
+
+  return (
+    getRecordString(auth.account ?? null, "username") ||
+    getRecordString(auth.account ?? null, "userName") ||
+    getRecordString(auth.account ?? null, "login") ||
+    getRecordString(auth.account ?? null, "email") ||
+    getRecordString(auth.account ?? null, "name")
+  );
 }
 
 function readVersionFromPackage(filePath: string): string | null {
@@ -687,9 +734,11 @@ async function closeCodexSessionForTests(): Promise<void> {
 }
 
 export class CodexClient {
-  async validateCredentials(
-    signal?: AbortSignal,
-  ): Promise<{ valid: boolean; message: string | null }> {
+  async getAuthStatus(signal?: AbortSignal): Promise<{
+    valid: boolean;
+    message: string | null;
+    username: string | null;
+  }> {
     try {
       return await withCodexSession({
         signal,
@@ -697,20 +746,22 @@ export class CodexClient {
           const auth = (await session.request("getAuthStatus", {
             includeToken: false,
             refreshToken: false,
-          })) as {
-            authMethod?: string | null;
-            requiresOpenaiAuth?: boolean | null;
-          };
+          })) as CodexAuthStatusResponse;
 
           if (!auth?.authMethod && auth?.requiresOpenaiAuth !== false) {
             return {
               valid: false,
               message:
                 "Codex is not authenticated in this container. Run `codex login` and try again.",
+              username: null,
             };
           }
 
-          return { valid: true, message: null };
+          return {
+            valid: true,
+            message: null,
+            username: extractCodexUsername(auth),
+          };
         },
       });
     } catch (error) {
@@ -718,13 +769,28 @@ export class CodexClient {
         return {
           valid: false,
           message: "Codex validation was cancelled.",
+          username: null,
         };
       }
       return {
         valid: false,
         message: buildCodexErrorMessage(error),
+        username: null,
       };
     }
+  }
+
+  async validateCredentials(signal?: AbortSignal): Promise<{
+    valid: boolean;
+    message: string | null;
+    username?: string | null;
+  }> {
+    const status = await this.getAuthStatus(signal);
+    return {
+      valid: status.valid,
+      message: status.message,
+      username: status.username,
+    };
   }
 
   async listModels(signal?: AbortSignal): Promise<string[]> {

--- a/orchestrator/src/server/services/llm/codex/login.test.ts
+++ b/orchestrator/src/server/services/llm/codex/login.test.ts
@@ -105,6 +105,29 @@ describe("codex device login service", () => {
     expect(second.verificationUrl).toBe(first.verificationUrl);
   });
 
+  it("tracks process completion when login exits immediately after printing device code", async () => {
+    vi.mocked(spawn).mockImplementation(() =>
+      createMockProcess((stdout, _stderr, proc) => {
+        setTimeout(() => {
+          stdout.write("https://auth.openai.com/codex/device\n");
+          stdout.write("ABCD-EFGH\n");
+          proc.emit("exit", 0, null);
+        }, 0);
+      }),
+    );
+
+    const snapshot = await startCodexDeviceAuth();
+    expect(snapshot.userCode).toBe("ABCD-EFGH");
+
+    await new Promise<void>((resolve) => {
+      setImmediate(resolve);
+    });
+
+    const current = getCodexDeviceAuthSnapshot();
+    expect(current.status).toBe("completed");
+    expect(current.loginInProgress).toBe(false);
+  });
+
   it("fails when the login process exits before yielding a device code", async () => {
     vi.mocked(spawn).mockImplementation(() =>
       createMockProcess((_stdout, _stderr, proc) => {

--- a/orchestrator/src/server/services/llm/codex/login.test.ts
+++ b/orchestrator/src/server/services/llm/codex/login.test.ts
@@ -1,0 +1,122 @@
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
+import { spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  __resetCodexDeviceAuthForTests,
+  getCodexDeviceAuthSnapshot,
+  startCodexDeviceAuth,
+} from "./login";
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: spawnMock,
+  default: {
+    spawn: spawnMock,
+  },
+}));
+
+function createMockProcess(
+  configure: (
+    stdout: PassThrough,
+    stderr: PassThrough,
+    proc: EventEmitter,
+  ) => void,
+): ChildProcessWithoutNullStreams {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+
+  const proc = new EventEmitter() as ChildProcessWithoutNullStreams & {
+    killed: boolean;
+  };
+  proc.stdin = stdin;
+  proc.stdout = stdout;
+  proc.stderr = stderr;
+  proc.killed = false;
+  proc.kill = vi.fn((signal?: NodeJS.Signals) => {
+    proc.killed = true;
+    setImmediate(() => {
+      proc.emit("exit", 0, signal ?? null);
+    });
+    return true;
+  });
+
+  configure(stdout, stderr, proc);
+  return proc;
+}
+
+describe("codex device login service", () => {
+  afterEach(() => {
+    __resetCodexDeviceAuthForTests();
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it("parses URL and device code from login output", async () => {
+    vi.mocked(spawn).mockImplementation(() =>
+      createMockProcess((stdout) => {
+        setTimeout(() => {
+          stdout.write(
+            [
+              "expires in 15 minutes",
+              "\u001b[94mhttps://auth.openai.com/codex/device\u001b[0m",
+              "\u001b[94mHU0J-CGNH0\u001b[0m",
+            ].join("\n"),
+          );
+        }, 0);
+      }),
+    );
+
+    const snapshot = await startCodexDeviceAuth();
+
+    expect(snapshot.status).toBe("running");
+    expect(snapshot.loginInProgress).toBe(true);
+    expect(snapshot.verificationUrl).toBe(
+      "https://auth.openai.com/codex/device",
+    );
+    expect(snapshot.userCode).toBe("HU0J-CGNH0");
+    expect(snapshot.expiresAt).not.toBeNull();
+
+    const current = getCodexDeviceAuthSnapshot();
+    expect(current.status).toBe("running");
+    expect(current.userCode).toBe("HU0J-CGNH0");
+  });
+
+  it("returns existing running session without spawning a second process", async () => {
+    vi.mocked(spawn).mockImplementation(() =>
+      createMockProcess((stdout) => {
+        setTimeout(() => {
+          stdout.write("https://auth.openai.com/codex/device\n");
+          stdout.write("ABCD-EFGH\n");
+        }, 0);
+      }),
+    );
+
+    const first = await startCodexDeviceAuth();
+    const second = await startCodexDeviceAuth();
+
+    expect(vi.mocked(spawn)).toHaveBeenCalledTimes(1);
+    expect(second.userCode).toBe(first.userCode);
+    expect(second.verificationUrl).toBe(first.verificationUrl);
+  });
+
+  it("fails when the login process exits before yielding a device code", async () => {
+    vi.mocked(spawn).mockImplementation(() =>
+      createMockProcess((_stdout, _stderr, proc) => {
+        setTimeout(() => {
+          proc.emit("exit", 1, null);
+        }, 0);
+      }),
+    );
+
+    await expect(startCodexDeviceAuth()).rejects.toThrow(
+      /device code|login exited/i,
+    );
+    expect(getCodexDeviceAuthSnapshot().status).toBe("failed");
+  });
+});

--- a/orchestrator/src/server/services/llm/codex/login.test.ts
+++ b/orchestrator/src/server/services/llm/codex/login.test.ts
@@ -105,6 +105,33 @@ describe("codex device login service", () => {
     expect(second.verificationUrl).toBe(first.verificationUrl);
   });
 
+  it("restarts device auth when forced and returns a new code", async () => {
+    vi.mocked(spawn)
+      .mockImplementationOnce(() =>
+        createMockProcess((stdout) => {
+          setTimeout(() => {
+            stdout.write("https://auth.openai.com/codex/device\n");
+            stdout.write("FIRST-CODE\n");
+          }, 0);
+        }),
+      )
+      .mockImplementationOnce(() =>
+        createMockProcess((stdout) => {
+          setTimeout(() => {
+            stdout.write("https://auth.openai.com/codex/device\n");
+            stdout.write("SECOND-CODE\n");
+          }, 0);
+        }),
+      );
+
+    const first = await startCodexDeviceAuth();
+    const second = await startCodexDeviceAuth(true);
+
+    expect(vi.mocked(spawn)).toHaveBeenCalledTimes(2);
+    expect(first.userCode).toBe("FIRST-CODE");
+    expect(second.userCode).toBe("SECOND-CODE");
+  });
+
   it("tracks process completion when login exits immediately after printing device code", async () => {
     vi.mocked(spawn).mockImplementation(() =>
       createMockProcess((stdout, _stderr, proc) => {

--- a/orchestrator/src/server/services/llm/codex/login.test.ts
+++ b/orchestrator/src/server/services/llm/codex/login.test.ts
@@ -119,4 +119,22 @@ describe("codex device login service", () => {
     );
     expect(getCodexDeviceAuthSnapshot().status).toBe("failed");
   });
+
+  it("provides host-login guidance when device auth is disabled upstream", async () => {
+    vi.mocked(spawn).mockImplementation(() =>
+      createMockProcess((stdout, _stderr, proc) => {
+        setTimeout(() => {
+          stdout.write(
+            "Enable device code authorization for Codex in ChatGPT Security Settings, then run `codex login --device-auth` again.\n",
+          );
+          proc.emit("exit", 1, null);
+        }, 0);
+      }),
+    );
+
+    await expect(startCodexDeviceAuth()).rejects.toThrow(/CODEX_HOME_MOUNT/i);
+    const snapshot = getCodexDeviceAuthSnapshot();
+    expect(snapshot.status).toBe("failed");
+    expect(snapshot.message).toMatch(/host/i);
+  });
 });

--- a/orchestrator/src/server/services/llm/codex/login.test.ts
+++ b/orchestrator/src/server/services/llm/codex/login.test.ts
@@ -5,6 +5,7 @@ import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __resetCodexDeviceAuthForTests,
+  disconnectCodexAuth,
   getCodexDeviceAuthSnapshot,
   startCodexDeviceAuth,
 } from "./login";
@@ -188,5 +189,34 @@ describe("codex device login service", () => {
     const snapshot = getCodexDeviceAuthSnapshot();
     expect(snapshot.status).toBe("failed");
     expect(snapshot.message).toMatch(/Security Settings/i);
+  });
+
+  it("disconnects codex auth successfully", async () => {
+    vi.mocked(spawn).mockImplementation(() =>
+      createMockProcess((_stdout, _stderr, proc) => {
+        setTimeout(() => {
+          proc.emit("exit", 0, null);
+        }, 0);
+      }),
+    );
+
+    const snapshot = await disconnectCodexAuth();
+    expect(snapshot.status).toBe("idle");
+    expect(snapshot.loginInProgress).toBe(false);
+  });
+
+  it("treats already-logged-out state as a successful disconnect", async () => {
+    vi.mocked(spawn).mockImplementation(() =>
+      createMockProcess((_stdout, stderr, proc) => {
+        setTimeout(() => {
+          stderr.write("Not logged in.\n");
+          proc.emit("exit", 1, null);
+        }, 0);
+      }),
+    );
+
+    const snapshot = await disconnectCodexAuth();
+    expect(snapshot.status).toBe("idle");
+    expect(snapshot.loginInProgress).toBe(false);
   });
 });

--- a/orchestrator/src/server/services/llm/codex/login.test.ts
+++ b/orchestrator/src/server/services/llm/codex/login.test.ts
@@ -120,7 +120,7 @@ describe("codex device login service", () => {
     expect(getCodexDeviceAuthSnapshot().status).toBe("failed");
   });
 
-  it("provides host-login guidance when device auth is disabled upstream", async () => {
+  it("guides user to security settings when device auth is disabled upstream", async () => {
     vi.mocked(spawn).mockImplementation(() =>
       createMockProcess((stdout, _stderr, proc) => {
         setTimeout(() => {
@@ -132,9 +132,11 @@ describe("codex device login service", () => {
       }),
     );
 
-    await expect(startCodexDeviceAuth()).rejects.toThrow(/CODEX_HOME_MOUNT/i);
+    await expect(startCodexDeviceAuth()).rejects.toThrow(
+      /ChatGPT Security Settings/i,
+    );
     const snapshot = getCodexDeviceAuthSnapshot();
     expect(snapshot.status).toBe("failed");
-    expect(snapshot.message).toMatch(/host/i);
+    expect(snapshot.message).toMatch(/Security Settings/i);
   });
 });

--- a/orchestrator/src/server/services/llm/codex/login.ts
+++ b/orchestrator/src/server/services/llm/codex/login.ts
@@ -138,7 +138,7 @@ function buildOutputMessage(session: DeviceAuthSession): string | null {
 function normalizeStartupFailureMessage(message: string): string {
   if (/enable device code authorization/i.test(message)) {
     return truncate(
-      "Device-code auth is disabled for this account. Enable it in ChatGPT Security Settings, or use host login reuse by setting CODEX_HOME_MOUNT to your host .codex path and running `codex login` on the host.",
+      "Device-code auth is disabled for this account. Enable it in ChatGPT Security Settings, then try Codex sign-in again.",
       400,
     );
   }

--- a/orchestrator/src/server/services/llm/codex/login.ts
+++ b/orchestrator/src/server/services/llm/codex/login.ts
@@ -209,7 +209,23 @@ async function waitForDeviceCode(
     const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
       clearTimeout(timeout);
       if (session.verificationUrl && session.userCode) {
+        if (code === 0) {
+          session.status = "completed";
+          session.message = "Codex login completed.";
+          stopSessionProcess(session);
+          cleanup();
+          resolve(toSnapshot(session));
+          return;
+        }
+
+        session.status = "failed";
+        const rawMessage =
+          buildOutputMessage(session) ||
+          `Codex login failed (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
+        session.message = normalizeStartupFailureMessage(rawMessage);
+        stopSessionProcess(session);
         cleanup();
+        reject(new Error(session.message));
         return;
       }
 
@@ -278,13 +294,19 @@ export function getCodexDeviceAuthSnapshot(): CodexDeviceAuthSnapshot {
   return toSnapshot(activeSession);
 }
 
-export async function startCodexDeviceAuth(): Promise<CodexDeviceAuthSnapshot> {
+export async function startCodexDeviceAuth(
+  forceRestart = false,
+): Promise<CodexDeviceAuthSnapshot> {
   if (activeSession) {
     if (
       activeSession.status === "starting" ||
       activeSession.status === "running"
     ) {
-      return toSnapshot(activeSession);
+      if (!forceRestart) {
+        return toSnapshot(activeSession);
+      }
+      stopSessionProcess(activeSession);
+      activeSession = null;
     }
   }
 

--- a/orchestrator/src/server/services/llm/codex/login.ts
+++ b/orchestrator/src/server/services/llm/codex/login.ts
@@ -167,15 +167,25 @@ async function waitForDeviceCode(
       session.message =
         "Timed out waiting for Codex device authorization code. Try again.";
       stopSessionProcess(session);
+      cleanup();
       reject(new Error(session.message));
     }, DEVICE_AUTH_TIMEOUT_MS);
 
+    const cleanup = () => {
+      proc.stdout.off("data", onStdout);
+      proc.stderr.off("data", onStderr);
+      proc.off("exit", onExit);
+      proc.off("error", onError);
+    };
+
     const tryResolve = () => {
       if (session.verificationUrl && session.userCode) {
+        attachExitTracking(session);
         clearTimeout(timeout);
         session.status = "running";
         session.message =
           "Open the verification URL and enter the one-time code to finish login.";
+        cleanup();
         resolve(toSnapshot(session));
       }
     };
@@ -199,6 +209,7 @@ async function waitForDeviceCode(
     const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
       clearTimeout(timeout);
       if (session.verificationUrl && session.userCode) {
+        cleanup();
         return;
       }
 
@@ -208,6 +219,7 @@ async function waitForDeviceCode(
         `Codex login exited before a device code was returned (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
       session.message = normalizeStartupFailureMessage(rawMessage);
       stopSessionProcess(session);
+      cleanup();
       reject(new Error(session.message));
     };
 
@@ -219,6 +231,7 @@ async function waitForDeviceCode(
         : normalizeStartupFailureMessage(error.message);
       session.message = normalizeStartupFailureMessage(message);
       stopSessionProcess(session);
+      cleanup();
       reject(new Error(session.message));
     };
 
@@ -297,7 +310,6 @@ export async function startCodexDeviceAuth(): Promise<CodexDeviceAuthSnapshot> {
 
   try {
     const snapshot = await waitForDeviceCode(session);
-    attachExitTracking(session);
     return snapshot;
   } catch (error) {
     logger.warn("Codex device-auth startup failed", {

--- a/orchestrator/src/server/services/llm/codex/login.ts
+++ b/orchestrator/src/server/services/llm/codex/login.ts
@@ -1,0 +1,304 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import { logger } from "@infra/logger";
+import { truncate } from "../utils/string";
+
+const DEVICE_AUTH_TIMEOUT_MS = 15_000;
+const MAX_BUFFERED_LINES = 80;
+const DEVICE_CODE_REGEX = /\b[A-Z0-9]{4,}-[A-Z0-9]{4,}\b/;
+const URL_REGEX = /(https?:\/\/[^\s]+)/i;
+const EXPIRES_MINUTES_REGEX = /expires in (\d+) minutes/i;
+
+type DeviceAuthFlowStatus =
+  | "idle"
+  | "starting"
+  | "running"
+  | "completed"
+  | "failed";
+
+type DeviceAuthSession = {
+  status: DeviceAuthFlowStatus;
+  startedAtMs: number;
+  verificationUrl: string | null;
+  userCode: string | null;
+  expiresAtMs: number | null;
+  message: string | null;
+  output: string[];
+  proc: ChildProcessWithoutNullStreams | null;
+};
+
+export type CodexDeviceAuthSnapshot = {
+  status: DeviceAuthFlowStatus;
+  loginInProgress: boolean;
+  verificationUrl: string | null;
+  userCode: string | null;
+  startedAt: string | null;
+  expiresAt: string | null;
+  message: string | null;
+};
+
+let activeSession: DeviceAuthSession | null = null;
+
+function stripAnsi(value: string): string {
+  if (!value.includes("\u001B")) {
+    return value;
+  }
+
+  let output = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char !== "\u001B") {
+      output += char;
+      continue;
+    }
+
+    if (value[index + 1] !== "[") {
+      continue;
+    }
+
+    index += 2;
+    while (index < value.length) {
+      const code = value.charCodeAt(index);
+      if (code >= 0x40 && code <= 0x7e) {
+        break;
+      }
+      index += 1;
+    }
+  }
+
+  return output;
+}
+
+function toSnapshot(
+  session: DeviceAuthSession | null,
+): CodexDeviceAuthSnapshot {
+  if (!session) {
+    return {
+      status: "idle",
+      loginInProgress: false,
+      verificationUrl: null,
+      userCode: null,
+      startedAt: null,
+      expiresAt: null,
+      message: null,
+    };
+  }
+
+  return {
+    status: session.status,
+    loginInProgress:
+      session.status === "starting" || session.status === "running",
+    verificationUrl: session.verificationUrl,
+    userCode: session.userCode,
+    startedAt: new Date(session.startedAtMs).toISOString(),
+    expiresAt: session.expiresAtMs
+      ? new Date(session.expiresAtMs).toISOString()
+      : null,
+    message: session.message,
+  };
+}
+
+function appendLine(session: DeviceAuthSession, line: string): void {
+  const normalized = stripAnsi(line).trim();
+  if (!normalized) return;
+  session.output.push(normalized);
+  if (session.output.length > MAX_BUFFERED_LINES) {
+    session.output.shift();
+  }
+
+  if (!session.verificationUrl) {
+    const urlMatch = normalized.match(URL_REGEX);
+    if (urlMatch?.[1]) {
+      session.verificationUrl = urlMatch[1];
+    }
+  }
+
+  if (!session.userCode) {
+    const codeMatch = normalized.match(DEVICE_CODE_REGEX);
+    if (codeMatch?.[0]) {
+      session.userCode = codeMatch[0];
+    }
+  }
+
+  if (!session.expiresAtMs) {
+    const expiresMatch = normalized.match(EXPIRES_MINUTES_REGEX);
+    const minutes = expiresMatch?.[1]
+      ? Number.parseInt(expiresMatch[1], 10)
+      : 0;
+    if (Number.isFinite(minutes) && minutes > 0) {
+      session.expiresAtMs = Date.now() + minutes * 60_000;
+    }
+  }
+}
+
+function buildOutputMessage(session: DeviceAuthSession): string | null {
+  const latest = session.output.at(-1);
+  return latest ? truncate(latest, 400) : null;
+}
+
+function stopSessionProcess(session: DeviceAuthSession): void {
+  if (session.proc && !session.proc.killed) {
+    session.proc.kill("SIGTERM");
+  }
+  session.proc = null;
+}
+
+async function waitForDeviceCode(
+  session: DeviceAuthSession,
+): Promise<CodexDeviceAuthSnapshot> {
+  return await new Promise<CodexDeviceAuthSnapshot>((resolve, reject) => {
+    const proc = session.proc;
+    if (!proc) {
+      reject(new Error("Codex login process failed to start."));
+      return;
+    }
+
+    const timeout = setTimeout(() => {
+      session.status = "failed";
+      session.message =
+        "Timed out waiting for Codex device authorization code. Try again.";
+      stopSessionProcess(session);
+      reject(new Error(session.message));
+    }, DEVICE_AUTH_TIMEOUT_MS);
+
+    const tryResolve = () => {
+      if (session.verificationUrl && session.userCode) {
+        clearTimeout(timeout);
+        session.status = "running";
+        session.message =
+          "Open the verification URL and enter the one-time code to finish login.";
+        resolve(toSnapshot(session));
+      }
+    };
+
+    const onStdout = (chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      for (const line of text.split(/\r?\n/)) {
+        appendLine(session, line);
+      }
+      tryResolve();
+    };
+
+    const onStderr = (chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      for (const line of text.split(/\r?\n/)) {
+        appendLine(session, line);
+      }
+      tryResolve();
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      clearTimeout(timeout);
+      if (session.verificationUrl && session.userCode) {
+        return;
+      }
+
+      session.status = "failed";
+      session.message =
+        buildOutputMessage(session) ||
+        `Codex login exited before a device code was returned (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
+      stopSessionProcess(session);
+      reject(new Error(session.message));
+    };
+
+    const onError = (error: Error) => {
+      clearTimeout(timeout);
+      session.status = "failed";
+      const message = error.message.includes("ENOENT")
+        ? "Codex CLI is not installed in this runtime."
+        : truncate(error.message, 400);
+      session.message = message;
+      stopSessionProcess(session);
+      reject(new Error(message));
+    };
+
+    proc.stdout.on("data", onStdout);
+    proc.stderr.on("data", onStderr);
+    proc.once("exit", onExit);
+    proc.once("error", onError);
+  });
+}
+
+function attachExitTracking(session: DeviceAuthSession): void {
+  const proc = session.proc;
+  if (!proc) return;
+
+  proc.once("exit", (code, signal) => {
+    const running =
+      session.status === "running" || session.status === "starting";
+    if (!running) return;
+
+    if (code === 0) {
+      session.status = "completed";
+      session.message = "Codex login completed.";
+    } else {
+      session.status = "failed";
+      session.message =
+        buildOutputMessage(session) ||
+        `Codex login failed (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
+    }
+    stopSessionProcess(session);
+  });
+
+  proc.once("error", (error) => {
+    const running =
+      session.status === "running" || session.status === "starting";
+    if (!running) return;
+
+    session.status = "failed";
+    session.message = truncate(error.message, 400);
+    stopSessionProcess(session);
+  });
+}
+
+export function getCodexDeviceAuthSnapshot(): CodexDeviceAuthSnapshot {
+  return toSnapshot(activeSession);
+}
+
+export async function startCodexDeviceAuth(): Promise<CodexDeviceAuthSnapshot> {
+  if (activeSession) {
+    if (
+      activeSession.status === "starting" ||
+      activeSession.status === "running"
+    ) {
+      return toSnapshot(activeSession);
+    }
+  }
+
+  const command = process.env.CODEX_APP_SERVER_BIN?.trim() || "codex";
+  const proc = spawn(command, ["login", "--device-auth"], {
+    stdio: "pipe",
+    cwd: process.cwd(),
+    env: process.env,
+  });
+
+  const session: DeviceAuthSession = {
+    status: "starting",
+    startedAtMs: Date.now(),
+    verificationUrl: null,
+    userCode: null,
+    expiresAtMs: null,
+    message: null,
+    output: [],
+    proc,
+  };
+
+  activeSession = session;
+
+  try {
+    const snapshot = await waitForDeviceCode(session);
+    attachExitTracking(session);
+    return snapshot;
+  } catch (error) {
+    logger.warn("Codex device-auth startup failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+export function __resetCodexDeviceAuthForTests(): void {
+  if (activeSession) {
+    stopSessionProcess(activeSession);
+  }
+  activeSession = null;
+}

--- a/orchestrator/src/server/services/llm/codex/login.ts
+++ b/orchestrator/src/server/services/llm/codex/login.ts
@@ -135,6 +135,16 @@ function buildOutputMessage(session: DeviceAuthSession): string | null {
   return latest ? truncate(latest, 400) : null;
 }
 
+function normalizeStartupFailureMessage(message: string): string {
+  if (/enable device code authorization/i.test(message)) {
+    return truncate(
+      "Device-code auth is disabled for this account. Enable it in ChatGPT Security Settings, or use host login reuse by setting CODEX_HOME_MOUNT to your host .codex path and running `codex login` on the host.",
+      400,
+    );
+  }
+  return truncate(message, 400);
+}
+
 function stopSessionProcess(session: DeviceAuthSession): void {
   if (session.proc && !session.proc.killed) {
     session.proc.kill("SIGTERM");
@@ -193,9 +203,10 @@ async function waitForDeviceCode(
       }
 
       session.status = "failed";
-      session.message =
+      const rawMessage =
         buildOutputMessage(session) ||
         `Codex login exited before a device code was returned (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
+      session.message = normalizeStartupFailureMessage(rawMessage);
       stopSessionProcess(session);
       reject(new Error(session.message));
     };
@@ -205,10 +216,10 @@ async function waitForDeviceCode(
       session.status = "failed";
       const message = error.message.includes("ENOENT")
         ? "Codex CLI is not installed in this runtime."
-        : truncate(error.message, 400);
-      session.message = message;
+        : normalizeStartupFailureMessage(error.message);
+      session.message = normalizeStartupFailureMessage(message);
       stopSessionProcess(session);
-      reject(new Error(message));
+      reject(new Error(session.message));
     };
 
     proc.stdout.on("data", onStdout);

--- a/orchestrator/src/server/services/llm/codex/login.ts
+++ b/orchestrator/src/server/services/llm/codex/login.ts
@@ -3,6 +3,7 @@ import { logger } from "@infra/logger";
 import { truncate } from "../utils/string";
 
 const DEVICE_AUTH_TIMEOUT_MS = 15_000;
+const LOGOUT_TIMEOUT_MS = 10_000;
 const MAX_BUFFERED_LINES = 80;
 const DEVICE_CODE_REGEX = /\b[A-Z0-9]{4,}-[A-Z0-9]{4,}\b/;
 const URL_REGEX = /(https?:\/\/[^\s]+)/i;
@@ -143,6 +144,12 @@ function normalizeStartupFailureMessage(message: string): string {
     );
   }
   return truncate(message, 400);
+}
+
+function isAlreadyLoggedOutMessage(message: string): boolean {
+  return /not logged in|not authenticated|already logged out|already signed out/i.test(
+    message,
+  );
 }
 
 function stopSessionProcess(session: DeviceAuthSession): void {
@@ -339,6 +346,73 @@ export async function startCodexDeviceAuth(
     });
     throw error;
   }
+}
+
+export async function disconnectCodexAuth(): Promise<CodexDeviceAuthSnapshot> {
+  if (activeSession) {
+    stopSessionProcess(activeSession);
+    activeSession = null;
+  }
+
+  const command = process.env.CODEX_APP_SERVER_BIN?.trim() || "codex";
+
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn(command, ["logout"], {
+      stdio: "pipe",
+      cwd: process.cwd(),
+      env: process.env,
+    });
+
+    const output: string[] = [];
+    const appendOutput = (chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      for (const line of text.split(/\r?\n/)) {
+        const normalized = stripAnsi(line).trim();
+        if (!normalized) continue;
+        output.push(normalized);
+        if (output.length > MAX_BUFFERED_LINES) {
+          output.shift();
+        }
+      }
+    };
+
+    const timer = setTimeout(() => {
+      proc.kill("SIGTERM");
+      reject(new Error("Timed out while disconnecting Codex."));
+    }, LOGOUT_TIMEOUT_MS);
+
+    proc.stdout.on("data", appendOutput);
+    proc.stderr.on("data", appendOutput);
+
+    proc.once("error", (error) => {
+      clearTimeout(timer);
+      if (error.message.includes("ENOENT")) {
+        reject(new Error("Codex CLI is not installed in this runtime."));
+        return;
+      }
+      reject(new Error(truncate(error.message, 400)));
+    });
+
+    proc.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      const latestOutput = output.at(-1);
+      const message =
+        latestOutput ||
+        `Codex logout failed (code=${code ?? "null"}, signal=${signal ?? "null"}).`;
+      if (isAlreadyLoggedOutMessage(message)) {
+        resolve();
+        return;
+      }
+      reject(new Error(truncate(message, 400)));
+    });
+  });
+
+  return toSnapshot(activeSession);
 }
 
 export function __resetCodexDeviceAuthForTests(): void {

--- a/orchestrator/src/server/services/llm/policies/retry-policy.ts
+++ b/orchestrator/src/server/services/llm/policies/retry-policy.ts
@@ -7,6 +7,7 @@ export function shouldRetryAttempt(args: {
     args.status === 429 ||
     (args.status !== undefined && args.status >= 500 && args.status <= 599) ||
     args.message.toLowerCase().includes("timeout") ||
+    args.message.toLowerCase().includes("timed out") ||
     args.message.toLowerCase().includes("fetch failed")
   );
 }

--- a/orchestrator/src/server/services/llm/providers/codex.ts
+++ b/orchestrator/src/server/services/llm/providers/codex.ts
@@ -1,0 +1,14 @@
+import { createProviderStrategy } from "./factory";
+
+export const codexStrategy = createProviderStrategy({
+  provider: "codex",
+  defaultBaseUrl: "stdio://",
+  requiresApiKey: false,
+  modes: ["none"],
+  validationPaths: [],
+  buildRequest: () => {
+    throw new Error("Codex provider does not use HTTP requests.");
+  },
+  extractText: () => null,
+  getValidationUrls: () => [],
+});

--- a/orchestrator/src/server/services/llm/providers/codex.ts
+++ b/orchestrator/src/server/services/llm/providers/codex.ts
@@ -2,7 +2,7 @@ import { createProviderStrategy } from "./factory";
 
 export const codexStrategy = createProviderStrategy({
   provider: "codex",
-  defaultBaseUrl: "stdio://",
+  defaultBaseUrl: "",
   requiresApiKey: false,
   modes: ["none"],
   validationPaths: [],

--- a/orchestrator/src/server/services/llm/providers/index.ts
+++ b/orchestrator/src/server/services/llm/providers/index.ts
@@ -1,4 +1,5 @@
 import type { LlmProvider, ProviderStrategy } from "../types";
+import { codexStrategy } from "./codex";
 import { geminiStrategy } from "./gemini";
 import { lmStudioStrategy } from "./lmstudio";
 import { ollamaStrategy } from "./ollama";
@@ -13,4 +14,5 @@ export const strategies: Record<LlmProvider, ProviderStrategy> = {
   openai: openAiStrategy,
   openai_compatible: openAiCompatibleStrategy,
   gemini: geminiStrategy,
+  codex: codexStrategy,
 };

--- a/orchestrator/src/server/services/llm/service.test.ts
+++ b/orchestrator/src/server/services/llm/service.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { CodexClient } from "./codex/client";
 import { LlmService } from "./service";
 
 describe("LlmService provider normalization", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("keeps legacy localhost openai_compatible configs on LM Studio", () => {
     const llm = new LlmService({
       provider: "openai_compatible",
@@ -30,5 +35,68 @@ describe("LlmService provider normalization", () => {
 
     expect(llm.getProvider()).toBe("openai_compatible");
     expect(llm.getBaseUrl()).toBe("https://llm.example.com");
+  });
+
+  it("supports codex provider normalization", () => {
+    const llm = new LlmService({
+      provider: "codex",
+    });
+
+    expect(llm.getProvider()).toBe("codex");
+    expect(llm.getBaseUrl()).toBe("stdio://");
+  });
+
+  it("retries codex JSON parsing failures and succeeds on a later attempt", async () => {
+    const codexCallSpy = vi
+      .spyOn(CodexClient.prototype, "callJson")
+      .mockResolvedValueOnce({ text: "not-json", turnId: "turn-1" })
+      .mockResolvedValueOnce({
+        text: '{"value":"ok"}',
+        turnId: "turn-2",
+      });
+
+    const llm = new LlmService({ provider: "codex" });
+    const result = await llm.callJson<{ value: string }>({
+      model: "",
+      messages: [{ role: "user", content: "Return JSON." }],
+      jsonSchema: {
+        name: "test",
+        schema: {
+          type: "object",
+          properties: { value: { type: "string" } },
+          required: ["value"],
+          additionalProperties: false,
+        },
+      },
+      maxRetries: 1,
+      retryDelayMs: 1,
+    });
+
+    expect(result).toEqual({ success: true, data: { value: "ok" } });
+    expect(codexCallSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("delegates codex credential validation to the codex client", async () => {
+    const validateSpy = vi
+      .spyOn(CodexClient.prototype, "validateCredentials")
+      .mockResolvedValue({ valid: true, message: null });
+
+    const llm = new LlmService({ provider: "codex" });
+    const result = await llm.validateCredentials();
+
+    expect(result).toEqual({ valid: true, message: null });
+    expect(validateSpy).toHaveBeenCalledOnce();
+  });
+
+  it("delegates codex model discovery to the codex client", async () => {
+    const listSpy = vi
+      .spyOn(CodexClient.prototype, "listModels")
+      .mockResolvedValue(["gpt-5", "o4-mini"]);
+
+    const llm = new LlmService({ provider: "codex" });
+    const models = await llm.listModels();
+
+    expect(models).toEqual(["gpt-5", "o4-mini"]);
+    expect(listSpy).toHaveBeenCalledOnce();
   });
 });

--- a/orchestrator/src/server/services/llm/service.test.ts
+++ b/orchestrator/src/server/services/llm/service.test.ts
@@ -43,7 +43,7 @@ describe("LlmService provider normalization", () => {
     });
 
     expect(llm.getProvider()).toBe("codex");
-    expect(llm.getBaseUrl()).toBe("stdio://");
+    expect(llm.getBaseUrl()).toBe("");
   });
 
   it("retries codex JSON parsing failures and succeeds on a later attempt", async () => {

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -1,5 +1,6 @@
 import { logger } from "@infra/logger";
 import { toStringOrNull } from "@shared/utils/type-conversion";
+import { CodexClient } from "./codex/client";
 import {
   buildModeCacheKey,
   getOrderedModes,
@@ -31,6 +32,7 @@ export class LlmService {
   private readonly baseUrl: string;
   private readonly apiKey: string | null;
   private readonly strategy: (typeof strategies)[LlmProvider];
+  private readonly codexClient: CodexClient;
 
   constructor(options: LlmServiceOptions = {}) {
     const normalizedBaseUrl =
@@ -71,9 +73,14 @@ export class LlmService {
     this.baseUrl = baseUrl;
     this.apiKey = apiKey;
     this.strategy = strategy;
+    this.codexClient = new CodexClient();
   }
 
   async callJson<T>(options: LlmRequestOptions<T>): Promise<LlmResponse<T>> {
+    if (this.provider === "codex") {
+      return this.callCodexJson(options);
+    }
+
     if (this.strategy.requiresApiKey && !this.apiKey) {
       return { success: false, error: "LLM API key not configured" };
     }
@@ -127,6 +134,10 @@ export class LlmService {
   }
 
   async validateCredentials(): Promise<LlmValidationResult> {
+    if (this.provider === "codex") {
+      return this.codexClient.validateCredentials();
+    }
+
     if (this.strategy.requiresApiKey && !this.apiKey) {
       return { valid: false, message: "LLM API key is missing." };
     }
@@ -184,6 +195,10 @@ export class LlmService {
   }
 
   async listModels(): Promise<string[]> {
+    if (this.provider === "codex") {
+      return this.codexClient.listModels();
+    }
+
     if (this.strategy.requiresApiKey && !this.apiKey) {
       throw new Error("LLM API key is missing.");
     }
@@ -207,6 +222,48 @@ export class LlmService {
     })();
 
     return sortModels(models, getPreferredModel(this.provider));
+  }
+
+  private async callCodexJson<T>(
+    options: LlmRequestOptions<T>,
+  ): Promise<LlmResponse<T>> {
+    const { maxRetries = 0, retryDelayMs = 500, signal, jobId } = options;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        if (attempt > 0) {
+          logger.info("LLM retry attempt", {
+            jobId: jobId ?? "unknown",
+            attempt,
+            maxRetries,
+          });
+          await sleep(getRetryDelayMs(retryDelayMs, attempt));
+        }
+
+        const result = await this.codexClient.callJson({
+          ...options,
+          signal,
+        });
+        const parsed = parseJsonContent<T>(result.text, jobId);
+        return { success: true, data: parsed };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+
+        if (attempt < maxRetries && shouldRetryAttempt({ message })) {
+          logger.warn("Codex attempt failed, retrying", {
+            jobId: jobId ?? "unknown",
+            attempt: attempt + 1,
+            maxRetries,
+            message,
+          });
+          continue;
+        }
+
+        return { success: false, error: message };
+      }
+    }
+
+    return { success: false, error: "All retry attempts failed" };
   }
 
   private async tryMode<T>(args: {
@@ -413,6 +470,7 @@ function normalizeProvider(
   if (normalized === "gemini") return "gemini";
   if (normalized === "lmstudio") return "lmstudio";
   if (normalized === "ollama") return "ollama";
+  if (normalized === "codex") return "codex";
   if (normalized && normalized !== "openrouter") {
     logger.warn("Unknown LLM provider, defaulting to openrouter", {
       normalized,

--- a/orchestrator/src/server/services/llm/types.ts
+++ b/orchestrator/src/server/services/llm/types.ts
@@ -51,6 +51,7 @@ export type LlmResponse<T> = LlmResult<T> | LlmError;
 export type LlmValidationResult = {
   valid: boolean;
   message: string | null;
+  username?: string | null;
 };
 
 export type LlmServiceOptions = {

--- a/orchestrator/src/server/services/llm/types.ts
+++ b/orchestrator/src/server/services/llm/types.ts
@@ -4,7 +4,8 @@ export type LlmProvider =
   | "ollama"
   | "openai"
   | "openai_compatible"
-  | "gemini";
+  | "gemini"
+  | "codex";
 
 export type ResponseMode = "json_schema" | "json_object" | "text" | "none";
 

--- a/orchestrator/src/server/services/settings.ts
+++ b/orchestrator/src/server/services/settings.ts
@@ -36,7 +36,7 @@ function resolveDefaultLlmBaseUrl(provider: string): string {
     return "https://generativelanguage.googleapis.com";
   }
   if (normalized === "codex") {
-    return "stdio://";
+    return "";
   }
   return "https://openrouter.ai";
 }

--- a/orchestrator/src/server/services/settings.ts
+++ b/orchestrator/src/server/services/settings.ts
@@ -35,6 +35,9 @@ function resolveDefaultLlmBaseUrl(provider: string): string {
   if (normalized === "gemini") {
     return "https://generativelanguage.googleapis.com";
   }
+  if (normalized === "codex") {
+    return "stdio://";
+  }
   return "https://openrouter.ai";
 }
 

--- a/scripts/set-orchestrator-version.mjs
+++ b/scripts/set-orchestrator-version.mjs
@@ -1,4 +1,5 @@
 import { readFileSync, writeFileSync } from "node:fs";
+
 const nextVersion = process.argv[2]?.trim();
 
 if (!nextVersion || !/^\d+\.\d+\.\d+$/.test(nextVersion)) {

--- a/shared/src/settings-registry.test.ts
+++ b/shared/src/settings-registry.test.ts
@@ -282,6 +282,7 @@ describe("settingsRegistry helpers", () => {
       expect(getDefaultModelForProvider("gemini")).toBe(
         "google/gemini-3-flash-preview",
       );
+      expect(getDefaultModelForProvider("codex")).toBe("");
       expect(getDefaultModelForProvider("openrouter")).toBe(
         "google/gemini-3-flash-preview",
       );

--- a/shared/src/settings-registry.ts
+++ b/shared/src/settings-registry.ts
@@ -43,6 +43,7 @@ function normalizeLlmProviderOrNull(raw: string | undefined): string | null {
 
 export const DEFAULT_GEMINI_MODEL = "google/gemini-3-flash-preview";
 export const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini";
+export const DEFAULT_CODEX_MODEL = "";
 
 export function getDefaultModelForProvider(
   provider: string | null | undefined,
@@ -61,6 +62,10 @@ export function getDefaultModelForProvider(
 
   if (normalizedProvider === "gemini") {
     return DEFAULT_GEMINI_MODEL;
+  }
+
+  if (normalizedProvider === "codex") {
+    return DEFAULT_CODEX_MODEL;
   }
   return DEFAULT_GEMINI_MODEL;
 }
@@ -169,6 +174,7 @@ export const settingsRegistry = {
           "openai",
           "openai_compatible",
           "gemini",
+          "codex",
         ])
         .nullable(),
     ),


### PR DESCRIPTION
## Summary
- Add `codex` as a first-class LLM provider across shared settings, provider normalization, and UI labels/help text
- Implement Codex app-server integration in server LLM stack (client, provider wiring, service routing, and tests)
- Add Codex auth endpoints in settings API for device-code flow status/start
- Add Codex sign-in UX in both Settings and Onboarding (start, refresh, status polling, and error handling)
- Update docs with a dedicated Codex auth guide and troubleshooting entries

## Testing
- Targeted tests run:
  - `orchestrator/src/server/services/llm/codex/client.test.ts`
  - `orchestrator/src/server/services/llm/codex/login.test.ts`
  - `orchestrator/src/server/api/routes/settings.codex-auth.test.ts`
  - `orchestrator/src/client/pages/SettingsPage.test.tsx`
  - `orchestrator/src/client/pages/OnboardingPage.test.tsx` (added coverage for onboarding Codex sign-in)
- Additional checks run:
  - `biome` checks on touched code/docs paths
- Known environment issues encountered during broader runs:
  - local dependency/runtime mismatches affected full-suite and docs build validation