### PR TITLE
Add confirmation dialog before removing Design Resume items

### DIFF
--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.test.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Accordion } from "@/components/ui/accordion";
+import { DesignResumeListSection } from "./DesignResumeListSection";
+import type { ItemDefinition } from "./definitions";
+
+const projectsDefinition: ItemDefinition = {
+  key: "projects",
+  title: "Projects",
+  singularTitle: "Project",
+  description: "Projects used for tailoring.",
+  primaryField: "name",
+  secondaryField: "period",
+  fields: [],
+  createItem: () => ({
+    id: "new-project",
+    name: "",
+    period: "",
+  }),
+};
+
+const projects = [
+  { id: "project-1", name: "Apollo", period: "2024" },
+  { id: "project-2", name: "Beacon", period: "2025" },
+];
+
+function renderListSection(onUpdateItems = vi.fn()) {
+  render(
+    <Accordion type="multiple" defaultValue={["projects"]}>
+      <DesignResumeListSection
+        definition={projectsDefinition}
+        items={projects}
+        onAdd={vi.fn()}
+        onEdit={vi.fn()}
+        onUpdateItems={onUpdateItems}
+      />
+    </Accordion>,
+  );
+  return onUpdateItems;
+}
+
+describe("DesignResumeListSection", () => {
+  it("asks for confirmation before removing an item", () => {
+    const onUpdateItems = renderListSection();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[0]);
+
+    expect(
+      screen.getByRole("alertdialog", { name: "Remove project?" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This will remove Apollo from your Design Resume. You can add it again later, but this change will be saved.",
+      ),
+    ).toBeInTheDocument();
+    expect(onUpdateItems).not.toHaveBeenCalled();
+  });
+
+  it("does not remove an item when confirmation is cancelled", () => {
+    const onUpdateItems = renderListSection();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    expect(onUpdateItems).not.toHaveBeenCalled();
+  });
+
+  it("removes the selected item after confirmation", () => {
+    const onUpdateItems = renderListSection();
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Remove" })[1]);
+    const dialog = screen.getByRole("alertdialog", {
+      name: "Remove project?",
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Remove" }));
+
+    expect(onUpdateItems).toHaveBeenCalledWith([projects[0]]);
+  });
+});

--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
@@ -1,4 +1,15 @@
-import { Plus } from "lucide-react";
+import { Plus, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { DesignResumeSection } from "./DesignResumeSection";
 import type { ItemDefinition } from "./definitions";
@@ -19,6 +30,29 @@ export function DesignResumeListSection({
   onEdit,
   onUpdateItems,
 }: DesignResumeListSectionProps) {
+  const [pendingRemovalIndex, setPendingRemovalIndex] = useState<number | null>(
+    null,
+  );
+  const pendingRemovalItem = useMemo(
+    () =>
+      pendingRemovalIndex == null ? null : (items[pendingRemovalIndex] ?? null),
+    [items, pendingRemovalIndex],
+  );
+  const pendingRemovalLabel = toText(
+    pendingRemovalItem
+      ? getByPath(pendingRemovalItem, definition.primaryField)
+      : null,
+    "this item",
+  );
+
+  const confirmRemoval = () => {
+    if (pendingRemovalIndex == null) return;
+    onUpdateItems(
+      items.filter((_, currentIndex) => currentIndex !== pendingRemovalIndex),
+    );
+    setPendingRemovalIndex(null);
+  };
+
   return (
     <DesignResumeSection
       value={definition.key}
@@ -123,11 +157,7 @@ export function DesignResumeListSection({
                   type="button"
                   variant="ghost"
                   className="text-rose-400 hover:bg-rose-500/10 hover:text-rose-300"
-                  onClick={() =>
-                    onUpdateItems(
-                      items.filter((_, currentIndex) => currentIndex !== index),
-                    )
-                  }
+                  onClick={() => setPendingRemovalIndex(index)}
                 >
                   Remove
                 </Button>
@@ -136,6 +166,35 @@ export function DesignResumeListSection({
           ))
         )}
       </div>
+
+      <AlertDialog
+        open={pendingRemovalIndex != null}
+        onOpenChange={(open) => {
+          if (!open) setPendingRemovalIndex(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Remove {definition.singularTitle.toLowerCase()}?
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove {pendingRemovalLabel} from your Design Resume.
+              You can add it again later, but this change will be saved.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={confirmRemoval}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              Remove
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </DesignResumeSection>
   );
 }


### PR DESCRIPTION
## Summary
- Add an alert dialog before deleting a Design Resume list item
- Show the item name in the confirmation copy and keep removal behind an explicit confirm action
- Add unit coverage for confirm, cancel, and successful delete flows

## Testing
- Added `DesignResumeListSection` unit tests for the new confirmation flow
- Verified the full orchestrator test suite passes