### PR TITLE
Ensure onboarding redirect works correctly

### DIFF
--- a/orchestrator/src/client/hooks/useOnboardingRequirement.test.ts
+++ b/orchestrator/src/client/hooks/useOnboardingRequirement.test.ts
@@ -149,6 +149,80 @@ describe("useOnboardingRequirement", () => {
     expect(result.current.complete).toBe(false);
   });
 
+  it("revalidates when validation inputs change after an earlier failure", async () => {
+    const validateLlm = vi.mocked(api.validateLlm);
+    validateLlm
+      .mockResolvedValueOnce({
+        valid: false,
+        message: "LM Studio is unreachable",
+      })
+      .mockResolvedValue({
+        valid: true,
+        message: null,
+      });
+
+    let currentSettings: any = {
+      llmProvider: { value: "lmstudio", default: "lmstudio", override: null },
+      llmBaseUrl: {
+        value: "http://localhost:1234",
+        default: "",
+        override: null,
+      },
+      pdfRenderer: {
+        value: "latex",
+        default: "rxresume",
+        override: null,
+      },
+      searchTerms: {
+        value: ["Platform Engineer"],
+        default: ["web developer"],
+        override: ["Platform Engineer"],
+      },
+      rxresumeUrl: null,
+      basicAuthActive: false,
+      onboardingBasicAuthDecision: "skipped",
+    };
+
+    vi.mocked(useSettings).mockImplementation(() => ({
+      settings: currentSettings,
+      isLoading: false,
+      refreshSettings: vi.fn(),
+      error: null,
+      showSponsorInfo: true,
+      renderMarkdownInJobDescriptions: true,
+    }));
+
+    const { result, rerender } = renderHookWithQueryClient(() =>
+      useOnboardingRequirement(),
+    );
+
+    await waitFor(() => {
+      expect(result.current.checking).toBe(false);
+    });
+    expect(result.current.complete).toBe(false);
+
+    currentSettings = {
+      ...currentSettings,
+      llmBaseUrl: {
+        value: "http://localhost:1235",
+        default: "",
+        override: "http://localhost:1235",
+      },
+    };
+    rerender();
+
+    await waitFor(() => {
+      expect(validateLlm).toHaveBeenCalledWith({
+        provider: "lmstudio",
+        baseUrl: "http://localhost:1235",
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.checking).toBe(false);
+    });
+    expect(result.current.complete).toBe(true);
+  });
+
   it("does not require Reactive Resume when LaTeX rendering and a local resume are ready", async () => {
     vi.mocked(api.validateRxresume).mockResolvedValue({
       valid: false,

--- a/orchestrator/src/client/hooks/useOnboardingRequirement.ts
+++ b/orchestrator/src/client/hooks/useOnboardingRequirement.ts
@@ -4,7 +4,7 @@ import { useSettings } from "@client/hooks/useSettings";
 import { isOnboardingComplete } from "@client/lib/onboarding";
 import { normalizeLlmProvider } from "@client/pages/settings/utils";
 import type { ValidationResult } from "@shared/types";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 const EMPTY_VALIDATION_STATE: ValidationResult & { checked: boolean } = {
   valid: false,
@@ -24,12 +24,31 @@ export function useOnboardingRequirement() {
   const [baseResumeValidation, setBaseResumeValidation] = useState(
     EMPTY_VALIDATION_STATE,
   );
+  const validationInputsKeyRef = useRef<string | null>(null);
 
   const selectedProvider = normalizeLlmProvider(settings?.llmProvider?.value);
   const shouldValidateRxresume = Boolean(
     settings?.pdfRenderer?.value === "rxresume" ||
       settings?.rxresumeBaseResumeId,
   );
+  const validationInputsKey = JSON.stringify({
+    provider: selectedProvider,
+    llmBaseUrl: settings?.llmBaseUrl?.value || null,
+    pdfRenderer: settings?.pdfRenderer?.value || null,
+    rxresumeBaseResumeId: settings?.rxresumeBaseResumeId || null,
+    rxresumeUrl: settings?.rxresumeUrl || null,
+  });
+
+  useEffect(() => {
+    if (validationInputsKeyRef.current === validationInputsKey) {
+      return;
+    }
+    validationInputsKeyRef.current = validationInputsKey;
+    setLlmValidation(EMPTY_VALIDATION_STATE);
+    setRxresumeValidation(EMPTY_VALIDATION_STATE);
+    setBaseResumeValidation(EMPTY_VALIDATION_STATE);
+  }, [validationInputsKey]);
+
   const runValidations = useCallback(async () => {
     if (!settings) return;
 

--- a/orchestrator/src/client/lib/onboarding.ts
+++ b/orchestrator/src/client/lib/onboarding.ts
@@ -1,5 +1,7 @@
 import type { AppSettings } from "@shared/types";
 
+type OnboardingStepId = "llm" | "baseresume" | "searchterms" | "basicauth";
+
 export function hasCompletedBasicAuthOnboarding(
   settings: AppSettings | null | undefined,
 ): boolean {
@@ -23,16 +25,23 @@ export function isOnboardingComplete(input: {
   llmValid: boolean;
   baseResumeValid: boolean;
   searchTermsValid?: boolean;
+  completedStepId?: OnboardingStepId | null;
 }): boolean {
   if (input.demoMode) return true;
   if (!input.settings) return false;
 
+  const llmValid = input.completedStepId === "llm" ? true : input.llmValid;
+  const baseResumeValid =
+    input.completedStepId === "baseresume" ? true : input.baseResumeValid;
   const searchTermsValid =
-    input.searchTermsValid ?? hasSavedSearchTermsOnboarding(input.settings);
+    input.completedStepId === "searchterms"
+      ? true
+      : (input.searchTermsValid ??
+        hasSavedSearchTermsOnboarding(input.settings));
 
   return Boolean(
-    input.llmValid &&
-      input.baseResumeValid &&
+    llmValid &&
+      baseResumeValid &&
       searchTermsValid &&
       hasCompletedBasicAuthOnboarding(input.settings),
   );

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -565,6 +565,140 @@ describe("OnboardingPage", () => {
     });
   });
 
+  it("lets the user enable basic auth and finish onboarding", async () => {
+    vi.mocked(useOnboardingRequirement).mockReturnValue({
+      checking: false,
+      complete: false,
+    });
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateRxresume).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateResumeConfig).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.updateSettings).mockImplementation(async (update) => {
+      currentSettings = {
+        ...currentSettings,
+        ...("enableBasicAuth" in update || "basicAuthUser" in update
+          ? {
+              basicAuthActive: true,
+              onboardingBasicAuthDecision: "enabled",
+              basicAuthUser:
+                update.basicAuthUser ?? currentSettings.basicAuthUser,
+            }
+          : {}),
+      };
+      return currentSettings;
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Choose the LLM connection Job Ops should use."),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /basic auth/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Secure your workspace")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText(/lock it down/i));
+    fireEvent.change(screen.getByLabelText(/username/i), {
+      target: { value: "jobops-admin" },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: "correct horse battery staple" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /enable authentication/i }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("ready page")).toBeInTheDocument();
+    });
+    expect(api.updateSettings).toHaveBeenCalledWith({
+      enableBasicAuth: true,
+      basicAuthUser: "jobops-admin",
+      basicAuthPassword: "correct horse battery staple",
+      onboardingBasicAuthDecision: "enabled",
+    });
+  });
+
+  it("redirects when search terms are the last missing step", async () => {
+    vi.mocked(useOnboardingRequirement).mockReturnValue({
+      checking: false,
+      complete: false,
+    });
+    currentSettings = {
+      ...baseSettings,
+      onboardingBasicAuthDecision: "skipped",
+      searchTerms: {
+        value: ["web developer"],
+        default: ["web developer"],
+        override: null,
+      },
+    };
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateRxresume).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateResumeConfig).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.updateSettings).mockImplementation(async (update) => {
+      currentSettings = {
+        ...currentSettings,
+        ...("searchTerms" in update
+          ? {
+              searchTerms: {
+                value: update.searchTerms,
+                default: ["web developer"],
+                override: update.searchTerms,
+              },
+            }
+          : {}),
+      };
+      return currentSettings;
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Choose the LLM connection Job Ops should use."),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /search terms/i }));
+
+    await waitFor(() => {
+      expect(api.suggestOnboardingSearchTerms).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /save search terms/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("ready page")).toBeInTheDocument();
+    });
+    expect(api.updateSettings).toHaveBeenCalledWith({
+      searchTerms: ["Platform Engineer", "Backend Engineer"],
+    });
+  });
+
   it("does not leave onboarding early when basic auth is saved before the other steps are complete", async () => {
     vi.mocked(api.validateLlm).mockResolvedValue({
       valid: false,

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -520,6 +520,10 @@ describe("OnboardingPage", () => {
   });
 
   it("lets the user skip basic auth and finish onboarding", async () => {
+    vi.mocked(useOnboardingRequirement).mockReturnValue({
+      checking: false,
+      complete: false,
+    });
     vi.mocked(api.validateLlm).mockResolvedValue({
       valid: true,
       message: null,
@@ -537,7 +541,13 @@ describe("OnboardingPage", () => {
         ...currentSettings,
         onboardingBasicAuthDecision: "skipped",
       };
-      return currentSettings;
+      return {
+        ...currentSettings,
+        searchTerms: {
+          ...currentSettings.searchTerms,
+          override: null,
+        },
+      };
     });
 
     renderPage();
@@ -1251,6 +1261,13 @@ describe("OnboardingPage", () => {
           },
         }) as any,
     );
+    vi.mocked(api.updateSettings).mockImplementation(async (update) => {
+      currentSettings = {
+        ...currentSettings,
+        ...update,
+      };
+      return currentSettings;
+    });
     vi.mocked(api.validateResumeConfig).mockResolvedValue({
       valid: false,
       message: "Choose a template resume to finish this step.",
@@ -1279,6 +1296,15 @@ describe("OnboardingPage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Template resume")).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Enter v5 API key"),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText("Upload a PDF or DOCX resume"),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /confirm resume template/i }),
+      ).toBeInTheDocument();
     });
     expect(screen.getByText("Base resume selection")).toBeInTheDocument();
   });

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -1,8 +1,9 @@
 import { PageHeader, PageMain } from "@client/components/layout";
 import { useOnboardingRequirement } from "@client/hooks/useOnboardingRequirement";
+import { isOnboardingComplete } from "@client/lib/onboarding";
 import { ArrowLeft, ArrowRight, Sparkles } from "lucide-react";
 import type React from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,6 +20,7 @@ import { useOnboardingFlow } from "./onboarding/useOnboardingFlow";
 export const OnboardingPage: React.FC = () => {
   const flow = useOnboardingFlow();
   const onboardingRequirement = useOnboardingRequirement();
+  const navigate = useNavigate();
 
   if (flow.demoMode) {
     return <Navigate to="/jobs/ready" replace />;
@@ -60,9 +62,21 @@ export const OnboardingPage: React.FC = () => {
             ) : (
               <form
                 className="flex min-h-[32rem] flex-col"
-                onSubmit={(event) => {
+                onSubmit={async (event) => {
                   event.preventDefault();
-                  void flow.handlePrimaryAction();
+                  const savedSettings = await flow.handlePrimaryAction();
+
+                  if (
+                    savedSettings &&
+                    isOnboardingComplete({
+                      demoMode: flow.demoMode,
+                      settings: savedSettings,
+                      llmValid: flow.llmValidation.valid,
+                      baseResumeValid: flow.baseResumeValidation.valid,
+                    })
+                  ) {
+                    navigate("/jobs/ready", { replace: true });
+                  }
                 }}
               >
                 <CardHeader className="space-y-4 border-b border-border/60">

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -71,8 +71,10 @@ export const OnboardingPage: React.FC = () => {
                     isOnboardingComplete({
                       demoMode: flow.demoMode,
                       settings: savedSettings,
-                      llmValid: flow.llmValidation.valid,
+                      llmValid: flow.llmValidated,
                       baseResumeValid: flow.baseResumeValidation.valid,
+                      searchTermsValid: flow.searchTermsComplete,
+                      completedStepId: flow.currentStep,
                     })
                   ) {
                     navigate("/jobs/ready", { replace: true });

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -383,14 +383,14 @@ export function useOnboardingFlow() {
 
     if (requiresLlmKey && !apiKeyValue && !hasLlmKey) {
       toast.info("Add your LLM API key to continue");
-      return false;
+      return null;
     }
 
     const validation = await validateLlm();
 
     if (!validation.valid) {
       toast.error(validation.message || "LLM validation failed");
-      return false;
+      return null;
     }
 
     const update: Partial<UpdateSettingsInput> = {
@@ -418,12 +418,12 @@ export function useOnboardingFlow() {
             ? `Default for ${providerConfig.label}: ${defaultModel}.`
             : "You can fine-tune models later in Settings.",
       });
-      return true;
+      return nextSettings;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to save LLM settings",
       );
-      return false;
+      return null;
     } finally {
       setIsSaving(false);
     }
@@ -455,11 +455,12 @@ export function useOnboardingFlow() {
       toast.info("Almost there", {
         description: `Missing: ${missing.join(", ")}`,
       });
-      return false;
+      return null;
     }
 
     try {
       setIsValidatingRxresume(true);
+      let nextSettings: AppSettings | null = null;
       const result = await validateAndMaybePersistRxResumeMode({
         stored: storedRxResume,
         draft: draftCredentials,
@@ -467,7 +468,7 @@ export function useOnboardingFlow() {
         persist: async (update: Parameters<typeof api.updateSettings>[0]) => {
           setIsSaving(true);
           try {
-            const nextSettings = await api.updateSettings({
+            nextSettings = await api.updateSettings({
               ...update,
               pdfRenderer: "rxresume",
               rxresumeBaseResumeId: values.rxresumeBaseResumeId,
@@ -491,14 +492,14 @@ export function useOnboardingFlow() {
       setRxresumeValidation(toValidationState(result.validation));
       if (!result.validation.valid) {
         toast.error(result.validation.message || "RxResume validation failed");
-        return false;
+        return null;
       }
 
       setValue("rxresumeApiKey", "");
       const resumeValidation = await validateBaseResume();
       if (resumeValidation.valid) {
         toast.success("Reactive Resume connected");
-        return true;
+        return nextSettings ?? settings;
       }
 
       toast.info("Reactive Resume connected", {
@@ -506,14 +507,14 @@ export function useOnboardingFlow() {
           resumeValidation.message ||
           "Choose a template resume to finish this step.",
       });
-      return false;
+      return nextSettings ?? settings;
     } catch (error) {
       toast.error(
         error instanceof Error
           ? error.message
           : "Failed to save RxResume credentials",
       );
-      return false;
+      return null;
     } finally {
       setIsValidatingRxresume(false);
       setIsSaving(false);
@@ -521,6 +522,7 @@ export function useOnboardingFlow() {
   }, [
     getValues,
     isRxResumeSelfHosted,
+    settings,
     setValue,
     storedRxResume,
     syncSettingsCache,
@@ -601,18 +603,18 @@ export function useOnboardingFlow() {
       const validation = await validateBaseResume();
       if (!validation.valid) {
         toast.error(validation.message || "Base resume validation failed");
-        return false;
+        return null;
       }
 
       toast.success("Resume source is ready");
-      return true;
+      return settings ?? null;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to validate resume",
       );
-      return false;
+      return null;
     }
-  }, [validateBaseResume]);
+  }, [settings, validateBaseResume]);
 
   const handleImportResumeFile = useCallback(
     async (file: File) => {
@@ -683,7 +685,7 @@ export function useOnboardingFlow() {
 
     if (nextTerms.length === 0) {
       toast.info("Add at least one job title to continue");
-      return false;
+      return null;
     }
 
     try {
@@ -698,12 +700,12 @@ export function useOnboardingFlow() {
       setHasSavedSearchTermsInSession(true);
       setSearchTermsStale(false);
       toast.success("Search terms saved");
-      return true;
+      return nextSettings;
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to save search terms",
       );
-      return false;
+      return null;
     } finally {
       setIsSaving(false);
     }
@@ -718,14 +720,14 @@ export function useOnboardingFlow() {
         });
         syncSettingsCache(nextSettings);
         toast.success("Authentication skipped for now");
-        return true;
+        return nextSettings;
       } catch (error) {
         toast.error(
           error instanceof Error
             ? error.message
             : "Failed to save onboarding progress",
         );
-        return false;
+        return null;
       } finally {
         setIsSaving(false);
       }
@@ -733,7 +735,7 @@ export function useOnboardingFlow() {
 
     if (basicAuthChoice !== "enable") {
       toast.info("Choose whether to enable authentication or skip it for now");
-      return false;
+      return null;
     }
 
     const { basicAuthUser, basicAuthPassword } = getValues();
@@ -742,7 +744,7 @@ export function useOnboardingFlow() {
 
     if (!normalizedUser || !normalizedPassword) {
       toast.info("Enter both a username and password to enable authentication");
-      return false;
+      return null;
     }
 
     try {
@@ -756,38 +758,34 @@ export function useOnboardingFlow() {
       syncSettingsCache(nextSettings);
       setValue("basicAuthPassword", "");
       toast.success("Authentication enabled");
-      return true;
+      return nextSettings;
     } catch (error) {
       toast.error(
         error instanceof Error
           ? error.message
           : "Failed to save authentication credentials",
       );
-      return false;
+      return null;
     } finally {
       setIsSaving(false);
     }
   }, [basicAuthChoice, getValues, setValue, syncSettingsCache]);
 
   const handlePrimaryAction = useCallback(async () => {
-    if (!currentStep) return;
+    if (!currentStep) return null;
     if (currentStep === "llm") {
-      await handleSaveLlm();
-      return;
+      return await handleSaveLlm();
     }
     if (currentStep === "baseresume") {
       if (resumeSetupMode === "rxresume") {
-        await handleSaveRxresume();
-        return;
+        return await handleSaveRxresume();
       }
-      await handleSaveBaseResume();
-      return;
+      return await handleSaveBaseResume();
     }
     if (currentStep === "searchterms") {
-      await handleSaveSearchTerms();
-      return;
+      return await handleSaveSearchTerms();
     }
-    await handleCompleteBasicAuth();
+    return await handleCompleteBasicAuth();
   }, [
     currentStep,
     handleCompleteBasicAuth,

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -74,6 +74,7 @@ export function useOnboardingFlow() {
   >(null);
   const [searchTermsStale, setSearchTermsStale] = useState(false);
   const [currentStep, setCurrentStep] = useState<StepId | null>(null);
+  const resumeSetupModeTouchedRef = useRef(false);
   const searchTermsOverrideKeyRef = useRef<string | null>(null);
   const autoSuggestionAttemptedRef = useRef(false);
 
@@ -133,7 +134,9 @@ export function useOnboardingFlow() {
           : "enable",
     );
     setIsRxResumeSelfHosted(Boolean(settings.rxresumeUrl));
-    setResumeSetupMode(selectedId ? "rxresume" : "upload");
+    if (!resumeSetupModeTouchedRef.current) {
+      setResumeSetupMode(selectedId ? "rxresume" : "upload");
+    }
     if (searchTermsOverrideKeyRef.current !== searchTermsOverrideKey) {
       searchTermsOverrideKeyRef.current = searchTermsOverrideKey;
       setSearchTermsSaved(hasExplicitSearchTermsOverride);
@@ -540,6 +543,11 @@ export function useOnboardingFlow() {
     [setValue],
   );
 
+  const handleResumeSetupModeChange = useCallback((mode: ResumeSetupMode) => {
+    resumeSetupModeTouchedRef.current = true;
+    setResumeSetupMode(mode);
+  }, []);
+
   const markSearchTermsStale = useCallback(() => {
     const currentTerms = getValues().searchTerms;
     if (currentTerms.length === 0 && !hasSavedSearchTermsInSession) return;
@@ -810,6 +818,7 @@ export function useOnboardingFlow() {
     isValidatingBaseResume;
 
   const currentCopy = currentStep ? STEP_COPY[currentStep] : STEP_COPY.llm;
+  const baseResumeValue = watch("rxresumeBaseResumeId");
 
   const primaryLabel =
     currentStep === "llm"
@@ -819,7 +828,9 @@ export function useOnboardingFlow() {
       : currentStep === "baseresume"
         ? resumeSetupMode === "rxresume"
           ? rxresumeValidation.valid
-            ? "Recheck Reactive Resume"
+            ? baseResumeValue
+              ? "Recheck Reactive Resume"
+              : "Confirm Resume Template"
             : "Connect Reactive Resume"
           : baseResumeValidation.valid
             ? "Recheck resume"
@@ -836,7 +847,7 @@ export function useOnboardingFlow() {
 
   return {
     baseResumeValidation,
-    baseResumeValue: watch("rxresumeBaseResumeId"),
+    baseResumeValue,
     basicAuthChoice,
     canGoBack,
     complete,
@@ -852,11 +863,13 @@ export function useOnboardingFlow() {
     isRxResumeSelfHosted,
     hasSavedSearchTermsInSession,
     llmKeyHint,
+    llmValidated,
     llmValidation,
     primaryLabel,
     progressValue,
     resumeSetupMode,
     rxresumeValidation,
+    searchTermsComplete,
     searchTermsSource,
     searchTermsStale,
     selectedProvider,
@@ -866,7 +879,7 @@ export function useOnboardingFlow() {
     watch,
     setCurrentStep,
     setBasicAuthChoice,
-    setResumeSetupMode,
+    setResumeSetupMode: handleResumeSetupModeChange,
     setValue,
     setBaseResumeId,
     handleRegenerateSearchTerms: async () => {


### PR DESCRIPTION
## Summary
- Return persisted settings from each onboarding save path so completion can be checked immediately after any successful step
- Redirect to `/jobs/ready` as soon as the saved state satisfies onboarding completion, regardless of step order
- Keep the existing requirement-based redirect as a fallback
- Add coverage for basic auth enable/skip and search-term completion paths

## Testing
- Added unit/UI coverage for onboarding completion after different final steps
- Verified onboarding page tests and type-safe client changes locally