### PR TITLE
Fix Gemini resume import JSON recovery

### DIFF
--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -66,6 +66,7 @@
     "framer-motion": "^12.34.3",
     "html-to-text": "^9.0.5",
     "jsdom": "^25.0.1",
+    "jsonrepair": "^3.14.0",
     "jsonwebtoken": "^9.0.3",
     "jszip": "^3.10.1",
     "lucide-react": "^0.561.0",

--- a/orchestrator/src/server/services/design-resume/import-file.test.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.test.ts
@@ -215,6 +215,106 @@ describe("importDesignResumeFromFile", () => {
     expect(contents[0]?.parts?.[0]?.text).toContain("Senior Engineer");
   });
 
+  it("repairs Gemini JSON with unescaped quotes inside description fields", async () => {
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
+      provider: "gemini",
+      model: "gemini-2.5-flash-lite",
+      baseUrl: null,
+      apiKey: "gemini-test",
+    });
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    text: `{"basics":{"name":"Taylor Quinn"},"sections":{"experience":{"items":[{"company":"Acme","position":"Engineer","description":"<ul><li>Led the "Employer Line" program.</li></ul>"}]}}}`,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await importDesignResumeFromFile({
+      fileName: "resume.pdf",
+      mediaType: "application/pdf",
+      dataBase64: Buffer.from("pdf-data").toString("base64"),
+    });
+
+    const savedInput =
+      designResumeService.replaceCurrentDesignResumeDocument.mock.calls[0]?.[0];
+    const experienceItems =
+      savedInput?.resumeJson?.sections?.experience?.items ?? [];
+
+    expect(experienceItems).toHaveLength(1);
+    expect(experienceItems[0]).toMatchObject({
+      company: "Acme",
+      position: "Engineer",
+      description: '<ul><li>Led the "Employer Line" program.</li></ul>',
+    });
+  });
+
+  it("ignores Gemini thought parts when extracting resume JSON", async () => {
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
+      provider: "gemini",
+      model: "gemini-2.5-flash-lite",
+      baseUrl: null,
+      apiKey: "gemini-test",
+    });
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [
+                  {
+                    thought: true,
+                    text: 'I should return {"not":"this"}',
+                  },
+                  {
+                    text: '{"basics":{"name":"Taylor Quinn"}}',
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await importDesignResumeFromFile({
+      fileName: "resume.pdf",
+      mediaType: "application/pdf",
+      dataBase64: Buffer.from("pdf-data").toString("base64"),
+    });
+
+    expect(
+      designResumeService.replaceCurrentDesignResumeDocument,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeJson: expect.objectContaining({
+          basics: expect.objectContaining({ name: "Taylor Quinn" }),
+        }),
+      }),
+    );
+  });
+
   it("accepts supported media types even when the file name has no extension", async () => {
     vi.mocked(fetch).mockResolvedValue(
       new Response(

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -14,6 +14,7 @@ import {
   safeParseV5ResumeData,
 } from "@server/services/rxresume/schema";
 import type { DesignResumeDocument, DesignResumeJson } from "@shared/types";
+import { jsonrepair } from "jsonrepair";
 import JSZip from "jszip";
 import { buildHeaders, getResponseDetail, joinUrl } from "../llm/utils/http";
 import { parseErrorMessage, truncate } from "../llm/utils/string";
@@ -610,6 +611,7 @@ function extractGeminiText(response: unknown): string | null {
   const firstCandidate = asRecord(candidates[0]);
   const parts = asArray(asRecord(firstCandidate?.content)?.parts);
   const text = parts
+    .filter((part) => !asRecord(part)?.thought)
     .map((part) => trimText(asRecord(part)?.text))
     .filter(Boolean)
     .join("");
@@ -645,10 +647,14 @@ function parseImportedResumeJson(content: string): unknown {
 
   try {
     return JSON.parse(repaired) as unknown;
-  } catch (error) {
-    throw badRequest(
-      `Imported resume did not produce valid JSON. ${error instanceof Error ? error.message : "Unknown parsing error."}`,
-    );
+  } catch {
+    try {
+      return JSON.parse(jsonrepair(repaired)) as unknown;
+    } catch (error) {
+      throw badRequest(
+        `Imported resume did not produce valid JSON. ${error instanceof Error ? error.message : "Unknown parsing error."}`,
+      );
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16594,6 +16594,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonrepair": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.14.0.tgz",
+      "integrity": "sha512-tWPGKMZf/8UPim+fcW2EfcQ/d/7aKUrP6IECz9G3Tu6Q5dX0orSleqJ9z6sSw7qrQkjF8/Edo4DvsWBZ8H+HNg==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
@@ -26346,6 +26355,7 @@
         "framer-motion": "^12.34.3",
         "html-to-text": "^9.0.5",
         "jsdom": "^25.0.1",
+        "jsonrepair": "^3.14.0",
         "jsonwebtoken": "^9.0.3",
         "jszip": "^3.10.1",
         "lucide-react": "^0.561.0",


### PR DESCRIPTION
## Summary
- Add `jsonrepair` as a fallback for malformed Gemini JSON in resume import.
- Skip Gemini `thought` parts when assembling the response text.
- Add regression coverage for unescaped quotes in descriptions and thought-part contamination.

## Testing
- Added unit tests for the Gemini quote-repair path and thought-part filtering.
- Verified the focused resume import test file passes.