### PR TITLE
Add local startup scripts for running without Docker on Windows

### DIFF
--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,15 @@
+@echo off
+echo Starting Job Ops on port 1000...
+set NODE_ENV=production
+set PORT=1000
+set NODE22=%~dp0..\..\..\tmp\node22\node-v22.22.2-win-x64\node.exe
+
+if not exist "%NODE22%" (
+    echo ERROR: Node 22 not found at %NODE22%
+    echo Please ensure /tmp/node22/node-v22.22.2-win-x64/node.exe exists
+    pause
+    exit /b 1
+)
+
+cd /d %~dp0orchestrator
+"%NODE22%" "%~dp0..\node_modules\tsx\dist\cli.mjs" src\server\index.ts

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Start Job Ops on port 1000 using Node 22
+export NODE22="/tmp/node22/node-v22.22.2-win-x64/node.exe"
+export NODE_ENV=production
+export PORT=1000
+
+cd "$(dirname "$0")/orchestrator"
+exec $NODE22 /c/Apps/job-ops/node_modules/tsx/dist/cli.mjs src/server/index.ts


### PR DESCRIPTION
## Summary

- Adds `start.sh` for Git Bash and `start.bat` for CMD to start the server locally without Docker
- Targets port 1000 with `NODE_ENV=production`, serving the pre-built frontend through Express
- Uses a portable Node 22 binary to work around the `better-sqlite3` native ABI mismatch with Node 24 on Windows (no pre-built binaries exist for Node 24 yet)

## Context

On Windows with Node 24, `better-sqlite3` fails to install from source (requires Visual Studio C++ build tools) and has no pre-built binaries for Node 24. The scripts use Node 22.22.2 portable (downloaded to `/tmp/node22/`) which has a compatible pre-built binary.

## Setup steps these scripts assume

1. `npm install --ignore-scripts` run at repo root
2. `better-sqlite3` pre-built binary downloaded for Node 22 via `prebuild-install`
3. Frontend built with `npm run build:client` inside `orchestrator/`
4. Node 22 portable extracted to `/tmp/node22/node-v22.22.2-win-x64/`

## Test plan

- [ ] Run `bash start.sh` on Windows (Git Bash) — server starts at http://localhost:1000
- [ ] Run `start.bat` in CMD — server starts at http://localhost:1000
- [ ] `GET /health` returns `{"status":"ok"}`
- [ ] Frontend loads at `http://localhost:1000/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)