### PR TITLE
Add local DOCX text extraction for resume import

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -65,6 +65,7 @@
     "html-to-text": "^9.0.5",
     "jsdom": "^25.0.1",
     "jsonwebtoken": "^9.0.3",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.561.0",
     "next-themes": "^0.4.6",
     "react-hook-form": "^7.71.1",

--- a/orchestrator/src/server/services/design-resume/import-file.test.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.test.ts
@@ -1,5 +1,6 @@
 import { AppError } from "@infra/errors";
 import type { DesignResumeDocument, DesignResumeJson } from "@shared/types";
+import JSZip from "jszip";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildDefaultReactiveResumeDocument } from "../rxresume/document";
 
@@ -37,6 +38,34 @@ function makeResumeDocument(
     updatedAt: "2026-04-11T00:00:00.000Z",
     assets: [],
   };
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+async function makeDocxBase64(text: string): Promise<string> {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:r>
+        <w:t>${escapeXml(text)}</w:t>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+  );
+  const buffer = await zip.generateAsync({ type: "nodebuffer" });
+  return buffer.toString("base64");
 }
 
 describe("importDesignResumeFromFile", () => {
@@ -124,6 +153,66 @@ describe("importDesignResumeFromFile", () => {
       hidden: false,
     });
     expect(result.title).toBe("Taylor Resume");
+  });
+
+  it("extracts DOCX text locally before sending it to Gemini", async () => {
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
+      provider: "gemini",
+      model: "google/gemini-3-flash-preview",
+      baseUrl: null,
+      apiKey: "gemini-test",
+    });
+
+    const docxBase64 = await makeDocxBase64("Taylor Quinn\nSenior Engineer");
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ text: '{"basics":{"name":"Taylor Quinn"}}' }],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await importDesignResumeFromFile({
+      fileName: "resume.docx",
+      mediaType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      dataBase64: docxBase64,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent",
+      ),
+      expect.any(Object),
+    );
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const body =
+      fetchCall?.[1] && "body" in fetchCall[1] ? fetchCall[1].body : "";
+    const parsedBody = JSON.parse(String(body)) as Record<string, unknown>;
+
+    expect(JSON.stringify(parsedBody)).not.toContain("inlineData");
+    expect(JSON.stringify(parsedBody)).not.toContain("input_file");
+
+    const contents = parsedBody.contents as Array<{
+      parts?: Array<{ text?: string }>;
+    }>;
+    expect(contents[0]?.parts?.[0]?.text).toContain(
+      "The resume file was uploaded as DOCX",
+    );
+    expect(contents[0]?.parts?.[0]?.text).toContain("Taylor Quinn");
+    expect(contents[0]?.parts?.[0]?.text).toContain("Senior Engineer");
   });
 
   it("accepts supported media types even when the file name has no extension", async () => {

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -14,6 +14,7 @@ import {
   safeParseV5ResumeData,
 } from "@server/services/rxresume/schema";
 import type { DesignResumeDocument, DesignResumeJson } from "@shared/types";
+import JSZip from "jszip";
 import { buildHeaders, getResponseDetail, joinUrl } from "../llm/utils/http";
 import { parseErrorMessage, truncate } from "../llm/utils/string";
 import { replaceCurrentDesignResumeDocument } from "./index";
@@ -49,7 +50,7 @@ const SYSTEM_PROMPT = `
 You extract a resume into a single JSON object.
 
 Rules:
-- Extract only information explicitly present in the attached file.
+- Extract only information explicitly present in the provided resume input.
 - Do not guess, infer, summarize, embellish, or invent missing values.
 - Preserve the source language and wording as closely as possible.
 - Return JSON only. Do not wrap it in markdown or prose.
@@ -485,11 +486,88 @@ function buildUserPrompt(): string {
   };
 
   return `
-The resume file is attached.
+The resume input is provided in the request.
 Return the final JSON object only.
 
 Use this exact target shape and keys:
 ${JSON.stringify(template, null, 2)}
+`.trim();
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(
+    /&(?:#x([0-9a-fA-F]+)|#([0-9]+)|amp|lt|gt|quot|apos);/g,
+    (match, hex, dec) => {
+      if (hex) return String.fromCodePoint(Number.parseInt(hex, 16));
+      if (dec) return String.fromCodePoint(Number.parseInt(dec, 10));
+      switch (match) {
+        case "&amp;":
+          return "&";
+        case "&lt;":
+          return "<";
+        case "&gt;":
+          return ">";
+        case "&quot;":
+          return '"';
+        case "&apos;":
+          return "'";
+        default:
+          return match;
+      }
+    },
+  );
+}
+
+function normalizeDocxXmlText(xml: string): string {
+  return decodeXmlEntities(
+    xml
+      .replace(/<w:tab\b[^>]*\/>/g, "\t")
+      .replace(/<w:br\b[^>]*\/>/g, "\n")
+      .replace(/<w:cr\b[^>]*\/>/g, "\n")
+      .replace(/<\/w:p>/g, "\n")
+      .replace(/<\/w:tr>/g, "\n")
+      .replace(/<\/w:tc>/g, "\t")
+      .replace(/<w:t\b[^>]*>/g, "")
+      .replace(/<\/w:t>/g, "")
+      .replace(/<[^>]+>/g, ""),
+  )
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function extractDocxText(decoded: Buffer): Promise<string> {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(decoded);
+  } catch {
+    throw badRequest("Resume DOCX file could not be read.");
+  }
+
+  const documentXml = zip.file("word/document.xml");
+  if (!documentXml) {
+    throw badRequest("Resume DOCX file is missing document content.");
+  }
+
+  const xml = await documentXml.async("string");
+  const text = normalizeDocxXmlText(xml);
+  if (!text) {
+    throw badRequest("Resume DOCX file did not contain readable text.");
+  }
+
+  return text;
+}
+
+function buildDocxPrompt(documentText: string, fileName: string): string {
+  return `
+The resume file was uploaded as DOCX and converted locally to plain text before extraction.
+File name: ${fileName}
+
+Extracted resume text:
+${documentText}
+
+${buildUserPrompt()}
 `.trim();
 }
 
@@ -662,7 +740,7 @@ function sanitizeNormalizedResume(input: unknown): DesignResumeJson {
 }
 
 function buildCapabilityErrorMessage(provider: string): string {
-  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, or Gemini to import PDF or DOCX resumes directly.`;
+  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, or Gemini to import resumes. DOCX files are converted to text locally before extraction.`;
 }
 
 function isFileCapabilityError(message: string): boolean {
@@ -691,6 +769,7 @@ async function extractWithOpenAi(args: {
   mediaType: SupportedImportMediaType;
   fileName: string;
   dataBase64: string;
+  documentText?: string | null;
   requestId: string | undefined;
 }): Promise<string> {
   const url = joinUrl(
@@ -717,17 +796,24 @@ async function extractWithOpenAi(args: {
         },
         {
           role: "user",
-          content: [
-            {
-              type: "input_text",
-              text: buildUserPrompt(),
-            },
-            {
-              type: "input_file",
-              filename: args.fileName,
-              file_data: buildDataUrl(args.mediaType, args.dataBase64),
-            },
-          ],
+          content: args.documentText
+            ? [
+                {
+                  type: "input_text",
+                  text: buildDocxPrompt(args.documentText, args.fileName),
+                },
+              ]
+            : [
+                {
+                  type: "input_text",
+                  text: buildUserPrompt(),
+                },
+                {
+                  type: "input_file",
+                  filename: args.fileName,
+                  file_data: buildDataUrl(args.mediaType, args.dataBase64),
+                },
+              ],
         },
       ],
     }),
@@ -762,6 +848,7 @@ async function extractWithOpenRouter(args: {
   mediaType: SupportedImportMediaType;
   fileName: string;
   dataBase64: string;
+  documentText?: string | null;
   requestId: string | undefined;
 }): Promise<string> {
   const url = joinUrl(
@@ -787,19 +874,21 @@ async function extractWithOpenRouter(args: {
         },
         {
           role: "user",
-          content: [
-            {
-              type: "text",
-              text: buildUserPrompt(),
-            },
-            {
-              type: "file",
-              file: {
-                filename: args.fileName,
-                file_data: buildDataUrl(args.mediaType, args.dataBase64),
-              },
-            },
-          ],
+          content: args.documentText
+            ? buildDocxPrompt(args.documentText, args.fileName)
+            : [
+                {
+                  type: "text",
+                  text: buildUserPrompt(),
+                },
+                {
+                  type: "file",
+                  file: {
+                    filename: args.fileName,
+                    file_data: buildDataUrl(args.mediaType, args.dataBase64),
+                  },
+                },
+              ],
         },
       ],
       ...(args.mediaType === "application/pdf"
@@ -847,6 +936,8 @@ async function extractWithGemini(args: {
   model: string;
   mediaType: SupportedImportMediaType;
   dataBase64: string;
+  documentText?: string | null;
+  fileName: string;
   requestId: string | undefined;
 }): Promise<string> {
   const model = normalizeGeminiModelName(args.model);
@@ -865,17 +956,23 @@ async function extractWithGemini(args: {
       contents: [
         {
           role: "user",
-          parts: [
-            {
-              text: buildUserPrompt(),
-            },
-            {
-              inlineData: {
-                mimeType: args.mediaType,
-                data: args.dataBase64,
-              },
-            },
-          ],
+          parts: args.documentText
+            ? [
+                {
+                  text: buildDocxPrompt(args.documentText, args.fileName),
+                },
+              ]
+            : [
+                {
+                  text: buildUserPrompt(),
+                },
+                {
+                  inlineData: {
+                    mimeType: args.mediaType,
+                    data: args.dataBase64,
+                  },
+                },
+              ],
         },
       ],
       generationConfig: {
@@ -914,6 +1011,7 @@ async function extractResumeFromProvider(args: {
   mediaType: SupportedImportMediaType;
   fileName: string;
   dataBase64: string;
+  documentText?: string | null;
   requestId: string | undefined;
 }): Promise<string> {
   if (args.provider === "openai") {
@@ -961,6 +1059,8 @@ export async function importDesignResumeFromFile(
   }
 
   try {
+    const documentText =
+      mediaType === DOCX_MIME ? await extractDocxText(decoded) : null;
     const rawText = await extractResumeFromProvider({
       provider,
       apiKey: runtime.apiKey,
@@ -969,6 +1069,7 @@ export async function importDesignResumeFromFile(
       mediaType,
       fileName,
       dataBase64: normalizedBase64,
+      documentText,
       requestId,
     });
     const parsed = parseImportedResumeJson(rawText);

--- a/package-lock.json
+++ b/package-lock.json
@@ -16586,6 +16586,48 @@
         "npm": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
@@ -16746,6 +16788,21 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/lie/node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/lightningcss-android-arm64": {
       "version": "1.30.2",
@@ -19521,6 +19578,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -23283,6 +23346,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -26246,6 +26315,7 @@
         "html-to-text": "^9.0.5",
         "jsdom": "^25.0.1",
         "jsonwebtoken": "^9.0.3",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.561.0",
         "next-themes": "^0.4.6",
         "react-hook-form": "^7.71.1",


### PR DESCRIPTION
## Summary
- Extract DOCX content locally with `jszip` before sending resume text to the model
- Update OpenAI, OpenRouter, and Gemini prompts to use plain extracted text for DOCX imports
- Add coverage proving DOCX payloads are not forwarded as inline files and that extracted text reaches the prompt

## Testing
- Added unit coverage for local DOCX extraction and prompt construction