### PR TITLE
feat: add URL-based manual ingestion endpoint and capture docs

### DIFF
--- a/docs-site/docs/extractors/manual.md
+++ b/docs-site/docs/extractors/manual.md
@@ -1,61 +1,173 @@
 ---
 id: manual
 title: Manual Import Extractor
-description: Import jobs from pasted descriptions and run AI-assisted inference.
+description: Import jobs from pasted descriptions or shared URLs and run AI-assisted inference.
 sidebar_position: 4
 ---
 
-Manual import lets users add jobs that automated scrapers miss.
+import BookmarkletGenerator from "@site/src/components/BookmarkletGenerator";
 
-## Big picture
+## What it is
 
-User pastes raw description, AI infers structure, user reviews edits, then import saves and scores the job.
+Manual import lets you add jobs that automated scrapers miss.
 
-## 1) Input
+It supports two workflows:
 
-Manual import accepts:
+- Review-first import in the UI for pasted descriptions or fetched URLs
+- Direct URL ingestion with `POST /api/manual-jobs/ingest` for bookmarklets and iOS Shortcuts
 
-- plain text job descriptions
-- raw HTML job descriptions
-- job links/URLs
+## Why it exists
 
-When a URL is provided, backend fetch attempts depend on whether the page can be resolved with `curl`. Some job sites block or heavily script content, so certain links will not resolve cleanly.
+Some job pages are worth saving immediately while you are browsing on desktop or mobile.
 
-## 2) AI inference
+The URL ingestion endpoint exists so you can send the current page URL to JobOps and let the server do the rest:
+
+- fetch the page
+- extract the job content
+- infer job fields with the configured LLM
+- create the manual job
+- try to move it to `ready` automatically
+
+This bypasses the in-app review sheet when speed matters more than manual cleanup.
+
+## How to use it
+
+### Review-first flow
+
+1. Paste a job description or a URL into the app
+2. Review the inferred fields
+3. Import the job
+4. The server stores the job and tries to move it to the `Ready` stage
+
+### Direct URL ingestion endpoint
 
 Endpoint:
 
+- `POST /api/manual-jobs/ingest`
+
+Request body:
+
+```json
+{
+  "url": "https://example.com/jobs/backend-engineer"
+}
+```
+
+Auth behavior:
+
+- If you have enabled Authentication, send the same `Authorization: Bearer ...` token used after signing in to JobOps
+- If auth is not enabled, no auth header is required
+
+Success response:
+
+- Returns `{ ok: true, data, meta.requestId }`
+- `data.job` is the created manual job
+- `data.ingestion.movedToReady` tells you whether the server reached the `ready` stage
+- `data.ingestion.warning` is present when the job was created but could not be moved to `ready`
+
+Example `fetch` call:
+
+```js
+await fetch("/api/manual-jobs/ingest", {
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    Authorization: "Bearer YOUR_TOKEN",
+  },
+  body: JSON.stringify({
+    url: "https://example.com/jobs/backend-engineer",
+  }),
+});
+```
+
+### Interactive bookmarklet generator
+
+Use this generator to produce a bookmarklet you can drag to your browser bookmarks bar:
+
+<BookmarkletGenerator />
+
+Generator notes:
+
+- Enter your JobOps host as an origin such as `https://jobops.example.com`
+- For local development, use the backend API origin such as `http://localhost:3001`, not the Vite client origin on `http://localhost:5173`
+- If auth is enabled, use a JobOps Bearer token rather than a raw username/password pair
+- The docs page keeps the host and token in the browser while generating the bookmarklet
+- Once you save the bookmark, the bookmark itself contains the generated script and any embedded token
+- When clicked, the bookmarklet sends the current page URL to your own JobOps server
+
+Short way to get your Bearer token:
+
+1. Sign in to JobOps.
+2. Open browser DevTools.
+3. Go to `Application` or `Storage` -> `Session Storage`.
+4. Select your JobOps origin and copy `jobops.authToken`.
+
+Fallback:
+
+- If you cannot find it in storage, inspect a protected `/api/*` request in the Network tab and copy the token from the `Authorization: Bearer ...` header.
+
+Static example bookmarklet:
+
+```js
+javascript:(async()=>{await fetch("http://YOUR_HOST/api/manual-jobs/ingest",{method:"POST",headers:{"Content-Type":"application/json","Authorization":"Bearer YOUR_TOKEN"},body:JSON.stringify({url:window.location.href})});})();
+```
+
+Notes:
+
+- Replace `https://YOUR_HOST` with your JobOps server origin
+- If auth is enabled, use a Bearer token from JobOps sign-in
+- If auth is disabled, remove the `Authorization` header entirely
+- The endpoint is optimized for URL-only capture; it does not require a pre-built draft
+
+### iOS Shortcut example
+
+If you prefer iPhone or iPad share-sheet capture, you can import this shared Shortcut:
+
+- [JobOps URL Ingest Shortcut](https://www.icloud.com/shortcuts/2b16d702b13b4a98bba2a946df531517)
+
+Shortcut notes:
+
+- Open the link on iOS or iPadOS and add it to Shortcuts
+- Review the host and token fields inside the Shortcut before using it
+- If auth is enabled, use the same JobOps Bearer token described above
+
+### Inference and storage behavior
+
+Inference endpoints and services:
+
 - `POST /api/manual-jobs/infer`
-
-Service:
-
+- `POST /api/manual-jobs/import`
+- `POST /api/manual-jobs/ingest`
 - `orchestrator/src/server/services/manualJob.ts`
 
 Behavior:
 
-- Converts the provided input into text context and sends it to the configured LLM
-- Extracts structured fields (title, employer, location, salary, etc.)
-- Returns inferred JSON for user review
+- Converts fetched HTML or pasted text into plain-text context
+- Uses the configured LLM to infer structured fields
+- Falls back to page metadata during URL ingestion when title or employer is missing
+- Stores the job with source `manual`
+- Starts async suitability scoring
 
-Practical limit:
+If the job can be created but `move_to_ready` fails, URL ingestion still keeps the manual job as a recoverable record and returns a warning instead of dropping it.
 
-- The inference quality ceiling is mostly the configured model capability and context behavior. Better model quality generally yields better field extraction.
+## Common problems
 
-If no LLM key is configured, inference is skipped and user can fill fields manually.
+- **Auth required**
+  If your instance protects API routes, bookmarklets and Shortcuts must send the same Bearer token used for the app after sign-in.
 
-## 3) Review and edit
+- **Fetch blocked by the target site**
+  Some job boards require client-side rendering or block automated fetches. In that case `POST /api/manual-jobs/ingest` may return `502 UPSTREAM_ERROR`.
 
-User reviews inferred fields and corrects missing/wrong values.
+- **Inference could not build a complete job**
+  If the fetched content is too thin, the endpoint can return `422 UNPROCESSABLE_ENTITY`.
 
-## 4) Storage and scoring
+- **Job created but not moved to ready**
+  If tailoring or PDF generation fails after creation, the endpoint still returns success with `movedToReady: false` and a warning so you can recover the job later in the app.
 
-Import endpoint:
+- **No LLM key configured**
+  Review-first manual import can still be used with manual edits. Direct URL ingestion is less reliable without inference support.
 
-- `POST /api/manual-jobs/import`
+## Related pages
 
-On import:
-
-- Generates unique job ID if URL absent
-- Stores source as `manual`
-- Triggers async suitability scoring
-- Persists score and reason
+- [Pipeline Run](/docs/features/pipeline-run)
+- [Extractors Overview](/docs/extractors/overview)

--- a/docs-site/src/components/BookmarkletGenerator/index.tsx
+++ b/docs-site/src/components/BookmarkletGenerator/index.tsx
@@ -54,12 +54,13 @@ export default function BookmarkletGenerator() {
 
   const { normalizedHost, warning } = normalizeHost(hostInput);
   const bookmarklet = buildBookmarklet(normalizedHost, tokenInput);
-  const hostIsInvalid = hostInput.trim().length > 0 && normalizedHost.length === 0;
+  const hostIsInvalid =
+    hostInput.trim().length > 0 && normalizedHost.length === 0;
 
   useEffect(() => {
     if (!linkRef.current) return;
     if (!bookmarklet) {
-      linkRef.current.removeAttribute("href");
+      linkRef.current.setAttribute("href", "about:blank");
       return;
     }
 
@@ -75,7 +76,9 @@ export default function BookmarkletGenerator() {
 
     try {
       await navigator.clipboard.writeText(bookmarklet);
-      setStatusMessage("Bookmarklet copied. Save it as a bookmark or drag the link below.");
+      setStatusMessage(
+        "Bookmarklet copied. Save it as a bookmark or drag the link below.",
+      );
     } catch {
       setStatusMessage(
         "Copy failed in this browser. Select the generated bookmarklet text and copy it manually.",
@@ -94,7 +97,9 @@ export default function BookmarkletGenerator() {
         <label className={styles.field} htmlFor={hostId}>
           <span className={styles.labelRow}>
             <span className={styles.label}>JobOps host</span>
-            <span className={styles.hint}>Use an origin like https://jobops.example.com</span>
+            <span className={styles.hint}>
+              Use an origin like https://jobops.example.com
+            </span>
           </span>
           <input
             id={hostId}
@@ -106,7 +111,8 @@ export default function BookmarkletGenerator() {
           />
           {hostIsInvalid ? (
             <span className={`${styles.hint} ${styles.error}`}>
-              Enter a full origin with protocol, such as https://jobops.example.com.
+              Enter a full origin with protocol, such as
+              https://jobops.example.com.
             </span>
           ) : warning ? (
             <span className={styles.hint}>{warning}</span>
@@ -116,7 +122,9 @@ export default function BookmarkletGenerator() {
         <label className={styles.field} htmlFor={tokenId}>
           <span className={styles.labelRow}>
             <span className={styles.label}>Bearer token</span>
-            <span className={styles.hint}>Optional if your JobOps API is public</span>
+            <span className={styles.hint}>
+              Optional if your JobOps API is public
+            </span>
           </span>
           <input
             id={tokenId}
@@ -145,13 +153,15 @@ export default function BookmarkletGenerator() {
           <a
             ref={linkRef}
             className={`${styles.bookmarkletLink} ${!bookmarklet ? styles.disabled : ""}`}
-            href={undefined}
+            href="about:blank"
           >
             Drag this to your bookmarks bar
           </a>
         </div>
 
-        {statusMessage ? <p className={styles.status}>{statusMessage}</p> : null}
+        {statusMessage ? (
+          <p className={styles.status}>{statusMessage}</p>
+        ) : null}
       </div>
 
       <p className={styles.privacy}>

--- a/docs-site/src/components/BookmarkletGenerator/index.tsx
+++ b/docs-site/src/components/BookmarkletGenerator/index.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useId, useRef, useState } from "react";
+import styles from "./styles.module.css";
+
+type NormalizedHostResult = {
+  normalizedHost: string;
+  warning: string;
+};
+
+function normalizeHost(rawValue: string): NormalizedHostResult {
+  const trimmed = rawValue.trim().replace(/\/+$/, "");
+  if (!trimmed) {
+    return { normalizedHost: "", warning: "" };
+  }
+
+  try {
+    const url = new URL(trimmed);
+    let warning = "";
+
+    // In local development the browser app runs on :5173, but cross-origin
+    // bookmarklets need to call the backend API server directly on :3001.
+    if (
+      (url.hostname === "localhost" || url.hostname === "127.0.0.1") &&
+      url.port === "5173"
+    ) {
+      url.port = "3001";
+      warning =
+        "Local development detected: using the backend API origin on :3001 instead of the Vite client on :5173.";
+    }
+
+    return { normalizedHost: url.origin, warning };
+  } catch {
+    return { normalizedHost: "", warning: "" };
+  }
+}
+
+function buildBookmarklet(host: string, token: string): string {
+  if (!host) return "";
+
+  const payload = JSON.stringify({
+    host,
+    token: token.trim(),
+  });
+
+  return `javascript:(async()=>{const c=${payload};const h={'Content-Type':'application/json'};if(c.token)h.Authorization='Bearer '+c.token;try{const r=await fetch(c.host+'/api/manual-jobs/ingest',{method:'POST',headers:h,body:JSON.stringify({url:window.location.href})});let b=null;try{b=await r.json()}catch{}if(r.ok&&b&&b.ok){const i=b.data&&b.data.ingestion;alert(i&&i.movedToReady===false?'Job captured in JobOps, but it still needs follow-up in the app.':'Job captured in JobOps.')}else if(r.status===401||r.status===403){alert('JobOps rejected the request. Check your host and Bearer token.')}else{const m=b&&b.error&&b.error.message?b.error.message:'Request failed.';alert('JobOps could not ingest this page. '+m)}}catch{alert('Could not reach JobOps. Check the host, network access, and CORS settings.')}})();`;
+}
+
+export default function BookmarkletGenerator() {
+  const hostId = useId();
+  const tokenId = useId();
+  const linkRef = useRef<HTMLAnchorElement | null>(null);
+  const [hostInput, setHostInput] = useState("");
+  const [tokenInput, setTokenInput] = useState("");
+  const [statusMessage, setStatusMessage] = useState("");
+
+  const { normalizedHost, warning } = normalizeHost(hostInput);
+  const bookmarklet = buildBookmarklet(normalizedHost, tokenInput);
+  const hostIsInvalid = hostInput.trim().length > 0 && normalizedHost.length === 0;
+
+  useEffect(() => {
+    if (!linkRef.current) return;
+    if (!bookmarklet) {
+      linkRef.current.removeAttribute("href");
+      return;
+    }
+
+    // React blocks javascript: href props, so set the bookmarklet directly.
+    linkRef.current.setAttribute("href", bookmarklet);
+  }, [bookmarklet]);
+
+  async function handleCopy() {
+    if (!bookmarklet) {
+      setStatusMessage("Enter a valid JobOps host to generate a bookmarklet.");
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(bookmarklet);
+      setStatusMessage("Bookmarklet copied. Save it as a bookmark or drag the link below.");
+    } catch {
+      setStatusMessage(
+        "Copy failed in this browser. Select the generated bookmarklet text and copy it manually.",
+      );
+    }
+  }
+
+  return (
+    <div className={styles.generator}>
+      <p className={styles.lead}>
+        Build a bookmarklet in your browser. The docs page does not send the
+        host or token anywhere while you edit this form.
+      </p>
+
+      <div className={styles.grid}>
+        <label className={styles.field} htmlFor={hostId}>
+          <span className={styles.labelRow}>
+            <span className={styles.label}>JobOps host</span>
+            <span className={styles.hint}>Use an origin like https://jobops.example.com</span>
+          </span>
+          <input
+            id={hostId}
+            className={styles.input}
+            type="text"
+            placeholder="https://jobops.example.com"
+            value={hostInput}
+            onChange={(event) => setHostInput(event.target.value)}
+          />
+          {hostIsInvalid ? (
+            <span className={`${styles.hint} ${styles.error}`}>
+              Enter a full origin with protocol, such as https://jobops.example.com.
+            </span>
+          ) : warning ? (
+            <span className={styles.hint}>{warning}</span>
+          ) : null}
+        </label>
+
+        <label className={styles.field} htmlFor={tokenId}>
+          <span className={styles.labelRow}>
+            <span className={styles.label}>Bearer token</span>
+            <span className={styles.hint}>Optional if your JobOps API is public</span>
+          </span>
+          <input
+            id={tokenId}
+            className={styles.input}
+            type="text"
+            placeholder="Paste a JobOps Bearer token"
+            value={tokenInput}
+            onChange={(event) => setTokenInput(event.target.value)}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <span className={styles.label}>Generated bookmarklet</span>
+          <textarea
+            className={styles.code}
+            value={bookmarklet}
+            readOnly
+            placeholder="Enter a valid host to generate a bookmarklet."
+          />
+        </label>
+
+        <div className={styles.actions}>
+          <button className={styles.button} type="button" onClick={handleCopy}>
+            Copy bookmarklet
+          </button>
+          <a
+            ref={linkRef}
+            className={`${styles.bookmarkletLink} ${!bookmarklet ? styles.disabled : ""}`}
+            href={undefined}
+          >
+            Drag this to your bookmarks bar
+          </a>
+        </div>
+
+        {statusMessage ? <p className={styles.status}>{statusMessage}</p> : null}
+      </div>
+
+      <p className={styles.privacy}>
+        Privacy note: this page builds the bookmarklet locally in your browser.
+        It does not submit the host or token to the docs site. If you save the
+        bookmarklet, any embedded token is stored in that bookmark. When you
+        click the bookmarklet later, it sends the current page URL to your own
+        JobOps server.
+      </p>
+    </div>
+  );
+}

--- a/docs-site/src/components/BookmarkletGenerator/styles.module.css
+++ b/docs-site/src/components/BookmarkletGenerator/styles.module.css
@@ -1,0 +1,153 @@
+.generator {
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  margin: 1.5rem 0;
+  background: linear-gradient(
+    180deg,
+    var(--ifm-background-surface-color) 0%,
+    color-mix(in srgb, var(--ifm-color-primary-lightest) 14%, var(--ifm-background-surface-color)) 100%
+  );
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.06);
+}
+
+.lead {
+  margin: 0 0 1rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+.labelRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: baseline;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ifm-color-emphasis-700);
+}
+
+.input,
+.code {
+  width: 100%;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 0.75rem;
+  background: var(--ifm-background-color);
+  color: var(--ifm-font-color-base);
+  font: inherit;
+}
+
+.input {
+  padding: 0.8rem 0.9rem;
+}
+
+.code {
+  min-height: 11rem;
+  padding: 0.9rem;
+  font-family: var(--ifm-font-family-monospace);
+  font-size: 0.86rem;
+  line-height: 1.45;
+  resize: vertical;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.button,
+.bookmarkletLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.75rem;
+  padding: 0.7rem 1rem;
+  border-radius: 999px;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.button {
+  border: 1px solid var(--ifm-color-primary);
+  background: var(--ifm-color-primary);
+  color: white;
+  cursor: pointer;
+}
+
+.button:hover {
+  background: var(--ifm-color-primary-dark);
+  border-color: var(--ifm-color-primary-dark);
+}
+
+.bookmarkletLink {
+  border: 1px dashed var(--ifm-color-primary);
+  color: var(--ifm-color-primary-darkest);
+  background: color-mix(in srgb, var(--ifm-color-primary-lightest) 30%, white);
+}
+
+.bookmarkletLink:hover {
+  text-decoration: none;
+  background: color-mix(in srgb, var(--ifm-color-primary-lightest) 45%, white);
+}
+
+.disabled {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.status {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--ifm-color-emphasis-800);
+}
+
+.privacy {
+  margin: 1rem 0 0;
+  padding: 0.9rem 1rem;
+  border-radius: 0.85rem;
+  background: color-mix(in srgb, var(--ifm-color-emphasis-100) 75%, white);
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.94rem;
+}
+
+.error {
+  color: var(--ifm-color-danger-dark);
+}
+
+@media (max-width: 640px) {
+  .generator {
+    padding: 1rem;
+  }
+
+  .labelRow {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .actions {
+    align-items: stretch;
+  }
+
+  .button,
+  .bookmarkletLink {
+    width: 100%;
+  }
+}

--- a/docs-site/src/components/BookmarkletGenerator/styles.module.css
+++ b/docs-site/src/components/BookmarkletGenerator/styles.module.css
@@ -6,7 +6,12 @@
   background: linear-gradient(
     180deg,
     var(--ifm-background-surface-color) 0%,
-    color-mix(in srgb, var(--ifm-color-primary-lightest) 14%, var(--ifm-background-surface-color)) 100%
+    color-mix(
+        in srgb,
+        var(--ifm-color-primary-lightest) 14%,
+        var(--ifm-background-surface-color)
+      )
+      100%
   );
   box-shadow: 0 16px 40px rgba(0, 0, 0, 0.06);
 }

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -73,6 +73,7 @@ orchestrator/
 | POST | `/api/jobs/actions` | Run job actions (`move_to_ready`, `rescore`, `skip`) for one or many jobs |
 | POST | `/api/jobs/actions/stream` | Stream job action progress/events for one or many jobs |
 | POST | `/api/jobs/:id/apply` | Mark as applied |
+| POST | `/api/manual-jobs/ingest` | Fetch a job URL, infer fields, create a manual job, and try to move it to ready |
 
 ### Pipeline
 

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -36,6 +36,7 @@ import type {
   ManualJobDraft,
   ManualJobFetchResponse,
   ManualJobInferenceResponse,
+  ManualJobIngestionResponse,
   PipelineStatusResponse,
   PostApplicationAction,
   PostApplicationActionResponse,
@@ -1520,6 +1521,15 @@ export async function importManualJob(input: {
   job: ManualJobDraft;
 }): Promise<Job> {
   return fetchApi<Job>("/manual-jobs/import", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function ingestManualJobUrl(input: {
+  url: string;
+}): Promise<ManualJobIngestionResponse> {
+  return fetchApi<ManualJobIngestionResponse>("/manual-jobs/ingest", {
     method: "POST",
     body: JSON.stringify(input),
   });

--- a/orchestrator/src/server/api/routes/manual-jobs.test.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.test.ts
@@ -7,12 +7,15 @@ describe.sequential("Manual jobs API routes", () => {
   let baseUrl: string;
   let closeDb: () => void;
   let tempDir: string;
+  let nativeFetch: typeof globalThis.fetch;
 
   beforeEach(async () => {
     ({ server, baseUrl, closeDb, tempDir } = await startServer());
+    nativeFetch = globalThis.fetch;
   });
 
   afterEach(async () => {
+    vi.unstubAllGlobals();
     await stopServer({ server, closeDb, tempDir });
   });
 
@@ -91,5 +94,264 @@ describe.sequential("Manual jobs API routes", () => {
       analyticsOrigin: "manual_job_create",
     });
     await new Promise((resolve) => setTimeout(resolve, 25));
+  });
+
+  describe("POST /api/manual-jobs/ingest", () => {
+    function stubExternalFetch(
+      implementation: (url: string) => Promise<Response>,
+    ): void {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url =
+            typeof input === "string"
+              ? input
+              : input instanceof URL
+                ? input.toString()
+                : input.url;
+          if (url.startsWith(baseUrl)) {
+            return nativeFetch(input as RequestInfo | URL, init);
+          }
+          return implementation(url);
+        }),
+      );
+    }
+
+    it("returns request timeout when upstream fetch aborts", async () => {
+      stubExternalFetch(async () => {
+        const error = new Error("Timed out");
+        error.name = "AbortError";
+        throw error;
+      });
+
+      const res = await fetch(`${baseUrl}/api/manual-jobs/ingest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://jobs.example.com/role" }),
+      });
+
+      expect(res.status).toBe(408);
+    });
+
+    it("returns upstream error when the remote URL cannot be fetched", async () => {
+      stubExternalFetch(async () => new Response("nope", { status: 503 }));
+
+      const res = await fetch(`${baseUrl}/api/manual-jobs/ingest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://jobs.example.com/role" }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(502);
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("UPSTREAM_ERROR");
+    });
+
+    it("creates a ready job on the happy path and passes through request id", async () => {
+      const { inferManualJobDetails } = await import(
+        "@server/services/manualJob"
+      );
+      const { processJob } = await import("@server/pipeline/index");
+      const { scoreJobSuitability } = await import("@server/services/scorer");
+      vi.mocked(inferManualJobDetails).mockResolvedValue({
+        job: {
+          title: "Backend Engineer",
+          employer: "Acme",
+          jobDescription: "Build APIs",
+        },
+        warning: null,
+      });
+      vi.mocked(scoreJobSuitability).mockResolvedValue({
+        score: 91,
+        reason: "Strong fit",
+      });
+      stubExternalFetch(
+        async () =>
+          new Response(
+            `
+            <html>
+              <head>
+                <title>Backend Engineer</title>
+                <meta property="og:title" content="Backend Engineer" />
+                <meta property="og:site-name" content="Acme" />
+              </head>
+              <body>
+                <main>Build APIs and services.</main>
+              </body>
+            </html>
+            `,
+            { status: 200 },
+          ),
+      );
+
+      const res = await fetch(`${baseUrl}/api/manual-jobs/ingest`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-request-id": "req-manual-ingest-success",
+        },
+        body: JSON.stringify({ url: "https://jobs.example.com/role" }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-request-id")).toBe("req-manual-ingest-success");
+      expect(body.meta.requestId).toBe("req-manual-ingest-success");
+      expect(body.data.ingestion).toEqual({
+        source: "url",
+        movedToReady: true,
+        warning: null,
+      });
+      expect(body.data.job.jobUrl).toBe("https://jobs.example.com/role");
+      expect(vi.mocked(processJob)).toHaveBeenCalledWith(body.data.job.id, {
+        analyticsOrigin: "manual_job_create",
+      });
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+
+    it("persists the submitted URL when inference omits jobUrl", async () => {
+      const { inferManualJobDetails } = await import(
+        "@server/services/manualJob"
+      );
+      vi.mocked(inferManualJobDetails).mockResolvedValue({
+        job: {
+          title: "Platform Engineer",
+          employer: "Example Corp",
+          jobDescription: "Role details",
+        },
+        warning: null,
+      });
+      stubExternalFetch(
+        async () =>
+          new Response("<html><body><main>Role details</main></body></html>", {
+            status: 200,
+          }),
+      );
+
+      const res = await fetch(`${baseUrl}/api/manual-jobs/ingest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://jobs.example.com/platform" }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.job.jobUrl).toBe("https://jobs.example.com/platform");
+    });
+
+    it("uses metadata fallbacks when inference omits title and employer", async () => {
+      const { inferManualJobDetails } = await import(
+        "@server/services/manualJob"
+      );
+      vi.mocked(inferManualJobDetails).mockResolvedValue({
+        job: {
+          jobDescription: "Design distributed systems",
+        },
+        warning: null,
+      });
+      stubExternalFetch(
+        async () =>
+          new Response(
+            `
+            <html>
+              <head>
+                <title>Ignored Title</title>
+                <meta property="og:title" content="Principal Engineer" />
+                <meta property="og:site-name" content="Site Employer" />
+              </head>
+              <body><main>Design distributed systems</main></body>
+            </html>
+            `,
+            { status: 200 },
+          ),
+      );
+
+      const res = await fetch(`${baseUrl}/api/manual-jobs/ingest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://jobs.example.com/principal" }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.job.title).toBe("Principal Engineer");
+      expect(body.data.job.employer).toBe("Site Employer");
+    });
+
+    it("creates a recoverable job when move-to-ready processing fails", async () => {
+      const { inferManualJobDetails } = await import(
+        "@server/services/manualJob"
+      );
+      const { processJob } = await import("@server/pipeline/index");
+      const jobsRepo = await import("@server/repositories/jobs");
+      vi.mocked(inferManualJobDetails).mockResolvedValue({
+        job: {
+          title: "Backend Engineer",
+          employer: "Acme",
+          jobDescription: "Build APIs",
+        },
+        warning: null,
+      });
+      vi.mocked(processJob).mockResolvedValueOnce({
+        success: false,
+        error: "LLM unavailable",
+      });
+      stubExternalFetch(
+        async () =>
+          new Response("<html><body><main>Build APIs</main></body></html>", {
+            status: 200,
+          }),
+      );
+
+      const res = await fetch(`${baseUrl}/api/manual-jobs/ingest`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://jobs.example.com/recoverable" }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.data.ingestion.movedToReady).toBe(false);
+      expect(body.data.ingestion.warning).toContain("LLM unavailable");
+
+      const savedJob = await jobsRepo.getJobById(body.data.job.id);
+      expect(savedJob?.status).not.toBe("ready");
+      expect(savedJob?.source).toBe("manual");
+    });
+
+    it("returns unprocessable entity when fetched content cannot create a job", async () => {
+      const { inferManualJobDetails } = await import(
+        "@server/services/manualJob"
+      );
+      vi.mocked(inferManualJobDetails).mockResolvedValue({
+        job: {},
+        warning: "No signal",
+      });
+      stubExternalFetch(
+        async () =>
+          new Response(
+            "<html><body><main>Not enough data</main></body></html>",
+            {
+              status: 200,
+            },
+          ),
+      );
+
+      const res = await fetch(`${baseUrl}/api/manual-jobs/ingest`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-request-id": "req-manual-ingest-fail",
+        },
+        body: JSON.stringify({ url: "https://jobs.example.com/unknown" }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(422);
+      expect(res.headers.get("x-request-id")).toBe("req-manual-ingest-fail");
+      expect(body.meta.requestId).toBe("req-manual-ingest-fail");
+      expect(body.error.code).toBe("UNPROCESSABLE_ENTITY");
+    });
   });
 });

--- a/orchestrator/src/server/api/routes/manual-jobs.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.ts
@@ -5,6 +5,7 @@ import {
   notFound,
   requestTimeout,
   toAppError,
+  unprocessableEntity,
 } from "@infra/errors";
 import { fail, ok } from "@infra/http";
 import { logger } from "@infra/logger";
@@ -13,6 +14,11 @@ import * as jobsRepo from "@server/repositories/jobs";
 import { inferManualJobDetails } from "@server/services/manualJob";
 import { getProfile } from "@server/services/profile";
 import { scoreJobSuitability } from "@server/services/scorer";
+import type {
+  Job,
+  ManualJobDraft,
+  ManualJobIngestionResponse,
+} from "@shared/types";
 import { type Request, type Response, Router } from "express";
 import { JSDOM } from "jsdom";
 import { z } from "zod";
@@ -52,16 +58,57 @@ const cleanOptional = (value?: string | null) => {
   return trimmed.length > 0 ? trimmed : undefined;
 };
 
-/**
- * POST /api/manual-jobs/fetch - Fetch and extract job content from a URL
- */
-manualJobsRouter.post("/fetch", async (req: Request, res: Response) => {
+type FetchedManualJobContent = {
+  content: string;
+  url: string;
+  pageTitle: string | null;
+  ogTitle: string | null;
+  ogSiteName: string | null;
+  host: string | null;
+};
+
+type ManualJobCreationResult = {
+  job: Job;
+  movedToReady: boolean;
+  warning: string | null;
+};
+
+function getRequestId(res: Response): string {
+  return String(res.getHeader("x-request-id") || "unknown");
+}
+
+function getHost(value: string): string | null {
+  try {
+    return new URL(value).hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+function formatHostLabel(host: string | null): string | null {
+  if (!host) return null;
+  const hostname = host.replace(/^www\./i, "");
+  const label = hostname.split(".")[0]?.trim();
+  if (!label) return hostname;
+  return label
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+function normalizeFetchedValue(value?: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+async function fetchManualJobContent(
+  input: z.infer<typeof manualJobFetchSchema>,
+): Promise<FetchedManualJobContent> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 15000);
+  const timeout = setTimeout(() => controller.abort(), 15_000);
 
   try {
-    const input = manualJobFetchSchema.parse(req.body ?? {});
-
     const response = await fetch(input.url, {
       signal: controller.signal,
       headers: {
@@ -73,49 +120,41 @@ manualJobsRouter.post("/fetch", async (req: Request, res: Response) => {
     });
 
     if (!response.ok) {
-      return fail(
-        res,
-        new AppError({
-          status: 502,
-          code: "UPSTREAM_ERROR",
-          message: `Failed to fetch URL: ${response.status} ${response.statusText}`,
-        }),
-      );
+      throw new AppError({
+        status: 502,
+        code: "UPSTREAM_ERROR",
+        message: `Failed to fetch URL: ${response.status} ${response.statusText}`,
+      });
     }
 
     const html = await response.text();
     const dom = new JSDOM(html);
     const document = dom.window.document;
 
-    // Extract page title (often contains job title)
-    const pageTitle =
-      document.querySelector("title")?.textContent?.trim() || "";
-
-    // Extract meta description
-    const metaDescription =
+    const pageTitle = normalizeFetchedValue(
+      document.querySelector("title")?.textContent,
+    );
+    const metaDescription = normalizeFetchedValue(
       document
         .querySelector('meta[name="description"]')
-        ?.getAttribute("content")
-        ?.trim() || "";
-
-    // Extract Open Graph data
-    const ogTitle =
+        ?.getAttribute("content"),
+    );
+    const ogTitle = normalizeFetchedValue(
       document
         .querySelector('meta[property="og:title"]')
-        ?.getAttribute("content")
-        ?.trim() || "";
-    const ogDescription =
+        ?.getAttribute("content"),
+    );
+    const ogDescription = normalizeFetchedValue(
       document
         .querySelector('meta[property="og:description"]')
-        ?.getAttribute("content")
-        ?.trim() || "";
-    const ogSiteName =
+        ?.getAttribute("content"),
+    );
+    const ogSiteName = normalizeFetchedValue(
       document
         .querySelector('meta[property="og:site-name"]')
-        ?.getAttribute("content")
-        ?.trim() || "";
+        ?.getAttribute("content"),
+    );
 
-    // Remove non-content elements
     const elementsToRemove = document.querySelectorAll(
       "script, style, nav, header, footer, aside, iframe, noscript, " +
         '[role="navigation"], [role="banner"], [role="contentinfo"], ' +
@@ -125,7 +164,6 @@ manualJobsRouter.post("/fetch", async (req: Request, res: Response) => {
       el.remove();
     });
 
-    // Try to find the main job content area
     const mainContent =
       document.querySelector(
         'main, [role="main"], article, ' +
@@ -134,36 +172,193 @@ manualJobsRouter.post("/fetch", async (req: Request, res: Response) => {
           '[class*="job-desc"], [class*="jobDesc"], [class*="vacancy"], [class*="posting"]',
       ) || document.body;
 
-    // Get text content
     let textContent = mainContent?.textContent || "";
-
-    // Clean up whitespace
     textContent = textContent
       .replace(/[\t ]+/g, " ")
       .replace(/\n\s*\n/g, "\n\n")
       .replace(/\n{3,}/g, "\n\n")
       .trim();
 
-    // Build enriched content with extracted metadata
     let enrichedContent = "";
     if (pageTitle) enrichedContent += `Page Title: ${pageTitle}\n`;
     if (ogTitle && ogTitle !== pageTitle)
       enrichedContent += `Job Title: ${ogTitle}\n`;
     if (ogSiteName) enrichedContent += `Company/Site: ${ogSiteName}\n`;
     if (ogDescription) enrichedContent += `Summary: ${ogDescription}\n`;
-    if (metaDescription && metaDescription !== ogDescription)
+    if (metaDescription && metaDescription !== ogDescription) {
       enrichedContent += `Description: ${metaDescription}\n`;
+    }
     if (enrichedContent) enrichedContent += "\n---\n\n";
     enrichedContent += textContent;
 
-    // Limit to reasonable size
-    if (enrichedContent.length > 50000) {
-      enrichedContent = enrichedContent.substring(0, 50000);
+    if (enrichedContent.length > 50_000) {
+      enrichedContent = enrichedContent.substring(0, 50_000);
     }
 
-    ok(res, {
+    if (!enrichedContent.trim()) {
+      throw new AppError({
+        status: 502,
+        code: "UPSTREAM_ERROR",
+        message: "Fetched URL did not contain usable job content",
+      });
+    }
+
+    return {
       content: enrichedContent,
       url: input.url,
+      pageTitle,
+      ogTitle,
+      ogSiteName,
+      host: getHost(input.url),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function applyUrlIngestionFallbacks(
+  draft: ManualJobDraft,
+  fetched: FetchedManualJobContent,
+): ManualJobDraft {
+  const hostLabel = formatHostLabel(fetched.host);
+  return {
+    ...draft,
+    title:
+      cleanOptional(draft.title) ??
+      cleanOptional(fetched.ogTitle) ??
+      cleanOptional(fetched.pageTitle) ??
+      hostLabel ??
+      undefined,
+    employer:
+      cleanOptional(draft.employer) ??
+      cleanOptional(fetched.ogSiteName) ??
+      hostLabel ??
+      undefined,
+    jobUrl: cleanOptional(draft.jobUrl) ?? fetched.url,
+  };
+}
+
+async function startManualJobScoring(jobId: string): Promise<void> {
+  (async () => {
+    try {
+      const job = await jobsRepo.getJobById(jobId);
+      if (!job) return;
+
+      const rawProfile = await getProfile();
+      if (
+        !rawProfile ||
+        typeof rawProfile !== "object" ||
+        Array.isArray(rawProfile)
+      ) {
+        throw new Error("Invalid resume profile format");
+      }
+      const profile = rawProfile as Record<string, unknown>;
+      const { score, reason } = await scoreJobSuitability(job, profile);
+      await jobsRepo.updateJob(job.id, {
+        suitabilityScore: score,
+        suitabilityReason: reason,
+      });
+    } catch (error) {
+      logger.warn("Manual job scoring failed", {
+        jobId,
+        error,
+      });
+    }
+  })().catch((error) => {
+    logger.warn("Manual job scoring task failed to start", {
+      jobId,
+      error,
+    });
+  });
+}
+
+async function createAndProcessManualJob(
+  job: z.infer<typeof manualJobImportSchema>["job"],
+  options?: {
+    analyticsOrigin?: "manual_job_create" | "move_to_ready";
+    allowProcessFailure?: boolean;
+    requestId?: string;
+    route?: string;
+    host?: string | null;
+  },
+): Promise<ManualJobCreationResult> {
+  const jobUrl =
+    cleanOptional(job.jobUrl) ||
+    cleanOptional(job.applicationLink) ||
+    `manual://${randomUUID()}`;
+
+  const createdJob = await jobsRepo.createJob({
+    source: "manual",
+    title: job.title.trim(),
+    employer: job.employer.trim(),
+    jobUrl,
+    applicationLink: cleanOptional(job.applicationLink) ?? undefined,
+    location: cleanOptional(job.location) ?? undefined,
+    salary: cleanOptional(job.salary) ?? undefined,
+    deadline: cleanOptional(job.deadline) ?? undefined,
+    jobDescription: job.jobDescription.trim(),
+    jobType: cleanOptional(job.jobType) ?? undefined,
+    jobLevel: cleanOptional(job.jobLevel) ?? undefined,
+    jobFunction: cleanOptional(job.jobFunction) ?? undefined,
+    disciplines: cleanOptional(job.disciplines) ?? undefined,
+    degreeRequired: cleanOptional(job.degreeRequired) ?? undefined,
+    starting: cleanOptional(job.starting) ?? undefined,
+  });
+
+  const processResult = await processJob(createdJob.id, {
+    analyticsOrigin: options?.analyticsOrigin ?? "manual_job_create",
+  });
+  const movedToReady = processResult.success;
+  const warning = movedToReady
+    ? null
+    : processResult.error ||
+      "Imported job but failed to move it to ready automatically";
+
+  if (!movedToReady) {
+    logger.warn("Manual job auto-processing failed", {
+      route: options?.route ?? "manual-jobs",
+      requestId: options?.requestId,
+      jobId: createdJob.id,
+      host: options?.host ?? null,
+      error: processResult.error ?? "Unknown error",
+    });
+    if (!options?.allowProcessFailure) {
+      throw new AppError({
+        status: 502,
+        code: "UPSTREAM_ERROR",
+        message:
+          warning ??
+          "Imported job but failed to move it to ready automatically",
+        details: { jobId: createdJob.id },
+      });
+    }
+  }
+
+  const processedJob = await jobsRepo.getJobById(createdJob.id);
+  if (!processedJob) {
+    throw notFound("Job not found");
+  }
+
+  await startManualJobScoring(processedJob.id);
+
+  return {
+    job: processedJob,
+    movedToReady,
+    warning,
+  };
+}
+
+/**
+ * POST /api/manual-jobs/fetch - Fetch and extract job content from a URL
+ */
+manualJobsRouter.post("/fetch", async (req: Request, res: Response) => {
+  try {
+    const input = manualJobFetchSchema.parse(req.body ?? {});
+    const fetched = await fetchManualJobContent(input);
+
+    ok(res, {
+      content: fetched.content,
+      url: fetched.url,
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -173,8 +368,6 @@ manualJobsRouter.post("/fetch", async (req: Request, res: Response) => {
       return fail(res, requestTimeout());
     }
     fail(res, toAppError(error));
-  } finally {
-    clearTimeout(timeout);
   }
 });
 
@@ -204,95 +397,109 @@ manualJobsRouter.post("/infer", async (req: Request, res: Response) => {
 manualJobsRouter.post("/import", async (req: Request, res: Response) => {
   try {
     const input = manualJobImportSchema.parse(req.body ?? {});
-    const job = input.job;
-
-    const jobUrl =
-      cleanOptional(job.jobUrl) ||
-      cleanOptional(job.applicationLink) ||
-      `manual://${randomUUID()}`;
-
-    const createdJob = await jobsRepo.createJob({
-      source: "manual",
-      title: job.title.trim(),
-      employer: job.employer.trim(),
-      jobUrl,
-      applicationLink: cleanOptional(job.applicationLink) ?? undefined,
-      location: cleanOptional(job.location) ?? undefined,
-      salary: cleanOptional(job.salary) ?? undefined,
-      deadline: cleanOptional(job.deadline) ?? undefined,
-      jobDescription: job.jobDescription.trim(),
-      jobType: cleanOptional(job.jobType) ?? undefined,
-      jobLevel: cleanOptional(job.jobLevel) ?? undefined,
-      jobFunction: cleanOptional(job.jobFunction) ?? undefined,
-      disciplines: cleanOptional(job.disciplines) ?? undefined,
-      degreeRequired: cleanOptional(job.degreeRequired) ?? undefined,
-      starting: cleanOptional(job.starting) ?? undefined,
-    });
-
-    const processResult = await processJob(createdJob.id, {
+    const result = await createAndProcessManualJob(input.job, {
       analyticsOrigin: "manual_job_create",
-    });
-    if (!processResult.success) {
-      logger.warn("Manual job auto-processing failed", {
-        jobId: createdJob.id,
-        error: processResult.error ?? "Unknown error",
-      });
-      return fail(
-        res,
-        new AppError({
-          status: 502,
-          code: "UPSTREAM_ERROR",
-          message:
-            processResult.error ||
-            "Imported job but failed to move it to ready automatically",
-          details: { jobId: createdJob.id },
-        }),
-      );
-    }
-
-    const processedJob = await jobsRepo.getJobById(createdJob.id);
-    if (!processedJob) {
-      return fail(res, notFound("Job not found"));
-    }
-
-    // Score asynchronously so the import returns immediately.
-    (async () => {
-      try {
-        const rawProfile = await getProfile();
-        if (
-          !rawProfile ||
-          typeof rawProfile !== "object" ||
-          Array.isArray(rawProfile)
-        ) {
-          throw new Error("Invalid resume profile format");
-        }
-        const profile = rawProfile as Record<string, unknown>;
-        const { score, reason } = await scoreJobSuitability(
-          processedJob,
-          profile,
-        );
-        await jobsRepo.updateJob(processedJob.id, {
-          suitabilityScore: score,
-          suitabilityReason: reason,
-        });
-      } catch (error) {
-        logger.warn("Manual job scoring failed", {
-          jobId: processedJob.id,
-          error,
-        });
-      }
-    })().catch((error) => {
-      logger.warn("Manual job scoring task failed to start", {
-        jobId: processedJob.id,
-        error,
-      });
+      route: "POST /api/manual-jobs/import",
+      requestId: getRequestId(res),
+      host: getHost(input.job.jobUrl ?? input.job.applicationLink ?? ""),
     });
 
-    ok(res, processedJob);
+    ok(res, result.job);
   } catch (error) {
     if (error instanceof z.ZodError) {
       return fail(res, badRequest(error.message, error.flatten()));
     }
     fail(res, toAppError(error));
+  }
+});
+
+/**
+ * POST /api/manual-jobs/ingest - Fetch a URL and import it directly
+ */
+manualJobsRouter.post("/ingest", async (req: Request, res: Response) => {
+  const requestId = getRequestId(res);
+
+  try {
+    const input = manualJobFetchSchema.parse(req.body ?? {});
+    const fetched = await fetchManualJobContent(input);
+    const inference = await inferManualJobDetails(fetched.content);
+    const draft = applyUrlIngestionFallbacks(inference.job, fetched);
+
+    const title = cleanOptional(draft.title);
+    const employer = cleanOptional(draft.employer);
+    const jobDescription = cleanOptional(draft.jobDescription);
+
+    if (!jobDescription) {
+      return fail(
+        res,
+        unprocessableEntity(
+          "Fetched content did not contain enough job details to import",
+        ),
+      );
+    }
+
+    if (!title || !employer) {
+      return fail(
+        res,
+        unprocessableEntity(
+          "Fetched content did not contain enough metadata to create a job",
+          {
+            missing: {
+              title: !title,
+              employer: !employer,
+            },
+          },
+        ),
+      );
+    }
+
+    const result = await createAndProcessManualJob(
+      {
+        ...draft,
+        title,
+        employer,
+        jobDescription,
+      },
+      {
+        analyticsOrigin: "manual_job_create",
+        allowProcessFailure: true,
+        route: "POST /api/manual-jobs/ingest",
+        requestId,
+        host: fetched.host,
+      },
+    );
+
+    logger.info("Manual job URL ingestion completed", {
+      route: "POST /api/manual-jobs/ingest",
+      requestId,
+      jobId: result.job?.id ?? null,
+      host: fetched.host,
+      movedToReady: result.movedToReady,
+    });
+
+    const payload: ManualJobIngestionResponse = {
+      job: result.job,
+      ingestion: {
+        source: "url",
+        movedToReady: result.movedToReady,
+        warning: result.warning,
+      },
+    };
+
+    ok(res, payload);
+  } catch (error) {
+    const err = toAppError(error);
+    logger.warn("Manual job URL ingestion failed", {
+      route: "POST /api/manual-jobs/ingest",
+      requestId,
+      host: getHost(String(req.body?.url ?? "")),
+      status: err.status,
+      code: err.code,
+      details: err.details,
+    });
+    if (error instanceof z.ZodError) {
+      return fail(res, badRequest(error.message, error.flatten()));
+    }
+    fail(res, err);
   }
 });

--- a/shared/src/types/jobs.ts
+++ b/shared/src/types/jobs.ts
@@ -313,6 +313,15 @@ export interface ManualJobFetchResponse {
   url: string;
 }
 
+export interface ManualJobIngestionResponse {
+  job: Job;
+  ingestion: {
+    source: "url";
+    movedToReady: boolean;
+    warning?: string | null;
+  };
+}
+
 export interface UpdateJobInput {
   title?: string;
   employer?: string;


### PR DESCRIPTION
<img width="967" height="817" alt="image" src="https://github.com/user-attachments/assets/ea5fe71a-6e1a-4a69-8e62-ca1923d6e6dd" />

## Description
- add `POST /api/manual-jobs/ingest` to accept a URL-only payload and run the manual ingestion flow end to end
- reuse the existing manual job fetch, inference, creation, processing, and async scoring pipeline instead of creating a separate path
- automatically attempt to move ingested jobs to `ready` after creation
- keep jobs recoverable when ready-stage processing fails, returning success with `movedToReady: false` and a warning instead of dropping the import
- add URL-specific fallback logic for missing inferred fields, including metadata-based title/employer fallback and defaulting `jobUrl` to the submitted URL
- return standardized API responses with request IDs and structured ingestion metadata
- add structured logging around URL ingestion, including host, request ID, job ID, and ready-stage outcome
- add shared types and a client API helper for manual URL ingestion
- expand manual-jobs route tests to cover invalid input, upstream failures, timeout handling, happy path ingestion, metadata fallbacks, persisted submitted URL, recoverable processing failure, and request ID passthrough
- update the manual extractor documentation to explain direct URL ingestion for bookmarklets and mobile capture
- add an interactive MDX bookmarklet generator that builds a drag-ready bookmarklet from a host and optional Bearer token
- document how users can retrieve their Bearer token from Job Ops and include the shared iOS Shortcut as a mobile ingestion example
- clarify the privacy boundary in the docs: generator inputs stay local to the browser, while the saved bookmark or Shortcut sends the current page URL to the user’s own Job Ops server
- verify the feature with route tests, type checks, client build, and docs build