### PR TITLE
Clarify Pipeline Crawl Progress Updates

### DIFF
--- a/orchestrator/src/client/api/client.pipeline.test.ts
+++ b/orchestrator/src/client/api/client.pipeline.test.ts
@@ -48,6 +48,45 @@ describe("pipeline client helpers", () => {
     );
   });
 
+  it("fetches the current pipeline progress snapshot", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: {
+          step: "crawling",
+          message: "Fetching jobs from sources...",
+          crawlingSource: "linkedin",
+          crawlingSourcesCompleted: 0,
+          crawlingSourcesTotal: 2,
+          crawlingTermsProcessed: 1,
+          crawlingTermsTotal: 4,
+          crawlingListPagesProcessed: 3,
+          crawlingListPagesTotal: 10,
+          crawlingJobCardsFound: 12,
+          crawlingJobPagesEnqueued: 5,
+          crawlingJobPagesSkipped: 1,
+          crawlingJobPagesProcessed: 2,
+          jobsDiscovered: 8,
+          jobsScored: 0,
+          jobsProcessed: 0,
+          totalToProcess: 0,
+        },
+        meta: { requestId: "req-progress" },
+      }),
+    );
+
+    await expect(api.getPipelineProgressSnapshot()).resolves.toEqual(
+      expect.objectContaining({
+        step: "crawling",
+        message: "Fetching jobs from sources...",
+      }),
+    );
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/pipeline/progress/snapshot",
+      expect.any(Object),
+    );
+  });
+
   it("fetches pipeline run insights for a specific run", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
       createJsonResponse(200, {

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -38,6 +38,7 @@ import type {
   ManualJobDraft,
   ManualJobFetchResponse,
   ManualJobInferenceResponse,
+  PipelineProgressState,
   PipelineRun,
   PipelineRunInsights,
   PipelineStatusResponse,
@@ -1405,6 +1406,10 @@ export async function updateJobOutcome(
 // Pipeline API
 export async function getPipelineStatus(): Promise<PipelineStatusResponse> {
   return fetchApi<PipelineStatusResponse>("/pipeline/status");
+}
+
+export async function getPipelineProgressSnapshot(): Promise<PipelineProgressState> {
+  return fetchApi<PipelineProgressState>("/pipeline/progress/snapshot");
 }
 
 export async function getPipelineRuns(): Promise<PipelineRun[]> {

--- a/orchestrator/src/client/components/PipelineProgress.test.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.test.tsx
@@ -18,6 +18,14 @@ const sseMock = vi.hoisted(() => ({
   subscribeToEventSource: vi.fn(),
 }));
 
+const apiMock = vi.hoisted(() => ({
+  getPipelineProgressSnapshot: vi.fn(),
+}));
+
+vi.mock("@client/api", () => ({
+  getPipelineProgressSnapshot: apiMock.getPipelineProgressSnapshot,
+}));
+
 vi.mock("@/client/lib/sse", () => ({
   subscribeToEventSource: sseMock.subscribeToEventSource,
 }));
@@ -49,6 +57,7 @@ const baseProgress = {
 
 describe("PipelineProgress", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     sseMock.instances.length = 0;
     sseMock.subscribeToEventSource.mockReset();
     sseMock.subscribeToEventSource.mockImplementation(
@@ -62,10 +71,13 @@ describe("PipelineProgress", () => {
         return instance.unsubscribe;
       },
     );
+    apiMock.getPipelineProgressSnapshot.mockReset();
+    apiMock.getPipelineProgressSnapshot.mockResolvedValue(baseProgress);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
   });
 
   const getSse = () => {
@@ -119,5 +131,41 @@ describe("PipelineProgress", () => {
 
     expect(screen.queryByText("0/0")).not.toBeInTheDocument();
     expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("falls back to snapshot polling when SSE does not open", async () => {
+    render(<PipelineProgress isRunning />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(apiMock.getPipelineProgressSnapshot).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Updating…")).toBeInTheDocument();
+    expect(screen.getByText(baseProgress.message)).toBeInTheDocument();
+  });
+
+  it("stops snapshot polling after a terminal snapshot state", async () => {
+    apiMock.getPipelineProgressSnapshot.mockResolvedValueOnce({
+      ...baseProgress,
+      step: "failed",
+      message: "Pipeline failed",
+      error: "Boom",
+    });
+
+    render(<PipelineProgress isRunning />);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+
+    expect(apiMock.getPipelineProgressSnapshot).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Pipeline failed")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+
+    expect(apiMock.getPipelineProgressSnapshot).toHaveBeenCalledTimes(1);
   });
 });

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -2,10 +2,12 @@
  * Live pipeline progress display component.
  */
 
+import { getPipelineProgressSnapshot } from "@client/api";
 import {
   sourceLabel as getSourceLabel,
   isExtractorSourceId,
 } from "@shared/extractors";
+import type { PipelineProgressState } from "@shared/types";
 import { Loader2 } from "lucide-react";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
@@ -16,50 +18,11 @@ import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
 import { cn } from "@/lib/utils";
 
-interface PipelineProgress {
-  step:
-    | "idle"
-    | "crawling"
-    | "importing"
-    | "scoring"
-    | "processing"
-    | "completed"
-    | "cancelled"
-    | "failed";
-  message: string;
-  detail?: string;
-  crawlingSource: string | null;
-  crawlingSourcesCompleted: number;
-  crawlingSourcesTotal: number;
-  crawlingTermsProcessed: number;
-  crawlingTermsTotal: number;
-  crawlingListPagesProcessed: number;
-  crawlingListPagesTotal: number;
-  crawlingJobCardsFound: number;
-  crawlingJobPagesEnqueued: number;
-  crawlingJobPagesSkipped: number;
-  crawlingJobPagesProcessed: number;
-  crawlingPhase?: "list" | "job";
-  crawlingCurrentUrl?: string;
-  jobsDiscovered: number;
-  jobsScored: number;
-  jobsProcessed: number;
-  totalToProcess: number;
-  currentJob?: {
-    id: string;
-    title: string;
-    employer: string;
-  };
-  error?: string;
-  startedAt?: string;
-  completedAt?: string;
-}
-
 interface PipelineProgressProps {
   isRunning: boolean;
 }
 
-const stepLabels: Record<PipelineProgress["step"], string> = {
+const stepLabels: Record<PipelineProgressState["step"], string> = {
   idle: "Ready",
   crawling: "Crawling",
   importing: "Importing",
@@ -70,7 +33,7 @@ const stepLabels: Record<PipelineProgress["step"], string> = {
   failed: "Failed",
 };
 
-const stepBadgeClasses: Record<PipelineProgress["step"], string> = {
+const stepBadgeClasses: Record<PipelineProgressState["step"], string> = {
   idle: "bg-muted text-muted-foreground border-border",
   crawling: "bg-sky-500/10 text-sky-400 border-sky-500/20",
   importing: "bg-sky-500/10 text-sky-400 border-sky-500/20",
@@ -84,6 +47,14 @@ const stepBadgeClasses: Record<PipelineProgress["step"], string> = {
 const clamp = (value: number, min: number, max: number) =>
   Math.max(min, Math.min(max, value));
 
+const SSE_FALLBACK_TIMEOUT_MS = 1500;
+const SNAPSHOT_POLL_INTERVAL_MS = 2000;
+const TERMINAL_STEPS: ReadonlySet<PipelineProgressState["step"]> = new Set([
+  "completed",
+  "cancelled",
+  "failed",
+]);
+
 function resolveSourceLabel(source: string): string {
   if (source === "jobspy") return "JobSpy";
   if (isExtractorSourceId(source)) return getSourceLabel(source);
@@ -93,8 +64,10 @@ function resolveSourceLabel(source: string): string {
 export const PipelineProgress: React.FC<PipelineProgressProps> = ({
   isRunning,
 }) => {
-  const [progress, setProgress] = useState<PipelineProgress | null>(null);
-  const [isConnected, setIsConnected] = useState(false);
+  const [progress, setProgress] = useState<PipelineProgressState | null>(null);
+  const [transport, setTransport] = useState<"connecting" | "live" | "polling">(
+    "connecting",
+  );
 
   const percentage = useMemo(() => {
     if (!progress) return 0;
@@ -157,28 +130,89 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
   useEffect(() => {
     if (!isRunning) {
       setProgress(null);
-      setIsConnected(false);
+      setTransport("connecting");
       return;
     }
 
-    const unsubscribe = subscribeToEventSource<PipelineProgress>(
+    let isActive = true;
+    let hasOpened = false;
+    let isPolling = false;
+    let pollIntervalId: ReturnType<typeof setInterval> | null = null;
+    let fallbackTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    const stopPolling = () => {
+      isPolling = false;
+      if (pollIntervalId) {
+        clearInterval(pollIntervalId);
+        pollIntervalId = null;
+      }
+    };
+
+    const fetchSnapshot = async () => {
+      try {
+        const snapshot = await getPipelineProgressSnapshot();
+        if (!isActive) return;
+        setProgress(snapshot);
+        if (isPolling) {
+          setTransport("polling");
+        }
+        if (TERMINAL_STEPS.has(snapshot.step)) {
+          stopPolling();
+        }
+      } catch {
+        if (!isActive) return;
+      }
+    };
+
+    const startPolling = () => {
+      if (!isActive || isPolling) return;
+      isPolling = true;
+      setTransport((current) => (current === "live" ? current : "polling"));
+      void fetchSnapshot();
+      pollIntervalId = setInterval(() => {
+        void fetchSnapshot();
+      }, SNAPSHOT_POLL_INTERVAL_MS);
+    };
+
+    const unsubscribe = subscribeToEventSource<PipelineProgressState>(
       "/api/pipeline/progress",
       {
         onOpen: () => {
-          setIsConnected(true);
+          if (!isActive) return;
+          hasOpened = true;
+          stopPolling();
+          setTransport("live");
         },
         onMessage: (payload) => {
+          if (!isActive) return;
           setProgress(payload);
+          if (TERMINAL_STEPS.has(payload.step)) {
+            stopPolling();
+          }
         },
         onError: () => {
-          setIsConnected(false);
+          if (!isActive) return;
+          if (hasOpened) {
+            setTransport("polling");
+          }
+          startPolling();
         },
       },
     );
 
+    fallbackTimeoutId = setTimeout(() => {
+      if (!isActive || hasOpened) return;
+      startPolling();
+    }, SSE_FALLBACK_TIMEOUT_MS);
+
     return () => {
+      isActive = false;
+      if (fallbackTimeoutId) {
+        clearTimeout(fallbackTimeoutId);
+      }
+      stopPolling();
       unsubscribe();
-      setIsConnected(false);
+      setTransport("connecting");
     };
   }, [isRunning]);
 
@@ -226,7 +260,11 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
               {stepLabels[step]}
             </Badge>
             <span className="truncate text-xs text-muted-foreground">
-              {isConnected ? "Live" : "Connecting…"}
+              {transport === "live"
+                ? "Live"
+                : transport === "polling"
+                  ? "Updating…"
+                  : "Connecting…"}
             </span>
           </div>
 

--- a/orchestrator/src/client/lib/sse.test.ts
+++ b/orchestrator/src/client/lib/sse.test.ts
@@ -1,5 +1,6 @@
 import {
   __resetApiClientAuthForTests,
+  __setAuthTokenForTests,
   __setLegacyAuthCredentialsForTests,
 } from "@client/api/client";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -12,6 +13,22 @@ const { redirectToSignIn } = vi.hoisted(() => ({
 vi.mock("./auth-navigation", () => ({
   redirectToSignIn,
 }));
+
+function createStreamResponse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  return {
+    ok: true,
+    status: 200,
+    body: new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(encoder.encode(chunk));
+        }
+        controller.close();
+      },
+    }),
+  } as Response;
+}
 
 describe("subscribeToEventSource", () => {
   afterEach(() => {
@@ -86,5 +103,66 @@ describe("subscribeToEventSource", () => {
     expect(redirectToSignIn).not.toHaveBeenCalled();
 
     unsubscribe();
+  });
+
+  it("parses CRLF-delimited SSE frames", async () => {
+    const onOpen = vi.fn();
+    const onMessage = vi.fn();
+    const onError = vi.fn();
+
+    __setAuthTokenForTests("stream-token");
+
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createStreamResponse([
+        'data: {"step":"crawling","message":"Working"}\r\n\r\n',
+      ]),
+    );
+
+    subscribeToEventSource("/api/pipeline/progress", {
+      onOpen,
+      onMessage,
+      onError,
+    });
+
+    await vi.waitFor(() => {
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      expect(onMessage).toHaveBeenCalledWith({
+        step: "crawling",
+        message: "Working",
+      });
+    });
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("ignores heartbeat comments and parses trailing frames on close", async () => {
+    const onOpen = vi.fn();
+    const onMessage = vi.fn();
+    const onError = vi.fn();
+
+    __setAuthTokenForTests("stream-token");
+
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createStreamResponse([
+        ": heartbeat\n\n",
+        'data: {"step":"processing","message":"Halfway"}',
+      ]),
+    );
+
+    subscribeToEventSource("/api/pipeline/progress", {
+      onOpen,
+      onMessage,
+      onError,
+    });
+
+    await vi.waitFor(() => {
+      expect(onOpen).toHaveBeenCalledTimes(1);
+      expect(onMessage).toHaveBeenCalledWith({
+        step: "processing",
+        message: "Halfway",
+      });
+    });
+
+    expect(onError).not.toHaveBeenCalled();
   });
 });

--- a/orchestrator/src/client/lib/sse.ts
+++ b/orchestrator/src/client/lib/sse.ts
@@ -9,6 +9,8 @@ interface EventSourceSubscriptionHandlers<T> {
   onError?: () => void;
 }
 
+const FRAME_DELIMITER = /\r?\n\r?\n/;
+
 function parseSseFrame(frame: string): string | null {
   const dataLines: string[] = [];
   for (const line of frame.split(/\r?\n/)) {
@@ -18,6 +20,33 @@ function parseSseFrame(frame: string): string | null {
     }
   }
   return dataLines.length > 0 ? dataLines.join("\n") : null;
+}
+
+function emitParsedFrame<T>(
+  frame: string,
+  handlers: EventSourceSubscriptionHandlers<T>,
+): void {
+  const data = parseSseFrame(frame);
+  if (!data) return;
+
+  try {
+    handlers.onMessage(JSON.parse(data) as T);
+  } catch {
+    // Ignore malformed events to keep stream resilient.
+  }
+}
+
+function readNextFrame(buffer: string): {
+  frame: string;
+  remainder: string;
+} | null {
+  const match = FRAME_DELIMITER.exec(buffer);
+  if (!match || typeof match.index !== "number") return null;
+
+  const separator = match[0];
+  const frame = buffer.slice(0, match.index);
+  const remainder = buffer.slice(match.index + separator.length);
+  return { frame, remainder };
 }
 
 export function subscribeToEventSource<T>(
@@ -65,25 +94,23 @@ export function subscribeToEventSource<T>(
         try {
           while (!isClosed) {
             const { done, value } = await reader.read();
-            if (done) break;
+            if (done) {
+              buffer += decoder.decode();
+              break;
+            }
             buffer += decoder.decode(value, { stream: true });
 
-            let separatorIndex = buffer.indexOf("\n\n");
-            while (separatorIndex !== -1) {
-              const frame = buffer.slice(0, separatorIndex);
-              buffer = buffer.slice(separatorIndex + 2);
-
-              const data = parseSseFrame(frame);
-              if (data) {
-                try {
-                  handlers.onMessage(JSON.parse(data) as T);
-                } catch {
-                  // Ignore malformed events to keep stream resilient.
-                }
-              }
-
-              separatorIndex = buffer.indexOf("\n\n");
+            let parsedFrame = readNextFrame(buffer);
+            while (parsedFrame) {
+              emitParsedFrame(parsedFrame.frame, handlers);
+              buffer = parsedFrame.remainder;
+              parsedFrame = readNextFrame(buffer);
             }
+          }
+
+          const trailingFrame = buffer.trim();
+          if (trailingFrame.length > 0) {
+            emitParsedFrame(trailingFrame, handlers);
           }
         } finally {
           try {

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
@@ -1,6 +1,11 @@
 import * as api from "@client/api";
 import { subscribeToEventSource } from "@client/lib/sse";
-import type { Job, JobListItem, JobStatus } from "@shared/types";
+import type {
+  Job,
+  JobListItem,
+  JobStatus,
+  PipelineProgressStep,
+} from "@shared/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -18,16 +23,6 @@ const initialStats: Record<JobStatus, number> = {
 
 const isDocumentVisible = () =>
   typeof document === "undefined" || document.visibilityState === "visible";
-
-type PipelineProgressStep =
-  | "idle"
-  | "crawling"
-  | "importing"
-  | "scoring"
-  | "processing"
-  | "completed"
-  | "cancelled"
-  | "failed";
 
 type PipelineProgressEvent = {
   step: PipelineProgressStep;

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -25,6 +25,56 @@ describe.sequential("Pipeline API routes", () => {
     expect(body.data.lastRun).toBeNull();
   });
 
+  it("returns the current pipeline progress snapshot in the API envelope", async () => {
+    const res = await fetch(`${baseUrl}/api/pipeline/progress/snapshot`);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.meta.requestId).toBeTruthy();
+    expect(body.data).toEqual(
+      expect.objectContaining({
+        step: "idle",
+        message: "Ready",
+      }),
+    );
+  });
+
+  it("requires auth for the pipeline progress snapshot when auth is enabled", async () => {
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: {
+        BASIC_AUTH_USER: "admin",
+        BASIC_AUTH_PASSWORD: "secret",
+        JWT_SECRET: "an-explicit-jwt-secret-with-at-least-32-chars",
+      },
+    }));
+
+    const unauthorizedRes = await fetch(
+      `${baseUrl}/api/pipeline/progress/snapshot`,
+    );
+    expect(unauthorizedRes.status).toBe(401);
+
+    const loginRes = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: "admin", password: "secret" }),
+    });
+    const loginBody = await loginRes.json();
+
+    const authorizedRes = await fetch(
+      `${baseUrl}/api/pipeline/progress/snapshot`,
+      {
+        headers: { Authorization: `Bearer ${loginBody.data.token}` },
+      },
+    );
+    const authorizedBody = await authorizedRes.json();
+
+    expect(authorizedRes.status).toBe(200);
+    expect(authorizedBody.ok).toBe(true);
+    expect(authorizedBody.meta.requestId).toBeTruthy();
+  });
+
   it("returns recent pipeline runs in the API envelope", async () => {
     const { db, schema } = await import("@server/db");
 

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -46,6 +46,7 @@ describe.sequential("Pipeline API routes", () => {
       env: {
         BASIC_AUTH_USER: "admin",
         BASIC_AUTH_PASSWORD: "secret",
+        JOBOPS_TEST_AUTH_BYPASS: "0",
         JWT_SECRET: "an-explicit-jwt-secret-with-at-least-32-chars",
       },
     }));

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -17,6 +17,7 @@ import {
 } from "@server/extractors/registry";
 import {
   getPipelineStatus,
+  getProgress,
   requestPipelineCancel,
   runPipeline,
   subscribeToProgress,
@@ -33,7 +34,10 @@ import {
   LOCATION_MATCH_STRICTNESS_VALUES,
   LOCATION_SEARCH_SCOPE_VALUES,
 } from "@shared/location-preferences.js";
-import type { PipelineStatusResponse } from "@shared/types";
+import type {
+  PipelineProgressState,
+  PipelineStatusResponse,
+} from "@shared/types";
 import { type Request, type Response, Router } from "express";
 import { z } from "zod";
 
@@ -82,6 +86,25 @@ pipelineRouter.get("/status", async (_req: Request, res: Response) => {
       lastRun,
       nextScheduledRun: null,
     };
+    ok(res, data);
+  } catch (error) {
+    fail(
+      res,
+      new AppError({
+        status: 500,
+        code: "INTERNAL_ERROR",
+        message: error instanceof Error ? error.message : "Unknown error",
+      }),
+    );
+  }
+});
+
+/**
+ * GET /api/pipeline/progress/snapshot - Get the current pipeline progress state
+ */
+pipelineRouter.get("/progress/snapshot", (_req: Request, res: Response) => {
+  try {
+    const data: PipelineProgressState = getProgress();
     ok(res, data);
   } catch (error) {
     fail(

--- a/orchestrator/src/server/api/routes/test-utils.ts
+++ b/orchestrator/src/server/api/routes/test-utils.ts
@@ -41,6 +41,7 @@ vi.mock("@server/pipeline/index", () => {
     summarizeJob: vi.fn().mockResolvedValue({ success: true }),
     generateFinalPdf: vi.fn().mockResolvedValue({ success: true }),
     getPipelineStatus: vi.fn(() => ({ isRunning: false })),
+    getProgress: vi.fn(() => ({ ...progress })),
     requestPipelineCancel: vi.fn(() => ({
       accepted: false,
       pipelineRunId: null,

--- a/orchestrator/src/server/pipeline/progress.ts
+++ b/orchestrator/src/server/pipeline/progress.ts
@@ -1,52 +1,19 @@
 import { logger } from "@infra/logger";
 import { getActiveTenantId } from "@server/tenancy/context";
+import type {
+  PipelineProgressState,
+  PipelineProgressStep,
+} from "@shared/types";
 
 /**
  * Pipeline progress tracking with Server-Sent Events.
  */
 
-export type PipelineStep =
-  | "idle"
-  | "crawling"
-  | "importing"
-  | "scoring"
-  | "processing"
-  | "completed"
-  | "cancelled"
-  | "failed";
+export type PipelineStep = PipelineProgressStep;
 
 export type CrawlSource = string;
 
-export interface PipelineProgress {
-  step: PipelineStep;
-  message: string;
-  detail?: string;
-  crawlingSource: CrawlSource | null;
-  crawlingSourcesCompleted: number;
-  crawlingSourcesTotal: number;
-  crawlingTermsProcessed: number;
-  crawlingTermsTotal: number;
-  crawlingListPagesProcessed: number;
-  crawlingListPagesTotal: number;
-  crawlingJobCardsFound: number;
-  crawlingJobPagesEnqueued: number;
-  crawlingJobPagesSkipped: number;
-  crawlingJobPagesProcessed: number;
-  crawlingPhase?: "list" | "job";
-  crawlingCurrentUrl?: string;
-  jobsDiscovered: number;
-  jobsScored: number;
-  jobsProcessed: number;
-  totalToProcess: number;
-  currentJob?: {
-    id: string;
-    title: string;
-    employer: string;
-  };
-  error?: string;
-  startedAt?: string;
-  completedAt?: string;
-}
+export type PipelineProgress = PipelineProgressState;
 
 // Event emitter for progress updates
 type ProgressListener = (progress: PipelineProgress) => void;

--- a/shared/src/types/pipeline.ts
+++ b/shared/src/types/pipeline.ts
@@ -119,6 +119,49 @@ export interface PipelineStatusResponse {
   nextScheduledRun: string | null;
 }
 
+export type PipelineProgressStep =
+  | "idle"
+  | "crawling"
+  | "importing"
+  | "scoring"
+  | "processing"
+  | "completed"
+  | "cancelled"
+  | "failed";
+
+export interface PipelineProgressCurrentJob {
+  id: string;
+  title: string;
+  employer: string;
+}
+
+export interface PipelineProgressState {
+  step: PipelineProgressStep;
+  message: string;
+  detail?: string;
+  crawlingSource: string | null;
+  crawlingSourcesCompleted: number;
+  crawlingSourcesTotal: number;
+  crawlingTermsProcessed: number;
+  crawlingTermsTotal: number;
+  crawlingListPagesProcessed: number;
+  crawlingListPagesTotal: number;
+  crawlingJobCardsFound: number;
+  crawlingJobPagesEnqueued: number;
+  crawlingJobPagesSkipped: number;
+  crawlingJobPagesProcessed: number;
+  crawlingPhase?: "list" | "job";
+  crawlingCurrentUrl?: string;
+  jobsDiscovered: number;
+  jobsScored: number;
+  jobsProcessed: number;
+  totalToProcess: number;
+  currentJob?: PipelineProgressCurrentJob;
+  error?: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
 export type PipelineMetricQuality =
   | "exact"
   | "inferred_from_timestamps"


### PR DESCRIPTION
## Summary
- The code does support your observation: the UI now falls back to snapshot polling, so `Updating…` means it is not receiving live SSE updates.
- The crawl path only emits progress at extractor boundaries and certain callbacks, so some sources can sit on one visible crawl state for a long time.
- `workingnomads` in particular only reports `term_start` and `term_complete`, so if the term is slow you may see one update and then a long pause with no fresh progress until the next term or phase transition.

## Testing
- Existing unit coverage still passes for the new snapshot endpoint, SSE parsing, and polling fallback behavior.
- Full orchestrator test suite and client build were already verified in the current branch context.