### PR TITLE
Fix automatic-run preset memory and Docker Compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,17 +31,6 @@ services:
     env_file:
       - path: ./.env
         required: false
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 10s
-
-secrets:
-  github_token:
-    environment: GITHUB_TOKEN
     develop:
       watch:
         # Rebuild container when package.json changes
@@ -78,6 +67,17 @@ secrets:
         - path: ./extractors/jobspy
           target: /app/extractors/jobspy
           action: sync+restart
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+secrets:
+  github_token:
+    environment: GITHUB_TOKEN
 
 # Volumes for data persistence
 volumes:

--- a/docs-site/docs/features/pipeline-run.md
+++ b/docs-site/docs/features/pipeline-run.md
@@ -43,6 +43,11 @@ Three presets set defaults for run aggressiveness:
 
 If values are edited manually, the UI shows **Custom**.
 
+The automatic modal remembers the last preset choice and `Max jobs discovered`
+value in this browser. If you picked **Custom**, it reopens in Custom mode with
+the same values. The pipeline run itself still derives per-source caps from the
+saved budget when you start the run.
+
 #### Country and source compatibility
 
 - Country selection affects which sources are available.

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
@@ -9,6 +9,7 @@ import {
 import type React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AutomaticRunTab } from "./AutomaticRunTab";
+import { AUTOMATIC_PRESETS, RUN_MEMORY_STORAGE_KEY } from "./automatic-run";
 
 const { getDetectedCountryKeyMock } = vi.hoisted(() => ({
   getDetectedCountryKeyMock: vi.fn((): string | null => null),
@@ -31,10 +32,56 @@ vi.mock("@/lib/user-location", () => ({
   getDetectedCountryKey: getDetectedCountryKeyMock,
 }));
 
+function ensureStorage(): Storage {
+  const existing = globalThis.localStorage as Partial<Storage> | undefined;
+  const hasStorageShape =
+    existing &&
+    typeof existing.getItem === "function" &&
+    typeof existing.setItem === "function" &&
+    typeof existing.removeItem === "function" &&
+    typeof existing.clear === "function";
+
+  if (hasStorageShape) {
+    return existing as Storage;
+  }
+
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      const value = store.get(key);
+      return value ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+
+  return storage;
+}
+
 describe("AutomaticRunTab", () => {
   beforeEach(() => {
     getDetectedCountryKeyMock.mockReset();
     getDetectedCountryKeyMock.mockReturnValue(null);
+    ensureStorage().clear();
   });
 
   it("uses detected country when location settings are still defaults", () => {
@@ -597,6 +644,173 @@ describe("AutomaticRunTab", () => {
         }),
       );
     });
+  });
+
+  it("remembers the balanced preset and its budget across reopen", async () => {
+    const onSaveAndRun = vi.fn().mockResolvedValue(undefined);
+
+    const { unmount } = render(
+      <AutomaticRunTab
+        open
+        settings={createAppSettings({
+          jobspyCountryIndeed: {
+            value: "croatia",
+            default: "",
+            override: "croatia",
+          },
+          jobspyResultsWanted: {
+            value: 80,
+            default: 20,
+            override: 80,
+          },
+        })}
+        enabledSources={["linkedin"]}
+        pipelineSources={["linkedin"]}
+        onToggleSource={vi.fn()}
+        onSetPipelineSources={vi.fn()}
+        isPipelineRunning={false}
+        onSaveAndRun={onSaveAndRun}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Balanced" }));
+    fireEvent.click(screen.getByRole("button", { name: "Start run now" }));
+
+    await waitFor(() => {
+      expect(onSaveAndRun).toHaveBeenCalled();
+    });
+
+    expect(
+      JSON.parse(localStorage.getItem(RUN_MEMORY_STORAGE_KEY) ?? "{}"),
+    ).toEqual(
+      expect.objectContaining({
+        presetId: "balanced",
+        runBudget: AUTOMATIC_PRESETS.balanced.runBudget,
+      }),
+    );
+
+    unmount();
+
+    render(
+      <AutomaticRunTab
+        open
+        settings={createAppSettings({
+          jobspyCountryIndeed: {
+            value: "croatia",
+            default: "",
+            override: "croatia",
+          },
+          jobspyResultsWanted: {
+            value: 90,
+            default: 20,
+            override: 90,
+          },
+        })}
+        enabledSources={["linkedin"]}
+        pipelineSources={["linkedin"]}
+        onToggleSource={vi.fn()}
+        onSetPipelineSources={vi.fn()}
+        isPipelineRunning={false}
+        onSaveAndRun={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Balanced" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Run settings" }));
+
+    expect(screen.getByLabelText("Max jobs discovered")).toHaveValue(
+      AUTOMATIC_PRESETS.balanced.runBudget,
+    );
+  });
+
+  it("remembers custom mode even when the values match Balanced", async () => {
+    const onSaveAndRun = vi.fn().mockResolvedValue(undefined);
+
+    const { unmount } = render(
+      <AutomaticRunTab
+        open
+        settings={createAppSettings({
+          jobspyCountryIndeed: {
+            value: "croatia",
+            default: "",
+            override: "croatia",
+          },
+          jobspyResultsWanted: {
+            value: 80,
+            default: 20,
+            override: 80,
+          },
+        })}
+        enabledSources={["linkedin"]}
+        pipelineSources={["linkedin"]}
+        onToggleSource={vi.fn()}
+        onSetPipelineSources={vi.fn()}
+        isPipelineRunning={false}
+        onSaveAndRun={onSaveAndRun}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Balanced" }));
+    fireEvent.click(screen.getByRole("button", { name: "Custom" }));
+    fireEvent.click(screen.getByRole("button", { name: "Start run now" }));
+
+    await waitFor(() => {
+      expect(onSaveAndRun).toHaveBeenCalled();
+    });
+
+    expect(
+      JSON.parse(localStorage.getItem(RUN_MEMORY_STORAGE_KEY) ?? "{}"),
+    ).toEqual(
+      expect.objectContaining({
+        presetId: "custom",
+        runBudget: AUTOMATIC_PRESETS.balanced.runBudget,
+      }),
+    );
+
+    unmount();
+
+    render(
+      <AutomaticRunTab
+        open
+        settings={createAppSettings({
+          jobspyCountryIndeed: {
+            value: "croatia",
+            default: "",
+            override: "croatia",
+          },
+          jobspyResultsWanted: {
+            value: 90,
+            default: 20,
+            override: 90,
+          },
+        })}
+        enabledSources={["linkedin"]}
+        pipelineSources={["linkedin"]}
+        onToggleSource={vi.fn()}
+        onSetPipelineSources={vi.fn()}
+        isPipelineRunning={false}
+        onSaveAndRun={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Custom" })).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Run settings" }));
+
+    expect(screen.getByLabelText("Max jobs discovered")).toHaveValue(
+      AUTOMATIC_PRESETS.balanced.runBudget,
+    );
   });
 
   it("shows the new location preference controls and a live summary", () => {

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
@@ -38,6 +38,7 @@ import { sourceLabel } from "@/lib/utils";
 import {
   AUTOMATIC_PRESETS,
   type AutomaticPresetId,
+  type AutomaticPresetSelection,
   type AutomaticRunValues,
   calculateAutomaticEstimate,
   loadAutomaticRunMemory,
@@ -91,8 +92,6 @@ interface AutomaticRunFormValues {
   searchTermDraft: string;
 }
 
-type AutomaticPresetSelection = AutomaticPresetId | "custom";
-
 const GLASSDOOR_COUNTRY_REASON =
   "Glassdoor is not available for the selected country.";
 const GLASSDOOR_LOCATION_REASON =
@@ -137,37 +136,6 @@ function formatWorkplaceTypeLabel(workplaceType: WorkplaceType): string {
   return workplaceType.charAt(0).toUpperCase() + workplaceType.slice(1);
 }
 
-function getPresetSelection(values: {
-  topN: number;
-  minSuitabilityScore: number;
-  runBudget: number;
-}): AutomaticPresetSelection {
-  if (
-    values.topN === AUTOMATIC_PRESETS.fast.topN &&
-    values.minSuitabilityScore === AUTOMATIC_PRESETS.fast.minSuitabilityScore &&
-    values.runBudget === AUTOMATIC_PRESETS.fast.runBudget
-  ) {
-    return "fast";
-  }
-  if (
-    values.topN === AUTOMATIC_PRESETS.balanced.topN &&
-    values.minSuitabilityScore ===
-      AUTOMATIC_PRESETS.balanced.minSuitabilityScore &&
-    values.runBudget === AUTOMATIC_PRESETS.balanced.runBudget
-  ) {
-    return "balanced";
-  }
-  if (
-    values.topN === AUTOMATIC_PRESETS.detailed.topN &&
-    values.minSuitabilityScore ===
-      AUTOMATIC_PRESETS.detailed.minSuitabilityScore &&
-    values.runBudget === AUTOMATIC_PRESETS.detailed.runBudget
-  ) {
-    return "detailed";
-  }
-  return "custom";
-}
-
 export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
   open,
   settings,
@@ -180,6 +148,8 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
 }) => {
   const [isSaving, setIsSaving] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [selectedPreset, setSelectedPreset] =
+    useState<AutomaticPresetSelection>("custom");
   const { watch, reset, setValue } = useForm<AutomaticRunFormValues>({
     defaultValues: {
       topN: String(DEFAULT_VALUES.topN),
@@ -211,17 +181,28 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
   useEffect(() => {
     if (!open) return;
     const memory = loadAutomaticRunMemory();
-    const topN = memory?.topN ?? DEFAULT_VALUES.topN;
-    const minSuitabilityScore =
-      memory?.minSuitabilityScore ?? DEFAULT_VALUES.minSuitabilityScore;
-
-    const rememberedRunBudget = normalizeRunBudget(
+    const fallbackRunBudget = normalizeRunBudget(
       settings?.jobspyResultsWanted?.value ??
         settings?.startupjobsMaxJobsPerTerm?.value ??
         settings?.adzunaMaxJobsPerTerm?.value ??
         settings?.gradcrackerMaxJobsPerTerm?.value ??
         settings?.ukvisajobsMaxJobs?.value ??
         DEFAULT_VALUES.runBudget,
+    );
+    const rememberedPresetValues =
+      memory?.presetId && memory.presetId !== "custom"
+        ? AUTOMATIC_PRESETS[memory.presetId]
+        : null;
+    const rememberedTopN =
+      rememberedPresetValues?.topN ?? memory?.topN ?? DEFAULT_VALUES.topN;
+    const rememberedMinSuitabilityScore =
+      rememberedPresetValues?.minSuitabilityScore ??
+      memory?.minSuitabilityScore ??
+      DEFAULT_VALUES.minSuitabilityScore;
+    const rememberedRunBudget = normalizeRunBudget(
+      rememberedPresetValues?.runBudget ??
+        memory?.runBudget ??
+        fallbackRunBudget,
     );
     const hasExplicitLocationOverride = Boolean(
       settings?.jobspyCountryIndeed?.override ||
@@ -258,8 +239,8 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
       DEFAULT_VALUES.matchStrictness;
 
     reset({
-      topN: String(topN),
-      minSuitabilityScore: String(minSuitabilityScore),
+      topN: String(rememberedTopN),
+      minSuitabilityScore: String(rememberedMinSuitabilityScore),
       runBudget: String(rememberedRunBudget),
       country: rememberedCountry || DEFAULT_VALUES.country,
       cityLocations: rememberedLocations,
@@ -270,6 +251,7 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
       searchTerms: settings?.searchTerms?.value ?? DEFAULT_VALUES.searchTerms,
       searchTermDraft: "",
     });
+    setSelectedPreset(memory?.presetId ?? "custom");
     setAdvancedOpen(false);
   }, [open, settings, reset]);
 
@@ -360,10 +342,6 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
     [values, compatiblePipelineSources],
   );
 
-  const activePreset = useMemo<AutomaticPresetSelection>(
-    () => getPresetSelection(values),
-    [values],
-  );
   const locationSummary = useMemo(
     () => summarizeLocationPreferences(values),
     [values],
@@ -390,6 +368,7 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
 
   const applyPreset = (presetId: AutomaticPresetId) => {
     const preset = AUTOMATIC_PRESETS[presetId];
+    setSelectedPreset(presetId);
     setValue("topN", String(preset.topN), { shouldDirty: true });
     setValue("minSuitabilityScore", String(preset.minSuitabilityScore), {
       shouldDirty: true,
@@ -403,6 +382,8 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
       saveAutomaticRunMemory({
         topN: values.topN,
         minSuitabilityScore: values.minSuitabilityScore,
+        runBudget: values.runBudget,
+        presetId: selectedPreset,
       });
       await onSaveAndRun(values);
     } finally {
@@ -432,7 +413,8 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                 <Button
                   type="button"
                   size="sm"
-                  variant={activePreset === "fast" ? "default" : "outline"}
+                  variant={selectedPreset === "fast" ? "default" : "outline"}
+                  aria-pressed={selectedPreset === "fast"}
                   onClick={() => applyPreset("fast")}
                 >
                   Fast
@@ -440,7 +422,10 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                 <Button
                   type="button"
                   size="sm"
-                  variant={activePreset === "balanced" ? "default" : "outline"}
+                  variant={
+                    selectedPreset === "balanced" ? "default" : "outline"
+                  }
+                  aria-pressed={selectedPreset === "balanced"}
                   onClick={() => applyPreset("balanced")}
                 >
                   Balanced
@@ -448,7 +433,10 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                 <Button
                   type="button"
                   size="sm"
-                  variant={activePreset === "detailed" ? "default" : "outline"}
+                  variant={
+                    selectedPreset === "detailed" ? "default" : "outline"
+                  }
+                  aria-pressed={selectedPreset === "detailed"}
                   onClick={() => applyPreset("detailed")}
                 >
                   Detailed
@@ -456,7 +444,11 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                 <Button
                   type="button"
                   size="sm"
-                  variant={activePreset === "custom" ? "secondary" : "outline"}
+                  variant={
+                    selectedPreset === "custom" ? "secondary" : "outline"
+                  }
+                  aria-pressed={selectedPreset === "custom"}
+                  onClick={() => setSelectedPreset("custom")}
                 >
                   Custom
                 </Button>
@@ -658,9 +650,10 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                         min={1}
                         max={50}
                         value={topNInput}
-                        onChange={(event) =>
-                          setValue("topN", event.target.value)
-                        }
+                        onChange={(event) => {
+                          setSelectedPreset("custom");
+                          setValue("topN", event.target.value);
+                        }}
                       />
                     </div>
                     <div className="space-y-2">
@@ -671,9 +664,10 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                         min={0}
                         max={100}
                         value={minScoreInput}
-                        onChange={(event) =>
-                          setValue("minSuitabilityScore", event.target.value)
-                        }
+                        onChange={(event) => {
+                          setSelectedPreset("custom");
+                          setValue("minSuitabilityScore", event.target.value);
+                        }}
                       />
                     </div>
                     <div className="space-y-2">
@@ -684,9 +678,10 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                         min={MIN_RUN_BUDGET}
                         max={MAX_RUN_BUDGET}
                         value={runBudgetInput}
-                        onChange={(event) =>
-                          setValue("runBudget", event.target.value)
-                        }
+                        onChange={(event) => {
+                          setSelectedPreset("custom");
+                          setValue("runBudget", event.target.value);
+                        }}
                       />
                     </div>
                   </div>

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.test.ts
@@ -1,12 +1,64 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   AUTOMATIC_PRESETS,
   calculateAutomaticEstimate,
   deriveExtractorLimits,
+  inferAutomaticPresetSelection,
+  loadAutomaticRunMemory,
   parseSearchTermsInput,
+  RUN_MEMORY_STORAGE_KEY,
 } from "./automatic-run";
 
+function ensureStorage(): Storage {
+  const existing = globalThis.localStorage as Partial<Storage> | undefined;
+  const hasStorageShape =
+    existing &&
+    typeof existing.getItem === "function" &&
+    typeof existing.setItem === "function" &&
+    typeof existing.removeItem === "function" &&
+    typeof existing.clear === "function";
+
+  if (hasStorageShape) {
+    return existing as Storage;
+  }
+
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      const value = store.get(key);
+      return value ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+
+  return storage;
+}
+
 describe("automatic-run utilities", () => {
+  beforeEach(() => {
+    ensureStorage().clear();
+  });
+
   it("exposes the expected preset values", () => {
     expect(AUTOMATIC_PRESETS.fast).toEqual({
       topN: 5,
@@ -64,6 +116,51 @@ describe("automatic-run utilities", () => {
 
     expect(limits.startupjobsMaxJobsPerTerm).toBeGreaterThan(0);
     expect(limits.startupjobsMaxJobsPerTerm).toBeLessThanOrEqual(120);
+  });
+
+  it("infers the balanced preset from legacy memory without an explicit preset id", () => {
+    ensureStorage().setItem(
+      RUN_MEMORY_STORAGE_KEY,
+      JSON.stringify({
+        topN: AUTOMATIC_PRESETS.balanced.topN,
+        minSuitabilityScore: AUTOMATIC_PRESETS.balanced.minSuitabilityScore,
+      }),
+    );
+
+    expect(loadAutomaticRunMemory()).toEqual({
+      topN: AUTOMATIC_PRESETS.balanced.topN,
+      minSuitabilityScore: AUTOMATIC_PRESETS.balanced.minSuitabilityScore,
+      runBudget: AUTOMATIC_PRESETS.balanced.runBudget,
+      presetId: "balanced",
+    });
+  });
+
+  it("preserves explicit custom memory even when the numbers match a preset", () => {
+    ensureStorage().setItem(
+      RUN_MEMORY_STORAGE_KEY,
+      JSON.stringify({
+        topN: AUTOMATIC_PRESETS.balanced.topN,
+        minSuitabilityScore: AUTOMATIC_PRESETS.balanced.minSuitabilityScore,
+        runBudget: AUTOMATIC_PRESETS.balanced.runBudget,
+        presetId: "custom",
+      }),
+    );
+
+    expect(loadAutomaticRunMemory()).toEqual({
+      topN: AUTOMATIC_PRESETS.balanced.topN,
+      minSuitabilityScore: AUTOMATIC_PRESETS.balanced.minSuitabilityScore,
+      runBudget: AUTOMATIC_PRESETS.balanced.runBudget,
+      presetId: "custom",
+    });
+  });
+
+  it("infers custom when legacy values do not match a preset", () => {
+    expect(
+      inferAutomaticPresetSelection({
+        topN: 7,
+        minSuitabilityScore: 60,
+      }),
+    ).toBe("custom");
   });
 
   it("returns zero estimate when no search terms are provided", () => {

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.ts
@@ -12,6 +12,7 @@ import {
 import type { JobSource } from "@shared/types";
 
 export type AutomaticPresetId = "fast" | "balanced" | "detailed";
+export type AutomaticPresetSelection = AutomaticPresetId | "custom";
 export type WorkplaceType = "remote" | "hybrid" | "onsite";
 export const WORKPLACE_TYPE_OPTIONS: WorkplaceType[] = [
   "remote",
@@ -47,6 +48,17 @@ export interface AutomaticEstimate {
     min: number;
     max: number;
   };
+}
+
+function isAutomaticPresetSelection(
+  value: unknown,
+): value is AutomaticPresetSelection {
+  return (
+    value === "custom" ||
+    value === "fast" ||
+    value === "balanced" ||
+    value === "detailed"
+  );
 }
 
 export const AUTOMATIC_PRESETS: Record<
@@ -107,6 +119,28 @@ export const MATCH_STRICTNESS_OPTIONS: Array<{
 export interface AutomaticRunMemory {
   topN: number;
   minSuitabilityScore: number;
+  runBudget?: number;
+  presetId?: AutomaticPresetSelection;
+}
+
+export function inferAutomaticPresetSelection(values: {
+  topN: number;
+  minSuitabilityScore: number;
+  runBudget?: number;
+}): AutomaticPresetSelection {
+  const matchesPreset = (presetId: AutomaticPresetId) => {
+    const preset = AUTOMATIC_PRESETS[presetId];
+    return (
+      values.topN === preset.topN &&
+      values.minSuitabilityScore === preset.minSuitabilityScore &&
+      (values.runBudget === undefined || values.runBudget === preset.runBudget)
+    );
+  };
+
+  if (matchesPreset("fast")) return "fast";
+  if (matchesPreset("balanced")) return "balanced";
+  if (matchesPreset("detailed")) return "detailed";
+  return "custom";
 }
 
 export function normalizeWorkplaceTypes(
@@ -338,12 +372,59 @@ export function loadAutomaticRunMemory(): AutomaticRunMemory | null {
     ) {
       return null;
     }
+    const topN = Math.min(50, Math.max(1, Math.round(parsed.topN)));
+    const minSuitabilityScore = Math.min(
+      100,
+      Math.max(0, Math.round(parsed.minSuitabilityScore)),
+    );
+    const runBudget =
+      typeof parsed.runBudget === "number"
+        ? Math.max(50, Math.round(parsed.runBudget))
+        : undefined;
+    const explicitPresetId = isAutomaticPresetSelection(parsed.presetId)
+      ? parsed.presetId
+      : null;
+
+    if (explicitPresetId && explicitPresetId !== "custom") {
+      const preset = AUTOMATIC_PRESETS[explicitPresetId];
+      return {
+        topN: preset.topN,
+        minSuitabilityScore: preset.minSuitabilityScore,
+        runBudget: preset.runBudget,
+        presetId: explicitPresetId,
+      };
+    }
+
+    if (explicitPresetId === "custom") {
+      return {
+        topN,
+        minSuitabilityScore,
+        ...(runBudget !== undefined ? { runBudget } : {}),
+        presetId: "custom",
+      };
+    }
+
+    const inferredPresetId = inferAutomaticPresetSelection({
+      topN,
+      minSuitabilityScore,
+      runBudget,
+    });
+
+    if (inferredPresetId !== "custom") {
+      const preset = AUTOMATIC_PRESETS[inferredPresetId];
+      return {
+        topN: preset.topN,
+        minSuitabilityScore: preset.minSuitabilityScore,
+        runBudget: preset.runBudget,
+        presetId: inferredPresetId,
+      };
+    }
+
     return {
-      topN: Math.min(50, Math.max(1, Math.round(parsed.topN))),
-      minSuitabilityScore: Math.min(
-        100,
-        Math.max(0, Math.round(parsed.minSuitabilityScore)),
-      ),
+      topN,
+      minSuitabilityScore,
+      ...(runBudget !== undefined ? { runBudget } : {}),
+      presetId: "custom",
     };
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- Remember the selected automatic-run preset in browser-local memory so Balanced and Custom reopen correctly
- Keep derived extractor caps for the actual pipeline run while preserving the user’s chosen modal state
- Fix `docker compose up` by moving `develop.watch` onto the service instead of nesting it under `secrets`
- Update pipeline-run docs to describe the remembered preset behavior

## Testing
- Unit tests for automatic-run memory and modal reopen behavior
- `docker compose config`
- `docker compose up --build -d`