### PR TITLE
Fix PDF regeneration failure handling

### DIFF
--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -885,6 +885,38 @@ describe.sequential("Jobs API routes", () => {
     }
   });
 
+  it("returns an upstream error when Reactive Resume PDF generation fails", async () => {
+    const { createJob } = await import("@server/repositories/jobs");
+    const { generateFinalPdf } = await import("@server/pipeline/index");
+    const job = await createJob({
+      source: "manual",
+      title: "PDF Failure Test",
+      employer: "Example Co",
+      jobUrl: "https://example.com/job/pdf-failure-test",
+      jobDescription: "Test description",
+    });
+
+    vi.mocked(generateFinalPdf).mockResolvedValueOnce({
+      success: false,
+      error:
+        "PDF generation failed. Your previous resume PDF is still available. Reactive Resume API error (500): Failed to generate PDF",
+      errorCode: "UPSTREAM_ERROR",
+    });
+
+    const res = await fetch(`${baseUrl}/api/jobs/${job.id}/generate-pdf`, {
+      method: "POST",
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(502);
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("UPSTREAM_ERROR");
+    expect(body.error.message).toContain(
+      "Your previous resume PDF is still available",
+    );
+    expect(typeof body.meta.requestId).toBe("string");
+  });
+
   it("returns 409 when patching to a duplicate job URL", async () => {
     const { createJob } = await import("@server/repositories/jobs");
     const first = await createJob({

--- a/orchestrator/src/server/api/routes/jobs.ts
+++ b/orchestrator/src/server/api/routes/jobs.ts
@@ -351,6 +351,37 @@ function mapErrorForResult(error: unknown): {
   };
 }
 
+const STATUS_BY_APP_ERROR_CODE: Record<AppErrorCode, number> = {
+  INVALID_REQUEST: 400,
+  UNAUTHORIZED: 401,
+  FORBIDDEN: 403,
+  NOT_FOUND: 404,
+  REQUEST_TIMEOUT: 408,
+  CONFLICT: 409,
+  UNPROCESSABLE_ENTITY: 422,
+  SERVICE_UNAVAILABLE: 503,
+  UPSTREAM_ERROR: 502,
+  INTERNAL_ERROR: 500,
+};
+
+function appErrorFromPipelineFailure(
+  result: { error?: string; errorCode?: AppErrorCode },
+  fallbackMessage: string,
+): AppError {
+  const code =
+    result.errorCode ?? (result.error === "Job not found" ? "NOT_FOUND" : null);
+
+  if (!code) {
+    return badRequest(result.error ?? fallbackMessage);
+  }
+
+  return new AppError({
+    status: STATUS_BY_APP_ERROR_CODE[code],
+    code,
+    message: result.error ?? fallbackMessage,
+  });
+}
+
 type JobActionExecutionOptions = {
   getProfileForRescore?: () => Promise<Record<string, unknown>>;
   forceMoveToReady?: boolean;
@@ -529,24 +560,14 @@ async function executeJobActionForJob(
 function mapJobActionFailure(
   failure: Extract<JobActionResult, { ok: false }>,
 ): AppError {
-  const statusByCode: Record<AppErrorCode, number> = {
-    INVALID_REQUEST: 400,
-    UNAUTHORIZED: 401,
-    FORBIDDEN: 403,
-    NOT_FOUND: 404,
-    REQUEST_TIMEOUT: 408,
-    CONFLICT: 409,
-    UNPROCESSABLE_ENTITY: 422,
-    SERVICE_UNAVAILABLE: 503,
-    UPSTREAM_ERROR: 502,
-    INTERNAL_ERROR: 500,
-  };
   const code = (
-    failure.error.code in statusByCode ? failure.error.code : "INTERNAL_ERROR"
+    failure.error.code in STATUS_BY_APP_ERROR_CODE
+      ? failure.error.code
+      : "INTERNAL_ERROR"
   ) as AppErrorCode;
 
   return new AppError({
-    status: statusByCode[code],
+    status: STATUS_BY_APP_ERROR_CODE[code],
     code,
     message: failure.error.message,
   });
@@ -1756,7 +1777,7 @@ jobsRouter.post("/:id/generate-pdf", async (req: Request, res: Response) => {
     if (!result.success) {
       return fail(
         res,
-        badRequest(result.error ?? "Failed to generate a resume PDF"),
+        appErrorFromPipelineFailure(result, "Failed to generate a resume PDF"),
       );
     }
 

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -8,12 +8,17 @@
  */
 
 import { join } from "node:path";
+import type { AppErrorCode } from "@infra/errors";
 import { logger } from "@infra/logger";
 import { trackServerProductEvent } from "@infra/product-analytics";
 import { runWithRequestContext } from "@infra/request-context";
 import { getActiveTenantId } from "@server/tenancy/context";
 import { createLocationIntentFromLegacyInputs } from "@shared/location-domain.js";
-import type { PipelineConfig, PipelineRunSavedDetails } from "@shared/types";
+import type {
+  JobStatus,
+  PipelineConfig,
+  PipelineRunSavedDetails,
+} from "@shared/types";
 import { getDataDir } from "../config/dataDir";
 import * as jobsRepo from "../repositories/jobs";
 import * as pipelineRepo from "../repositories/pipeline";
@@ -581,16 +586,21 @@ export async function generateFinalPdf(
 ): Promise<{
   success: boolean;
   error?: string;
+  errorCode?: AppErrorCode;
 }> {
   return runWithRequestContext({ jobId }, async () => {
     const jobLogger = logger.child({ jobId });
     jobLogger.info("Generating final PDF");
+    let jobStatusToRestore: JobStatus | null = null;
     try {
       const job = await jobsRepo.getJobById(jobId);
       if (!job) return { success: false, error: "Job not found" };
+      jobStatusToRestore = job.status;
 
-      // Mark as processing
-      await jobsRepo.updateJob(job.id, { status: "processing" });
+      // Ready jobs already have a usable PDF; keep them visible while regenerating.
+      if (job.status !== "ready") {
+        await jobsRepo.updateJob(job.id, { status: "processing" });
+      }
 
       const pdfResult = await generatePdf(
         job.id,
@@ -610,9 +620,18 @@ export async function generateFinalPdf(
       );
 
       if (!pdfResult.success) {
-        // Revert status if failed
-        await jobsRepo.updateJob(job.id, { status: "discovered" });
-        return { success: false, error: pdfResult.error };
+        await jobsRepo.updateJob(job.id, { status: job.status });
+        const preservedPdfMessage =
+          job.status === "ready" && job.pdfPath
+            ? " Your previous resume PDF is still available."
+            : "";
+        return {
+          success: false,
+          error: `PDF generation failed.${preservedPdfMessage}${
+            pdfResult.error ? ` ${pdfResult.error}` : ""
+          }`,
+          errorCode: pdfResult.errorCode,
+        };
       }
 
       await jobsRepo.updateJob(job.id, {
@@ -654,6 +673,16 @@ export async function generateFinalPdf(
       return { success: true };
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown error";
+      if (jobStatusToRestore) {
+        try {
+          await jobsRepo.updateJob(jobId, { status: jobStatusToRestore });
+        } catch (restoreError) {
+          jobLogger.warn("Failed to restore job status after PDF error", {
+            restoreStatus: jobStatusToRestore,
+            error: restoreError,
+          });
+        }
+      }
       jobLogger.error("PDF generation failed", error);
       return { success: false, error: message };
     }

--- a/orchestrator/src/server/services/pdf.ts
+++ b/orchestrator/src/server/services/pdf.ts
@@ -5,7 +5,7 @@
 
 import { existsSync } from "node:fs";
 import { access, mkdir, writeFile } from "node:fs/promises";
-import { notFound } from "@infra/errors";
+import { AppError, type AppErrorCode, notFound } from "@infra/errors";
 import { logger } from "@infra/logger";
 import { getSetting } from "@server/repositories/settings";
 import { settingsRegistry } from "@shared/settings-registry";
@@ -37,6 +37,7 @@ export interface PdfResult {
   success: boolean;
   pdfPath?: string;
   error?: string;
+  errorCode?: AppErrorCode;
 }
 
 export interface TailoredPdfContent {
@@ -132,6 +133,25 @@ async function renderRxResumePdf(args: {
       }
     }
   }
+}
+
+function classifyPdfGenerationError(error: unknown): AppErrorCode {
+  if (error instanceof AppError) {
+    return error.code;
+  }
+
+  if (
+    error instanceof Error &&
+    /Reactive Resume|RxResume/i.test(error.message)
+  ) {
+    return "UPSTREAM_ERROR";
+  }
+
+  if (error instanceof Error && error.name === "AbortError") {
+    return "REQUEST_TIMEOUT";
+  }
+
+  return "INTERNAL_ERROR";
 }
 
 async function resolveDesignResumeForRenderer(args: {
@@ -325,7 +345,11 @@ export async function generatePdf(
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     logger.error("PDF generation failed", { jobId, renderer, error });
-    return { success: false, error: message };
+    return {
+      success: false,
+      error: message,
+      errorCode: classifyPdfGenerationError(error),
+    };
   }
 }
 

--- a/orchestrator/src/server/tailoring-flow.test.ts
+++ b/orchestrator/src/server/tailoring-flow.test.ts
@@ -96,4 +96,65 @@ describe("Tailoring Flow", () => {
       }),
     );
   });
+
+  it("keeps ready jobs ready when PDF regeneration fails", async () => {
+    const readyJob = {
+      id: "job-ready-789",
+      jobDescription: "Senior Product Engineer",
+      status: "ready",
+      pdfPath: "data/pdfs/resume_job-ready-789.pdf",
+      tailoredSummary: "Existing tailored summary.",
+      tailoredHeadline: "Existing headline",
+      tailoredSkills: JSON.stringify(["React"]),
+      selectedProjectIds: "project-a",
+    };
+
+    vi.mocked(jobsRepo.getJobById).mockResolvedValue(readyJob as any);
+    vi.mocked(pdfService.generatePdf).mockResolvedValue({
+      success: false,
+      error: "Reactive Resume API error (500): Failed to generate PDF",
+      errorCode: "UPSTREAM_ERROR",
+    });
+
+    const result = await generateFinalPdf("job-ready-789");
+
+    expect(result).toEqual({
+      success: false,
+      error:
+        "PDF generation failed. Your previous resume PDF is still available. Reactive Resume API error (500): Failed to generate PDF",
+      errorCode: "UPSTREAM_ERROR",
+    });
+    expect(jobsRepo.updateJob).toHaveBeenCalledTimes(1);
+    expect(jobsRepo.updateJob).toHaveBeenCalledWith("job-ready-789", {
+      status: "ready",
+    });
+  });
+
+  it("restores the previous status when generation throws before rendering", async () => {
+    const discoveredJob = {
+      id: "job-discovered-bad-skills",
+      jobDescription: "Backend Developer",
+      status: "discovered",
+      tailoredSummary: "Summary",
+      tailoredHeadline: "Headline",
+      tailoredSkills: "{",
+    };
+
+    vi.mocked(jobsRepo.getJobById).mockResolvedValue(discoveredJob as any);
+
+    const result = await generateFinalPdf("job-discovered-bad-skills");
+
+    expect(result.success).toBe(false);
+    expect(pdfService.generatePdf).not.toHaveBeenCalled();
+    expect(jobsRepo.updateJob).toHaveBeenNthCalledWith(
+      1,
+      "job-discovered-bad-skills",
+      { status: "processing" },
+    );
+    expect(jobsRepo.updateJob).toHaveBeenNthCalledWith(
+      2,
+      "job-discovered-bad-skills",
+      { status: "discovered" },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Preserve the previous job status when PDF regeneration fails instead of sending ready jobs back to Discovery.
- Return `UPSTREAM_ERROR` for Reactive Resume PDF failures so the API responds with `502` and a clearer message.
- Add regression coverage for status restoration and API error mapping.

## Testing
- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`