### PR TITLE
Fix project description rendering

### DIFF
--- a/orchestrator/src/client/components/discovered-panel/ProjectSelector.test.tsx
+++ b/orchestrator/src/client/components/discovered-panel/ProjectSelector.test.tsx
@@ -1,0 +1,26 @@
+import { createResumeProjectCatalogItem } from "@shared/testing/factories.js";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProjectSelector } from "./ProjectSelector";
+
+describe("ProjectSelector", () => {
+  it("renders html project descriptions as plain text", () => {
+    render(
+      <ProjectSelector
+        catalog={[
+          createResumeProjectCatalogItem({
+            description:
+              "<ul><li><p><strong>Built analytics</strong> using FastAPI.</p></li></ul>",
+          }),
+        ]}
+        selectedIds={new Set()}
+        onToggle={vi.fn()}
+        maxProjects={3}
+        disabled={false}
+      />,
+    );
+
+    expect(screen.getByText("Built analytics using FastAPI.")).toBeVisible();
+    expect(screen.queryByText(/<strong>/)).not.toBeInTheDocument();
+  });
+});

--- a/orchestrator/src/client/components/discovered-panel/ProjectSelector.tsx
+++ b/orchestrator/src/client/components/discovered-panel/ProjectSelector.tsx
@@ -2,7 +2,7 @@ import type { ResumeProjectCatalogItem } from "@shared/types.js";
 import { AlertTriangle } from "lucide-react";
 import type React from "react";
 import { Checkbox } from "@/components/ui/checkbox";
-import { cn } from "@/lib/utils";
+import { cn, stripHtml } from "@/lib/utils";
 
 interface ProjectSelectorProps {
   catalog: ResumeProjectCatalogItem[];
@@ -38,33 +38,37 @@ export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
             Loading projects...
           </div>
         ) : (
-          catalog.map((project) => (
-            <label
-              key={project.id}
-              htmlFor={`project-${project.id}`}
-              className={cn(
-                "flex items-start gap-2.5 rounded-lg border p-2.5 text-xs transition-colors cursor-pointer",
-                selectedIds.has(project.id)
-                  ? "border-primary/40 bg-primary/5"
-                  : "border-border/40 bg-muted/5 hover:bg-muted/10",
-                disabled && "opacity-50 cursor-not-allowed",
-              )}
-            >
-              <Checkbox
-                id={`project-${project.id}`}
-                checked={selectedIds.has(project.id)}
-                onCheckedChange={() => onToggle(project.id)}
-                disabled={disabled}
-                className="mt-0.5"
-              />
-              <div className="flex-1 min-w-0">
-                <div className="font-medium truncate">{project.name}</div>
-                <div className="text-[10px] text-muted-foreground line-clamp-1 mt-0.5">
-                  {project.description}
+          catalog.map((project) => {
+            const description = stripHtml(project.description);
+
+            return (
+              <label
+                key={project.id}
+                htmlFor={`project-${project.id}`}
+                className={cn(
+                  "flex items-start gap-2.5 rounded-lg border p-2.5 text-xs transition-colors cursor-pointer",
+                  selectedIds.has(project.id)
+                    ? "border-primary/40 bg-primary/5"
+                    : "border-border/40 bg-muted/5 hover:bg-muted/10",
+                  disabled && "opacity-50 cursor-not-allowed",
+                )}
+              >
+                <Checkbox
+                  id={`project-${project.id}`}
+                  checked={selectedIds.has(project.id)}
+                  onCheckedChange={() => onToggle(project.id)}
+                  disabled={disabled}
+                  className="mt-0.5"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium truncate">{project.name}</div>
+                  <div className="text-[10px] text-muted-foreground line-clamp-1 mt-0.5">
+                    {description}
+                  </div>
                 </div>
-              </div>
-            </label>
-          ))
+              </label>
+            );
+          })
         )}
       </div>
     </div>

--- a/orchestrator/src/server/services/resumeProjects.test.ts
+++ b/orchestrator/src/server/services/resumeProjects.test.ts
@@ -60,6 +60,29 @@ describe("Resume Projects Logic", () => {
       expect(selectionItems).toHaveLength(2);
       expect(selectionItems[0].summaryText).toBe("Desc 1");
     });
+
+    it("should strip html from catalog descriptions", () => {
+      const profile = {
+        sections: {
+          projects: {
+            items: [
+              {
+                id: "p1",
+                name: "Proj 1",
+                description:
+                  "<ul><li><p><strong>Built analytics</strong> using FastAPI.</p></li></ul>",
+                date: "2024",
+                visible: true,
+              },
+            ],
+          },
+        },
+      } as any;
+
+      const { catalog } = rp.extractProjectsFromProfile(profile);
+
+      expect(catalog[0].description).toBe("Built analytics using FastAPI.");
+    });
   });
 
   describe("normalizeResumeProjectsSettings", () => {

--- a/orchestrator/src/server/services/resumeProjects.ts
+++ b/orchestrator/src/server/services/resumeProjects.ts
@@ -25,7 +25,7 @@ export function extractProjectsFromProfile(profile: ResumeProfile): {
     if (!id) continue;
 
     const name = item.name || "";
-    const description = item.description || "";
+    const description = stripHtml(item.description || "");
     const date = item.date || "";
     const isVisibleInBase = Boolean(item.visible);
     const summary = item.summary || "";

--- a/orchestrator/src/server/services/rxresume/tailoring.test.ts
+++ b/orchestrator/src/server/services/rxresume/tailoring.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { extractProjectsFromResume } from "./tailoring";
+
+describe("rxresume tailoring", () => {
+  it("strips html from project catalog descriptions", () => {
+    const { catalog, selectionItems } = extractProjectsFromResume({
+      sections: {
+        projects: {
+          items: [
+            {
+              id: "p1",
+              name: "Analytics",
+              description:
+                "<ul><li><p><strong>Built analytics</strong> using FastAPI.</p></li></ul>",
+              hidden: false,
+              period: "2024",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(catalog[0].description).toBe("Built analytics using FastAPI.");
+    expect(selectionItems[0].summaryText).toBe(
+      "Built analytics using FastAPI.",
+    );
+  });
+});

--- a/orchestrator/src/server/services/rxresume/tailoring.ts
+++ b/orchestrator/src/server/services/rxresume/tailoring.ts
@@ -193,7 +193,9 @@ export function extractProjectsFromResume(resumeData: RecordLike): {
 
     const name = typeof item.name === "string" ? item.name : id;
     const description =
-      typeof item.description === "string" ? item.description : "";
+      typeof item.description === "string"
+        ? stripHtmlTags(item.description)
+        : "";
     const date = typeof item.period === "string" ? item.period : "";
 
     const isVisibleInBase = !(typeof item.hidden === "boolean"


### PR DESCRIPTION
## Summary
- Strip HTML from project descriptions before they reach the selector UI
- Normalize project descriptions in both local profile extraction and RxResume tailoring paths
- Add regression tests for the selector and both extraction flows

## Testing
- Unit tests added for `ProjectSelector`, `resumeProjects`, and `rxresume/tailoring`
- Existing CI checks were not rerun in this request