### PR TITLE
Fix LaTeX resume section titles to follow the resolved language

### DIFF
--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -94,6 +94,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
   - `Match Resume`: detect the dominant language from your resume/profile content and use that language for generated output
 - If language detection is unclear or there is not enough resume/profile text, JobOps falls back to English
 - Resume tailoring keeps the exact source wording for ATS-sensitive resume headlines and job titles, even when the rest of the tailored content is generated in the selected language
+- When using the local LaTeX PDF renderer, fixed resume section titles follow the resolved output language
 - Summary max words: optional cap on AI-generated summary length (empty = no limit)
 - Max keywords per skill: optional cap on keywords per skill category in tailoring (empty = no limit)
 - These numeric limits override any similar constraints written in the Constraints text field
@@ -120,6 +121,7 @@ Defaults and constraints:
 - `Match Resume` is best when your base resume is already written in the language you want to preserve.
 - If JobOps cannot determine a reliable resume/profile language, it safely uses English.
 - The generated resume content follows the resolved language, but ATS-sensitive headline and job-title wording stays exact so matching and parsing remain safer.
+- The local LaTeX PDF renderer uses the resolved language for fixed section headings such as Summary, Experience, Education, Projects, and Technical Skills.
 
 ### Prompt Templates
 

--- a/docs-site/versioned_docs/version-0.4.0/features/settings.md
+++ b/docs-site/versioned_docs/version-0.4.0/features/settings.md
@@ -94,6 +94,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
   - `Match Resume`: detect the dominant language from your resume/profile content and use that language for generated output
 - If language detection is unclear or there is not enough resume/profile text, JobOps falls back to English
 - Resume tailoring keeps the exact source wording for ATS-sensitive resume headlines and job titles, even when the rest of the tailored content is generated in the selected language
+- When using the local LaTeX PDF renderer, fixed resume section titles follow the resolved output language
 - Summary max words: optional cap on AI-generated summary length (empty = no limit)
 - Max keywords per skill: optional cap on keywords per skill category in tailoring (empty = no limit)
 - These numeric limits override any similar constraints written in the Constraints text field
@@ -120,6 +121,7 @@ Defaults and constraints:
 - `Match Resume` is best when your base resume is already written in the language you want to preserve.
 - If JobOps cannot determine a reliable resume/profile language, it safely uses English.
 - The generated resume content follows the resolved language, but ATS-sensitive headline and job-title wording stays exact so matching and parsing remain safer.
+- The local LaTeX PDF renderer uses the resolved language for fixed section headings such as Summary, Experience, Education, Projects, and Technical Skills.
 
 ### Prompt Templates
 

--- a/orchestrator/src/server/services/output-language.test.ts
+++ b/orchestrator/src/server/services/output-language.test.ts
@@ -2,7 +2,9 @@ import type { ResumeProfile } from "@shared/types";
 import { describe, expect, it } from "vitest";
 import {
   detectProfileLanguage,
+  detectReactiveResumeV5Language,
   resolveWritingOutputLanguage,
+  resolveWritingOutputLanguageForResumeJson,
 } from "./output-language";
 
 describe("resolveWritingOutputLanguage", () => {
@@ -64,6 +66,119 @@ describe("resolveWritingOutputLanguage", () => {
     });
 
     expect(result).toEqual({
+      language: "english",
+      source: "fallback",
+    });
+  });
+
+  it.each([
+    [
+      "german",
+      {
+        basics: {
+          headline: "Plattformingenieur",
+        },
+        summary: {
+          content:
+            "Ich entwickle Plattformen und übernehme Verantwortung für zuverlässige Lieferung.",
+        },
+        sections: {
+          experience: {
+            items: [
+              {
+                hidden: false,
+                position: "Entwicklung",
+                description:
+                  "Erfahrung mit verteilten Systemen und Zusammenarbeit mit Produktteams.",
+              },
+            ],
+          },
+        },
+      },
+    ],
+    [
+      "french",
+      {
+        basics: {
+          headline: "Ingénieur plateforme",
+        },
+        summary: {
+          content:
+            "Je construis des systèmes fiables avec une expérience forte dans le développement.",
+        },
+        sections: {
+          projects: {
+            items: [
+              {
+                hidden: false,
+                name: "Plateforme interne",
+                description:
+                  "Responsable des APIs et du développement pour les équipes produit.",
+              },
+            ],
+          },
+        },
+      },
+    ],
+    [
+      "spanish",
+      {
+        basics: {
+          headline: "Ingeniera de plataforma",
+        },
+        summary: {
+          content:
+            "Lideré el desarrollo de sistemas y tengo experiencia con APIs para los equipos.",
+        },
+        sections: {
+          skills: {
+            items: [
+              {
+                hidden: false,
+                name: "Desarrollo",
+                keywords: ["responsable", "experiencia", "integración"],
+              },
+            ],
+          },
+        },
+      },
+    ],
+  ] as const)("detects %s from Reactive Resume v5 JSON", (language, resumeJson) => {
+    expect(detectReactiveResumeV5Language(resumeJson)).toBe(language);
+  });
+
+  it("resolves v5 resume language using writing language settings", () => {
+    const resumeJson = {
+      basics: {
+        headline: "Senior Engineer",
+      },
+      summary: {
+        content: "Short profile.",
+      },
+    };
+
+    expect(
+      resolveWritingOutputLanguageForResumeJson({
+        style: {
+          languageMode: "manual",
+          manualLanguage: "french",
+        },
+        resumeJson,
+      }),
+    ).toEqual({
+      language: "french",
+      source: "manual",
+    });
+
+    expect(
+      resolveWritingOutputLanguageForResumeJson({
+        style: {
+          languageMode: "match-resume",
+          manualLanguage: "french",
+        },
+        resumeJson,
+      }),
+    ).toEqual({
       language: "english",
       source: "fallback",
     });

--- a/orchestrator/src/server/services/output-language.ts
+++ b/orchestrator/src/server/services/output-language.ts
@@ -108,6 +108,82 @@ function collectProfileLanguageSample(profile: ResumeProfile): string {
   return segments.join("\n");
 }
 
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function toText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function collectReactiveResumeV5LanguageSample(
+  resumeJson: Record<string, unknown>,
+): string {
+  const segments: string[] = [];
+
+  const add = (value: unknown): void => {
+    const text = toText(value).trim();
+    if (!text) return;
+    segments.push(text);
+  };
+
+  const basics = asRecord(resumeJson.basics);
+  const summary = asRecord(resumeJson.summary);
+  const sections = asRecord(resumeJson.sections);
+
+  add(basics?.headline);
+  add(summary?.content);
+
+  const experience = asRecord(sections?.experience);
+  for (const rawItem of asArray(experience?.items)) {
+    const item = asRecord(rawItem);
+    if (!item || item.hidden === true) continue;
+    add(item.position);
+    add(item.description);
+    for (const rawRole of asArray(item.roles)) {
+      const role = asRecord(rawRole);
+      if (!role) continue;
+      add(role.position);
+      add(role.description);
+    }
+  }
+
+  const education = asRecord(sections?.education);
+  for (const rawItem of asArray(education?.items)) {
+    const item = asRecord(rawItem);
+    if (!item || item.hidden === true) continue;
+    add(item.degree);
+    add(item.area);
+    add(item.description);
+  }
+
+  const projects = asRecord(sections?.projects);
+  for (const rawItem of asArray(projects?.items)) {
+    const item = asRecord(rawItem);
+    if (!item || item.hidden === true) continue;
+    add(item.name);
+    add(item.description);
+  }
+
+  const skills = asRecord(sections?.skills);
+  for (const rawItem of asArray(skills?.items)) {
+    const item = asRecord(rawItem);
+    if (!item || item.hidden === true) continue;
+    add(item.name);
+    for (const keyword of asArray(item.keywords)) {
+      add(keyword);
+    }
+  }
+
+  return segments.join("\n");
+}
+
 function scoreLanguageSample(
   sample: string,
   language: ChatStyleManualLanguage,
@@ -134,7 +210,20 @@ function scoreLanguageSample(
 export function detectProfileLanguage(
   profile: ResumeProfile,
 ): ChatStyleManualLanguage | null {
-  const sample = collectProfileLanguageSample(profile);
+  return detectLanguageFromSample(collectProfileLanguageSample(profile));
+}
+
+export function detectReactiveResumeV5Language(
+  resumeJson: Record<string, unknown>,
+): ChatStyleManualLanguage | null {
+  return detectLanguageFromSample(
+    collectReactiveResumeV5LanguageSample(resumeJson),
+  );
+}
+
+function detectLanguageFromSample(
+  sample: string,
+): ChatStyleManualLanguage | null {
   if (!sample.trim()) {
     return null;
   }
@@ -174,6 +263,31 @@ export function resolveWritingOutputLanguage(args: {
   }
 
   const detectedLanguage = detectProfileLanguage(args.profile);
+  if (detectedLanguage) {
+    return {
+      language: detectedLanguage,
+      source: "detected",
+    };
+  }
+
+  return {
+    language: "english",
+    source: "fallback",
+  };
+}
+
+export function resolveWritingOutputLanguageForResumeJson(args: {
+  style: WritingLanguageConfig;
+  resumeJson: Record<string, unknown>;
+}): ResolvedWritingLanguage {
+  if (args.style.languageMode === "manual") {
+    return {
+      language: args.style.manualLanguage,
+      source: "manual",
+    };
+  }
+
+  const detectedLanguage = detectReactiveResumeV5Language(args.resumeJson);
   if (detectedLanguage) {
     return {
       language: detectedLanguage,

--- a/orchestrator/src/server/services/pdf-tailoring.test.ts
+++ b/orchestrator/src/server/services/pdf-tailoring.test.ts
@@ -3,218 +3,227 @@ import { generatePdf } from "./pdf";
 import * as projectSelection from "./projectSelection";
 
 // Define mock data in hoisted block
-const { currentPdfRenderer, mocks, mockProfile, mockResumeRenderer } =
-  vi.hoisted(() => {
-    const profile = {
-      $schema: "https://rxresu.me/schema.json",
-      version: "5.0.0",
-      picture: {
-        hidden: true,
+const {
+  currentLanguageSettings,
+  currentPdfRenderer,
+  mocks,
+  mockProfile,
+  mockResumeRenderer,
+} = vi.hoisted(() => {
+  const profile = {
+    $schema: "https://rxresu.me/schema.json",
+    version: "5.0.0",
+    picture: {
+      hidden: true,
+      url: "",
+      size: 96,
+      rotation: 0,
+      aspectRatio: 1,
+      borderRadius: 0,
+      borderColor: "#000000",
+      borderWidth: 0,
+      shadowColor: "#000000",
+      shadowWidth: 0,
+    },
+    basics: {
+      name: "",
+      headline: "Original Headline",
+      email: "",
+      phone: "",
+      location: "",
+      website: {
         url: "",
-        size: 96,
-        rotation: 0,
-        aspectRatio: 1,
-        borderRadius: 0,
-        borderColor: "#000000",
-        borderWidth: 0,
-        shadowColor: "#000000",
-        shadowWidth: 0,
+        label: "",
       },
-      basics: {
-        name: "",
-        headline: "Original Headline",
-        email: "",
-        phone: "",
-        location: "",
-        website: {
-          url: "",
-          label: "",
-        },
-        customFields: [],
-      },
-      summary: {
-        title: "Summary",
+      customFields: [],
+    },
+    summary: {
+      title: "Summary",
+      columns: 1,
+      hidden: false,
+      content: "Original Summary",
+    },
+    sections: {
+      profiles: { title: "Profiles", columns: 1, hidden: false, items: [] },
+      experience: {
+        title: "Experience",
         columns: 1,
         hidden: false,
-        content: "Original Summary",
+        items: [],
       },
-      sections: {
-        profiles: { title: "Profiles", columns: 1, hidden: false, items: [] },
-        experience: {
-          title: "Experience",
-          columns: 1,
-          hidden: false,
-          items: [],
-        },
-        education: {
-          title: "Education",
-          columns: 1,
-          hidden: false,
-          items: [],
-        },
-        projects: {
-          title: "Projects",
-          columns: 1,
-          hidden: false,
-          items: [
-            {
-              id: "p1",
-              hidden: false,
-              name: "Project 1",
-              period: "",
-              website: { url: "", label: "" },
-              description: "",
-              options: { showLinkInTitle: false },
-            },
-            {
-              id: "p2",
-              hidden: false,
-              name: "Project 2",
-              period: "",
-              website: { url: "", label: "" },
-              description: "",
-              options: { showLinkInTitle: false },
-            },
-          ],
-        },
-        skills: {
-          title: "Skills",
-          columns: 1,
-          hidden: false,
-          items: [
-            {
-              id: "skill-1",
-              hidden: false,
-              icon: "",
-              name: "Original Skill",
-              proficiency: "",
-              level: 0,
-              keywords: [],
-            },
-          ],
-        },
-        languages: {
-          title: "Languages",
-          columns: 1,
-          hidden: false,
-          items: [],
-        },
-        interests: {
-          title: "Interests",
-          columns: 1,
-          hidden: false,
-          items: [],
-        },
-        awards: { title: "Awards", columns: 1, hidden: false, items: [] },
-        certifications: {
-          title: "Certifications",
-          columns: 1,
-          hidden: false,
-          items: [],
-        },
-        publications: {
-          title: "Publications",
-          columns: 1,
-          hidden: false,
-          items: [],
-        },
-        volunteer: {
-          title: "Volunteer",
-          columns: 1,
-          hidden: false,
-          items: [],
-        },
-        references: {
-          title: "References",
-          columns: 1,
-          hidden: false,
-          items: [],
+      education: {
+        title: "Education",
+        columns: 1,
+        hidden: false,
+        items: [],
+      },
+      projects: {
+        title: "Projects",
+        columns: 1,
+        hidden: false,
+        items: [
+          {
+            id: "p1",
+            hidden: false,
+            name: "Project 1",
+            period: "",
+            website: { url: "", label: "" },
+            description: "",
+            options: { showLinkInTitle: false },
+          },
+          {
+            id: "p2",
+            hidden: false,
+            name: "Project 2",
+            period: "",
+            website: { url: "", label: "" },
+            description: "",
+            options: { showLinkInTitle: false },
+          },
+        ],
+      },
+      skills: {
+        title: "Skills",
+        columns: 1,
+        hidden: false,
+        items: [
+          {
+            id: "skill-1",
+            hidden: false,
+            icon: "",
+            name: "Original Skill",
+            proficiency: "",
+            level: 0,
+            keywords: [],
+          },
+        ],
+      },
+      languages: {
+        title: "Languages",
+        columns: 1,
+        hidden: false,
+        items: [],
+      },
+      interests: {
+        title: "Interests",
+        columns: 1,
+        hidden: false,
+        items: [],
+      },
+      awards: { title: "Awards", columns: 1, hidden: false, items: [] },
+      certifications: {
+        title: "Certifications",
+        columns: 1,
+        hidden: false,
+        items: [],
+      },
+      publications: {
+        title: "Publications",
+        columns: 1,
+        hidden: false,
+        items: [],
+      },
+      volunteer: {
+        title: "Volunteer",
+        columns: 1,
+        hidden: false,
+        items: [],
+      },
+      references: {
+        title: "References",
+        columns: 1,
+        hidden: false,
+        items: [],
+      },
+    },
+    customSections: [],
+    metadata: {
+      template: "rhyhorn",
+      layout: {
+        sidebarWidth: 220,
+        pages: [
+          {
+            fullWidth: false,
+            main: ["summary", "experience", "education", "projects"],
+            sidebar: ["profiles", "skills", "languages"],
+          },
+        ],
+      },
+      css: {
+        enabled: false,
+        value: "",
+      },
+      page: {
+        gapX: 18,
+        gapY: 18,
+        marginX: 18,
+        marginY: 18,
+        format: "a4",
+        locale: "en",
+        hideIcons: false,
+        options: {
+          breakLine: true,
+          pageNumbers: true,
         },
       },
-      customSections: [],
-      metadata: {
-        template: "rhyhorn",
-        layout: {
-          sidebarWidth: 220,
-          pages: [
-            {
-              fullWidth: false,
-              main: ["summary", "experience", "education", "projects"],
-              sidebar: ["profiles", "skills", "languages"],
-            },
-          ],
+      design: {
+        level: {
+          icon: "circle",
+          type: "hidden",
         },
-        css: {
-          enabled: false,
-          value: "",
+        colors: {
+          background: "#ffffff",
+          text: "#000000",
+          primary: "#2563eb",
         },
-        page: {
-          gapX: 18,
-          gapY: 18,
-          marginX: 18,
-          marginY: 18,
-          format: "a4",
-          locale: "en",
-          hideIcons: false,
-          options: {
-            breakLine: true,
-            pageNumbers: true,
-          },
-        },
-        design: {
-          level: {
-            icon: "circle",
-            type: "hidden",
-          },
-          colors: {
-            background: "#ffffff",
-            text: "#000000",
-            primary: "#2563eb",
-          },
-        },
-        typography: {
-          body: {
-            fontFamily: "Inter",
-            fontWeights: ["regular"],
-            fontSize: 14,
-            lineHeight: 1.5,
-          },
-          heading: {
-            fontFamily: "Inter",
-            fontWeights: ["600"],
-            fontSize: 14,
-            lineHeight: 1.25,
-          },
-        },
-        notes: "",
       },
-    };
+      typography: {
+        body: {
+          fontFamily: "Inter",
+          fontWeights: ["regular"],
+          fontSize: 14,
+          lineHeight: 1.5,
+        },
+        heading: {
+          fontFamily: "Inter",
+          fontWeights: ["600"],
+          fontSize: 14,
+          lineHeight: 1.25,
+        },
+      },
+      notes: "",
+    },
+  };
 
-    let lastResumeArgs: any = null;
-    const renderer = {
-      renderResumePdf: vi.fn().mockImplementation(async (args: any) => {
-        lastResumeArgs = JSON.parse(JSON.stringify(args));
-      }),
-      getLastResumeJson: () => lastResumeArgs?.resumeJson ?? null,
-      getLastResumeArgs: () => lastResumeArgs,
-      clearLastResumeJson: () => {
-        lastResumeArgs = null;
-      },
-    };
+  let lastResumeArgs: any = null;
+  const renderer = {
+    renderResumePdf: vi.fn().mockImplementation(async (args: any) => {
+      lastResumeArgs = JSON.parse(JSON.stringify(args));
+    }),
+    getLastResumeJson: () => lastResumeArgs?.resumeJson ?? null,
+    getLastResumeArgs: () => lastResumeArgs,
+    clearLastResumeJson: () => {
+      lastResumeArgs = null;
+    },
+  };
 
-    return {
-      currentPdfRenderer: { value: "latex" as "latex" | "rxresume" },
-      mockProfile: profile,
-      mocks: {
-        readFile: vi.fn(),
-        writeFile: vi.fn(),
-        mkdir: vi.fn().mockResolvedValue(undefined),
-        access: vi.fn().mockResolvedValue(undefined),
-        unlink: vi.fn().mockResolvedValue(undefined),
-      },
-      mockResumeRenderer: renderer,
-    };
-  });
+  return {
+    currentLanguageSettings: {
+      mode: "manual" as "manual" | "match-resume",
+      manual: "english" as "english" | "german" | "french" | "spanish",
+    },
+    currentPdfRenderer: { value: "latex" as "latex" | "rxresume" },
+    mockProfile: profile,
+    mocks: {
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      mkdir: vi.fn().mockResolvedValue(undefined),
+      access: vi.fn().mockResolvedValue(undefined),
+      unlink: vi.fn().mockResolvedValue(undefined),
+    },
+    mockResumeRenderer: renderer,
+  };
+});
 
 // Configure base mock implementations
 mocks.readFile.mockResolvedValue(JSON.stringify(mockProfile));
@@ -271,6 +280,12 @@ vi.mock("node:fs", () => ({
 vi.mock("../repositories/settings", () => ({
   getSetting: vi.fn().mockImplementation((key: string) => {
     if (key === "pdfRenderer") return Promise.resolve(currentPdfRenderer.value);
+    if (key === "chatStyleLanguageMode") {
+      return Promise.resolve(currentLanguageSettings.mode);
+    }
+    if (key === "chatStyleManualLanguage") {
+      return Promise.resolve(currentLanguageSettings.manual);
+    }
     if (key === "rxresumeEmail") return Promise.resolve("test@example.com");
     if (key === "rxresumePassword") return Promise.resolve("testpassword");
     return Promise.resolve(null);
@@ -403,6 +418,10 @@ describe("PDF Service Tailoring Logic", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     currentPdfRenderer.value = "latex";
+    currentLanguageSettings.mode = "manual";
+    currentLanguageSettings.manual = "english";
+    mockProfile.summary.content = "Original Summary";
+    mockProfile.sections.projects.items[0].description = "";
     mocks.readFile.mockResolvedValue(JSON.stringify(mockProfile));
     mockResumeRenderer.clearLastResumeJson();
     mockTracerLinks.resolveTracerPublicBaseUrl.mockReturnValue(
@@ -514,8 +533,40 @@ describe("PDF Service Tailoring Logic", () => {
     );
   });
 
+  it("passes the manual output language to the local LaTeX renderer", async () => {
+    currentLanguageSettings.mode = "manual";
+    currentLanguageSettings.manual = "spanish";
+
+    await generatePdf("job-spanish-latex", {}, "desc");
+
+    expect(mockResumeRenderer.renderResumePdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-spanish-latex",
+        language: "spanish",
+      }),
+    );
+  });
+
+  it("detects the resume language for local LaTeX rendering", async () => {
+    currentLanguageSettings.mode = "match-resume";
+    mockProfile.summary.content =
+      "Je construis des systèmes fiables avec une expérience forte dans le développement.";
+    mockProfile.sections.projects.items[0].description =
+      "Responsable des APIs et du développement pour les équipes produit.";
+
+    await generatePdf("job-french-latex", {}, "desc");
+
+    expect(mockResumeRenderer.renderResumePdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-french-latex",
+        language: "french",
+      }),
+    );
+  });
+
   it("uses the RxResume export flow when the renderer setting is rxresume", async () => {
     currentPdfRenderer.value = "rxresume";
+    currentLanguageSettings.manual = "german";
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       arrayBuffer: async () => new TextEncoder().encode("pdf-bytes").buffer,

--- a/orchestrator/src/server/services/pdf.ts
+++ b/orchestrator/src/server/services/pdf.ts
@@ -11,6 +11,7 @@ import { getSetting } from "@server/repositories/settings";
 import { settingsRegistry } from "@shared/settings-registry";
 import type { DesignResumePdfResponse, PdfRenderer } from "@shared/types";
 import { getCurrentDesignResume } from "./design-resume";
+import { resolveWritingOutputLanguageForResumeJson } from "./output-language";
 import {
   getLegacyJobPdfPath,
   getTenantDesignResumePdfPath,
@@ -32,6 +33,7 @@ import {
   prepareReactiveResumeV5DocumentForExternalUse,
 } from "./rxresume/document";
 import { parseV5ResumeData } from "./rxresume/schema/v5";
+import { getWritingStyle } from "./writing-style";
 
 export interface PdfResult {
   success: boolean;
@@ -73,6 +75,14 @@ async function resolvePdfRenderer(): Promise<PdfRenderer> {
     settingsRegistry.pdfRenderer.parse(storedValue ?? undefined) ??
     settingsRegistry.pdfRenderer.default()
   );
+}
+
+async function resolveLatexResumeLanguage(resumeJson: Record<string, unknown>) {
+  const writingStyle = await getWritingStyle();
+  return resolveWritingOutputLanguageForResumeJson({
+    style: writingStyle,
+    resumeJson,
+  }).language;
 }
 
 async function downloadRxResumePdf(
@@ -306,10 +316,12 @@ export async function generatePdf(
 
     const outputPath = getTenantJobPdfPath(jobId);
     if (renderer === "latex") {
+      const language = await resolveLatexResumeLanguage(preparedResume.data);
       await renderResumePdf({
         resumeJson: preparedResume.data,
         outputPath,
         jobId,
+        language,
       });
     } else {
       await renderRxResumePdf({
@@ -354,10 +366,12 @@ export async function generateDesignResumePdf(options?: {
   });
 
   if (renderer === "latex") {
+    const language = await resolveLatexResumeLanguage(designResume.data);
     await renderResumePdf({
       resumeJson: designResume.data,
       outputPath,
       jobId: "design-resume",
+      language,
     });
   } else {
     await renderRxResumePdf({

--- a/orchestrator/src/server/services/resume-renderer/document.ts
+++ b/orchestrator/src/server/services/resume-renderer/document.ts
@@ -1,8 +1,54 @@
 import { buildDesignResumeJakeDocument } from "@shared/design-resume-jake";
-import type { LatexResumeDocument } from "./types";
+import type { ChatStyleManualLanguage } from "@shared/types";
+import type {
+  LatexResumeDocument,
+  LatexResumeSectionTitles,
+  NormalizeResumeJsonToLatexDocumentOptions,
+} from "./types";
+
+const LATEX_RESUME_SECTION_TITLES: Record<
+  ChatStyleManualLanguage,
+  LatexResumeSectionTitles
+> = {
+  english: {
+    summary: "Summary",
+    experience: "Experience",
+    education: "Education",
+    projects: "Projects",
+    skills: "Technical Skills",
+  },
+  german: {
+    summary: "Zusammenfassung",
+    experience: "Berufserfahrung",
+    education: "Ausbildung",
+    projects: "Projekte",
+    skills: "Fachliche Kenntnisse",
+  },
+  french: {
+    summary: "Résumé",
+    experience: "Expérience",
+    education: "Formation",
+    projects: "Projets",
+    skills: "Compétences techniques",
+  },
+  spanish: {
+    summary: "Resumen",
+    experience: "Experiencia",
+    education: "Educación",
+    projects: "Proyectos",
+    skills: "Habilidades técnicas",
+  },
+};
+
+export function getLatexResumeSectionTitles(
+  language: ChatStyleManualLanguage = "english",
+): LatexResumeSectionTitles {
+  return LATEX_RESUME_SECTION_TITLES[language];
+}
 
 export function normalizeResumeJsonToLatexDocument(
   resumeJson: Record<string, unknown>,
+  options: NormalizeResumeJsonToLatexDocumentOptions = {},
 ): LatexResumeDocument {
   const document = buildDesignResumeJakeDocument(resumeJson);
 
@@ -38,5 +84,6 @@ export function normalizeResumeJsonToLatexDocument(
       name: group.name,
       keywords: group.keywords,
     })),
+    sectionTitles: getLatexResumeSectionTitles(options.language),
   };
 }

--- a/orchestrator/src/server/services/resume-renderer/index.ts
+++ b/orchestrator/src/server/services/resume-renderer/index.ts
@@ -1,5 +1,6 @@
 import { normalizeResumeJsonToLatexDocument } from "./document";
 import { renderLatexPdf } from "./latex";
+import type { NormalizeResumeJsonToLatexDocumentOptions } from "./types";
 
 export { normalizeResumeJsonToLatexDocument } from "./document";
 export {
@@ -13,8 +14,11 @@ export async function renderResumePdf(args: {
   resumeJson: Record<string, unknown>;
   outputPath: string;
   jobId: string;
+  language?: NormalizeResumeJsonToLatexDocumentOptions["language"];
 }): Promise<void> {
-  const document = normalizeResumeJsonToLatexDocument(args.resumeJson);
+  const document = normalizeResumeJsonToLatexDocument(args.resumeJson, {
+    language: args.language,
+  });
   await renderLatexPdf({
     document,
     outputPath: args.outputPath,

--- a/orchestrator/src/server/services/resume-renderer/latex.test.ts
+++ b/orchestrator/src/server/services/resume-renderer/latex.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  buildLatexDocument,
   getLatexTemplatePath,
   getTectonicBinary,
   readLatexTemplate,
@@ -76,6 +77,58 @@ describe("latex resume renderer", () => {
     } else {
       process.env.TECTONIC_BIN = previous;
     }
+  });
+
+  it("defaults LaTeX section titles to English", () => {
+    const latex = buildLatexDocument(
+      {
+        ...baseDocument,
+        sectionTitles: undefined,
+      },
+      "__NAME__\n__HEADLINE_BLOCK__\n__CONTACT_BLOCK__\n__BODY__",
+    );
+
+    expect(latex).toContain("\\section{Summary}");
+    expect(latex).toContain("\\section{Experience}");
+    expect(latex).toContain("\\section{Technical Skills}");
+  });
+
+  it("renders localized LaTeX section titles", () => {
+    const latex = buildLatexDocument(
+      {
+        ...baseDocument,
+        education: [
+          {
+            title: "University",
+            subtitle: "MSc",
+            date: "2020",
+            bullets: ["Studied distributed systems"],
+          },
+        ],
+        projects: [
+          {
+            title: "Platform",
+            subtitle: "TypeScript",
+            date: "2024",
+            bullets: ["Built deployment tooling"],
+          },
+        ],
+        sectionTitles: {
+          summary: "Resumen",
+          experience: "Experiencia",
+          education: "Educación",
+          projects: "Proyectos",
+          skills: "Habilidades técnicas",
+        },
+      },
+      "__NAME__\n__HEADLINE_BLOCK__\n__CONTACT_BLOCK__\n__BODY__",
+    );
+
+    expect(latex).toContain("\\section{Resumen}");
+    expect(latex).toContain("\\section{Experiencia}");
+    expect(latex).toContain("\\section{Educación}");
+    expect(latex).toContain("\\section{Proyectos}");
+    expect(latex).toContain("\\section{Habilidades técnicas}");
   });
 
   it("fails with a helpful error when tectonic is unavailable", async () => {

--- a/orchestrator/src/server/services/resume-renderer/latex.ts
+++ b/orchestrator/src/server/services/resume-renderer/latex.ts
@@ -10,6 +10,7 @@ import type {
   LatexResumeContactItem,
   LatexResumeDocument,
   LatexResumeEntry,
+  LatexResumeSectionTitles,
   ResumeRenderer,
 } from "./types";
 
@@ -47,6 +48,13 @@ function resolveTemplatePath(): string {
 const TEMPLATE_PATH = resolveTemplatePath();
 const TECTONIC_TIMEOUT_MS = 120_000;
 const OUTPUT_FILENAME = "resume.pdf";
+const DEFAULT_SECTION_TITLES: LatexResumeSectionTitles = {
+  summary: "Summary",
+  experience: "Experience",
+  education: "Education",
+  projects: "Projects",
+  skills: "Technical Skills",
+};
 
 function normalizeText(value: string): string {
   return value
@@ -134,8 +142,9 @@ function renderProjectEntry(entry: LatexResumeEntry): string {
 
 function renderSummarySection(document: LatexResumeDocument): string {
   if (!document.summary) return "";
+  const titles = document.sectionTitles ?? DEFAULT_SECTION_TITLES;
   return [
-    "\\section{Summary}",
+    `\\section{${escapeForCommand(titles.summary)}}`,
     " \\begin{itemize}[leftmargin=0.15in, label={}]",
     `    \\small{\\item{${escapeForCommand(document.summary)}}}`,
     " \\end{itemize}",
@@ -157,7 +166,7 @@ function renderEntrySection(args: {
     )
     .join("\n\n");
   return [
-    `\\section{${args.title}}`,
+    `\\section{${escapeForCommand(args.title)}}`,
     "  \\resumeSubHeadingListStart",
     body,
     "  \\resumeSubHeadingListEnd",
@@ -167,6 +176,7 @@ function renderEntrySection(args: {
 
 function renderSkillsSection(document: LatexResumeDocument): string {
   if (document.skillGroups.length === 0) return "";
+  const titles = document.sectionTitles ?? DEFAULT_SECTION_TITLES;
   const items = document.skillGroups
     .map((group) => {
       const keywords = group.keywords.map((keyword) =>
@@ -177,7 +187,7 @@ function renderSkillsSection(document: LatexResumeDocument): string {
     })
     .join("\n");
   return [
-    "\\section{Technical Skills}",
+    `\\section{${escapeForCommand(titles.skills)}}`,
     " \\begin{itemize}[leftmargin=0.15in, label={}]",
     "    \\small{\\item{",
     items,
@@ -191,10 +201,11 @@ async function loadTemplate(): Promise<string> {
   return await readFile(TEMPLATE_PATH, "utf8");
 }
 
-function buildLatexDocument(
+export function buildLatexDocument(
   document: LatexResumeDocument,
   template: string,
 ): string {
+  const titles = document.sectionTitles ?? DEFAULT_SECTION_TITLES;
   const headlineBlock = document.headline
     ? `    \\small ${escapeForCommand(document.headline)} \\\\ \\vspace{1pt}\n`
     : "";
@@ -205,17 +216,17 @@ function buildLatexDocument(
   const body = [
     renderSummarySection(document),
     renderEntrySection({
-      title: "Experience",
+      title: titles.experience,
       entries: document.experience,
       kind: "subheading",
     }),
     renderEntrySection({
-      title: "Education",
+      title: titles.education,
       entries: document.education,
       kind: "subheading",
     }),
     renderEntrySection({
-      title: "Projects",
+      title: titles.projects,
       entries: document.projects,
       kind: "project",
     }),

--- a/orchestrator/src/server/services/resume-renderer/latex.ts
+++ b/orchestrator/src/server/services/resume-renderer/latex.ts
@@ -6,11 +6,11 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { logger } from "@infra/logger";
 import { sanitizeUnknown } from "@infra/sanitize";
+import { getLatexResumeSectionTitles } from "./document";
 import type {
   LatexResumeContactItem,
   LatexResumeDocument,
   LatexResumeEntry,
-  LatexResumeSectionTitles,
   ResumeRenderer,
 } from "./types";
 
@@ -48,13 +48,6 @@ function resolveTemplatePath(): string {
 const TEMPLATE_PATH = resolveTemplatePath();
 const TECTONIC_TIMEOUT_MS = 120_000;
 const OUTPUT_FILENAME = "resume.pdf";
-const DEFAULT_SECTION_TITLES: LatexResumeSectionTitles = {
-  summary: "Summary",
-  experience: "Experience",
-  education: "Education",
-  projects: "Projects",
-  skills: "Technical Skills",
-};
 
 function normalizeText(value: string): string {
   return value
@@ -142,7 +135,7 @@ function renderProjectEntry(entry: LatexResumeEntry): string {
 
 function renderSummarySection(document: LatexResumeDocument): string {
   if (!document.summary) return "";
-  const titles = document.sectionTitles ?? DEFAULT_SECTION_TITLES;
+  const titles = document.sectionTitles ?? getLatexResumeSectionTitles();
   return [
     `\\section{${escapeForCommand(titles.summary)}}`,
     " \\begin{itemize}[leftmargin=0.15in, label={}]",
@@ -176,7 +169,7 @@ function renderEntrySection(args: {
 
 function renderSkillsSection(document: LatexResumeDocument): string {
   if (document.skillGroups.length === 0) return "";
-  const titles = document.sectionTitles ?? DEFAULT_SECTION_TITLES;
+  const titles = document.sectionTitles ?? getLatexResumeSectionTitles();
   const items = document.skillGroups
     .map((group) => {
       const keywords = group.keywords.map((keyword) =>
@@ -205,7 +198,7 @@ export function buildLatexDocument(
   document: LatexResumeDocument,
   template: string,
 ): string {
-  const titles = document.sectionTitles ?? DEFAULT_SECTION_TITLES;
+  const titles = document.sectionTitles ?? getLatexResumeSectionTitles();
   const headlineBlock = document.headline
     ? `    \\small ${escapeForCommand(document.headline)} \\\\ \\vspace{1pt}\n`
     : "";

--- a/orchestrator/src/server/services/resume-renderer/types.ts
+++ b/orchestrator/src/server/services/resume-renderer/types.ts
@@ -1,3 +1,5 @@
+import type { ChatStyleManualLanguage } from "@shared/types";
+
 export interface LatexResumeContactItem {
   text: string;
   url?: string | null;
@@ -19,6 +21,14 @@ export interface LatexResumeSkillGroup {
   keywords: string[];
 }
 
+export interface LatexResumeSectionTitles {
+  summary: string;
+  experience: string;
+  education: string;
+  projects: string;
+  skills: string;
+}
+
 export interface LatexResumeDocument {
   name: string;
   headline?: string | null;
@@ -28,6 +38,7 @@ export interface LatexResumeDocument {
   education: LatexResumeEntry[];
   projects: LatexResumeEntry[];
   skillGroups: LatexResumeSkillGroup[];
+  sectionTitles?: LatexResumeSectionTitles;
 }
 
 export interface RenderResumePdfArgs {
@@ -38,4 +49,8 @@ export interface RenderResumePdfArgs {
 
 export interface ResumeRenderer {
   render(args: RenderResumePdfArgs): Promise<void>;
+}
+
+export interface NormalizeResumeJsonToLatexDocumentOptions {
+  language?: ChatStyleManualLanguage;
 }


### PR DESCRIPTION
## Summary
- Local LaTeX resume rendering now uses the resolved output language for fixed section headings
- Added v5 resume language detection so `match-resume` works on Reactive Resume JSON, and kept RxResume export unchanged
- Updated settings docs to note the LaTeX renderer behavior

## Testing
- Added unit coverage for Reactive Resume v5 language detection and fallback behavior
- Added renderer tests for localized section titles and English defaults
- Added PDF service tests to verify manual language selection and match-resume detection reach the local LaTeX renderer
- Full CI-parity checks passed, including formatting, type checks, client build, and the orchestrator test suite