### PR TITLE
Add job header status tooltips

### DIFF
--- a/orchestrator/src/client/components/JobHeader.test.tsx
+++ b/orchestrator/src/client/components/JobHeader.test.tsx
@@ -145,6 +145,41 @@ describe("JobHeader", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows contextual tooltips for discovered, tracer off, and suitability score", () => {
+    const jobWithTooltips = {
+      ...mockJob,
+      tracerLinksEnabled: false,
+      suitabilityScore: 45,
+    };
+
+    renderWithRouter(<JobHeader job={jobWithTooltips} />);
+
+    expect(
+      screen.getByText("Found by the pipeline. Not tailored yet."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Tracer links are turned off for this job, so click tracking will not be recorded.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Suitability score: 45/100. Higher is better."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a tooltip for ready jobs", () => {
+    const readyJob = {
+      ...mockJob,
+      status: "ready" as const,
+    };
+
+    renderWithRouter(<JobHeader job={readyJob} />);
+
+    expect(
+      screen.getByText("Tailored and ready to apply."),
+    ).toBeInTheDocument();
+  });
+
   it("hides sponsor info when showSponsorInfo is false", () => {
     (useSettings as any).mockReturnValue({
       showSponsorInfo: false,

--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -33,12 +33,15 @@ interface JobHeaderProps {
   onCheckSponsor?: () => Promise<void>;
 }
 
-const ScoreMeter: React.FC<{ score: number | null }> = ({ score }) => {
+const ScoreMeter: React.FC<{
+  score: number | null;
+  tooltip?: React.ReactNode;
+}> = ({ score, tooltip }) => {
   if (score == null) {
     return <span className="text-[10px] text-muted-foreground/60">-</span>;
   }
 
-  return (
+  const content = (
     <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground/70">
       <div className="h-1 w-12 rounded-full bg-muted/30">
         <div
@@ -48,6 +51,21 @@ const ScoreMeter: React.FC<{ score: number | null }> = ({ score }) => {
       </div>
       <span className="tabular-nums">{score}</span>
     </div>
+  );
+
+  if (!tooltip) {
+    return content;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={0}>
+        <TooltipTrigger asChild>{content}</TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };
 
@@ -198,6 +216,24 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
   const { pathname } = useLocation();
   const isJobPage = pathname.startsWith("/job/");
   const deadline = formatDate(job.deadline);
+  const jobStatusTooltip =
+    job.status === "discovered" ? (
+      <p className="text-xs">Found by the pipeline. Not tailored yet.</p>
+    ) : job.status === "ready" ? (
+      <p className="text-xs">Tailored and ready to apply.</p>
+    ) : undefined;
+  const tracerStatusTooltip = !job.tracerLinksEnabled ? (
+    <p className="text-xs">
+      Tracer links are turned off for this job, so click tracking will not be
+      recorded.
+    </p>
+  ) : undefined;
+  const scoreTooltip =
+    job.suitabilityScore == null ? undefined : (
+      <p className="text-xs">
+        Suitability score: {job.suitabilityScore}/100. Higher is better.
+      </p>
+    );
 
   return (
     <div className={cn("space-y-3", className)}>
@@ -273,10 +309,16 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
           <StatusIndicator
             dotColor={jobStatus.dotColor}
             label={jobStatus.label}
+            tooltip={jobStatusTooltip}
+            tooltipClassName="max-w-xs"
+            className={jobStatusTooltip ? "cursor-help" : undefined}
           />
           <StatusIndicator
             dotColor={tracerStatus.dotColor}
             label={tracerStatus.label}
+            tooltip={tracerStatusTooltip}
+            tooltipClassName="max-w-xs"
+            className={tracerStatusTooltip ? "cursor-help" : undefined}
           />
           <AppliedDuplicatePill match={job.appliedDuplicateMatch} />
           {showSponsorInfo && (
@@ -287,7 +329,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
             />
           )}
         </div>
-        <ScoreMeter score={job.suitabilityScore} />
+        <ScoreMeter score={job.suitabilityScore} tooltip={scoreTooltip} />
       </div>
     </div>
   );

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
@@ -76,6 +76,20 @@ describe("OrchestratorFilters", () => {
     expect(props.onOpenCommandBar).toHaveBeenCalled();
   });
 
+  it("shows contextual tab descriptions on hover", async () => {
+    renderFilters();
+
+    const discoveredTab = screen.getByRole("tab", { name: /discovered/i });
+    fireEvent.pointerOver(discoveredTab);
+    fireEvent.pointerMove(discoveredTab);
+
+    expect(
+      await screen.findAllByText(
+        "Jobs that match your search but haven't been tailored yet",
+      ),
+    ).toHaveLength(2);
+  });
+
   it("updates source, sponsor, salary range, and sort from the drawer", async () => {
     const { props } = renderFilters();
 

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
@@ -84,9 +84,7 @@ describe("OrchestratorFilters", () => {
     fireEvent.pointerMove(discoveredTab);
 
     expect(
-      await screen.findAllByText(
-        "Jobs that match your search but haven't been tailored yet",
-      ),
+      await screen.findAllByText("Jobs searched, ready to be tailored"),
     ).toHaveLength(2);
   });
 

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
@@ -25,6 +25,12 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { sourceLabel } from "@/lib/utils";
 import type {
   DateFilterDimension,
@@ -102,6 +108,12 @@ const sortFieldLabels: Record<JobSort["key"], string> = {
   salary: "Salary",
   title: "Title",
   employer: "Company",
+};
+
+const tabDescriptions: Partial<Record<FilterTab, string>> = {
+  discovered: "Jobs searched, ready to be tailored",
+  ready: "Jobs with tailored CVs, ready to apply",
+  applied: "Jobs you've marked as applied",
 };
 
 const datePresetOptions: Array<{
@@ -232,23 +244,41 @@ export const OrchestratorFilters: React.FC<OrchestratorFiltersProps> = ({
       onValueChange={(value) => onTabChange(value as FilterTab)}
     >
       <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-        <TabsList className="h-auto w-full flex-wrap justify-start gap-1 lg:w-auto">
-          {tabs.map((tab, index) => (
-            <TabsTrigger
-              key={tab.id}
-              value={tab.id}
-              className="flex-1 flex items-center lg:flex-none gap-1.5"
-            >
-              <KbdHint shortcut={String(index + 1)} className="mr-0.5" />
-              <span>{tab.label}</span>
-              {counts[tab.id] > 0 && (
-                <span className="text-[10px] mt-[2px] tabular-nums opacity-60">
-                  {counts[tab.id]}
-                </span>
-              )}
-            </TabsTrigger>
-          ))}
-        </TabsList>
+        <TooltipProvider delayDuration={0}>
+          <TabsList className="h-auto w-full flex-wrap justify-start gap-1 lg:w-auto">
+            {tabs.map((tab, index) => {
+              const description = tabDescriptions[tab.id];
+              const trigger = (
+                <TabsTrigger
+                  key={tab.id}
+                  value={tab.id}
+                  className="flex-1 flex items-center lg:flex-none gap-1.5"
+                >
+                  <KbdHint shortcut={String(index + 1)} className="mr-0.5" />
+                  <span>{tab.label}</span>
+                  {counts[tab.id] > 0 && (
+                    <span className="text-[10px] mt-[2px] tabular-nums opacity-60">
+                      {counts[tab.id]}
+                    </span>
+                  )}
+                </TabsTrigger>
+              );
+
+              if (!description) {
+                return trigger;
+              }
+
+              return (
+                <Tooltip key={tab.id}>
+                  <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+                  <TooltipContent className="max-w-xs text-center">
+                    <p>{description}</p>
+                  </TooltipContent>
+                </Tooltip>
+              );
+            })}
+          </TabsList>
+        </TooltipProvider>
 
         <div className="flex lg:flex-nowrap flex-wrap items-center justify-end gap-2">
           <Button

--- a/orchestrator/src/components/ui/tabs.tsx
+++ b/orchestrator/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 aria-selected:bg-background aria-selected:text-foreground aria-selected:shadow",
       className,
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Add concise hover tooltips to JobHeader status pills for Discovered, Ready, and Tracer Off
- Add a hover tooltip for the suitability score meter
- Keep the existing tab tooltip behavior intact after the shared tabs styling fix

<img width="513" height="144" alt="image" src="https://github.com/user-attachments/assets/6f8d82d1-ce0b-4ad5-be22-2651318d5830" />
<img width="986" height="298" alt="image" src="https://github.com/user-attachments/assets/a6885432-4b21-4eca-9402-d94997486a31" />


## Testing
- Added and updated unit tests for JobHeader tooltip copy
- Ran focused Biome checks on the touched client files
- Ran the focused Vitest suite for JobHeader