### PR TITLE
feat: Add 'alter personality' button for Ghostwriter (#372)

### DIFF
--- a/orchestrator/src/client/components/ghostwriter/GhostwriterPanel.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterPanel.tsx
@@ -5,8 +5,10 @@ import type {
   JobChatMessage,
   JobChatStreamEvent,
 } from "@shared/types";
+import { Settings2 } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
 import { toast } from "sonner";
 import {
   AlertDialog,
@@ -18,6 +20,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { bucketQueryLength, trackProductEvent } from "@/lib/analytics";
 import { Composer } from "./Composer";
 import { MessageList } from "./MessageList";
@@ -381,6 +384,19 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({ job }) => {
               writing style preferences. Ask for tailored response drafts, or
               concise role-fit talking points.
             </p>
+            <div className="mt-4">
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1.5 w-fit"
+                asChild
+              >
+                <Link to="/settings#chat">
+                  <Settings2 className="h-4 w-4" />
+                  Alter personality
+                </Link>
+              </Button>
+            </div>
           </div>
         ) : (
           <MessageList

--- a/orchestrator/src/client/pages/SettingsPage.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.tsx
@@ -51,6 +51,7 @@ import {
   useForm,
   useWatch,
 } from "react-hook-form";
+import { useLocation } from "react-router-dom";
 import { toast } from "sonner";
 import { useQueryErrorToast } from "@/client/hooks/useQueryErrorToast";
 import { queryKeys } from "@/client/lib/queryKeys";
@@ -655,10 +656,30 @@ const getDerivedSettings = (settings: AppSettings | null) => {
 
 export const SettingsPage: React.FC = () => {
   const queryClient = useQueryClient();
+  const location = useLocation();
   const [settings, setSettings] = useState<AppSettings | null>(null);
   const [activeSection, setActiveSection] =
     useState<SettingsSectionId>("model");
   const [openGroups, setOpenGroups] = useState<SettingsGroupId[]>([]);
+
+  useEffect(() => {
+    const hash = location.hash.replace(/^#/, "");
+    const allSectionIds = SETTINGS_NAV_GROUPS.flatMap((g) =>
+      g.items.map((i) => i.id),
+    );
+    if (hash && allSectionIds.includes(hash as SettingsSectionId)) {
+      setActiveSection(hash as SettingsSectionId);
+      const parentGroup = SETTINGS_NAV_GROUPS.find((g) =>
+        g.items.some((i) => i.id === hash),
+      );
+      if (parentGroup) {
+        setOpenGroups((prev) =>
+          prev.includes(parentGroup.id) ? prev : [...prev, parentGroup.id],
+        );
+      }
+    }
+  }, [location.hash]);
+
   const [settingsSearch, setSettingsSearch] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const [rxresumeValidationStatus, setRxresumeValidationStatus] =


### PR DESCRIPTION
As requested, this PR improves the Ghostwriter UX by adding a quick-access "Alter personality" CTA button to the empty state of the Ghostwriter panel. 
The button acts as a deep-link shortcut pointing directly to `/settings#chat`, enabling users to seamlessly configure AI tone, constraints, and writing style preferences from within their workflow.
### Changes Overview
- **`GhostwriterPanel.tsx`**: Added the new `Button` linking to `/settings#chat` with improved spacing for the empty state.
- **`SettingsPage.tsx`**: Added location hash handling to automatically activate the "chat" settings section when parsed from the URL fragment.

### Screenshots
**1. Ghostwriter Empty State (with new Button)**
<img width="2557" height="1322" alt="image" src="https://github.com/user-attachments/assets/a04878b3-abd0-4a91-9acb-94d1b8596ba7" />
**2. Resulting Settings Page (hash automatically selects the Chat section)**
<img width="2557" height="1322" alt="image" src="https://github.com/user-attachments/assets/aca2d031-5144-4f28-922b-d9e9d3cacd96" />