### PR TITLE
Added icon picker for "design resume" sections and Re-import confirmation pop-up

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -28,6 +28,8 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@iconify-json/tabler": "^1.2.33",
+    "@iconify/react": "^6.0.2",
     "@paralleldrive/cuid2": "^3.0.6",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/orchestrator/src/client/components/design-resume/IconPickerField.tsx
+++ b/orchestrator/src/client/components/design-resume/IconPickerField.tsx
@@ -1,0 +1,148 @@
+import { Icon } from "@iconify/react";
+import tablerIcons from "@iconify-json/tabler/icons.json";
+import { Search } from "lucide-react";
+import { useMemo, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+
+// All tabler icon keys (e.g. "a-b", "brand-python", …)
+const ALL_ICONS: string[] = Object.keys(
+  (tablerIcons as { icons: Record<string, unknown> }).icons,
+);
+
+const MAX_VISIBLE = 300;
+
+interface IconPickerFieldProps {
+  id?: string;
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function IconPickerField({ id, value, onChange }: IconPickerFieldProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // Strip prefix for display/matching — value stored as "tabler:brand-python"
+  const storedToKey = (v: string) => (v.startsWith("tabler:") ? v.slice(7) : v);
+  const keyToStored = (k: string) => `tabler:${k}`;
+
+  const selectedKey = storedToKey(value);
+
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase().trim();
+    const list = q ? ALL_ICONS.filter((k) => k.includes(q)) : ALL_ICONS;
+    return list.slice(0, MAX_VISIBLE);
+  }, [search]);
+
+  const handleSelect = (key: string) => {
+    onChange(keyToStored(key));
+    setOpen(false);
+    setSearch("");
+  };
+
+  const handleClear = () => {
+    onChange("");
+  };
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (next) {
+          // Focus search after popover opens
+          setTimeout(() => searchRef.current?.focus(), 50);
+        } else {
+          setSearch("");
+        }
+      }}
+    >
+      <PopoverTrigger asChild>
+        <button
+          id={id}
+          type="button"
+          title={value || "Pick an icon"}
+          className="flex h-10 w-10 shrink-0 items-center justify-center bg-transparent transition-colors hover:bg-accent focus:outline-none"
+        >
+          {value ? (
+            <Icon icon={value} width={22} height={22} />
+          ) : (
+            <span className="text-xl leading-none text-muted-foreground">
+              +
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="w-80 p-0 shadow-xl"
+        align="start"
+        side="bottom"
+        sideOffset={6}
+        style={{ zIndex: 9999 }}
+      >
+        {/* Search */}
+        <div className="flex items-center gap-2 border-b px-3 py-2">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <Input
+            ref={searchRef}
+            className="h-8 border-0 bg-transparent p-0 text-sm shadow-none focus-visible:ring-0"
+            placeholder="Search for an icon"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+
+        {/* Icon grid */}
+        <div
+          className="grid max-h-72 grid-cols-8 gap-0.5 overflow-y-auto overscroll-contain p-2"
+          onWheelCapture={(e) => e.stopPropagation()}
+          onTouchMoveCapture={(e) => e.stopPropagation()}
+        >
+          {filtered.length === 0 ? (
+            <p className="col-span-8 py-6 text-center text-sm text-muted-foreground">
+              No icons found.
+            </p>
+          ) : (
+            filtered.map((key) => (
+              <button
+                key={key}
+                type="button"
+                title={key}
+                onClick={() => handleSelect(key)}
+                className={`flex h-9 w-9 items-center justify-center rounded-md transition-colors ${
+                  selectedKey === key
+                    ? "bg-[#F1703E] text-white"
+                    : "hover:bg-accent"
+                }`}
+              >
+                <Icon icon={`tabler:${key}`} width={20} height={20} />
+              </button>
+            ))
+          )}
+        </div>
+
+        {/* Footer: selected name + clear */}
+        <div className="flex items-center justify-between border-t px-3 py-2">
+          <span className="text-xs text-muted-foreground">
+            {selectedKey || ""}
+          </span>
+          {value && (
+            <button
+              type="button"
+              onClick={handleClear}
+              className="text-xs text-[#F1703E] hover:underline"
+            >
+              clear
+            </button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/orchestrator/src/client/components/design-resume/ItemDialog.tsx
+++ b/orchestrator/src/client/components/design-resume/ItemDialog.tsx
@@ -14,6 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import { IconPickerField } from "./IconPickerField";
 import { RichTextEditor } from "./RichTextEditor";
 
 export type ItemFieldType =
@@ -22,7 +23,8 @@ export type ItemFieldType =
   | "textarea"
   | "richtext"
   | "tags"
-  | "toggle";
+  | "toggle"
+  | "icon";
 
 export type ItemFieldConfig = {
   key: string;
@@ -32,6 +34,8 @@ export type ItemFieldConfig = {
   required?: boolean;
   min?: number;
   step?: number;
+  /** When true on an icon field, render it inline to the left of the next field with no separate label */
+  groupWithNext?: boolean;
 };
 
 type ItemDialogProps = {
@@ -135,8 +139,44 @@ function renderTextField(
         {field.label}
         {field.required ? <span className="ml-1 text-rose-400">*</span> : null}
       </label>
-      <div className={iconPrefix ? "flex items-center gap-2" : undefined}>
-        {iconPrefix}
+      {iconPrefix ? (
+        <div
+          className={`flex items-stretch overflow-hidden rounded-md border ${fieldErrors[field.key] ? "border-rose-500" : "border-input"} bg-background/60 focus-within:ring-1 focus-within:ring-ring`}
+        >
+          {/* icon square — borderless, flush left */}
+          <div className="flex shrink-0 items-center border-r border-input">
+            {iconPrefix}
+          </div>
+          <input
+            id={fieldId}
+            type={field.type === "number" ? "number" : "text"}
+            value={
+              field.type === "number"
+                ? String(value as number)
+                : (value as string)
+            }
+            min={field.min}
+            step={field.step}
+            placeholder={field.placeholder}
+            onChange={(event) => {
+              if (fieldErrors[field.key]) {
+                setFieldErrors((current) => {
+                  const next = { ...current };
+                  delete next[field.key];
+                  return next;
+                });
+              }
+              updateField(
+                field.key,
+                field.type === "number"
+                  ? Number(event.currentTarget.value || 0)
+                  : event.currentTarget.value,
+              );
+            }}
+            className="flex-1 bg-transparent px-3 py-2 text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </div>
+      ) : (
         <Input
           id={fieldId}
           type={field.type === "number" ? "number" : "text"}
@@ -169,7 +209,7 @@ function renderTextField(
               : "bg-background/60"
           }
         />
-      </div>
+      )}
       {fieldErrors[field.key] ? (
         <p className="text-xs text-rose-400">{fieldErrors[field.key]}</p>
       ) : null}
@@ -272,6 +312,55 @@ function renderFields(
           <Switch
             checked={value as boolean}
             onCheckedChange={(checked) => updateField(field.key, checked)}
+          />
+        </div>,
+      );
+      i++;
+      continue;
+    }
+
+    // Icon picker — grouped inline to the left of the next field (no separate label)
+    if (field.type === "icon" && field.groupWithNext && i + 1 < fields.length) {
+      const nextField = fields[i + 1];
+      if (nextField) {
+        const nextValue = coerceDraftValue(
+          nextField,
+          getValue(draft, nextField.key),
+        );
+        const nextFieldId = fieldIdForPath(nextField.key);
+        const iconNode = (
+          <IconPickerField
+            value={value as string}
+            onChange={(next) => updateField(field.key, next)}
+          />
+        );
+        nodes.push(
+          renderTextField(
+            nextField,
+            nextValue as string | number,
+            fieldErrors,
+            updateField,
+            setFieldErrors,
+            nextFieldId,
+            iconNode,
+          ),
+        );
+        i += 2;
+        continue;
+      }
+    }
+
+    // Icon picker — standalone (with label)
+    if (field.type === "icon") {
+      nodes.push(
+        <div key={field.key} className="grid gap-2">
+          <label className="text-sm font-medium" htmlFor={fieldId}>
+            {field.label}
+          </label>
+          <IconPickerField
+            id={fieldId}
+            value={value as string}
+            onChange={(next) => updateField(field.key, next)}
           />
         </div>,
       );

--- a/orchestrator/src/client/components/design-resume/definitions.ts
+++ b/orchestrator/src/client/components/design-resume/definitions.ts
@@ -161,17 +161,17 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
     secondaryField: "proficiency",
     fields: [
       {
+        key: "icon",
+        label: "Icon",
+        type: "icon",
+        groupWithNext: true,
+      },
+      {
         key: "name",
         label: "Name",
         type: "text",
         required: true,
         placeholder: "e.g. Python, or Programming Languages",
-      },
-      {
-        key: "icon",
-        label: "Icon",
-        type: "text",
-        placeholder: "e.g. tabler:brand-python (Iconify icon name)",
       },
       { key: "proficiency", label: "Proficiency", type: "text" },
       { key: "level", label: "Level", type: "number", min: 0, step: 1 },

--- a/orchestrator/src/client/pages/DesignResumePage.tsx
+++ b/orchestrator/src/client/pages/DesignResumePage.tsx
@@ -22,6 +22,16 @@ import {
 import type React from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -63,6 +73,7 @@ export const DesignResumePage: React.FC = () => {
   const [mobileRailOpen, setMobileRailOpen] = useState(false);
   const [pictureUploading, setPictureUploading] = useState(false);
   const [resumeImporting, setResumeImporting] = useState(false);
+  const [showReimportConfirm, setShowReimportConfirm] = useState(false);
   const [pdfDownloading, setPdfDownloading] = useState(false);
   const [rendererUpdating, setRendererUpdating] = useState(false);
   const [dirty, setDirty] = useState(false);
@@ -235,6 +246,14 @@ export const DesignResumePage: React.FC = () => {
       toast.error(
         formatUserFacingError(importError, "Failed to import your resume."),
       );
+    }
+  };
+
+  const handleImportWithConfirm = () => {
+    if (status?.exists) {
+      setShowReimportConfirm(true);
+    } else {
+      void handleImport();
     }
   };
 
@@ -500,7 +519,11 @@ export const DesignResumePage: React.FC = () => {
                 {resumeImporting ? "Importing File" : "Import File"}
               </Button>
 
-              <Button type="button" variant="outline" onClick={handleImport}>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleImportWithConfirm}
+              >
                 <Import className="mr-2 h-4 w-4" />
                 {status?.exists ? "Re-import RxResume" : "Import RxResume"}
               </Button>
@@ -546,7 +569,7 @@ export const DesignResumePage: React.FC = () => {
                   <Import className="mr-2 h-4 w-4" />
                   {resumeImporting ? "Importing File" : "Import File"}
                 </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => handleImport()}>
+                <DropdownMenuItem onSelect={() => handleImportWithConfirm()}>
                   <Import className="mr-2 h-4 w-4" />
                   {status?.exists ? "Re-import RxResume" : "Import RxResume"}
                 </DropdownMenuItem>
@@ -700,6 +723,35 @@ export const DesignResumePage: React.FC = () => {
           }
         />
       ) : null}
+
+      <AlertDialog
+        open={showReimportConfirm}
+        onOpenChange={setShowReimportConfirm}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Re-import from RxResume?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will replace your current Design Resume with the latest data
+              from RxResume. Any edits you've made here will be permanently
+              overwritten and cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-[#F1703E] text-white hover:bg-[#d9612f]"
+              onClick={() => {
+                setShowReimportConfirm(false);
+                void handleImport();
+              }}
+            >
+              <Import className="mr-2 h-4 w-4" />
+              Re-import
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5861,6 +5861,36 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@iconify-json/tabler": {
+      "version": "1.2.33",
+      "resolved": "https://registry.npmjs.org/@iconify-json/tabler/-/tabler-1.2.33.tgz",
+      "integrity": "sha512-q9nUQfE/cjIrGh5bAKHTphitAZpT0kX9SxDgZo3Sx8ofeDTsaHVdRwrn+CfKiJ5vQ1b1btqVwizXzIgz9KEPjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/react": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@iconify/react/-/react-6.0.2.tgz",
+      "integrity": "sha512-SMmC2sactfpJD427WJEDN6PMyznTFMhByK9yLW0gOTtnjzzbsi/Ke/XqsumsavFPwNiXs8jSiYeZTmLCLwO+Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@iconify/types": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyberalien"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.3.tgz",
@@ -26278,6 +26308,8 @@
       "version": "0.3.2",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@iconify-json/tabler": "^1.2.33",
+        "@iconify/react": "^6.0.2",
         "@paralleldrive/cuid2": "^3.0.6",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.15",


### PR DESCRIPTION
## Summary

- Add a scrollable Iconify icon picker to Skills, Profiles, and Interests sections — icon square sits inline to the left of the name field
- Add a confirmation dialog before Re-importing from RxResume to prevent accidental overwrites

## What changed

- `IconPickerField.tsx` (new) — 6,140 tabler icons, searchable, selected icon highlighted orange, manual entry fallback
- `ItemDialog.tsx` — new `"icon"` field type with `groupWithNext` to render inline with the next field
- `definitions.ts` — Skills, Profiles, Interests icon fields use the new picker
- `DesignResumePage.tsx` — Re-import confirmation dialog with orange button; first-time import skips confirmation

## Test plan
- [ ] Open Skills dialog — icon square appears left of Name, click to open picker
- [ ] Search, select an icon, save — icon persists on reopen
- [ ] Repeat for Profiles and Interests
- [ ] Click Re-import when resume exists — confirmation dialog appears
- [ ] Cancel does nothing, orange Re-import button proceeds
- [ ] First-time Import skips confirmation