### PR TITLE
Add Ghostwriter fullscreen pop-up mode

### DIFF
--- a/docs-site/docs/features/ghostwriter.md
+++ b/docs-site/docs/features/ghostwriter.md
@@ -16,7 +16,7 @@ Ghostwriter uses:
 - global writing style settings
 - the configurable Ghostwriter system prompt template from Settings
 
-The UI behavior is one persistent conversation per job, shown in the right-side drawer from job details.
+The UI behavior is one persistent conversation per job, shown in the right-side drawer from job details, with an optional desktop pop-up mode for focused writing.
 
 ## Why it exists
 
@@ -34,9 +34,10 @@ Typical use cases:
 
 1. Open a job in `discovered` or `ready`.
 2. Open the Ghostwriter drawer.
-3. Enter your prompt and stream a response.
-4. Use the `Copy` button on any completed Ghostwriter reply to copy the full output.
-5. Stop or regenerate responses when needed.
+3. On desktop, use the header expand button to open pop-up mode and the restore button to return to drawer mode.
+4. Enter your prompt and stream a response.
+5. Use the `Copy` button on any completed Ghostwriter reply to copy the full output.
+6. Stop or regenerate responses when needed.
 
 ### Writing style settings impact
 
@@ -100,6 +101,11 @@ Compatibility thread endpoints remain, but UI behavior is one thread per job.
 
 - Update profile data and relevant project details used by Ghostwriter context.
 - Regenerate after updating job notes/description.
+
+### I need more reading space for long drafts
+
+- On desktop, switch Ghostwriter to pop-up mode with the header expand button.
+- Use restore when you want to return to the right-side drawer layout.
 
 ### I need to reuse a reply outside JobOps
 

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterDrawer.test.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterDrawer.test.tsx
@@ -1,0 +1,208 @@
+import { createJob } from "@shared/testing/factories.js";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GhostwriterDrawer } from "./GhostwriterDrawer";
+
+const DISPLAY_MODE_STORAGE_KEY = "jobops.ghostwriter.display-mode.v1";
+
+const panelLifecycle = vi.hoisted(() => ({
+  mounts: 0,
+  unmounts: 0,
+}));
+
+vi.mock("@/components/ui/sheet", async () => {
+  const ReactModule = await import("react");
+
+  type SheetContextValue = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+  };
+  const SheetContext = ReactModule.createContext<SheetContextValue | null>(
+    null,
+  );
+
+  const useSheetContext = () => {
+    const context = ReactModule.useContext(SheetContext);
+    if (!context) {
+      throw new Error("Sheet components must be used within Sheet");
+    }
+    return context;
+  };
+
+  return {
+    Sheet: ({
+      open,
+      onOpenChange,
+      children,
+    }: {
+      open: boolean;
+      onOpenChange: (open: boolean) => void;
+      children: React.ReactNode;
+    }) => (
+      <SheetContext.Provider value={{ open, onOpenChange }}>
+        {children}
+      </SheetContext.Provider>
+    ),
+    SheetTrigger: ({ children }: { children: React.ReactElement }) => {
+      const { onOpenChange } = useSheetContext();
+      return ReactModule.cloneElement(children, {
+        onClick: () => onOpenChange(true),
+      });
+    },
+    SheetContent: ({
+      className,
+      children,
+    }: {
+      className?: string;
+      children: React.ReactNode;
+    }) => {
+      const { open } = useSheetContext();
+      if (!open) return null;
+      return (
+        <div data-testid="sheet-content" className={className}>
+          {children}
+        </div>
+      );
+    },
+    SheetHeader: ({ children }: { children: React.ReactNode }) => (
+      <div>{children}</div>
+    ),
+    SheetTitle: ({ children }: { children: React.ReactNode }) => (
+      <h2>{children}</h2>
+    ),
+    SheetDescription: ({ children }: { children: React.ReactNode }) => (
+      <p>{children}</p>
+    ),
+  };
+});
+
+vi.mock("./GhostwriterPanel", async () => {
+  const ReactModule = await import("react");
+  return {
+    GhostwriterPanel: () => {
+      ReactModule.useEffect(() => {
+        panelLifecycle.mounts += 1;
+        return () => {
+          panelLifecycle.unmounts += 1;
+        };
+      }, []);
+
+      return <div data-testid="ghostwriter-panel">ghostwriter panel</div>;
+    },
+  };
+});
+
+const createMatchMedia = (matches: boolean) =>
+  vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+
+describe("GhostwriterDrawer", () => {
+  beforeEach(() => {
+    panelLifecycle.mounts = 0;
+    panelLifecycle.unmounts = 0;
+    window.localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("opens in drawer mode by default when no preference exists", () => {
+    window.matchMedia = createMatchMedia(true) as typeof window.matchMedia;
+
+    render(<GhostwriterDrawer job={createJob()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ghostwriter" }));
+
+    const content = screen.getByTestId("sheet-content");
+    expect(content.className).toContain("lg:w-[50vw]");
+    expect(content.className).not.toContain("w-screen");
+    expect(
+      screen.getByRole("button", { name: "Open Ghostwriter pop-up" }),
+    ).toBeInTheDocument();
+  });
+
+  it("restores fullscreen mode from localStorage on desktop", () => {
+    window.localStorage.setItem(DISPLAY_MODE_STORAGE_KEY, "fullscreen");
+    window.matchMedia = createMatchMedia(true) as typeof window.matchMedia;
+
+    render(<GhostwriterDrawer job={createJob()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ghostwriter" }));
+
+    const content = screen.getByTestId("sheet-content");
+    expect(content.className).toContain("w-screen");
+    expect(content.className).toContain("max-w-none");
+    expect(
+      screen.getByRole("button", { name: "Restore Ghostwriter drawer" }),
+    ).toBeInTheDocument();
+  });
+
+  it("toggles display mode on desktop and persists the new preference", () => {
+    window.matchMedia = createMatchMedia(true) as typeof window.matchMedia;
+
+    render(<GhostwriterDrawer job={createJob()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ghostwriter" }));
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Ghostwriter pop-up" }),
+    );
+    expect(window.localStorage.getItem(DISPLAY_MODE_STORAGE_KEY)).toBe(
+      "fullscreen",
+    );
+    expect(screen.getByTestId("sheet-content").className).toContain("w-screen");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Restore Ghostwriter drawer" }),
+    );
+    expect(window.localStorage.getItem(DISPLAY_MODE_STORAGE_KEY)).toBe(
+      "drawer",
+    );
+    expect(screen.getByTestId("sheet-content").className).toContain(
+      "lg:w-[50vw]",
+    );
+  });
+
+  it("hides mode toggle on mobile and keeps drawer layout", () => {
+    window.localStorage.setItem(DISPLAY_MODE_STORAGE_KEY, "fullscreen");
+    window.matchMedia = createMatchMedia(false) as typeof window.matchMedia;
+
+    render(<GhostwriterDrawer job={createJob()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ghostwriter" }));
+
+    const content = screen.getByTestId("sheet-content");
+    expect(content.className).toContain("lg:w-[50vw]");
+    expect(content.className).not.toContain("w-screen");
+    expect(
+      screen.queryByRole("button", { name: "Open Ghostwriter pop-up" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Restore Ghostwriter drawer" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps GhostwriterPanel mounted while switching modes", () => {
+    window.matchMedia = createMatchMedia(true) as typeof window.matchMedia;
+
+    render(<GhostwriterDrawer job={createJob()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Ghostwriter" }));
+
+    expect(screen.getByTestId("ghostwriter-panel")).toBeInTheDocument();
+    expect(panelLifecycle.mounts).toBe(1);
+    expect(panelLifecycle.unmounts).toBe(0);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open Ghostwriter pop-up" }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Restore Ghostwriter drawer" }),
+    );
+
+    expect(screen.getByTestId("ghostwriter-panel")).toBeInTheDocument();
+    expect(panelLifecycle.mounts).toBe(1);
+    expect(panelLifecycle.unmounts).toBe(0);
+  });
+});

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterDrawer.test.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterDrawer.test.tsx
@@ -50,6 +50,12 @@ vi.mock("@/components/ui/sheet", async () => {
         onClick: () => onOpenChange(true),
       });
     },
+    SheetClose: ({ children }: { children: React.ReactElement }) => {
+      const { onOpenChange } = useSheetContext();
+      return ReactModule.cloneElement(children, {
+        onClick: () => onOpenChange(false),
+      });
+    },
     SheetContent: ({
       className,
       children,

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterDrawer.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterDrawer.tsx
@@ -1,7 +1,7 @@
 import type { Job } from "@shared/types";
-import { PanelRightOpen } from "lucide-react";
+import { Maximize2, Minimize2, PanelRightOpen } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
@@ -19,11 +19,71 @@ type GhostwriterDrawerProps = {
   triggerClassName?: string;
 };
 
+type DisplayMode = "drawer" | "fullscreen";
+
+const DESKTOP_MEDIA_QUERY = "(min-width: 1024px)";
+const DISPLAY_MODE_STORAGE_KEY = "jobops.ghostwriter.display-mode.v1";
+
+function getIsDesktopViewport(): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof window.matchMedia !== "function") return false;
+  return window.matchMedia(DESKTOP_MEDIA_QUERY).matches;
+}
+
+function getStoredDisplayMode(): DisplayMode {
+  if (typeof window === "undefined") return "drawer";
+  try {
+    const value = window.localStorage.getItem(DISPLAY_MODE_STORAGE_KEY);
+    return value === "fullscreen" ? "fullscreen" : "drawer";
+  } catch {
+    return "drawer";
+  }
+}
+
 export const GhostwriterDrawer: React.FC<GhostwriterDrawerProps> = ({
   job,
   triggerClassName,
 }) => {
   const [open, setOpen] = useState(false);
+  const [displayMode, setDisplayMode] = useState<DisplayMode>(() =>
+    getStoredDisplayMode(),
+  );
+  const [isDesktop, setIsDesktop] = useState(() => getIsDesktopViewport());
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (typeof window.matchMedia !== "function") return;
+    const media = window.matchMedia(DESKTOP_MEDIA_QUERY);
+    const handleChange = () => setIsDesktop(media.matches);
+    handleChange();
+    if (media.addEventListener) {
+      media.addEventListener("change", handleChange);
+      return () => media.removeEventListener("change", handleChange);
+    }
+    media.addListener(handleChange);
+    return () => media.removeListener(handleChange);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(DISPLAY_MODE_STORAGE_KEY, displayMode);
+    } catch {
+      // Ignore storage failures and continue with in-memory mode.
+    }
+  }, [displayMode]);
+
+  const isFullscreen = isDesktop && displayMode === "fullscreen";
+  const panelClassName = useMemo(
+    () =>
+      cn(
+        "flex w-full flex-col p-0",
+        isFullscreen
+          ? "inset-0 h-dvh w-screen max-w-none sm:max-w-none border-0 rounded-none shadow-none"
+          : "sm:max-w-none lg:w-[50vw] xl:w-[40vw] 2xl:w-[30vw]",
+      ),
+    [isFullscreen],
+  );
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -39,16 +99,45 @@ export const GhostwriterDrawer: React.FC<GhostwriterDrawerProps> = ({
         </Button>
       </SheetTrigger>
 
-      <SheetContent
-        side="right"
-        className="flex w-full flex-col p-0 sm:max-w-none lg:w-[50vw] xl:w-[40vw] 2xl:w-[30vw]"
-      >
+      <SheetContent side="right" className={panelClassName}>
         <div className="border-b border-border/50 p-4">
           <SheetHeader>
-            <SheetTitle>Ghostwriter</SheetTitle>
-            <SheetDescription>
-              {job && `${job.title} at ${job.employer}.`}
-            </SheetDescription>
+            <div className="flex items-start justify-between gap-2">
+              <div className="min-w-0">
+                <SheetTitle>Ghostwriter</SheetTitle>
+                <SheetDescription>
+                  {job && `${job.title} at ${job.employer}.`}
+                </SheetDescription>
+              </div>
+              {isDesktop && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 shrink-0"
+                  onClick={() =>
+                    setDisplayMode((current) =>
+                      current === "fullscreen" ? "drawer" : "fullscreen",
+                    )
+                  }
+                  aria-label={
+                    isFullscreen
+                      ? "Restore Ghostwriter drawer"
+                      : "Open Ghostwriter pop-up"
+                  }
+                  title={
+                    isFullscreen
+                      ? "Restore Ghostwriter drawer"
+                      : "Open Ghostwriter pop-up"
+                  }
+                >
+                  {isFullscreen ? (
+                    <Minimize2 className="h-4 w-4" />
+                  ) : (
+                    <Maximize2 className="h-4 w-4" />
+                  )}
+                </Button>
+              )}
+            </div>
           </SheetHeader>
         </div>
 

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterDrawer.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterDrawer.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetDescription,
   SheetHeader,
@@ -81,6 +82,7 @@ export const GhostwriterDrawer: React.FC<GhostwriterDrawerProps> = ({
         isFullscreen
           ? "inset-0 h-dvh w-screen max-w-none sm:max-w-none border-0 rounded-none shadow-none"
           : "sm:max-w-none lg:w-[50vw] xl:w-[40vw] 2xl:w-[30vw]",
+        "[&>button]:hidden",
       ),
     [isFullscreen],
   );
@@ -102,41 +104,54 @@ export const GhostwriterDrawer: React.FC<GhostwriterDrawerProps> = ({
       <SheetContent side="right" className={panelClassName}>
         <div className="border-b border-border/50 p-4">
           <SheetHeader>
-            <div className="flex items-start justify-between gap-2">
+            <div className="flex items-start justify-between gap-2 w-full max-w-6xl mx-auto">
               <div className="min-w-0">
                 <SheetTitle>Ghostwriter</SheetTitle>
                 <SheetDescription>
                   {job && `${job.title} at ${job.employer}.`}
                 </SheetDescription>
               </div>
-              {isDesktop && (
-                <Button
-                  size="icon"
-                  variant="ghost"
-                  className="h-8 w-8 shrink-0"
-                  onClick={() =>
-                    setDisplayMode((current) =>
-                      current === "fullscreen" ? "drawer" : "fullscreen",
-                    )
-                  }
-                  aria-label={
-                    isFullscreen
-                      ? "Restore Ghostwriter drawer"
-                      : "Open Ghostwriter pop-up"
-                  }
-                  title={
-                    isFullscreen
-                      ? "Restore Ghostwriter drawer"
-                      : "Open Ghostwriter pop-up"
-                  }
-                >
-                  {isFullscreen ? (
-                    <Minimize2 className="h-4 w-4" />
-                  ) : (
-                    <Maximize2 className="h-4 w-4" />
-                  )}
-                </Button>
-              )}
+              <div className="flex shrink-0 items-center gap-1 rounded-md border border-border/60 bg-background/70 p-1">
+                {isDesktop && (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7"
+                    onClick={() =>
+                      setDisplayMode((current) =>
+                        current === "fullscreen" ? "drawer" : "fullscreen",
+                      )
+                    }
+                    aria-label={
+                      isFullscreen
+                        ? "Restore Ghostwriter drawer"
+                        : "Open Ghostwriter pop-up"
+                    }
+                    title={
+                      isFullscreen
+                        ? "Restore Ghostwriter drawer"
+                        : "Open Ghostwriter pop-up"
+                    }
+                  >
+                    {isFullscreen ? (
+                      <Minimize2 className="h-4 w-4" />
+                    ) : (
+                      <Maximize2 className="h-4 w-4" />
+                    )}
+                  </Button>
+                )}
+                <SheetClose asChild>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-7 w-7"
+                    aria-label="Close Ghostwriter"
+                    title="Close Ghostwriter"
+                  >
+                    <span className="text-base leading-none">×</span>
+                  </Button>
+                </SheetClose>
+              </div>
             </div>
           </SheetHeader>
         </div>

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterPanel.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterPanel.tsx
@@ -369,7 +369,7 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({ job }) => {
   }, [job.id]);
 
   return (
-    <div className="flex h-full min-h-0 flex-1 flex-col">
+    <div className="flex h-full min-h-0 flex-1 flex-col max-w-6xl mx-auto">
       <div
         ref={messageListRef}
         className="min-h-0 flex-1 overflow-y-auto border-b border-border/50 pb-3 pr-1"

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -18,6 +18,18 @@ if (!existsSync(dataDir)) {
 
 const sqlite = new Database(DB_PATH);
 
+function hasTableColumn(tableName: string, columnName: string): boolean {
+  const columns = sqlite
+    .prepare(`PRAGMA table_info(${tableName})`)
+    .all() as Array<{ name: string }>;
+  return columns.some((column) => column.name === columnName);
+}
+
+const pipelineRunsHasConfigSnapshot = hasTableColumn(
+  "pipeline_runs",
+  "config_snapshot",
+);
+
 const migrations = [
   `CREATE TABLE IF NOT EXISTS jobs (
     id TEXT PRIMARY KEY,
@@ -454,7 +466,7 @@ const migrations = [
     result_summary TEXT
   )`,
   `INSERT OR REPLACE INTO pipeline_runs_new (id, started_at, completed_at, status, jobs_discovered, jobs_processed, error_message, config_snapshot, requested_config, effective_config, result_summary)
-   SELECT id, started_at, completed_at, status, jobs_discovered, jobs_processed, error_message, config_snapshot, NULL, NULL, NULL
+   SELECT id, started_at, completed_at, status, jobs_discovered, jobs_processed, error_message, ${pipelineRunsHasConfigSnapshot ? "config_snapshot" : "NULL"}, NULL, NULL, NULL
    FROM pipeline_runs`,
   `DROP TABLE IF EXISTS pipeline_runs`,
   `ALTER TABLE pipeline_runs_new RENAME TO pipeline_runs`,


### PR DESCRIPTION
## Summary
- Add a desktop-only Ghostwriter pop-up mode that expands to the full viewport while preserving the same live chat state.
- Persist the last-used display mode per browser and keep mobile behavior on the standard drawer layout.
- Update Ghostwriter docs to explain how to open, restore, and use the larger writing surface.

## Testing
- Added focused unit tests for drawer default mode, fullscreen restore, desktop toggle persistence, mobile fallback, and panel mount stability.
- Verified the Ghostwriter drawer test suite and full orchestrator test suite pass locally.