### PR TITLE
Add saved pipeline run details to overview runs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,6 @@
 
 MODEL=google/gemini-3-flash-preview
 
-# Optional: GitHub token used only during Docker image builds to avoid
-# rate limits when Camoufox binaries are downloaded.
-GITHUB_TOKEN=
-
 # Optional: Authentication for protected app and API access
 # The app is fully unauthenticated if this isn't set, which is the default.
 BASIC_AUTH_USER=

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 
 MODEL=google/gemini-3-flash-preview
 
+# Optional: GitHub token used only during Docker image builds to avoid
+# rate limits when Camoufox binaries are downloaded.
+GITHUB_TOKEN=
+
 # Optional: Authentication for protected app and API access
 # The app is fully unauthenticated if this isn't set, which is the default.
 BASIC_AUTH_USER=

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,8 @@ RUN --mount=type=cache,target=/root/.npm \
     --no-audit --no-fund --progress=false
 
 # Fetch Camoufox binaries before copying source to keep the download cached.
-ARG GITHUB_TOKEN
-RUN GITHUB_TOKEN="${GITHUB_TOKEN}" node ./scripts/camoufox-fetch.mjs
+RUN --mount=type=secret,id=github_token,required=false \
+    sh -c 'GITHUB_TOKEN="$([ -f /run/secrets/github_token ] && cat /run/secrets/github_token || true)" node ./scripts/camoufox-fetch.mjs'
 
 FROM node-deps AS build-sources
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ FROM build-base AS node-deps
 
 # Copy package files for dependency installation.
 COPY package*.json ./
+COPY scripts/camoufox-fetch.mjs ./scripts/camoufox-fetch.mjs
 COPY docs-site/package*.json ./docs-site/
 COPY shared/package*.json ./shared/
 COPY orchestrator/package*.json ./orchestrator/
@@ -70,7 +71,8 @@ RUN --mount=type=cache,target=/root/.npm \
     --no-audit --no-fund --progress=false
 
 # Fetch Camoufox binaries before copying source to keep the download cached.
-RUN npx camoufox-js fetch
+ARG GITHUB_TOKEN
+RUN GITHUB_TOKEN="${GITHUB_TOKEN}" node ./scripts/camoufox-fetch.mjs
 
 FROM node-deps AS build-sources
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      secrets:
+        - github_token
     image: ghcr.io/dakheera47/job-ops:latest
     container_name: job-ops
     ports:
@@ -38,6 +38,10 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+
+secrets:
+  github_token:
+    environment: GITHUB_TOKEN
     develop:
       watch:
         # Rebuild container when package.json changes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     image: ghcr.io/dakheera47/job-ops:latest
     container_name: job-ops
     ports:

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -35,8 +35,9 @@ echo "GITHUB_TOKEN=ghp_your_token_here" >> .env
 docker compose up -d --build
 ```
 
-JobOps uses this token only during the Docker build step that downloads
-Camoufox browser binaries.
+JobOps passes this token to the Docker build as a BuildKit secret only for the
+Camoufox download step. It is not stored in the runtime container
+environment.
 
 ## 2) Access the app and onboard
 

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -27,6 +27,17 @@ To build locally instead:
 docker compose up -d --build
 ```
 
+If GitHub rate limits the Camoufox download during local builds, set an
+optional `GITHUB_TOKEN` in your shell or `.env` first:
+
+```bash
+echo "GITHUB_TOKEN=ghp_your_token_here" >> .env
+docker compose up -d --build
+```
+
+JobOps uses this token only during the Docker build step that downloads
+Camoufox browser binaries.
+
 ## 2) Access the app and onboard
 
 Open:

--- a/orchestrator/src/client/api/client.pipeline.test.ts
+++ b/orchestrator/src/client/api/client.pipeline.test.ts
@@ -63,6 +63,7 @@ describe("pipeline client helpers", () => {
             errorMessage: null,
           },
           exactMetrics: { durationMs: 300000 },
+          savedDetails: null,
           inferredMetrics: {
             jobsCreated: { value: 5, quality: "inferred_from_timestamps" },
             jobsUpdated: { value: 4, quality: "inferred_from_timestamps" },

--- a/orchestrator/src/client/api/client.pipeline.test.ts
+++ b/orchestrator/src/client/api/client.pipeline.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "./client";
+
+function createJsonResponse(status: number, payload: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(payload),
+    json: async () => payload,
+  } as Response;
+}
+
+describe("pipeline client helpers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    api.__resetApiClientAuthForTests();
+  });
+
+  afterEach(() => {
+    api.__resetApiClientAuthForTests();
+  });
+
+  it("fetches recent pipeline runs", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: [
+          {
+            id: "run-1",
+            startedAt: "2026-04-18T10:00:00.000Z",
+            completedAt: "2026-04-18T10:05:00.000Z",
+            status: "completed",
+            jobsDiscovered: 10,
+            jobsProcessed: 2,
+            errorMessage: null,
+          },
+        ],
+        meta: { requestId: "req-runs" },
+      }),
+    );
+
+    await expect(api.getPipelineRuns()).resolves.toEqual([
+      expect.objectContaining({ id: "run-1", status: "completed" }),
+    ]);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/pipeline/runs",
+      expect.any(Object),
+    );
+  });
+
+  it("fetches pipeline run insights for a specific run", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: {
+          run: {
+            id: "run insight/1",
+            startedAt: "2026-04-18T10:00:00.000Z",
+            completedAt: "2026-04-18T10:05:00.000Z",
+            status: "completed",
+            jobsDiscovered: 10,
+            jobsProcessed: 2,
+            errorMessage: null,
+          },
+          exactMetrics: { durationMs: 300000 },
+          inferredMetrics: {
+            jobsCreated: { value: 5, quality: "inferred_from_timestamps" },
+            jobsUpdated: { value: 4, quality: "inferred_from_timestamps" },
+            jobsProcessed: { value: 2, quality: "inferred_from_timestamps" },
+          },
+        },
+        meta: { requestId: "req-insights" },
+      }),
+    );
+
+    await expect(api.getPipelineRunInsights("run insight/1")).resolves.toEqual(
+      expect.objectContaining({
+        exactMetrics: { durationMs: 300000 },
+      }),
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/pipeline/runs/run%20insight%2F1/insights",
+      expect.any(Object),
+    );
+  });
+});

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -36,6 +36,8 @@ import type {
   ManualJobDraft,
   ManualJobFetchResponse,
   ManualJobInferenceResponse,
+  PipelineRun,
+  PipelineRunInsights,
   PipelineStatusResponse,
   PostApplicationAction,
   PostApplicationActionResponse,
@@ -1225,6 +1227,18 @@ export async function updateJobOutcome(
 // Pipeline API
 export async function getPipelineStatus(): Promise<PipelineStatusResponse> {
   return fetchApi<PipelineStatusResponse>("/pipeline/status");
+}
+
+export async function getPipelineRuns(): Promise<PipelineRun[]> {
+  return fetchApi<PipelineRun[]>("/pipeline/runs");
+}
+
+export async function getPipelineRunInsights(
+  id: string,
+): Promise<PipelineRunInsights> {
+  return fetchApi<PipelineRunInsights>(
+    `/pipeline/runs/${encodeURIComponent(id)}/insights`,
+  );
 }
 
 export async function runPipeline(config?: {

--- a/orchestrator/src/client/lib/queryKeys.ts
+++ b/orchestrator/src/client/lib/queryKeys.ts
@@ -50,6 +50,9 @@ export const queryKeys = {
   pipeline: {
     all: ["pipeline"] as const,
     status: () => [...queryKeys.pipeline.all, "status"] as const,
+    runs: () => [...queryKeys.pipeline.all, "runs"] as const,
+    runInsights: (id: string) =>
+      [...queryKeys.pipeline.all, "run-insights", id] as const,
   },
   visaSponsors: {
     all: ["visa-sponsors"] as const,

--- a/orchestrator/src/client/pages/HomePage.tsx
+++ b/orchestrator/src/client/pages/HomePage.tsx
@@ -14,6 +14,7 @@ import type React from "react";
 import { useCallback, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { queryKeys } from "@/client/lib/queryKeys";
+import { OverviewPipelineRunsSection } from "./overview/OverviewPipelineRunsSection";
 
 type JobWithEvents = {
   id: string;
@@ -141,6 +142,8 @@ export const HomePage: React.FC = () => {
       />
 
       <PageMain>
+        <OverviewPipelineRunsSection />
+
         <ApplicationsPerDayChart
           appliedAt={appliedDates}
           isLoading={isLoading}

--- a/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.test.tsx
+++ b/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.test.tsx
@@ -1,0 +1,155 @@
+import { renderWithQueryClient } from "@client/test/renderWithQueryClient";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { OverviewPipelineRunsSection } from "./OverviewPipelineRunsSection";
+
+vi.mock("@client/api", () => ({
+  getPipelineStatus: vi.fn(),
+  getPipelineRuns: vi.fn(),
+  getPipelineRunInsights: vi.fn(),
+}));
+
+vi.mock("@client/components/PipelineProgress", () => ({
+  PipelineProgress: ({ isRunning }: { isRunning: boolean }) =>
+    isRunning ? <div data-testid="pipeline-progress">live progress</div> : null,
+}));
+
+import * as api from "@client/api";
+
+describe("OverviewPipelineRunsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the last run summary and recent run statuses", async () => {
+    vi.mocked(api.getPipelineStatus).mockResolvedValue({
+      isRunning: false,
+      lastRun: {
+        id: "run-last",
+        startedAt: "2026-04-18T10:00:00.000Z",
+        completedAt: "2026-04-18T10:05:00.000Z",
+        status: "completed",
+        jobsDiscovered: 12,
+        jobsProcessed: 3,
+        errorMessage: null,
+      },
+      nextScheduledRun: null,
+    });
+    vi.mocked(api.getPipelineRuns).mockResolvedValue([
+      {
+        id: "run-last",
+        startedAt: "2026-04-18T10:00:00.000Z",
+        completedAt: "2026-04-18T10:05:00.000Z",
+        status: "completed",
+        jobsDiscovered: 12,
+        jobsProcessed: 3,
+        errorMessage: null,
+      },
+      {
+        id: "run-failed",
+        startedAt: "2026-04-17T10:00:00.000Z",
+        completedAt: "2026-04-17T10:04:00.000Z",
+        status: "failed",
+        jobsDiscovered: 4,
+        jobsProcessed: 0,
+        errorMessage: "Scoring failed",
+      },
+      {
+        id: "run-stale",
+        startedAt: "2026-04-16T10:00:00.000Z",
+        completedAt: null,
+        status: "running",
+        jobsDiscovered: 7,
+        jobsProcessed: 0,
+        errorMessage: null,
+      },
+    ]);
+    vi.mocked(api.getPipelineRunInsights).mockResolvedValue({
+      run: {
+        id: "run-failed",
+        startedAt: "2026-04-17T10:00:00.000Z",
+        completedAt: "2026-04-17T10:04:00.000Z",
+        status: "failed",
+        jobsDiscovered: 4,
+        jobsProcessed: 0,
+        errorMessage: "Scoring failed",
+      },
+      exactMetrics: { durationMs: 240000 },
+      inferredMetrics: {
+        jobsCreated: { value: 4, quality: "inferred_from_timestamps" },
+        jobsUpdated: { value: 4, quality: "inferred_from_timestamps" },
+        jobsProcessed: { value: 0, quality: "inferred_from_timestamps" },
+      },
+    });
+
+    renderWithQueryClient(<OverviewPipelineRunsSection />);
+
+    expect(await screen.findByText("Pipeline runs")).toBeInTheDocument();
+    expect(await screen.findByText("Current status")).toBeInTheDocument();
+    expect(screen.getByText("Recent runs")).toBeInTheDocument();
+    expect(screen.getAllByText("Completed").length).toBeGreaterThan(0);
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("Incomplete")).toBeInTheDocument();
+    expect(screen.getAllByText("12").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("3").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByRole("button", { name: /17 Apr 2026/i }));
+
+    await waitFor(() =>
+      expect(api.getPipelineRunInsights).toHaveBeenCalledWith("run-failed"),
+    );
+    expect(await screen.findByText("Run details")).toBeInTheDocument();
+    expect(screen.getByText("What changed")).toBeInTheDocument();
+    expect(screen.getByText("Inferred from timestamps")).toBeInTheDocument();
+    expect(screen.getByText("Scoring failed")).toBeInTheDocument();
+  });
+
+  it("shows live progress when a run is active", async () => {
+    vi.mocked(api.getPipelineStatus).mockResolvedValue({
+      isRunning: true,
+      lastRun: {
+        id: "run-active",
+        startedAt: "2026-04-18T10:00:00.000Z",
+        completedAt: null,
+        status: "running",
+        jobsDiscovered: 2,
+        jobsProcessed: 0,
+        errorMessage: null,
+      },
+      nextScheduledRun: null,
+    });
+    vi.mocked(api.getPipelineRuns).mockResolvedValue([
+      {
+        id: "run-active",
+        startedAt: "2026-04-18T10:00:00.000Z",
+        completedAt: null,
+        status: "running",
+        jobsDiscovered: 2,
+        jobsProcessed: 0,
+        errorMessage: null,
+      },
+    ]);
+    vi.mocked(api.getPipelineRunInsights).mockResolvedValue({
+      run: {
+        id: "run-active",
+        startedAt: "2026-04-18T10:00:00.000Z",
+        completedAt: null,
+        status: "running",
+        jobsDiscovered: 2,
+        jobsProcessed: 0,
+        errorMessage: null,
+      },
+      exactMetrics: { durationMs: null },
+      inferredMetrics: {
+        jobsCreated: { value: null, quality: "unavailable" },
+        jobsUpdated: { value: null, quality: "unavailable" },
+        jobsProcessed: { value: null, quality: "unavailable" },
+      },
+    });
+
+    renderWithQueryClient(<OverviewPipelineRunsSection />);
+
+    expect(await screen.findByTestId("pipeline-progress")).toBeInTheDocument();
+    expect(screen.getAllByText("Running").length).toBeGreaterThan(0);
+  });
+});

--- a/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.test.tsx
+++ b/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.test.tsx
@@ -75,6 +75,54 @@ describe("OverviewPipelineRunsSection", () => {
         errorMessage: "Scoring failed",
       },
       exactMetrics: { durationMs: 240000 },
+      savedDetails: {
+        requestedConfig: {
+          topN: 5,
+          minSuitabilityScore: 75,
+          sources: ["linkedin", "indeed"],
+          enableCrawling: true,
+          enableScoring: true,
+          enableImporting: true,
+          enableAutoTailoring: false,
+        },
+        effectiveConfig: {
+          country: "united states",
+          countryLabel: "United States",
+          searchCities: ["London"],
+          searchTermsCount: 3,
+          workplaceTypes: ["remote", "hybrid"],
+          locationSearchScope: "selected_only",
+          locationMatchStrictness: "exact_only",
+          compatibleSources: ["linkedin", "indeed"],
+          skippedSources: [],
+          blockedCompanyKeywordsCount: 2,
+          sourceLimits: {
+            ukvisajobsMaxJobs: 50,
+            adzunaMaxJobsPerTerm: 50,
+            gradcrackerMaxJobsPerTerm: 50,
+            startupjobsMaxJobsPerTerm: 50,
+            jobspyResultsWanted: 20,
+          },
+          autoSkipScoreThreshold: 60,
+          pdfRenderer: "rxresume",
+          models: {
+            scorer: "gpt-scorer",
+            tailoring: "gpt-tailor",
+            projectSelection: "gpt-projects",
+          },
+          resumeProjects: {
+            maxProjects: 3,
+            lockedProjectCount: 1,
+            aiSelectableProjectCount: 4,
+          },
+        },
+        resultSummary: {
+          stage: "selection",
+          jobsScored: 4,
+          jobsSelected: 2,
+          sourceErrors: ["linkedin: temporary rate limit"],
+        },
+      },
       inferredMetrics: {
         jobsCreated: { value: 4, quality: "inferred_from_timestamps" },
         jobsUpdated: { value: 4, quality: "inferred_from_timestamps" },
@@ -99,9 +147,16 @@ describe("OverviewPipelineRunsSection", () => {
       expect(api.getPipelineRunInsights).toHaveBeenCalledWith("run-failed"),
     );
     expect(await screen.findByText("Run details")).toBeInTheDocument();
+    expect(screen.getByText("Saved settings")).toBeInTheDocument();
+    expect(screen.getByText("Requested run")).toBeInTheDocument();
+    expect(screen.getByText("Effective settings")).toBeInTheDocument();
+    expect(screen.getByText("Saved execution summary")).toBeInTheDocument();
     expect(screen.getByText("What changed")).toBeInTheDocument();
     expect(screen.getByText("Inferred from timestamps")).toBeInTheDocument();
     expect(screen.getByText("Scoring failed")).toBeInTheDocument();
+    expect(
+      screen.getByText("linkedin: temporary rate limit"),
+    ).toBeInTheDocument();
   });
 
   it("shows live progress when a run is active", async () => {
@@ -140,6 +195,7 @@ describe("OverviewPipelineRunsSection", () => {
         errorMessage: null,
       },
       exactMetrics: { durationMs: null },
+      savedDetails: null,
       inferredMetrics: {
         jobsCreated: { value: null, quality: "unavailable" },
         jobsUpdated: { value: null, quality: "unavailable" },

--- a/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.tsx
+++ b/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.tsx
@@ -1,0 +1,505 @@
+import * as api from "@client/api";
+import { ListItem } from "@client/components/layout";
+import { PipelineProgress } from "@client/components/PipelineProgress";
+import { queryKeys } from "@client/lib/queryKeys";
+import type { PipelineRun, PipelineRunInsights } from "@shared/types";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Activity,
+  AlertCircle,
+  Clock3,
+  GitCompareArrows,
+  History,
+  Loader2,
+} from "lucide-react";
+import type React from "react";
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { formatDateTime } from "@/lib/utils";
+import {
+  formatPipelineDuration,
+  getPipelineRunDisplayStatus,
+  getPipelineRunStatusLabel,
+  type PipelineRunDisplayStatus,
+} from "./pipelineRuns";
+
+const RECENT_RUN_LIMIT = 8;
+
+const statusBadgeClasses: Record<PipelineRunDisplayStatus, string> = {
+  running: "border-sky-500/30 bg-sky-500/10 text-sky-200",
+  completed: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
+  failed: "border-rose-500/30 bg-rose-500/10 text-rose-200",
+  cancelled: "border-amber-500/30 bg-amber-500/10 text-amber-200",
+  incomplete: "border-slate-500/30 bg-slate-500/10 text-slate-200",
+};
+
+function getDurationMs(run: PipelineRun): number | null {
+  if (run.completedAt == null) return null;
+  return Math.max(
+    0,
+    new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime(),
+  );
+}
+
+function getRunReason(
+  run: PipelineRun,
+  displayStatus: PipelineRunDisplayStatus,
+) {
+  if (run.errorMessage) return run.errorMessage;
+  if (displayStatus === "cancelled") return "Run cancelled before completion.";
+  if (displayStatus === "incomplete") {
+    return "This historical run never recorded a completion timestamp.";
+  }
+  return null;
+}
+
+function MetricCard(props: {
+  label: string;
+  value: React.ReactNode;
+  hint?: string | null;
+}) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+      <div className="text-xs text-muted-foreground">{props.label}</div>
+      <div className="mt-1 text-lg font-semibold tabular-nums">
+        {props.value}
+      </div>
+      {props.hint ? (
+        <div className="mt-1 text-xs text-muted-foreground">{props.hint}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function RunStatusBadge(props: { status: PipelineRunDisplayStatus }) {
+  return (
+    <Badge variant="outline" className={statusBadgeClasses[props.status]}>
+      {getPipelineRunStatusLabel(props.status)}
+    </Badge>
+  );
+}
+
+function RunsList(props: {
+  runs: PipelineRun[];
+  activeRunId: string | null;
+  selectedRunId: string | null;
+  onSelectRun: (runId: string) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="hidden grid-cols-[minmax(0,1.6fr)_auto_auto_auto] gap-3 px-3 text-xs text-muted-foreground md:grid">
+        <div>Run</div>
+        <div>Status</div>
+        <div>Discovered</div>
+        <div>Processed</div>
+      </div>
+
+      <div className="space-y-2">
+        {props.runs.map((run) => {
+          const displayStatus = getPipelineRunDisplayStatus(run, {
+            isActive: props.activeRunId === run.id,
+          });
+          const duration = formatPipelineDuration(getDurationMs(run));
+          const isSelected = props.selectedRunId === run.id;
+
+          return (
+            <ListItem
+              key={run.id}
+              onClick={() => props.onSelectRun(run.id)}
+              selected={isSelected}
+              className={`grid gap-3 rounded-lg border px-3 py-3 md:grid-cols-[minmax(0,1.6fr)_auto_auto_auto] ${
+                isSelected
+                  ? "border-primary/40 bg-primary/5"
+                  : "border-border/60 hover:bg-muted/30"
+              }`}
+            >
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-medium">
+                    {formatDateTime(run.startedAt) ?? run.startedAt}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    Run {run.id.slice(0, 8)}
+                  </span>
+                </div>
+                <div className="mt-1 text-sm text-muted-foreground">
+                  Duration {duration}
+                </div>
+              </div>
+              <div className="md:self-center">
+                <RunStatusBadge status={displayStatus} />
+              </div>
+              <div className="md:self-center md:text-right">
+                <div className="text-xs text-muted-foreground md:hidden">
+                  Discovered
+                </div>
+                <div className="font-medium tabular-nums">
+                  {run.jobsDiscovered.toLocaleString()}
+                </div>
+              </div>
+              <div className="md:self-center md:text-right">
+                <div className="text-xs text-muted-foreground md:hidden">
+                  Processed
+                </div>
+                <div className="font-medium tabular-nums">
+                  {run.jobsProcessed.toLocaleString()}
+                </div>
+              </div>
+            </ListItem>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function RunInsightsBody(props: {
+  insights: PipelineRunInsights;
+  isActiveRun: boolean;
+}) {
+  const { run, exactMetrics, inferredMetrics } = props.insights;
+  const displayStatus = getPipelineRunDisplayStatus(run, {
+    isActive: props.isActiveRun,
+  });
+  const runReason = getRunReason(run, displayStatus);
+  const inferredHint =
+    inferredMetrics.jobsCreated.quality === "unavailable"
+      ? "Unavailable for incomplete runs."
+      : "Approximate counts inferred from job timestamps in the run window. Other job activity in the same period may be included.";
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-2">
+        <RunStatusBadge status={displayStatus} />
+        <span className="text-sm text-muted-foreground">
+          Started {formatDateTime(run.startedAt) ?? run.startedAt}
+        </span>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <MetricCard
+          label="Duration"
+          value={formatPipelineDuration(exactMetrics.durationMs)}
+        />
+        <MetricCard
+          label="Jobs discovered"
+          value={run.jobsDiscovered.toLocaleString()}
+        />
+        <MetricCard
+          label="Jobs processed"
+          value={run.jobsProcessed.toLocaleString()}
+        />
+        <MetricCard
+          label="Completed"
+          value={formatDateTime(run.completedAt) ?? "Not recorded"}
+        />
+      </div>
+
+      {runReason ? (
+        <div className="rounded-lg border border-border/60 bg-muted/20 p-3 text-sm">
+          <div className="font-medium">Notes</div>
+          <div className="mt-1 text-muted-foreground">{runReason}</div>
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="font-medium">What changed</div>
+          <Badge variant="outline">Inferred from timestamps</Badge>
+        </div>
+        <p className="text-sm text-muted-foreground">{inferredHint}</p>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <MetricCard
+            label="Jobs created"
+            value={
+              inferredMetrics.jobsCreated.value == null
+                ? "Not available"
+                : inferredMetrics.jobsCreated.value.toLocaleString()
+            }
+          />
+          <MetricCard
+            label="Jobs updated"
+            value={
+              inferredMetrics.jobsUpdated.value == null
+                ? "Not available"
+                : inferredMetrics.jobsUpdated.value.toLocaleString()
+            }
+          />
+          <MetricCard
+            label="Jobs processed"
+            value={
+              inferredMetrics.jobsProcessed.value == null
+                ? "Not available"
+                : inferredMetrics.jobsProcessed.value.toLocaleString()
+            }
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const OverviewPipelineRunsSection: React.FC = () => {
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+
+  const pipelineStatusQuery = useQuery({
+    queryKey: queryKeys.pipeline.status(),
+    queryFn: api.getPipelineStatus,
+    refetchInterval: 15000,
+    refetchIntervalInBackground: true,
+  });
+  const pipelineRunsQuery = useQuery({
+    queryKey: queryKeys.pipeline.runs(),
+    queryFn: api.getPipelineRuns,
+    refetchInterval: 30000,
+    refetchIntervalInBackground: true,
+  });
+  const runInsightsQuery = useQuery({
+    queryKey: queryKeys.pipeline.runInsights(selectedRunId ?? ""),
+    queryFn: () => api.getPipelineRunInsights(selectedRunId as string),
+    enabled: selectedRunId != null,
+  });
+
+  const recentRuns = useMemo(
+    () => (pipelineRunsQuery.data ?? []).slice(0, RECENT_RUN_LIMIT),
+    [pipelineRunsQuery.data],
+  );
+  const latestRun = pipelineStatusQuery.data?.lastRun ?? recentRuns[0] ?? null;
+  const activeRunId = pipelineStatusQuery.data?.isRunning
+    ? (latestRun?.id ?? null)
+    : null;
+  const currentStatus = latestRun
+    ? getPipelineRunDisplayStatus(latestRun, {
+        isActive: activeRunId === latestRun.id,
+      })
+    : null;
+  const currentStatusText = pipelineStatusQuery.data?.isRunning
+    ? "A pipeline run is currently in progress."
+    : latestRun
+      ? (getRunReason(latestRun, currentStatus as PipelineRunDisplayStatus) ??
+        "The most recent pipeline activity is shown below.")
+      : "No pipeline runs recorded yet.";
+  const selectedRun = useMemo(
+    () =>
+      (pipelineRunsQuery.data ?? []).find((run) => run.id === selectedRunId) ??
+      (latestRun?.id === selectedRunId ? latestRun : null),
+    [latestRun, pipelineRunsQuery.data, selectedRunId],
+  );
+
+  const isLoading =
+    pipelineStatusQuery.isLoading ||
+    pipelineRunsQuery.isLoading ||
+    (selectedRunId != null && runInsightsQuery.isLoading);
+  const error =
+    pipelineStatusQuery.error ??
+    pipelineRunsQuery.error ??
+    runInsightsQuery.error;
+  const statusError = pipelineStatusQuery.error;
+  const runsError = pipelineRunsQuery.error;
+
+  return (
+    <>
+      <Card className="border-border/60 bg-card/40 shadow-none">
+        <CardHeader className="gap-3">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <History className="h-4 w-4 text-muted-foreground" />
+                <CardTitle>Pipeline runs</CardTitle>
+              </div>
+              <CardDescription>
+                Review recent pipeline activity without leaving Overview.
+              </CardDescription>
+            </div>
+            {currentStatus ? <RunStatusBadge status={currentStatus} /> : null}
+          </div>
+        </CardHeader>
+
+        <CardContent className="space-y-6">
+          {pipelineStatusQuery.data?.isRunning ? (
+            <PipelineProgress isRunning />
+          ) : null}
+
+          {isLoading && !latestRun && recentRuns.length === 0 ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Loading pipeline history…</span>
+            </div>
+          ) : null}
+
+          {error && !latestRun && recentRuns.length === 0 ? (
+            <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
+              {error instanceof Error
+                ? error.message
+                : "Failed to load pipeline history"}
+            </div>
+          ) : null}
+
+          {latestRun ? (
+            <>
+              <div className="grid gap-3 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,2fr)]">
+                <div className="rounded-lg border border-border/60 bg-muted/20 p-4">
+                  <div className="flex items-center gap-2 text-sm font-medium">
+                    <Activity className="h-4 w-4 text-muted-foreground" />
+                    <span>Current status</span>
+                  </div>
+                  {statusError ? (
+                    <div className="mt-3 rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
+                      Live status is temporarily unavailable. Showing the latest
+                      persisted run history.
+                    </div>
+                  ) : null}
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    {currentStatus ? (
+                      <RunStatusBadge status={currentStatus} />
+                    ) : null}
+                    <span className="text-sm text-muted-foreground">
+                      {currentStatusText}
+                    </span>
+                  </div>
+                  {pipelineStatusQuery.data?.nextScheduledRun ? (
+                    <div className="mt-3 text-xs text-muted-foreground">
+                      Next scheduled run{" "}
+                      {formatDateTime(
+                        pipelineStatusQuery.data.nextScheduledRun,
+                      ) ?? pipelineStatusQuery.data.nextScheduledRun}
+                    </div>
+                  ) : null}
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                  <MetricCard
+                    label="Last run"
+                    value={
+                      formatDateTime(latestRun.startedAt) ?? latestRun.startedAt
+                    }
+                  />
+                  <MetricCard
+                    label="Duration"
+                    value={formatPipelineDuration(getDurationMs(latestRun))}
+                  />
+                  <MetricCard
+                    label="Jobs discovered"
+                    value={latestRun.jobsDiscovered.toLocaleString()}
+                  />
+                  <MetricCard
+                    label="Jobs processed"
+                    value={latestRun.jobsProcessed.toLocaleString()}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-3">
+                <div className="flex items-center gap-2">
+                  <Clock3 className="h-4 w-4 text-muted-foreground" />
+                  <div className="font-medium">Recent runs</div>
+                </div>
+                {runsError ? (
+                  <div className="rounded-lg border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-sm text-amber-100">
+                    Recent run history could not be refreshed just now.
+                  </div>
+                ) : null}
+                <RunsList
+                  runs={recentRuns}
+                  activeRunId={activeRunId}
+                  selectedRunId={selectedRunId}
+                  onSelectRun={setSelectedRunId}
+                />
+              </div>
+            </>
+          ) : null}
+
+          {!isLoading && !error && !latestRun ? (
+            <div className="rounded-lg border border-dashed border-border/60 px-4 py-8 text-center">
+              <div className="font-medium">No pipeline runs yet</div>
+              <div className="mt-1 text-sm text-muted-foreground">
+                Once the pipeline runs, this section will show status, recent
+                history, and inferred changes.
+              </div>
+            </div>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Sheet
+        open={selectedRunId != null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedRunId(null);
+        }}
+      >
+        <SheetContent
+          side="right"
+          className="w-full overflow-y-auto sm:max-w-2xl"
+        >
+          <SheetHeader>
+            <SheetTitle className="flex items-center gap-2">
+              <GitCompareArrows className="h-4 w-4" />
+              Run details
+            </SheetTitle>
+            <SheetDescription>
+              {selectedRun
+                ? `Inspect exact and inferred signals for run ${selectedRun.id.slice(
+                    0,
+                    8,
+                  )}.`
+                : "Inspect exact and inferred signals for the selected run."}
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="mt-6">
+            {runInsightsQuery.isLoading ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span>Loading run details…</span>
+              </div>
+            ) : null}
+
+            {runInsightsQuery.error ? (
+              <div className="rounded-lg border border-destructive/20 bg-destructive/10 p-3 text-sm text-destructive">
+                {runInsightsQuery.error instanceof Error
+                  ? runInsightsQuery.error.message
+                  : "Failed to load run details"}
+              </div>
+            ) : null}
+
+            {runInsightsQuery.data ? (
+              <RunInsightsBody
+                insights={runInsightsQuery.data}
+                isActiveRun={activeRunId === runInsightsQuery.data.run.id}
+              />
+            ) : null}
+
+            {!runInsightsQuery.isLoading &&
+            !runInsightsQuery.error &&
+            selectedRunId != null &&
+            !runInsightsQuery.data ? (
+              <div className="rounded-lg border border-border/60 bg-muted/20 p-4 text-sm text-muted-foreground">
+                <div className="flex items-center gap-2 font-medium text-foreground">
+                  <AlertCircle className="h-4 w-4" />
+                  <span>Run details unavailable</span>
+                </div>
+                <div className="mt-2">
+                  The selected run could not be loaded. Try selecting it again.
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+};

--- a/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.tsx
+++ b/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.tsx
@@ -2,6 +2,7 @@ import * as api from "@client/api";
 import { ListItem } from "@client/components/layout";
 import { PipelineProgress } from "@client/components/PipelineProgress";
 import { queryKeys } from "@client/lib/queryKeys";
+import { sourceLabel } from "@shared/extractors";
 import type { PipelineRun, PipelineRunInsights } from "@shared/types";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -93,6 +94,19 @@ function RunStatusBadge(props: { status: PipelineRunDisplayStatus }) {
   );
 }
 
+function formatSourceList(sources: string[]) {
+  if (sources.length === 0) return "None";
+  return sources.join(", ");
+}
+
+function formatToggleState(value: boolean) {
+  return value ? "Enabled" : "Disabled";
+}
+
+function formatStageLabel(stage: string) {
+  return stage.replace(/_/g, " ");
+}
+
 function RunsList(props: {
   runs: PipelineRun[];
   activeRunId: string | null;
@@ -172,6 +186,7 @@ function RunInsightsBody(props: {
   isActiveRun: boolean;
 }) {
   const { run, exactMetrics, inferredMetrics } = props.insights;
+  const savedDetails = props.insights.savedDetails;
   const displayStatus = getPipelineRunDisplayStatus(run, {
     isActive: props.isActiveRun,
   });
@@ -215,6 +230,193 @@ function RunInsightsBody(props: {
           <div className="mt-1 text-muted-foreground">{runReason}</div>
         </div>
       ) : null}
+
+      <div className="space-y-3">
+        <div className="font-medium">Saved settings</div>
+        {savedDetails ? (
+          <div className="space-y-4">
+            <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+              <div className="text-sm font-medium">Requested run</div>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <MetricCard
+                  label="Top N"
+                  value={savedDetails.requestedConfig.topN.toLocaleString()}
+                />
+                <MetricCard
+                  label="Min suitability score"
+                  value={savedDetails.requestedConfig.minSuitabilityScore.toLocaleString()}
+                />
+                <MetricCard
+                  label="Sources"
+                  value={formatSourceList(
+                    savedDetails.requestedConfig.sources.map(sourceLabel),
+                  )}
+                />
+                <MetricCard
+                  label="Crawling"
+                  value={formatToggleState(
+                    savedDetails.requestedConfig.enableCrawling,
+                  )}
+                />
+                <MetricCard
+                  label="Scoring"
+                  value={formatToggleState(
+                    savedDetails.requestedConfig.enableScoring,
+                  )}
+                />
+                <MetricCard
+                  label="Importing"
+                  value={formatToggleState(
+                    savedDetails.requestedConfig.enableImporting,
+                  )}
+                />
+                <MetricCard
+                  label="Auto tailoring"
+                  value={formatToggleState(
+                    savedDetails.requestedConfig.enableAutoTailoring,
+                  )}
+                />
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+              <div className="text-sm font-medium">Effective settings</div>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <MetricCard
+                  label="Country"
+                  value={
+                    savedDetails.effectiveConfig.countryLabel ??
+                    "Not restricted"
+                  }
+                />
+                <MetricCard
+                  label="Cities"
+                  value={
+                    savedDetails.effectiveConfig.searchCities.length > 0
+                      ? savedDetails.effectiveConfig.searchCities.join(", ")
+                      : "Not restricted"
+                  }
+                />
+                <MetricCard
+                  label="Workplace types"
+                  value={
+                    savedDetails.effectiveConfig.workplaceTypes.length > 0
+                      ? savedDetails.effectiveConfig.workplaceTypes.join(", ")
+                      : "Not restricted"
+                  }
+                />
+                <MetricCard
+                  label="Location matching"
+                  value={`${formatStageLabel(
+                    savedDetails.effectiveConfig.locationSearchScope,
+                  )}; ${formatStageLabel(
+                    savedDetails.effectiveConfig.locationMatchStrictness,
+                  )}`}
+                />
+                <MetricCard
+                  label="Compatible sources"
+                  value={formatSourceList(
+                    savedDetails.effectiveConfig.compatibleSources.map(
+                      sourceLabel,
+                    ),
+                  )}
+                />
+                <MetricCard
+                  label="Skipped sources"
+                  value={
+                    savedDetails.effectiveConfig.skippedSources.length > 0
+                      ? savedDetails.effectiveConfig.skippedSources
+                          .map((entry) => sourceLabel(entry.source))
+                          .join(", ")
+                      : "None"
+                  }
+                  hint={
+                    savedDetails.effectiveConfig.skippedSources.length > 0
+                      ? savedDetails.effectiveConfig.skippedSources
+                          .map((entry) => entry.reason)
+                          .join(" ")
+                      : null
+                  }
+                />
+                <MetricCard
+                  label="Search terms"
+                  value={savedDetails.effectiveConfig.searchTermsCount.toLocaleString()}
+                />
+                <MetricCard
+                  label="Blocked company filters"
+                  value={savedDetails.effectiveConfig.blockedCompanyKeywordsCount.toLocaleString()}
+                />
+                <MetricCard
+                  label="Auto-skip threshold"
+                  value={
+                    savedDetails.effectiveConfig.autoSkipScoreThreshold == null
+                      ? "Off"
+                      : savedDetails.effectiveConfig.autoSkipScoreThreshold.toLocaleString()
+                  }
+                />
+                <MetricCard
+                  label="PDF renderer"
+                  value={savedDetails.effectiveConfig.pdfRenderer}
+                />
+                <MetricCard
+                  label="Source limits"
+                  value={`Indeed ${savedDetails.effectiveConfig.sourceLimits.jobspyResultsWanted}; UK Visa Jobs ${savedDetails.effectiveConfig.sourceLimits.ukvisajobsMaxJobs}`}
+                  hint={`Adzuna ${savedDetails.effectiveConfig.sourceLimits.adzunaMaxJobsPerTerm}; Gradcracker ${savedDetails.effectiveConfig.sourceLimits.gradcrackerMaxJobsPerTerm}; startup.jobs ${savedDetails.effectiveConfig.sourceLimits.startupjobsMaxJobsPerTerm}`}
+                />
+                <MetricCard
+                  label="Resume projects"
+                  value={`${savedDetails.effectiveConfig.resumeProjects.maxProjects} max`}
+                  hint={`${savedDetails.effectiveConfig.resumeProjects.lockedProjectCount} locked, ${savedDetails.effectiveConfig.resumeProjects.aiSelectableProjectCount} AI-selectable`}
+                />
+                <MetricCard
+                  label="Models"
+                  value={savedDetails.effectiveConfig.models.scorer}
+                  hint={`Tailoring ${savedDetails.effectiveConfig.models.tailoring}; project selection ${savedDetails.effectiveConfig.models.projectSelection}`}
+                />
+              </div>
+            </div>
+
+            <div className="rounded-lg border border-border/60 bg-muted/20 p-3">
+              <div className="text-sm font-medium">Saved execution summary</div>
+              <div className="mt-3 grid gap-3 sm:grid-cols-2">
+                <MetricCard
+                  label="Last recorded stage"
+                  value={formatStageLabel(savedDetails.resultSummary.stage)}
+                />
+                <MetricCard
+                  label="Jobs scored"
+                  value={
+                    savedDetails.resultSummary.jobsScored == null
+                      ? "Not recorded"
+                      : savedDetails.resultSummary.jobsScored.toLocaleString()
+                  }
+                />
+                <MetricCard
+                  label="Jobs selected"
+                  value={
+                    savedDetails.resultSummary.jobsSelected == null
+                      ? "Not recorded"
+                      : savedDetails.resultSummary.jobsSelected.toLocaleString()
+                  }
+                />
+                <MetricCard
+                  label="Source errors"
+                  value={savedDetails.resultSummary.sourceErrors.length.toLocaleString()}
+                />
+              </div>
+              {savedDetails.resultSummary.sourceErrors.length > 0 ? (
+                <div className="mt-3 rounded-lg border border-border/60 bg-background/40 p-3 text-sm text-muted-foreground">
+                  {savedDetails.resultSummary.sourceErrors.join(" ")}
+                </div>
+              ) : null}
+            </div>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-border/60 bg-muted/20 p-3 text-sm text-muted-foreground">
+            Saved run settings are available for newer pipeline runs.
+          </div>
+        )}
+      </div>
 
       <div className="space-y-3">
         <div className="flex flex-wrap items-center gap-2">

--- a/orchestrator/src/client/pages/overview/pipelineRuns.ts
+++ b/orchestrator/src/client/pages/overview/pipelineRuns.ts
@@ -1,0 +1,48 @@
+import type { PipelineRun } from "@shared/types";
+
+export type PipelineRunDisplayStatus = PipelineRun["status"] | "incomplete";
+
+export function getPipelineRunDisplayStatus(
+  run: PipelineRun,
+  options?: { isActive?: boolean },
+): PipelineRunDisplayStatus {
+  if (options?.isActive && run.status === "running") {
+    return "running";
+  }
+
+  if (run.status === "running" && run.completedAt == null) {
+    return "incomplete";
+  }
+
+  return run.status;
+}
+
+export function getPipelineRunStatusLabel(
+  status: PipelineRunDisplayStatus,
+): string {
+  switch (status) {
+    case "running":
+      return "Running";
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "cancelled":
+      return "Cancelled";
+    case "incomplete":
+      return "Incomplete";
+  }
+}
+
+export function formatPipelineDuration(durationMs: number | null): string {
+  if (durationMs == null) return "—";
+
+  const totalSeconds = Math.max(0, Math.round(durationMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) return `${hours}h ${minutes}m`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -24,6 +24,158 @@ describe.sequential("Pipeline API routes", () => {
     expect(body.data.lastRun).toBeNull();
   });
 
+  it("returns recent pipeline runs in the API envelope", async () => {
+    const { db, schema } = await import("@server/db");
+
+    await db.insert(schema.pipelineRuns).values({
+      id: "run-history-1",
+      startedAt: "2026-04-18T10:00:00.000Z",
+      completedAt: "2026-04-18T10:05:00.000Z",
+      status: "completed",
+      jobsDiscovered: 12,
+      jobsProcessed: 3,
+      errorMessage: null,
+    });
+
+    const res = await fetch(`${baseUrl}/api/pipeline/runs`);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.meta.requestId).toBeTruthy();
+    expect(body.data).toEqual([
+      expect.objectContaining({
+        id: "run-history-1",
+        status: "completed",
+        jobsDiscovered: 12,
+        jobsProcessed: 3,
+      }),
+    ]);
+  });
+
+  it("returns pipeline run insights for a completed run", async () => {
+    const { db, schema } = await import("@server/db");
+
+    await db.insert(schema.pipelineRuns).values({
+      id: "run-insight-1",
+      startedAt: "2026-04-18T10:00:00.000Z",
+      completedAt: "2026-04-18T10:10:00.000Z",
+      status: "completed",
+      jobsDiscovered: 8,
+      jobsProcessed: 1,
+      errorMessage: null,
+    });
+
+    await db.insert(schema.jobs).values([
+      {
+        id: "job-in-window-1",
+        source: "manual",
+        title: "Backend Engineer",
+        employer: "Acme",
+        jobUrl: "https://example.com/jobs/1",
+        discoveredAt: "2026-04-18T10:01:00.000Z",
+        createdAt: "2026-04-18T10:01:00.000Z",
+        updatedAt: "2026-04-18T10:03:00.000Z",
+        processedAt: "2026-04-18T10:06:00.000Z",
+      },
+      {
+        id: "job-in-window-2",
+        source: "manual",
+        title: "Platform Engineer",
+        employer: "Acme",
+        jobUrl: "https://example.com/jobs/2",
+        discoveredAt: "2026-04-18T10:02:00.000Z",
+        createdAt: "2026-04-18T10:02:00.000Z",
+        updatedAt: "2026-04-18T10:08:00.000Z",
+      },
+      {
+        id: "job-outside-window",
+        source: "manual",
+        title: "Site Reliability Engineer",
+        employer: "Acme",
+        jobUrl: "https://example.com/jobs/3",
+        discoveredAt: "2026-04-18T09:40:00.000Z",
+        createdAt: "2026-04-18T09:40:00.000Z",
+        updatedAt: "2026-04-18T09:50:00.000Z",
+        processedAt: "2026-04-18T09:55:00.000Z",
+      },
+    ]);
+
+    const res = await fetch(
+      `${baseUrl}/api/pipeline/runs/run-insight-1/insights`,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.meta.requestId).toBeTruthy();
+    expect(body.data.run).toEqual(
+      expect.objectContaining({
+        id: "run-insight-1",
+        status: "completed",
+      }),
+    );
+    expect(body.data.exactMetrics.durationMs).toBe(600000);
+    expect(body.data.inferredMetrics.jobsCreated).toEqual({
+      value: 2,
+      quality: "inferred_from_timestamps",
+    });
+    expect(body.data.inferredMetrics.jobsUpdated).toEqual({
+      value: 2,
+      quality: "inferred_from_timestamps",
+    });
+    expect(body.data.inferredMetrics.jobsProcessed).toEqual({
+      value: 1,
+      quality: "inferred_from_timestamps",
+    });
+  });
+
+  it("returns unavailable inferred metrics for incomplete runs", async () => {
+    const { db, schema } = await import("@server/db");
+
+    await db.insert(schema.pipelineRuns).values({
+      id: "run-incomplete-1",
+      startedAt: "2026-04-18T11:00:00.000Z",
+      completedAt: null,
+      status: "running",
+      jobsDiscovered: 4,
+      jobsProcessed: 0,
+      errorMessage: null,
+    });
+
+    const res = await fetch(
+      `${baseUrl}/api/pipeline/runs/run-incomplete-1/insights`,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.inferredMetrics.jobsCreated).toEqual({
+      value: null,
+      quality: "unavailable",
+    });
+    expect(body.data.inferredMetrics.jobsUpdated).toEqual({
+      value: null,
+      quality: "unavailable",
+    });
+    expect(body.data.inferredMetrics.jobsProcessed).toEqual({
+      value: null,
+      quality: "unavailable",
+    });
+  });
+
+  it("returns not found for an unknown run insights request", async () => {
+    const res = await fetch(
+      `${baseUrl}/api/pipeline/runs/does-not-exist/insights`,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(body.meta.requestId).toBeTruthy();
+  });
+
   it("validates pipeline run payloads", async () => {
     const badRun = await fetch(`${baseUrl}/api/pipeline/run`, {
       method: "POST",

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -64,6 +64,52 @@ describe.sequential("Pipeline API routes", () => {
       jobsDiscovered: 8,
       jobsProcessed: 1,
       errorMessage: null,
+      requestedConfig: {
+        topN: 10,
+        minSuitabilityScore: 55,
+        sources: ["linkedin", "indeed"],
+        enableCrawling: true,
+        enableScoring: true,
+        enableImporting: true,
+        enableAutoTailoring: true,
+      },
+      effectiveConfig: {
+        country: "united states",
+        countryLabel: "United States",
+        searchCities: ["London"],
+        searchTermsCount: 2,
+        workplaceTypes: ["remote"],
+        locationSearchScope: "selected_only",
+        locationMatchStrictness: "exact_only",
+        compatibleSources: ["linkedin", "indeed"],
+        skippedSources: [],
+        blockedCompanyKeywordsCount: 1,
+        sourceLimits: {
+          ukvisajobsMaxJobs: 50,
+          adzunaMaxJobsPerTerm: 50,
+          gradcrackerMaxJobsPerTerm: 50,
+          startupjobsMaxJobsPerTerm: 50,
+          jobspyResultsWanted: 20,
+        },
+        autoSkipScoreThreshold: 65,
+        pdfRenderer: "rxresume",
+        models: {
+          scorer: "model-scorer",
+          tailoring: "model-tailoring",
+          projectSelection: "model-project-selection",
+        },
+        resumeProjects: {
+          maxProjects: 3,
+          lockedProjectCount: 1,
+          aiSelectableProjectCount: 2,
+        },
+      },
+      resultSummary: {
+        stage: "processing",
+        jobsScored: 5,
+        jobsSelected: 2,
+        sourceErrors: ["indeed: upstream timeout"],
+      },
     });
 
     await db.insert(schema.jobs).values([
@@ -116,6 +162,18 @@ describe.sequential("Pipeline API routes", () => {
       }),
     );
     expect(body.data.exactMetrics.durationMs).toBe(600000);
+    expect(body.data.savedDetails).toEqual(
+      expect.objectContaining({
+        requestedConfig: expect.objectContaining({
+          topN: 10,
+          sources: ["linkedin", "indeed"],
+        }),
+        resultSummary: expect.objectContaining({
+          stage: "processing",
+          sourceErrors: ["indeed: upstream timeout"],
+        }),
+      }),
+    );
     expect(body.data.inferredMetrics.jobsCreated).toEqual({
       value: 2,
       quality: "inferred_from_timestamps",
@@ -150,6 +208,7 @@ describe.sequential("Pipeline API routes", () => {
 
     expect(res.status).toBe(200);
     expect(body.ok).toBe(true);
+    expect(body.data.savedDetails).toBeNull();
     expect(body.data.inferredMetrics.jobsCreated).toEqual({
       value: null,
       quality: "unavailable",

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -2,6 +2,7 @@ import {
   AppError,
   badRequest,
   conflict,
+  notFound,
   requestTimeout,
   serviceUnavailable,
 } from "@infra/errors";
@@ -100,6 +101,31 @@ pipelineRouter.get("/runs", async (_req: Request, res: Response) => {
     );
   }
 });
+
+/**
+ * GET /api/pipeline/runs/:id/insights - Get exact and inferred metrics for a run
+ */
+pipelineRouter.get(
+  "/runs/:id/insights",
+  async (req: Request, res: Response) => {
+    try {
+      const insights = await pipelineRepo.getPipelineRunInsights(req.params.id);
+      if (!insights) {
+        return fail(res, notFound("Pipeline run not found"));
+      }
+      ok(res, insights);
+    } catch (error) {
+      fail(
+        res,
+        new AppError({
+          status: 500,
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "Unknown error",
+        }),
+      );
+    }
+  },
+);
 
 /**
  * POST /api/pipeline/run - Trigger the pipeline manually

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -87,7 +87,10 @@ const migrations = [
     status TEXT NOT NULL DEFAULT 'running' CHECK(status IN ('running', 'completed', 'failed', 'cancelled')),
     jobs_discovered INTEGER NOT NULL DEFAULT 0,
     jobs_processed INTEGER NOT NULL DEFAULT 0,
-    error_message TEXT
+    error_message TEXT,
+    requested_config TEXT,
+    effective_config TEXT,
+    result_summary TEXT
   )`,
 
   `CREATE TABLE IF NOT EXISTS settings (
@@ -441,13 +444,20 @@ const migrations = [
     status TEXT NOT NULL DEFAULT 'running' CHECK(status IN ('running', 'completed', 'failed', 'cancelled')),
     jobs_discovered INTEGER NOT NULL DEFAULT 0,
     jobs_processed INTEGER NOT NULL DEFAULT 0,
-    error_message TEXT
+    error_message TEXT,
+    requested_config TEXT,
+    effective_config TEXT,
+    result_summary TEXT
   )`,
-  `INSERT OR REPLACE INTO pipeline_runs_new (id, started_at, completed_at, status, jobs_discovered, jobs_processed, error_message)
-   SELECT id, started_at, completed_at, status, jobs_discovered, jobs_processed, error_message
+  `INSERT OR REPLACE INTO pipeline_runs_new (id, started_at, completed_at, status, jobs_discovered, jobs_processed, error_message, requested_config, effective_config, result_summary)
+   SELECT id, started_at, completed_at, status, jobs_discovered, jobs_processed, error_message, NULL, NULL, NULL
    FROM pipeline_runs`,
   `DROP TABLE IF EXISTS pipeline_runs`,
   `ALTER TABLE pipeline_runs_new RENAME TO pipeline_runs`,
+
+  `ALTER TABLE pipeline_runs ADD COLUMN requested_config TEXT`,
+  `ALTER TABLE pipeline_runs ADD COLUMN effective_config TEXT`,
+  `ALTER TABLE pipeline_runs ADD COLUMN result_summary TEXT`,
 
   // Ensure jobs status supports "in_progress" for existing databases.
   `CREATE TABLE IF NOT EXISTS jobs_new (
@@ -721,6 +731,9 @@ for (const migration of migrations) {
     const message = error instanceof Error ? error.message : String(error);
     const isDuplicateColumn =
       (migration.toLowerCase().includes("alter table jobs add column") ||
+        migration
+          .toLowerCase()
+          .includes("alter table pipeline_runs add column") ||
         migration.toLowerCase().includes("alter table tasks add column") ||
         migration
           .toLowerCase()

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -455,10 +455,6 @@ const migrations = [
   `DROP TABLE IF EXISTS pipeline_runs`,
   `ALTER TABLE pipeline_runs_new RENAME TO pipeline_runs`,
 
-  `ALTER TABLE pipeline_runs ADD COLUMN requested_config TEXT`,
-  `ALTER TABLE pipeline_runs ADD COLUMN effective_config TEXT`,
-  `ALTER TABLE pipeline_runs ADD COLUMN result_summary TEXT`,
-
   // Ensure jobs status supports "in_progress" for existing databases.
   `CREATE TABLE IF NOT EXISTS jobs_new (
     id TEXT PRIMARY KEY,

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -184,6 +184,9 @@ export const pipelineRuns = sqliteTable("pipeline_runs", {
   jobsDiscovered: integer("jobs_discovered").notNull().default(0),
   jobsProcessed: integer("jobs_processed").notNull().default(0),
   errorMessage: text("error_message"),
+  requestedConfig: text("requested_config", { mode: "json" }),
+  effectiveConfig: text("effective_config", { mode: "json" }),
+  resultSummary: text("result_summary", { mode: "json" }),
 });
 
 export const jobChatThreads = sqliteTable(

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -11,7 +11,7 @@ import { join } from "node:path";
 import { logger } from "@infra/logger";
 import { trackServerProductEvent } from "@infra/product-analytics";
 import { runWithRequestContext } from "@infra/request-context";
-import type { PipelineConfig } from "@shared/types";
+import type { PipelineConfig, PipelineRunSavedDetails } from "@shared/types";
 import { getDataDir } from "../config/dataDir";
 import * as jobsRepo from "../repositories/jobs";
 import * as pipelineRepo from "../repositories/pipeline";
@@ -25,6 +25,11 @@ import {
 } from "../services/resumeProjects";
 import { generateTailoring } from "../services/summary";
 import { progressHelpers, resetProgress } from "./progress";
+import {
+  buildPipelineRunSavedDetails,
+  createPipelineRunResultSummary,
+  updatePipelineRunResultSummary,
+} from "./run-details";
 import {
   discoverJobsStep,
   importJobsStep,
@@ -90,14 +95,32 @@ export async function runPipeline(
   cancelRequestedAt = null;
   resetProgress();
   const mergedConfig = { ...DEFAULT_CONFIG, ...config };
+  let savedDetails: PipelineRunSavedDetails | null = null;
+  try {
+    savedDetails = await buildPipelineRunSavedDetails(mergedConfig);
+  } catch (error) {
+    logger.warn("Failed to capture pipeline run settings snapshot", { error });
+  }
 
-  const pipelineRun = await pipelineRepo.createPipelineRun();
+  const pipelineRun = await pipelineRepo.createPipelineRun({
+    savedDetails,
+  });
   activePipelineRunId = pipelineRun.id;
 
   return runWithRequestContext({ pipelineRunId: pipelineRun.id }, async () => {
     const pipelineLogger = logger.child({ pipelineRunId: pipelineRun.id });
     let jobsDiscovered = 0;
     let jobsProcessed = 0;
+    let resultSummary =
+      savedDetails?.resultSummary ?? createPipelineRunResultSummary();
+    const persistResultSummary = async (
+      update: Parameters<typeof updatePipelineRunResultSummary>[1],
+    ) => {
+      resultSummary = updatePipelineRunResultSummary(resultSummary, update);
+      await pipelineRepo.updatePipelineRun(pipelineRun.id, {
+        resultSummary,
+      });
+    };
     pipelineLogger.info("Starting pipeline run", {
       topN: mergedConfig.topN,
       minSuitabilityScore: mergedConfig.minSuitabilityScore,
@@ -106,38 +129,62 @@ export async function runPipeline(
 
     try {
       ensureNotCancelled();
+      await persistResultSummary({ stage: "started" });
       const profile = await loadProfileStep();
+      await persistResultSummary({ stage: "profile_loaded" });
 
       ensureNotCancelled();
-      const { discoveredJobs } = await discoverJobsStep({
+      await persistResultSummary({ stage: "discovery" });
+      const { discoveredJobs, sourceErrors } = await discoverJobsStep({
         mergedConfig,
         shouldCancel: () => cancelRequestedAt !== null,
+      });
+      await persistResultSummary({
+        stage: "discovery",
+        sourceErrors,
       });
 
       ensureNotCancelled();
       const { created } = await importJobsStep({ discoveredJobs });
       jobsDiscovered = created;
 
+      await persistResultSummary({ stage: "import" });
       await pipelineRepo.updatePipelineRun(pipelineRun.id, {
         jobsDiscovered: created,
       });
 
       ensureNotCancelled();
+      await persistResultSummary({ stage: "scoring" });
       const { unprocessedJobs, scoredJobs } = await scoreJobsStep({
         profile,
         shouldCancel: () => cancelRequestedAt !== null,
       });
+      await persistResultSummary({
+        stage: "scoring",
+        jobsScored: scoredJobs.length,
+      });
 
       ensureNotCancelled();
+      await persistResultSummary({ stage: "selection" });
       const jobsToProcess = await selectJobsStep({
         scoredJobs,
         mergedConfig,
+      });
+      await persistResultSummary({
+        stage: "selection",
+        jobsScored: scoredJobs.length,
+        jobsSelected: jobsToProcess.length,
       });
 
       pipelineLogger.info("Selected jobs for processing", {
         candidates: jobsToProcess.length,
       });
 
+      await persistResultSummary({
+        stage: "processing",
+        jobsScored: scoredJobs.length,
+        jobsSelected: jobsToProcess.length,
+      });
       const { processedCount } = await processJobsStep({
         jobsToProcess,
         processJob,
@@ -145,10 +192,16 @@ export async function runPipeline(
       });
       jobsProcessed = processedCount;
 
+      resultSummary = updatePipelineRunResultSummary(resultSummary, {
+        stage: "completed",
+        jobsScored: scoredJobs.length,
+        jobsSelected: jobsToProcess.length,
+      });
       await pipelineRepo.updatePipelineRun(pipelineRun.id, {
         status: "completed",
         completedAt: new Date().toISOString(),
         jobsProcessed: processedCount,
+        resultSummary,
       });
 
       progressHelpers.complete(created, processedCount);
@@ -178,6 +231,7 @@ export async function runPipeline(
           jobsDiscovered,
           jobsProcessed,
           errorMessage: message,
+          resultSummary,
         });
         progressHelpers.cancelled(message);
         pipelineLogger.info("Pipeline run cancelled", {
@@ -198,6 +252,7 @@ export async function runPipeline(
         status: "failed",
         completedAt: new Date().toISOString(),
         errorMessage: message,
+        resultSummary,
       });
 
       progressHelpers.failed(message);

--- a/orchestrator/src/server/pipeline/run-details.ts
+++ b/orchestrator/src/server/pipeline/run-details.ts
@@ -1,0 +1,124 @@
+import {
+  formatCountryLabel,
+  getCompatibleSourcesForCountry,
+} from "@shared/location-support.js";
+import { parseSearchCitiesSetting } from "@shared/search-cities.js";
+import type {
+  AppSettings,
+  PipelineConfig,
+  PipelineRunEffectiveConfig,
+  PipelineRunExecutionStage,
+  PipelineRunRequestedConfig,
+  PipelineRunResultSummary,
+  PipelineRunSavedDetails,
+} from "@shared/types";
+import { getEffectiveSettings } from "../services/settings";
+
+export function buildRequestedConfigSnapshot(
+  config: PipelineConfig,
+): PipelineRunRequestedConfig {
+  return {
+    topN: config.topN,
+    minSuitabilityScore: config.minSuitabilityScore,
+    sources: [...config.sources],
+    enableCrawling: config.enableCrawling !== false,
+    enableScoring: config.enableScoring !== false,
+    enableImporting: config.enableImporting !== false,
+    enableAutoTailoring: config.enableAutoTailoring !== false,
+  };
+}
+
+function buildEffectiveConfigSnapshot(args: {
+  requestedConfig: PipelineRunRequestedConfig;
+  settings: AppSettings;
+}): PipelineRunEffectiveConfig {
+  const country = args.settings.jobspyCountryIndeed.value.trim() || null;
+  const compatibleSources = getCompatibleSourcesForCountry(
+    args.requestedConfig.sources,
+    country,
+  );
+  const skippedSources = args.requestedConfig.sources
+    .filter((source) => !compatibleSources.includes(source))
+    .map((source) => ({
+      source,
+      reason: country
+        ? `Not available for ${formatCountryLabel(country) || country}`
+        : "Not selected at runtime",
+    }));
+
+  return {
+    country,
+    countryLabel: country ? formatCountryLabel(country) || country : null,
+    searchCities: parseSearchCitiesSetting(args.settings.searchCities.value),
+    searchTermsCount: args.settings.searchTerms.value.length,
+    workplaceTypes: [...args.settings.workplaceTypes.value],
+    locationSearchScope: args.settings.locationSearchScope.value,
+    locationMatchStrictness: args.settings.locationMatchStrictness.value,
+    compatibleSources,
+    skippedSources,
+    blockedCompanyKeywordsCount:
+      args.settings.blockedCompanyKeywords.value.length,
+    sourceLimits: {
+      ukvisajobsMaxJobs: args.settings.ukvisajobsMaxJobs.value,
+      adzunaMaxJobsPerTerm: args.settings.adzunaMaxJobsPerTerm.value,
+      gradcrackerMaxJobsPerTerm: args.settings.gradcrackerMaxJobsPerTerm.value,
+      startupjobsMaxJobsPerTerm: args.settings.startupjobsMaxJobsPerTerm.value,
+      jobspyResultsWanted: args.settings.jobspyResultsWanted.value,
+    },
+    autoSkipScoreThreshold: args.settings.autoSkipScoreThreshold.value,
+    pdfRenderer: args.settings.pdfRenderer.value,
+    models: {
+      scorer: args.settings.modelScorer.value,
+      tailoring: args.settings.modelTailoring.value,
+      projectSelection: args.settings.modelProjectSelection.value,
+    },
+    resumeProjects: {
+      maxProjects: args.settings.resumeProjects.value.maxProjects,
+      lockedProjectCount:
+        args.settings.resumeProjects.value.lockedProjectIds.length,
+      aiSelectableProjectCount:
+        args.settings.resumeProjects.value.aiSelectableProjectIds.length,
+    },
+  };
+}
+
+export async function buildPipelineRunSavedDetails(
+  config: PipelineConfig,
+): Promise<PipelineRunSavedDetails> {
+  const requestedConfig = buildRequestedConfigSnapshot(config);
+  const settings = await getEffectiveSettings();
+
+  return {
+    requestedConfig,
+    effectiveConfig: buildEffectiveConfigSnapshot({
+      requestedConfig,
+      settings,
+    }),
+    resultSummary: createPipelineRunResultSummary(),
+  };
+}
+
+export function createPipelineRunResultSummary(
+  overrides: Partial<PipelineRunResultSummary> = {},
+): PipelineRunResultSummary {
+  return {
+    stage: "started",
+    jobsScored: null,
+    jobsSelected: null,
+    sourceErrors: [],
+    ...overrides,
+  };
+}
+
+export function updatePipelineRunResultSummary(
+  current: PipelineRunResultSummary | null | undefined,
+  update: Partial<PipelineRunResultSummary> & {
+    stage?: PipelineRunExecutionStage;
+  },
+): PipelineRunResultSummary {
+  return {
+    ...createPipelineRunResultSummary(),
+    ...(current ?? {}),
+    ...update,
+  };
+}

--- a/orchestrator/src/server/repositories/pipeline.ts
+++ b/orchestrator/src/server/repositories/pipeline.ts
@@ -3,7 +3,12 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { PipelineRun, PipelineRunInsights } from "@shared/types";
+import type {
+  PipelineRun,
+  PipelineRunInsights,
+  PipelineRunResultSummary,
+  PipelineRunSavedDetails,
+} from "@shared/types";
 import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db, schema } from "../db/index";
 
@@ -23,10 +28,29 @@ function mapRowToPipelineRun(
   };
 }
 
+function mapRowToSavedDetails(
+  row: typeof schema.pipelineRuns.$inferSelect,
+): PipelineRunSavedDetails | null {
+  if (!row.requestedConfig || !row.effectiveConfig || !row.resultSummary) {
+    return null;
+  }
+
+  return {
+    requestedConfig:
+      row.requestedConfig as PipelineRunSavedDetails["requestedConfig"],
+    effectiveConfig:
+      row.effectiveConfig as PipelineRunSavedDetails["effectiveConfig"],
+    resultSummary:
+      row.resultSummary as PipelineRunSavedDetails["resultSummary"],
+  };
+}
+
 /**
  * Create a new pipeline run.
  */
-export async function createPipelineRun(): Promise<PipelineRun> {
+export async function createPipelineRun(args?: {
+  savedDetails?: PipelineRunSavedDetails | null;
+}): Promise<PipelineRun> {
   const id = randomUUID();
   const now = new Date().toISOString();
 
@@ -34,6 +58,9 @@ export async function createPipelineRun(): Promise<PipelineRun> {
     id,
     startedAt: now,
     status: "running",
+    requestedConfig: args?.savedDetails?.requestedConfig ?? null,
+    effectiveConfig: args?.savedDetails?.effectiveConfig ?? null,
+    resultSummary: args?.savedDetails?.resultSummary ?? null,
   });
 
   return {
@@ -58,6 +85,7 @@ export async function updatePipelineRun(
     jobsDiscovered: number;
     jobsProcessed: number;
     errorMessage: string;
+    resultSummary: PipelineRunResultSummary | null;
   }>,
 ): Promise<void> {
   await db.update(pipelineRuns).set(update).where(eq(pipelineRuns.id, id));
@@ -108,8 +136,15 @@ export async function getPipelineRunById(
 export async function getPipelineRunInsights(
   id: string,
 ): Promise<PipelineRunInsights | null> {
-  const run = await getPipelineRunById(id);
-  if (!run) return null;
+  const [row] = await db
+    .select()
+    .from(pipelineRuns)
+    .where(eq(pipelineRuns.id, id))
+    .limit(1);
+  if (!row) return null;
+
+  const run = mapRowToPipelineRun(row);
+  const savedDetails = mapRowToSavedDetails(row);
 
   const durationMs =
     run.completedAt == null
@@ -124,6 +159,7 @@ export async function getPipelineRunInsights(
     return {
       run,
       exactMetrics: { durationMs },
+      savedDetails,
       inferredMetrics: {
         jobsCreated: { value: null, quality: "unavailable" },
         jobsUpdated: { value: null, quality: "unavailable" },
@@ -166,6 +202,7 @@ export async function getPipelineRunInsights(
   return {
     run,
     exactMetrics: { durationMs },
+    savedDetails,
     inferredMetrics: {
       jobsCreated: {
         value: createdRow?.count ?? 0,

--- a/orchestrator/src/server/repositories/pipeline.ts
+++ b/orchestrator/src/server/repositories/pipeline.ts
@@ -3,11 +3,25 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { PipelineRun } from "@shared/types";
-import { desc, eq } from "drizzle-orm";
+import type { PipelineRun, PipelineRunInsights } from "@shared/types";
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db, schema } from "../db/index";
 
-const { pipelineRuns } = schema;
+const { jobs, pipelineRuns } = schema;
+
+function mapRowToPipelineRun(
+  row: typeof schema.pipelineRuns.$inferSelect,
+): PipelineRun {
+  return {
+    id: row.id,
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+    status: row.status as PipelineRun["status"],
+    jobsDiscovered: row.jobsDiscovered,
+    jobsProcessed: row.jobsProcessed,
+    errorMessage: row.errorMessage,
+  };
+}
 
 /**
  * Create a new pipeline run.
@@ -61,15 +75,7 @@ export async function getLatestPipelineRun(): Promise<PipelineRun | null> {
 
   if (!row) return null;
 
-  return {
-    id: row.id,
-    startedAt: row.startedAt,
-    completedAt: row.completedAt,
-    status: row.status as PipelineRun["status"],
-    jobsDiscovered: row.jobsDiscovered,
-    jobsProcessed: row.jobsProcessed,
-    errorMessage: row.errorMessage,
-  };
+  return mapRowToPipelineRun(row);
 }
 
 /**
@@ -84,13 +90,95 @@ export async function getRecentPipelineRuns(
     .orderBy(desc(pipelineRuns.startedAt))
     .limit(limit);
 
-  return rows.map((row) => ({
-    id: row.id,
-    startedAt: row.startedAt,
-    completedAt: row.completedAt,
-    status: row.status as PipelineRun["status"],
-    jobsDiscovered: row.jobsDiscovered,
-    jobsProcessed: row.jobsProcessed,
-    errorMessage: row.errorMessage,
-  }));
+  return rows.map(mapRowToPipelineRun);
+}
+
+export async function getPipelineRunById(
+  id: string,
+): Promise<PipelineRun | null> {
+  const [row] = await db
+    .select()
+    .from(pipelineRuns)
+    .where(eq(pipelineRuns.id, id))
+    .limit(1);
+
+  return row ? mapRowToPipelineRun(row) : null;
+}
+
+export async function getPipelineRunInsights(
+  id: string,
+): Promise<PipelineRunInsights | null> {
+  const run = await getPipelineRunById(id);
+  if (!run) return null;
+
+  const durationMs =
+    run.completedAt == null
+      ? null
+      : Math.max(
+          0,
+          new Date(run.completedAt).getTime() -
+            new Date(run.startedAt).getTime(),
+        );
+
+  if (!run.completedAt) {
+    return {
+      run,
+      exactMetrics: { durationMs },
+      inferredMetrics: {
+        jobsCreated: { value: null, quality: "unavailable" },
+        jobsUpdated: { value: null, quality: "unavailable" },
+        jobsProcessed: { value: null, quality: "unavailable" },
+      },
+    };
+  }
+
+  const countSelection = { count: sql<number>`count(*)` };
+  const [[createdRow], [updatedRow], [processedRow]] = await Promise.all([
+    db
+      .select(countSelection)
+      .from(jobs)
+      .where(
+        and(
+          gte(jobs.createdAt, run.startedAt),
+          lte(jobs.createdAt, run.completedAt),
+        ),
+      ),
+    db
+      .select(countSelection)
+      .from(jobs)
+      .where(
+        and(
+          gte(jobs.updatedAt, run.startedAt),
+          lte(jobs.updatedAt, run.completedAt),
+        ),
+      ),
+    db
+      .select(countSelection)
+      .from(jobs)
+      .where(
+        and(
+          gte(jobs.processedAt, run.startedAt),
+          lte(jobs.processedAt, run.completedAt),
+        ),
+      ),
+  ]);
+
+  return {
+    run,
+    exactMetrics: { durationMs },
+    inferredMetrics: {
+      jobsCreated: {
+        value: createdRow?.count ?? 0,
+        quality: "inferred_from_timestamps",
+      },
+      jobsUpdated: {
+        value: updatedRow?.count ?? 0,
+        quality: "inferred_from_timestamps",
+      },
+      jobsProcessed: {
+        value: processedRow?.count ?? 0,
+        quality: "inferred_from_timestamps",
+      },
+    },
+  };
 }

--- a/orchestrator/src/server/services/demo-simulator.ts
+++ b/orchestrator/src/server/services/demo-simulator.ts
@@ -1,5 +1,6 @@
 import { logger } from "@infra/logger";
 import * as pipeline from "@server/pipeline/index";
+import { buildPipelineRunSavedDetails } from "@server/pipeline/run-details";
 import * as jobsRepo from "@server/repositories/jobs";
 import * as pipelineRepo from "@server/repositories/pipeline";
 import { transitionStage } from "@server/services/applicationTracking";
@@ -50,7 +51,20 @@ async function ensureJob(jobId: string): Promise<Job> {
 export async function simulatePipelineRun(
   config?: Partial<PipelineConfig>,
 ): Promise<{ message: string; runId: string; jobsDiscovered: number }> {
-  const run = await pipelineRepo.createPipelineRun();
+  const mergedConfig: PipelineConfig = {
+    topN: config?.topN ?? 10,
+    minSuitabilityScore: config?.minSuitabilityScore ?? 50,
+    sources: config?.sources ?? ["manual"],
+    outputDir: "/tmp",
+    enableCrawling: config?.enableCrawling ?? true,
+    enableScoring: config?.enableScoring ?? true,
+    enableImporting: config?.enableImporting ?? true,
+    enableAutoTailoring: config?.enableAutoTailoring ?? true,
+  };
+  const savedDetails = await buildPipelineRunSavedDetails(mergedConfig).catch(
+    () => null,
+  );
+  const run = await pipelineRepo.createPipelineRun({ savedDetails });
   const source = config?.sources?.[0] ?? "manual";
   const now = new Date();
   const isoNow = now.toISOString();
@@ -73,6 +87,15 @@ export async function simulatePipelineRun(
     completedAt: isoNow,
     jobsDiscovered: 1,
     jobsProcessed: 0,
+    resultSummary: savedDetails?.resultSummary
+      ? {
+          ...savedDetails.resultSummary,
+          stage: "completed",
+          jobsScored: 0,
+          jobsSelected: 0,
+          sourceErrors: [],
+        }
+      : null,
   });
   pipeline.progressHelpers.complete(1, 0);
   logger.info("Simulated demo pipeline run", { pipelineRunId: run.id });

--- a/scripts/camoufox-fetch.mjs
+++ b/scripts/camoufox-fetch.mjs
@@ -1,0 +1,52 @@
+import { CamoufoxFetcher } from "camoufox-js/dist/pkgman.js";
+
+const githubToken = process.env.GITHUB_TOKEN?.trim() || "";
+const originalFetch = globalThis.fetch;
+
+function getUrl(input) {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.href;
+  if (input && typeof input === "object" && "url" in input) {
+    return String(input.url);
+  }
+  return "";
+}
+
+function shouldAttachGithubToken(url) {
+  return (
+    url.startsWith("https://api.github.com/") ||
+    url.startsWith("https://github.com/") ||
+    url.startsWith("https://objects.githubusercontent.com/")
+  );
+}
+
+if (githubToken) {
+  console.log("Using GITHUB_TOKEN for Camoufox GitHub downloads.");
+
+  globalThis.fetch = async (input, init) => {
+    const url = getUrl(input);
+    if (!shouldAttachGithubToken(url)) {
+      return originalFetch(input, init);
+    }
+
+    const headers = new Headers(
+      init?.headers ??
+        (input && typeof input === "object" && "headers" in input
+          ? input.headers
+          : undefined),
+    );
+
+    if (!headers.has("authorization")) {
+      headers.set("authorization", `Bearer ${githubToken}`);
+    }
+
+    if (url.startsWith("https://api.github.com/")) {
+      headers.set("accept", "application/vnd.github+json");
+      headers.set("x-github-api-version", "2022-11-28");
+    }
+
+    return originalFetch(input, { ...init, headers });
+  };
+}
+
+await new CamoufoxFetcher().install();

--- a/shared/src/types/pipeline.ts
+++ b/shared/src/types/pipeline.ts
@@ -28,6 +28,28 @@ export interface PipelineStatusResponse {
   nextScheduledRun: string | null;
 }
 
+export type PipelineMetricQuality =
+  | "exact"
+  | "inferred_from_timestamps"
+  | "unavailable";
+
+export interface PipelineRunMetric<T = number | null> {
+  value: T;
+  quality: PipelineMetricQuality;
+}
+
+export interface PipelineRunInsights {
+  run: PipelineRun;
+  exactMetrics: {
+    durationMs: number | null;
+  };
+  inferredMetrics: {
+    jobsCreated: PipelineRunMetric<number | null>;
+    jobsUpdated: PipelineRunMetric<number | null>;
+    jobsProcessed: PipelineRunMetric<number | null>;
+  };
+}
+
 export interface JobsListResponse<TJob = Job> {
   jobs: TJob[];
   total: number;

--- a/shared/src/types/pipeline.ts
+++ b/shared/src/types/pipeline.ts
@@ -1,5 +1,10 @@
 import type { ExtractorSourceId } from "../extractors";
+import type {
+  LocationMatchStrictness,
+  LocationSearchScope,
+} from "../location-preferences";
 import type { Job, JobStatus } from "./jobs";
+import type { PdfRenderer } from "./settings";
 
 export interface PipelineConfig {
   topN: number; // Number of top jobs to process
@@ -20,6 +25,82 @@ export interface PipelineRun {
   jobsDiscovered: number;
   jobsProcessed: number;
   errorMessage: string | null;
+}
+
+export type PipelineRunExecutionStage =
+  | "started"
+  | "profile_loaded"
+  | "discovery"
+  | "import"
+  | "scoring"
+  | "selection"
+  | "processing"
+  | "completed";
+
+export interface PipelineRunRequestedConfig {
+  topN: number;
+  minSuitabilityScore: number;
+  sources: ExtractorSourceId[];
+  enableCrawling: boolean;
+  enableScoring: boolean;
+  enableImporting: boolean;
+  enableAutoTailoring: boolean;
+}
+
+export interface PipelineRunSourceLimitSnapshot {
+  ukvisajobsMaxJobs: number;
+  adzunaMaxJobsPerTerm: number;
+  gradcrackerMaxJobsPerTerm: number;
+  startupjobsMaxJobsPerTerm: number;
+  jobspyResultsWanted: number;
+}
+
+export interface PipelineRunModelSnapshot {
+  scorer: string;
+  tailoring: string;
+  projectSelection: string;
+}
+
+export interface PipelineRunResumeProjectsSnapshot {
+  maxProjects: number;
+  lockedProjectCount: number;
+  aiSelectableProjectCount: number;
+}
+
+export interface PipelineRunSkippedSource {
+  source: ExtractorSourceId;
+  reason: string;
+}
+
+export interface PipelineRunEffectiveConfig {
+  country: string | null;
+  countryLabel: string | null;
+  searchCities: string[];
+  searchTermsCount: number;
+  workplaceTypes: Array<"remote" | "hybrid" | "onsite">;
+  locationSearchScope: LocationSearchScope;
+  locationMatchStrictness: LocationMatchStrictness;
+  compatibleSources: ExtractorSourceId[];
+  skippedSources: PipelineRunSkippedSource[];
+  blockedCompanyKeywordsCount: number;
+  sourceLimits: PipelineRunSourceLimitSnapshot;
+  autoSkipScoreThreshold: number | null;
+  pdfRenderer: PdfRenderer;
+  models: PipelineRunModelSnapshot;
+  resumeProjects: PipelineRunResumeProjectsSnapshot;
+}
+
+export interface PipelineRunResultSummary {
+  stage: PipelineRunExecutionStage;
+  jobsScored: number | null;
+  jobsSelected: number | null;
+  sourceErrors: string[];
+}
+
+export interface PipelineRunSavedDetails {
+  requestedConfig: PipelineRunRequestedConfig;
+  effectiveConfig: PipelineRunEffectiveConfig;
+  resultSummary: PipelineRunResultSummary;
 }
 
 export interface PipelineStatusResponse {
@@ -43,6 +124,7 @@ export interface PipelineRunInsights {
   exactMetrics: {
     durationMs: number | null;
   };
+  savedDetails: PipelineRunSavedDetails | null;
   inferredMetrics: {
     jobsCreated: PipelineRunMetric<number | null>;
     jobsUpdated: PipelineRunMetric<number | null>;


### PR DESCRIPTION
## Summary
- Persist requested, effective, and execution summary snapshots for future pipeline runs
- Surface saved run settings and execution details in the Overview run drawer
- Extend pipeline run tests and demo-mode fixtures to cover the new saved details contract

## Testing
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`