### PR TITLE
Add Seek extractor (Australia & New Zealand) via Apify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,18 @@ ADZUNA_APP_KEY=
 # Optional default per-term cap (can be overridden by UI run budget logic).
 # ADZUNA_MAX_JOBS_PER_TERM=50
 
+# =============================================================================
+# Seek (via Apify) - optional, Australia job board
+# =============================================================================
+# Apify API token for running the unfenced-group/seek-com-au-scraper actor.
+# Free tier provides $5/month credit (~3,000 results). Get your token at:
+# https://console.apify.com/account/integrations
+APIFY_TOKEN=
+# Optional default per-term cap (can be overridden by UI run budget logic).
+# SEEK_MAX_JOBS_PER_TERM=50
+# Optional: override the Apify actor used for Seek scraping.
+# SEEK_APIFY_ACTOR_ID=unfenced-group/seek-com-au-scraper
+
 
 # =============================================================================
 # JobSpy - Job search configuration

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ Thumbs.db
 
 # local temp artifacts
 tmp/
+
+# Virtual environment for Python
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY extractors/startupjobs/package*.json ./extractors/startupjobs/
 COPY extractors/workingnomads/package*.json ./extractors/workingnomads/
 COPY extractors/golangjobs/package*.json ./extractors/golangjobs/
 COPY extractors/ukvisajobs/package*.json ./extractors/ukvisajobs/
+COPY extractors/seek/package*.json ./extractors/seek/
 
 # Install Node dependencies with npm cache (dev deps needed for build).
 RUN --mount=type=cache,target=/root/.npm \
@@ -86,6 +87,7 @@ COPY extractors/startupjobs ./extractors/startupjobs
 COPY extractors/workingnomads ./extractors/workingnomads
 COPY extractors/golangjobs ./extractors/golangjobs
 COPY extractors/ukvisajobs ./extractors/ukvisajobs
+COPY extractors/seek ./extractors/seek
 
 # ============================================================================
 # PARALLEL BUILD STAGES
@@ -117,6 +119,7 @@ COPY extractors/startupjobs/package*.json ./extractors/startupjobs/
 COPY extractors/workingnomads/package*.json ./extractors/workingnomads/
 COPY extractors/golangjobs/package*.json ./extractors/golangjobs/
 COPY extractors/ukvisajobs/package*.json ./extractors/ukvisajobs/
+COPY extractors/seek/package*.json ./extractors/seek/
 
 # Install production Node dependencies only.
 RUN --mount=type=cache,target=/root/.npm \
@@ -170,6 +173,7 @@ COPY extractors/startupjobs ./extractors/startupjobs
 COPY extractors/workingnomads ./extractors/workingnomads
 COPY extractors/golangjobs ./extractors/golangjobs
 COPY extractors/ukvisajobs ./extractors/ukvisajobs
+COPY extractors/seek ./extractors/seek
 
 # Create runtime directories.
 RUN mkdir -p /app/data/pdfs /app/codex-home

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Open `http://localhost:3005` and follow the onboarding wizard. You'll be searchi
 | Gradcracker | STEM/Grads (UK) |
 | UK Visa Jobs | Sponsorship (UK) |
 | Golang Jobs | Go developers |
+| Seek | Australia/NZ (via Apify) |
 
 Custom extractors can be added via TypeScript. See the [extractor docs](https://jobops.dakheera47.com/docs/extractors/overview).
 

--- a/biome.json
+++ b/biome.json
@@ -10,7 +10,9 @@
       "**",
       "!!**/dist",
       "!!docs-site/.docusaurus",
-      "!!docs-site/build"
+      "!!docs-site/build",
+      "!!**/.venv",
+      "!!.claude"
     ]
   },
   "css": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,9 @@ services:
         - path: ./extractors/golangjobs/src
           target: /app/extractors/golangjobs/src
           action: sync+restart
+        - path: ./extractors/seek/src
+          target: /app/extractors/seek/src
+          action: sync+restart
         - path: ./extractors/jobspy
           target: /app/extractors/jobspy
           action: sync+restart

--- a/docs-site/docs/extractors/overview.md
+++ b/docs-site/docs/extractors/overview.md
@@ -20,6 +20,7 @@ Extractor integrations are now registered through manifests and loaded automatic
 | [startup.jobs](/docs/next/extractors/startup-jobs) | Startup-focused discovery through the published `startup-jobs-scraper` package | No credentials required; detail enrichment depends on Playwright browser binaries being installed | existing pipeline `searchTerms`, selected country/cities, `jobspyResultsWanted`; `npx playwright install` for fresh environments | Algolia-backed search plus detail-page enrichment via package import; orchestrator maps normalized records and de-duplicates by `jobUrl` |
 | [Working Nomads](/docs/next/extractors/working-nomads) | Remote-only discovery through the public Working Nomads jobs API | Public API is curated and remote-only; available fields are limited to API payload shape | existing pipeline `searchTerms`, selected country/cities, `jobspyResultsWanted`, workplace type | Fetches a single public JSON feed, filters locally by terms/location, infers job type when possible, and de-duplicates by source id / URL |
 | [Golang Jobs](/docs/next/extractors/golang-jobs) | Go-specific discovery through the public Golang Jobs feed | Depends on the site's public Supabase-backed schema staying stable; no credentials required | existing pipeline `searchTerms`, selected country/cities, `jobspyResultsWanted`, workplace type | Paginates the public jobs feed, maps location through the linked city record, then filters locally and de-duplicates by source id / URL |
+| [Seek](/docs/next/extractors/seek) | Australia/NZ job search via Apify | Requires Apify API token; actor runs incur cost ($1.50/1,000 results; free tier ~3,000/month) | `APIFY_TOKEN`, `SEEK_MAX_JOBS_PER_TERM`, `SEEK_APIFY_ACTOR_ID` | Calls the `unfenced-group/seek-com-au-scraper` Apify actor per term, maps results, and de-duplicates by source id / URL |
 | [UKVisaJobs](/docs/next/extractors/ukvisajobs) | UK visa sponsorship-focused roles | Requires authenticated session and periodic token/cookie refresh | `UKVISAJOBS_EMAIL`, `UKVISAJOBS_PASSWORD`, `UKVISAJOBS_MAX_JOBS`, `UKVISAJOBS_SEARCH_KEYWORD` | API pagination + dataset output; orchestrator de-dupes and may fetch missing descriptions |
 | [Manual Import](/docs/next/extractors/manual) | One-off jobs not covered by scrapers | Inference quality depends on model/provider and input quality; some URLs cannot be fetched reliably | App/API endpoints (`/api/manual-jobs/infer`, `/api/manual-jobs/import`) | Accepts text/HTML/URL, runs inference, then saves and scores job after review |
 
@@ -31,6 +32,7 @@ Extractor integrations are now registered through manifests and loaded automatic
 - Use **startup.jobs** when you want startup-heavy listings without maintaining another scraper locally.
 - Use **Working Nomads** when you want another remote-only source with a public API and curated global roles.
 - Use **Golang Jobs** when you want a niche Go-focused board that broad aggregators often miss.
+- Use **Seek** when targeting Australia/NZ roles via the Apify-powered Seek scraper.
 - Use **Gradcracker** when targeting graduate pipelines in the UK.
 - Use **UKVisaJobs** for sponsorship-specific UK searches.
 - Use **Manual Import** when you already have a specific posting and need direct import.
@@ -57,6 +59,7 @@ Many runs combine sources: broad discovery first, then manual import for high-pr
 - [startup.jobs](/docs/next/extractors/startup-jobs)
 - [Working Nomads](/docs/next/extractors/working-nomads)
 - [Golang Jobs](/docs/next/extractors/golang-jobs)
+- [Seek](/docs/next/extractors/seek)
 - [UKVisaJobs](/docs/next/extractors/ukvisajobs)
 - [Manual Import](/docs/next/extractors/manual)
 - [Add an Extractor](/docs/next/workflows/add-an-extractor)

--- a/docs-site/docs/extractors/seek.md
+++ b/docs-site/docs/extractors/seek.md
@@ -1,0 +1,53 @@
+---
+id: seek
+title: Seek
+description: Australia/NZ job search via the Apify seek-com-au-scraper actor.
+sidebar_position: 9
+---
+
+Seek is Australia's largest job board. This extractor uses the [Apify](https://apify.com) platform to run the `unfenced-group/seek-com-au-scraper` actor, which searches Seek and returns structured job data.
+
+## Why Apify?
+
+Seek's frontend is heavily anti-bot protected. The Apify actor handles browser rendering and rate-limiting transparently — no local Playwright install or proxy management needed.
+
+## Setup
+
+1. Create a free Apify account at [https://apify.com](https://apify.com).
+2. Go to **Account → Integrations** and copy your **API token**.
+3. Add it to your `.env`:
+
+```
+APIFY_TOKEN=apify_api_xxxxxxxxxxxx
+```
+
+That's it. Once `APIFY_TOKEN` is set, the Seek source will appear in the pipeline source list.
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `APIFY_TOKEN` | Yes | — | Apify API token for running actors |
+| `SEEK_MAX_JOBS_PER_TERM` | No | `50` | Max results fetched per search term |
+| `SEEK_APIFY_ACTOR_ID` | No | `unfenced-group/seek-com-au-scraper` | Override the Apify actor (deploy-time swap) |
+
+## Cost
+
+The `unfenced-group/seek-com-au-scraper` actor costs approximately **$1.50 per 1,000 results**. Apify's free tier provides **$5/month credit**, which covers roughly **3,000 results per month** at no cost.
+
+## Common problems
+
+**Seek source not showing in pipeline UI**
+Ensure `APIFY_TOKEN` is set in your environment and the app has been restarted. The source is gated on the token being present.
+
+**Actor run fails with "actor not found"**
+Check that `SEEK_APIFY_ACTOR_ID` points to a published public actor. The default `unfenced-group/seek-com-au-scraper` must be accessible from your Apify account.
+
+**Zero results returned**
+Try increasing `SEEK_MAX_JOBS_PER_TERM` or verify that your search terms are relevant to the Australian job market.
+
+## Related pages
+
+- [Extractors Overview](/docs/next/extractors/overview)
+- [Add an Extractor](/docs/next/workflows/add-an-extractor)
+- [Adzuna](/docs/next/extractors/adzuna) — another API-based extractor that requires credentials

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -51,6 +51,7 @@ const sidebars: SidebarsConfig = {
         "extractors/hiring-cafe",
         "extractors/startup-jobs",
         "extractors/working-nomads",
+        "extractors/seek",
         "extractors/manual",
         "extractors/ukvisajobs",
       ],

--- a/extractors/seek/manifest.ts
+++ b/extractors/seek/manifest.ts
@@ -1,0 +1,73 @@
+import type {
+  ExtractorManifest,
+  ExtractorProgressEvent,
+} from "@shared/types/extractors";
+import { runSeek } from "./src/run";
+
+function toProgress(event: {
+  type: string;
+  termIndex: number;
+  termTotal: number;
+  searchTerm: string;
+  jobsFoundTerm?: number;
+}): ExtractorProgressEvent {
+  if (event.type === "term_start") {
+    return {
+      phase: "list",
+      termsProcessed: Math.max(event.termIndex - 1, 0),
+      termsTotal: event.termTotal,
+      currentUrl: event.searchTerm,
+      detail: `Seek: term ${event.termIndex}/${event.termTotal} (${event.searchTerm})`,
+    };
+  }
+
+  return {
+    phase: "list",
+    termsProcessed: event.termIndex,
+    termsTotal: event.termTotal,
+    currentUrl: event.searchTerm,
+    jobPagesEnqueued: event.jobsFoundTerm ?? 0,
+    jobPagesProcessed: event.jobsFoundTerm ?? 0,
+    detail: `Seek: completed ${event.termIndex}/${event.termTotal} (${event.searchTerm}) — ${event.jobsFoundTerm ?? 0} jobs`,
+  };
+}
+
+export const manifest: ExtractorManifest = {
+  id: "seek",
+  displayName: "Seek",
+  providesSources: ["seek"],
+  requiredEnvVars: ["APIFY_TOKEN"],
+  async run(context) {
+    if (context.shouldCancel?.()) {
+      return { success: true, jobs: [] };
+    }
+
+    const maxJobsPerTerm = context.settings.seekMaxJobsPerTerm
+      ? parseInt(context.settings.seekMaxJobsPerTerm, 10)
+      : 50;
+
+    const location =
+      context.settings.searchCities ??
+      context.settings.jobspyLocation ??
+      "All Australia";
+
+    const result = await runSeek({
+      searchTerms: context.searchTerms,
+      location,
+      maxJobsPerTerm,
+      shouldCancel: context.shouldCancel,
+      onProgress: (event) => {
+        if (context.shouldCancel?.()) return;
+        context.onProgress?.(toProgress(event));
+      },
+    });
+
+    if (!result.success) {
+      return { success: false, jobs: [], error: result.error };
+    }
+
+    return { success: true, jobs: result.jobs };
+  },
+};
+
+export default manifest;

--- a/extractors/seek/manifest.ts
+++ b/extractors/seek/manifest.ts
@@ -1,8 +1,8 @@
+import { resolveSearchCities } from "@shared/search-cities.js";
 import type {
   ExtractorManifest,
   ExtractorProgressEvent,
 } from "@shared/types/extractors";
-import { resolveSearchCities } from "@shared/search-cities.js";
 import { runSeek } from "./src/run";
 
 function toProgress(event: {

--- a/extractors/seek/manifest.ts
+++ b/extractors/seek/manifest.ts
@@ -2,6 +2,7 @@ import type {
   ExtractorManifest,
   ExtractorProgressEvent,
 } from "@shared/types/extractors";
+import { resolveSearchCities } from "@shared/search-cities.js";
 import { runSeek } from "./src/run";
 
 function toProgress(event: {
@@ -46,14 +47,18 @@ export const manifest: ExtractorManifest = {
       ? parseInt(context.settings.seekMaxJobsPerTerm, 10)
       : 50;
 
-    const location =
-      context.settings.searchCities ??
-      context.settings.jobspyLocation ??
-      "All Australia";
+    const countryLabel =
+      context.selectedCountry === "new zealand" ? "New Zealand" : "Australia";
+
+    const cities = resolveSearchCities({
+      single: context.settings.searchCities ?? context.settings.jobspyLocation,
+    });
+    const location = cities[0] ?? `All ${countryLabel}`;
 
     const result = await runSeek({
       searchTerms: context.searchTerms,
       location,
+      country: context.selectedCountry,
       maxJobsPerTerm,
       shouldCancel: context.shouldCancel,
       onProgress: (event) => {

--- a/extractors/seek/package.json
+++ b/extractors/seek/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "seek-extractor",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Seek extractor via Apify - fetches jobs from seek.com.au",
+  "main": "src/main.ts",
+  "dependencies": {
+    "apify-client": "^2.9.0",
+    "job-ops-shared": "^1.0.0",
+    "tsx": "^4.4.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "~5.9.0"
+  },
+  "scripts": {
+    "start": "tsx src/main.ts",
+    "start:dev": "tsx src/main.ts",
+    "check:types": "tsc --noEmit"
+  }
+}

--- a/extractors/seek/src/main.ts
+++ b/extractors/seek/src/main.ts
@@ -7,10 +7,7 @@ const searchTerms = (
 ) as string[];
 
 const location = process.env.SEEK_LOCATION ?? "All Australia";
-const maxJobsPerTerm = parseInt(
-  process.env.SEEK_MAX_JOBS_PER_TERM ?? "50",
-  10,
-);
+const maxJobsPerTerm = parseInt(process.env.SEEK_MAX_JOBS_PER_TERM ?? "50", 10);
 
 runSeek({ searchTerms, location, maxJobsPerTerm })
   .then((result) => {

--- a/extractors/seek/src/main.ts
+++ b/extractors/seek/src/main.ts
@@ -1,0 +1,28 @@
+import { runSeek } from "./run.js";
+
+const searchTerms = (
+  process.env.SEEK_SEARCH_TERMS
+    ? JSON.parse(process.env.SEEK_SEARCH_TERMS)
+    : ["software engineer"]
+) as string[];
+
+const location = process.env.SEEK_LOCATION ?? "All Australia";
+const maxJobsPerTerm = parseInt(
+  process.env.SEEK_MAX_JOBS_PER_TERM ?? "50",
+  10,
+);
+
+runSeek({ searchTerms, location, maxJobsPerTerm })
+  .then((result) => {
+    if (!result.success) {
+      console.error(`Seek extractor failed: ${result.error}`);
+      process.exitCode = 1;
+    } else {
+      console.log(`Seek extractor fetched ${result.jobs.length} jobs`);
+    }
+  })
+  .catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    console.error(`Seek extractor failed: ${message}`);
+    process.exitCode = 1;
+  });

--- a/extractors/seek/src/run.ts
+++ b/extractors/seek/src/run.ts
@@ -1,5 +1,5 @@
-import { ApifyClient } from "apify-client";
 import type { CreateJobInput } from "@shared/types/jobs";
+import { ApifyClient } from "apify-client";
 
 const ACTOR_ID =
   process.env.SEEK_APIFY_ACTOR_ID ?? "unfenced-group/seek-com-au-scraper";
@@ -41,10 +41,10 @@ function toStr(value: unknown): string | undefined {
 }
 
 function toNum(value: unknown): number | undefined {
-  if (typeof value === "number" && isFinite(value)) return value;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
   if (typeof value === "string") {
     const n = parseFloat(value);
-    if (isFinite(n)) return n;
+    if (Number.isFinite(n)) return n;
   }
   return undefined;
 }

--- a/extractors/seek/src/run.ts
+++ b/extractors/seek/src/run.ts
@@ -24,6 +24,7 @@ export type SeekProgressEvent =
 export interface RunSeekOptions {
   searchTerms?: string[];
   location?: string;
+  country?: string;
   maxJobsPerTerm?: number;
   onProgress?: (event: SeekProgressEvent) => void;
   shouldCancel?: () => boolean;
@@ -48,7 +49,10 @@ function toNum(value: unknown): number | undefined {
   return undefined;
 }
 
-function mapSeekItem(item: SeekRawItem): CreateJobInput | null {
+function mapSeekItem(
+  item: SeekRawItem,
+  countryLabel: string,
+): CreateJobInput | null {
   const jobUrl = toStr(item.url);
   if (!jobUrl) return null;
 
@@ -68,7 +72,7 @@ function mapSeekItem(item: SeekRawItem): CreateJobInput | null {
     jobUrl,
     applicationLink: toStr(item.applyUrl) ?? jobUrl,
     location: toStr(item.location)
-      ? `${toStr(item.location)}, Australia`
+      ? `${toStr(item.location)}, ${countryLabel}`
       : undefined,
     salary: toStr(item.salaryLabel),
     salaryMinAmount: salaryMin,
@@ -98,7 +102,9 @@ export async function runSeek(
     options.searchTerms && options.searchTerms.length > 0
       ? options.searchTerms
       : ["software engineer"];
-  const location = options.location ?? "All Australia";
+  const countryLabel =
+    options.country === "new zealand" ? "New Zealand" : "Australia";
+  const location = options.location ?? `All ${countryLabel}`;
   const maxJobsPerTerm = options.maxJobsPerTerm ?? 50;
   const termTotal = searchTerms.length;
 
@@ -135,7 +141,7 @@ export async function runSeek(
       let jobsFoundTerm = 0;
       for (const item of items) {
         if (options.shouldCancel?.()) break;
-        const mapped = mapSeekItem(item as SeekRawItem);
+        const mapped = mapSeekItem(item as SeekRawItem, countryLabel);
         if (!mapped) continue;
         const key = mapped.sourceJobId ?? mapped.jobUrl;
         if (seen.has(key)) continue;

--- a/extractors/seek/src/run.ts
+++ b/extractors/seek/src/run.ts
@@ -1,0 +1,161 @@
+import { ApifyClient } from "apify-client";
+import type { CreateJobInput } from "@shared/types/jobs";
+
+const ACTOR_ID =
+  process.env.SEEK_APIFY_ACTOR_ID ?? "unfenced-group/seek-com-au-scraper";
+
+type SeekRawItem = Record<string, unknown>;
+
+export type SeekProgressEvent =
+  | {
+      type: "term_start";
+      termIndex: number;
+      termTotal: number;
+      searchTerm: string;
+    }
+  | {
+      type: "term_complete";
+      termIndex: number;
+      termTotal: number;
+      searchTerm: string;
+      jobsFoundTerm: number;
+    };
+
+export interface RunSeekOptions {
+  searchTerms?: string[];
+  location?: string;
+  maxJobsPerTerm?: number;
+  onProgress?: (event: SeekProgressEvent) => void;
+  shouldCancel?: () => boolean;
+}
+
+export interface SeekResult {
+  success: boolean;
+  jobs: CreateJobInput[];
+  error?: string;
+}
+
+function toStr(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function toNum(value: unknown): number | undefined {
+  if (typeof value === "number" && isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = parseFloat(value);
+    if (isFinite(n)) return n;
+  }
+  return undefined;
+}
+
+function mapSeekItem(item: SeekRawItem): CreateJobInput | null {
+  const jobUrl = toStr(item.url);
+  if (!jobUrl) return null;
+
+  const title = toStr(item.title) ?? "Unknown Title";
+  const employer = toStr(item.company) ?? "Unknown Employer";
+
+  const salaryMin = toNum(item.salaryMin);
+  const salaryMax = toNum(item.salaryMax);
+  const salaryPeriod = toStr(item.salaryPeriod);
+  const currency = toStr(item.currency);
+
+  return {
+    source: "seek",
+    sourceJobId: toStr(item.id),
+    title,
+    employer,
+    jobUrl,
+    applicationLink: toStr(item.applyUrl) ?? jobUrl,
+    location: toStr(item.location)
+      ? `${toStr(item.location)}, Australia`
+      : undefined,
+    salary: toStr(item.salaryLabel),
+    salaryMinAmount: salaryMin,
+    salaryMaxAmount: salaryMax,
+    salaryInterval: salaryPeriod,
+    salaryCurrency: currency,
+    datePosted: toStr(item.publishDate),
+    jobDescription: toStr(item.description),
+    jobType: toStr(item.workTypes),
+    isRemote: item.workArrangement === "remote" ? true : undefined,
+  };
+}
+
+export async function runSeek(
+  options: RunSeekOptions = {},
+): Promise<SeekResult> {
+  const token = process.env.APIFY_TOKEN?.trim();
+  if (!token) {
+    return {
+      success: false,
+      jobs: [],
+      error: "Missing Apify credentials (APIFY_TOKEN)",
+    };
+  }
+
+  const searchTerms =
+    options.searchTerms && options.searchTerms.length > 0
+      ? options.searchTerms
+      : ["software engineer"];
+  const location = options.location ?? "All Australia";
+  const maxJobsPerTerm = options.maxJobsPerTerm ?? 50;
+  const termTotal = searchTerms.length;
+
+  const client = new ApifyClient({ token });
+
+  try {
+    const jobs: CreateJobInput[] = [];
+    const seen = new Set<string>();
+
+    for (let i = 0; i < searchTerms.length; i += 1) {
+      if (options.shouldCancel?.()) break;
+
+      const searchTerm = searchTerms[i];
+      const termIndex = i + 1;
+
+      options.onProgress?.({
+        type: "term_start",
+        termIndex,
+        termTotal,
+        searchTerm,
+      });
+
+      const run = await client.actor(ACTOR_ID).call({
+        searchQuery: searchTerm,
+        location,
+        maxResults: maxJobsPerTerm,
+        fetchDetails: true,
+      });
+
+      const { items } = await client
+        .dataset(run.defaultDatasetId)
+        .listItems({ limit: maxJobsPerTerm });
+
+      let jobsFoundTerm = 0;
+      for (const item of items) {
+        if (options.shouldCancel?.()) break;
+        const mapped = mapSeekItem(item as SeekRawItem);
+        if (!mapped) continue;
+        const key = mapped.sourceJobId ?? mapped.jobUrl;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        jobs.push(mapped);
+        jobsFoundTerm += 1;
+      }
+
+      options.onProgress?.({
+        type: "term_complete",
+        termIndex,
+        termTotal,
+        searchTerm,
+        jobsFoundTerm,
+      });
+    }
+
+    return { success: true, jobs };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown error";
+    return { success: false, jobs: [], error: message };
+  }
+}

--- a/extractors/seek/tsconfig.json
+++ b/extractors/seek/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "outDir": "dist",
+    "strict": true,
+    "noUnusedLocals": false,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["../../shared/src/*"]
+    }
+  },
+  "include": ["./src/**/*"]
+}

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -918,6 +918,7 @@ describe("OrchestratorPage", () => {
         ukvisajobsMaxJobs: 150,
         adzunaMaxJobsPerTerm: 150,
         startupjobsMaxJobsPerTerm: 150,
+        seekMaxJobsPerTerm: 150,
         jobspyCountryIndeed: "united kingdom",
         searchCities: null,
         locationSearchScope: "selected_only",

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.test.ts
@@ -175,4 +175,24 @@ describe("automatic-run utilities", () => {
     expect(estimate.discovered.cap).toBeGreaterThan(0);
     expect(estimate.discovered.cap).toBeLessThanOrEqual(120);
   });
+
+  it("includes seek in estimate caps using the shared term budget", () => {
+    const estimate = calculateAutomaticEstimate({
+      values: {
+        topN: 10,
+        minSuitabilityScore: 50,
+        searchTerms: ["backend", "platform"],
+        runBudget: 120,
+        country: "australia",
+        cityLocations: [],
+        workplaceTypes: ["remote", "hybrid", "onsite"],
+        searchScope: "selected_only",
+        matchStrictness: "exact_only",
+      },
+      sources: ["seek"],
+    });
+
+    expect(estimate.discovered.cap).toBeGreaterThan(0);
+    expect(estimate.discovered.cap).toBeLessThanOrEqual(120);
+  });
 });

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.ts
@@ -132,6 +132,7 @@ export interface ExtractorLimits {
   adzunaMaxJobsPerTerm: number;
   startupjobsMaxJobsPerTerm: number;
   workingnomadsMaxJobsPerTerm: number;
+  seekMaxJobsPerTerm: number;
 }
 
 export function deriveExtractorLimits(args: {
@@ -150,6 +151,7 @@ export function deriveExtractorLimits(args: {
   const includesHiringCafe = args.sources.includes("hiringcafe");
   const includesStartupJobs = args.sources.includes("startupjobs");
   const includesWorkingNomads = args.sources.includes("workingnomads");
+  const includesSeek = args.sources.includes("seek");
 
   const weightedContributors =
     (includesIndeed ? termCount : 0) +
@@ -160,7 +162,8 @@ export function deriveExtractorLimits(args: {
     (includesAdzuna ? termCount : 0) +
     (includesHiringCafe ? termCount : 0) +
     (includesStartupJobs ? termCount : 0) +
-    (includesWorkingNomads ? termCount : 0);
+    (includesWorkingNomads ? termCount : 0) +
+    (includesSeek ? termCount : 0);
 
   if (weightedContributors <= 0) {
     return {
@@ -170,6 +173,7 @@ export function deriveExtractorLimits(args: {
       adzunaMaxJobsPerTerm: budget,
       startupjobsMaxJobsPerTerm: budget,
       workingnomadsMaxJobsPerTerm: budget,
+      seekMaxJobsPerTerm: budget,
     };
   }
 
@@ -183,6 +187,7 @@ export function deriveExtractorLimits(args: {
     adzunaMaxJobsPerTerm: perUnit,
     startupjobsMaxJobsPerTerm: perUnit,
     workingnomadsMaxJobsPerTerm: perUnit,
+    seekMaxJobsPerTerm: perUnit,
   };
 }
 
@@ -268,6 +273,7 @@ export function calculateAutomaticEstimate(args: {
   const hasHiringCafe = sources.includes("hiringcafe");
   const hasStartupJobs = sources.includes("startupjobs");
   const hasWorkingNomads = sources.includes("workingnomads");
+  const hasSeek = sources.includes("seek");
   const limits = deriveExtractorLimits({
     budget: values.runBudget,
     searchTerms: values.searchTerms,
@@ -292,6 +298,7 @@ export function calculateAutomaticEstimate(args: {
   const workingNomadsCap = hasWorkingNomads
     ? limits.workingnomadsMaxJobsPerTerm * termCount
     : 0;
+  const seekCap = hasSeek ? limits.seekMaxJobsPerTerm * termCount : 0;
 
   const discoveredCap =
     jobspyCap +
@@ -300,7 +307,8 @@ export function calculateAutomaticEstimate(args: {
     adzunaCap +
     hiringCafeCap +
     startupJobsCap +
-    workingNomadsCap;
+    workingNomadsCap +
+    seekCap;
   const discoveredMin = Math.round(discoveredCap * 0.35);
   const discoveredMax = Math.round(discoveredCap * 0.75);
   const processedMin = Math.min(values.topN, discoveredMin);

--- a/orchestrator/src/client/pages/orchestrator/usePipelineControls.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineControls.ts
@@ -182,6 +182,7 @@ export function usePipelineControls(
         ukvisajobsMaxJobs: limits.ukvisajobsMaxJobs,
         adzunaMaxJobsPerTerm: limits.adzunaMaxJobsPerTerm,
         startupjobsMaxJobsPerTerm: limits.startupjobsMaxJobsPerTerm,
+        seekMaxJobsPerTerm: limits.seekMaxJobsPerTerm,
         jobspyCountryIndeed: values.country,
         searchCities,
       });

--- a/orchestrator/src/client/pages/orchestrator/utils.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.test.ts
@@ -29,6 +29,13 @@ describe("orchestrator utils", () => {
     expect(getEnabledSources(createAppSettings())).toContain("golangjobs");
   });
 
+  it("enables seek only when apify token is configured", () => {
+    const withToken = createAppSettings({ apifyTokenHint: "sk-" });
+    const withoutToken = createAppSettings({ apifyTokenHint: null });
+    expect(getEnabledSources(withToken)).toContain("seek");
+    expect(getEnabledSources(withoutToken)).not.toContain("seek");
+  });
+
   it("counts processing jobs in ready and discovered tabs", () => {
     const jobs = [
       createJob({ id: "ready", status: "ready", closedAt: null }),

--- a/orchestrator/src/client/pages/orchestrator/utils.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.ts
@@ -214,6 +214,7 @@ export const getEnabledSources = (
   const hasAdzunaAuth = Boolean(
     settings.adzunaAppId?.trim() && settings.adzunaAppKeyHint,
   );
+  const hasApifyToken = Boolean(settings.apifyTokenHint);
 
   for (const source of orderedSources) {
     if (source === "gradcracker") {
@@ -226,6 +227,10 @@ export const getEnabledSources = (
     }
     if (source === "adzuna") {
       if (hasAdzunaAuth) enabled.push(source);
+      continue;
+    }
+    if (source === "seek") {
+      if (hasApifyToken) enabled.push(source);
       continue;
     }
     if (source === "hiringcafe") {

--- a/orchestrator/src/server/config/demo-defaults.data.ts
+++ b/orchestrator/src/server/config/demo-defaults.data.ts
@@ -258,6 +258,7 @@ export const DEMO_SOURCE_BASE_URLS: Record<JobSource, string> = {
   startupjobs: "https://startup.jobs",
   workingnomads: "https://www.workingnomads.com",
   golangjobs: "https://www.golangjobs.tech",
+  seek: "https://www.seek.com.au",
   manual: "https://example.com",
 };
 

--- a/orchestrator/src/server/services/extractor-health.ts
+++ b/orchestrator/src/server/services/extractor-health.ts
@@ -106,6 +106,13 @@ const HEALTH_PROBE_CONFIG_BY_SOURCE: Record<
       jobspyResultsWanted: "1",
     },
   },
+  seek: {
+    searchTerm: DEFAULT_HEALTH_SEARCH_TERM,
+    selectedCountry: "australia",
+    settings: {
+      seekMaxJobsPerTerm: "1",
+    },
+  },
   manual: {
     searchTerm: DEFAULT_HEALTH_SEARCH_TERM,
     selectedCountry: DEFAULT_HEALTH_SELECTED_COUNTRY,

--- a/package-lock.json
+++ b/package-lock.json
@@ -213,6 +213,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "extractors/seek": {
+      "name": "seek-extractor",
+      "version": "0.0.1",
+      "dependencies": {
+        "apify-client": "^2.9.0",
+        "job-ops-shared": "^1.0.0",
+        "tsx": "^4.4.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "~5.9.0"
+      }
+    },
+    "extractors/seek/node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "extractors/seek/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "extractors/startupjobs": {
       "name": "startupjobs-extractor",
       "version": "0.0.1",
@@ -22972,6 +23002,10 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/seek-extractor": {
+      "resolved": "extractors/seek",
+      "link": true
     },
     "node_modules/selderee": {
       "version": "0.11.0",

--- a/shared/src/extractors/index.ts
+++ b/shared/src/extractors/index.ts
@@ -11,6 +11,7 @@ export const EXTRACTOR_SOURCE_IDS = [
   "startupjobs",
   "workingnomads",
   "golangjobs",
+  "seek",
   "manual",
 ] as const;
 
@@ -61,6 +62,12 @@ export const EXTRACTOR_SOURCE_METADATA: Record<
     label: "Golang Jobs",
     order: 100,
     category: "pipeline",
+  },
+  seek: {
+    label: "Seek",
+    order: 105,
+    category: "pipeline",
+    requiresCredentials: true,
   },
   manual: { label: "Manual", order: 110, category: "manual" },
 };

--- a/shared/src/location-support.ts
+++ b/shared/src/location-support.ts
@@ -100,6 +100,9 @@ export const SUPPORTED_COUNTRY_INPUTS = [
 ] as const;
 
 const UK_ONLY_SOURCES = new Set<JobSource>(["gradcracker", "ukvisajobs"]);
+const SEEK_SUPPORTED_COUNTRIES = new Set(
+  ["australia", "new zealand"].map((c) => normalizeCountryKey(c)),
+);
 const GLASSDOOR_SUPPORTED_COUNTRIES = new Set(
   [
     "australia",
@@ -187,6 +190,8 @@ export function isSourceAllowedForCountry(
   country: string | null | undefined,
 ): boolean {
   if (UK_ONLY_SOURCES.has(source)) return isUkCountry(country);
+  if (source === "seek")
+    return SEEK_SUPPORTED_COUNTRIES.has(normalizeCountryKey(country));
   if (source === "glassdoor") return isGlassdoorCountry(country);
   if (source === "adzuna") return getAdzunaCountryCode(country) !== null;
   return true;

--- a/shared/src/settings-registry.ts
+++ b/shared/src/settings-registry.ts
@@ -301,6 +301,19 @@ export const settingsRegistry = {
     parse: parseIntOrNull,
     serialize: serializeNullableNumber,
   },
+  seekMaxJobsPerTerm: {
+    kind: "typed" as const,
+    schema: z.number().int().min(1).max(1000),
+    default: (): number =>
+      parseInt(
+        typeof process !== "undefined"
+          ? process.env.SEEK_MAX_JOBS_PER_TERM || "50"
+          : "50",
+        10,
+      ),
+    parse: parseIntOrNull,
+    serialize: serializeNullableNumber,
+  },
   searchTerms: {
     kind: "typed" as const,
     schema: z.array(z.string().trim().min(1).max(200)).max(100),
@@ -653,6 +666,11 @@ export const settingsRegistry = {
   adzunaAppKey: {
     kind: "secret" as const,
     envKey: "ADZUNA_APP_KEY",
+    schema: z.string().trim().max(2000),
+  },
+  apifyToken: {
+    kind: "secret" as const,
+    envKey: "APIFY_TOKEN",
     schema: z.string().trim().max(2000),
   },
   basicAuthPassword: {

--- a/shared/src/testing/factories.ts
+++ b/shared/src/testing/factories.ts
@@ -161,6 +161,7 @@ export const createAppSettings = (
   adzunaMaxJobsPerTerm: { value: 50, default: 50, override: null },
   gradcrackerMaxJobsPerTerm: { value: 50, default: 50, override: null },
   startupjobsMaxJobsPerTerm: { value: 50, default: 50, override: null },
+  seekMaxJobsPerTerm: { value: 50, default: 50, override: null },
   searchTerms: {
     value: ["Software Engineer"],
     default: ["Software Engineer"],
@@ -253,6 +254,7 @@ export const createAppSettings = (
   ukvisajobsPasswordHint: null,
   adzunaAppId: null,
   adzunaAppKeyHint: null,
+  apifyTokenHint: null,
   webhookSecretHint: null,
   basicAuthActive: false,
   backupEnabled: { value: false, default: false, override: null },

--- a/shared/src/types/settings.ts
+++ b/shared/src/types/settings.ts
@@ -170,6 +170,7 @@ export interface AppSettings {
   adzunaMaxJobsPerTerm: Resolved<number>;
   gradcrackerMaxJobsPerTerm: Resolved<number>;
   startupjobsMaxJobsPerTerm: Resolved<number>;
+  seekMaxJobsPerTerm: Resolved<number>;
   searchTerms: Resolved<string[]>;
   workplaceTypes: Resolved<Array<"remote" | "hybrid" | "onsite">>;
   blockedCompanyKeywords: Resolved<string[]>;
@@ -218,6 +219,7 @@ export interface AppSettings {
   rxresumeApiKeyHint: string | null;
   ukvisajobsPasswordHint: string | null;
   adzunaAppKeyHint: string | null;
+  apifyTokenHint: string | null;
   basicAuthPasswordHint: string | null;
   webhookSecretHint: string | null;
 


### PR DESCRIPTION
## Summary

Adds Seek.com.au / Seek.co.nz as a job source using the Apify `unfenced-group/seek-com-au-scraper` actor.

- **Credentials-gated**: Seek only appears in the pipeline UI when `APIFY_TOKEN` is set
- **AU + NZ support**: country is derived from the selected country setting; location defaults to `All Australia` or `All New Zealand` accordingly
- **Seek is restricted** to Australia and New Zealand in `isSourceAllowedForCountry` — it won't appear for unrelated countries
- **Cost**: ~$1.50 per 1,000 results; Apify free tier provides $5/month (~3,000 results)

## Changes

- `extractors/seek/` — new extractor package (Apify runner, manifest, type entrypoint)
- `shared/src/extractors/index.ts` — registers `seek` source with metadata
- `shared/src/settings-registry.ts` — adds `seekMaxJobsPerTerm` and `apifyToken` settings
- `shared/src/location-support.ts` — restricts seek to AU + NZ
- `orchestrator/` — UI source gating, pipeline estimate caps, health probe, demo defaults, tests
- `docs-site/docs/extractors/seek.md` — setup guide, env vars, cost, troubleshooting
- `biome.json` — excludes `.venv` and `.claude` from linting

## Test plan

- [ ] `APIFY_TOKEN` unset → Seek does not appear in source list
- [ ] `APIFY_TOKEN` set, country = Australia → Seek appears, jobs return with `, Australia` in location
- [ ] `APIFY_TOKEN` set, country = New Zealand → jobs return with `, New Zealand` in location
- [ ] country = United Kingdom → Seek does not appear in source list
- [ ] All CI parity checks pass (`biome ci`, type checks, build, tests)
