### PR TITLE
Add job description to job page using markdown renderer

### DIFF
--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -1036,6 +1036,21 @@ export const JobPage: React.FC = () => {
           </div>
         </div>
       )}
+      {job?.jobDescription && (
+        <Card className="border-border/50">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <FileText className="h-4 w-4" />
+              Job description
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <JobDescriptionMarkdown
+              description={getRenderableJobDescription(job.jobDescription)}
+            />
+          </CardContent>
+        </Card>
+      )}
 
       <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
         <Card className="border-border/50">


### PR DESCRIPTION
Job description already exists in the database and a markdown renderer is available,
but it was not being displayed on the job page.

This change simply renders it using the existing component.

Closes #407