### PR TITLE
Refine manual import review flow

### DIFF
--- a/orchestrator/src/client/components/ManualImportFlow.tsx
+++ b/orchestrator/src/client/components/ManualImportFlow.tsx
@@ -1,6 +1,25 @@
 import * as api from "@client/api";
 import type { ManualJobDraft } from "@shared/types.js";
-import { ArrowDown, ArrowLeft, Link, Loader2, Sparkles } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowLeft,
+  Briefcase,
+  Building2,
+  Calendar,
+  CheckCircle2,
+  CircleAlert,
+  DollarSign,
+  FileText,
+  GraduationCap,
+  Link,
+  Link2,
+  ListChecks,
+  Loader2,
+  MapPin,
+  Sparkles,
+  Tag,
+  Users,
+} from "lucide-react";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -37,6 +56,18 @@ type ManualJobDraftState = {
   starting: string;
 };
 
+type DraftFieldKey = keyof ManualJobDraftState;
+
+type ReviewFieldConfig = {
+  id: string;
+  key: DraftFieldKey;
+  label: string;
+  placeholder: string;
+  icon: React.ComponentType<{ className?: string }>;
+  required?: boolean;
+  multiline?: boolean;
+};
+
 const emptyDraft: ManualJobDraftState = {
   title: "",
   employer: "",
@@ -63,6 +94,114 @@ const STEP_LABEL_BY_ID: Record<ManualImportProgressStep, string> = {
   paste: "Add JD",
   review: "Review & import",
 };
+
+const REQUIRED_REVIEW_FIELDS: ReviewFieldConfig[] = [
+  {
+    id: "draft-title",
+    key: "title",
+    label: "Title",
+    placeholder: "e.g. Junior Backend Engineer",
+    icon: Tag,
+    required: true,
+  },
+  {
+    id: "draft-employer",
+    key: "employer",
+    label: "Employer",
+    placeholder: "e.g. Acme Labs",
+    icon: Building2,
+    required: true,
+  },
+  {
+    id: "draft-jobDescription",
+    key: "jobDescription",
+    label: "Description",
+    placeholder: "Paste the job description...",
+    icon: FileText,
+    required: true,
+    multiline: true,
+  },
+];
+
+const OTHER_REVIEW_FIELDS: ReviewFieldConfig[] = [
+  {
+    id: "draft-location",
+    key: "location",
+    label: "Location",
+    placeholder: "e.g. London, UK",
+    icon: MapPin,
+  },
+  {
+    id: "draft-salary",
+    key: "salary",
+    label: "Salary",
+    placeholder: "e.g. GBP 45k-55k",
+    icon: DollarSign,
+  },
+  {
+    id: "draft-jobType",
+    key: "jobType",
+    label: "Job type",
+    placeholder: "e.g. Full-time",
+    icon: Briefcase,
+  },
+  {
+    id: "draft-jobLevel",
+    key: "jobLevel",
+    label: "Job level",
+    placeholder: "e.g. Graduate",
+    icon: ListChecks,
+  },
+  {
+    id: "draft-jobFunction",
+    key: "jobFunction",
+    label: "Job function",
+    placeholder: "e.g. Software Engineering",
+    icon: Users,
+  },
+  {
+    id: "draft-disciplines",
+    key: "disciplines",
+    label: "Disciplines",
+    placeholder: "e.g. Computer Science",
+    icon: ListChecks,
+  },
+  {
+    id: "draft-deadline",
+    key: "deadline",
+    label: "Deadline",
+    placeholder: "e.g. 30 Sep 2025",
+    icon: Calendar,
+  },
+  {
+    id: "draft-degreeRequired",
+    key: "degreeRequired",
+    label: "Degree required",
+    placeholder: "e.g. BSc or MSc",
+    icon: GraduationCap,
+  },
+  {
+    id: "draft-starting",
+    key: "starting",
+    label: "Starting",
+    placeholder: "e.g. September 2026",
+    icon: Calendar,
+  },
+  {
+    id: "draft-jobUrl",
+    key: "jobUrl",
+    label: "Job URL",
+    placeholder: "https://...",
+    icon: Link2,
+  },
+  {
+    id: "draft-applicationLink",
+    key: "applicationLink",
+    label: "Application URL",
+    placeholder: "https://...",
+    icon: Link,
+  },
+];
 
 const BLOCKED_AUTOFETCH_HOSTS: Array<{
   label: string;
@@ -442,182 +581,85 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
         )}
 
         {step === "review" && (
-          <div className="space-y-4 pb-4">
+          <div className="space-y-5 pb-4">
             {warning && (
               <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
                 {warning}
               </div>
             )}
 
-            <div className="flex items-center justify-between">
+            <div className="space-y-2">
+              <h3 className="text-2xl font-semibold tracking-tight">
+                Review job details
+              </h3>
+              <p className="max-w-lg text-sm leading-6 text-muted-foreground">
+                AI extracted these from the job description. Review anything
+                missing or odd before importing.
+              </p>
+            </div>
+
+            <ReviewSection
+              icon={CheckCircle2}
+              title="Required"
+              description="Title, employer, and description are needed to import."
+            >
+              <div className="divide-y divide-border/70">
+                {REQUIRED_REVIEW_FIELDS.map((field) => (
+                  <ReviewField
+                    key={field.id}
+                    field={field}
+                    value={draft[field.key]}
+                    onChange={(value) =>
+                      setDraft((prev) => ({ ...prev, [field.key]: value }))
+                    }
+                  />
+                ))}
+              </div>
+            </ReviewSection>
+
+            <ReviewSection
+              icon={CircleAlert}
+              title="Other details"
+              description="Useful if available; blank fields can be added later."
+            >
+              <div className="grid gap-2 sm:grid-cols-2">
+                {OTHER_REVIEW_FIELDS.map((field) => (
+                  <ReviewField
+                    key={field.id}
+                    field={field}
+                    value={draft[field.key]}
+                    onChange={(value) =>
+                      setDraft((prev) => ({ ...prev, [field.key]: value }))
+                    }
+                    compact
+                  />
+                ))}
+              </div>
+            </ReviewSection>
+
+            <div className="sticky bottom-0 -mx-1 flex gap-3 border-t border-border/70 bg-background/95 px-1 py-4 backdrop-blur">
               <Button
                 type="button"
-                variant="ghost"
-                size="sm"
+                variant="outline"
                 onClick={() => setStep("paste")}
-                className="gap-1 text-xs text-muted-foreground hover:text-foreground"
+                className="h-11 flex-1 gap-2"
               >
-                <ArrowLeft className="h-3.5 w-3.5" />
+                <ArrowLeft className="h-4 w-4" />
                 Edit JD
               </Button>
-              <span className="text-[11px] text-muted-foreground">
-                Required: title, employer, description
-              </span>
-            </div>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <FieldInput
-                id="draft-title"
-                label="Title *"
-                value={draft.title}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, title: value }))
-                }
-                placeholder="e.g. Junior Backend Engineer"
-              />
-              <FieldInput
-                id="draft-employer"
-                label="Employer *"
-                value={draft.employer}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, employer: value }))
-                }
-                placeholder="e.g. Acme Labs"
-              />
-              <FieldInput
-                id="draft-location"
-                label="Location"
-                value={draft.location}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, location: value }))
-                }
-                placeholder="e.g. London, UK"
-              />
-              <FieldInput
-                id="draft-salary"
-                label="Salary"
-                value={draft.salary}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, salary: value }))
-                }
-                placeholder="e.g. GBP 45k-55k"
-              />
-              <FieldInput
-                id="draft-deadline"
-                label="Deadline"
-                value={draft.deadline}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, deadline: value }))
-                }
-                placeholder="e.g. 30 Sep 2025"
-              />
-              <FieldInput
-                id="draft-jobType"
-                label="Job type"
-                value={draft.jobType}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, jobType: value }))
-                }
-                placeholder="e.g. Full-time"
-              />
-              <FieldInput
-                id="draft-jobLevel"
-                label="Job level"
-                value={draft.jobLevel}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, jobLevel: value }))
-                }
-                placeholder="e.g. Graduate"
-              />
-              <FieldInput
-                id="draft-jobFunction"
-                label="Job function"
-                value={draft.jobFunction}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, jobFunction: value }))
-                }
-                placeholder="e.g. Software Engineering"
-              />
-              <FieldInput
-                id="draft-disciplines"
-                label="Disciplines"
-                value={draft.disciplines}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, disciplines: value }))
-                }
-                placeholder="e.g. Computer Science"
-              />
-              <FieldInput
-                id="draft-degreeRequired"
-                label="Degree required"
-                value={draft.degreeRequired}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, degreeRequired: value }))
-                }
-                placeholder="e.g. BSc or MSc"
-              />
-              <FieldInput
-                id="draft-starting"
-                label="Starting"
-                value={draft.starting}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, starting: value }))
-                }
-                placeholder="e.g. September 2026"
-              />
-              <FieldInput
-                id="draft-jobUrl"
-                label="Job URL"
-                value={draft.jobUrl}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, jobUrl: value }))
-                }
-                placeholder="https://..."
-              />
-              <FieldInput
-                id="draft-applicationLink"
-                label="Application URL"
-                value={draft.applicationLink}
-                onChange={(value) =>
-                  setDraft((prev) => ({ ...prev, applicationLink: value }))
-                }
-                placeholder="https://..."
-              />
-            </div>
-
-            <div className="space-y-1">
-              <label
-                htmlFor="draft-jobDescription"
-                className="text-xs font-medium text-muted-foreground"
+              <Button
+                onClick={() => void handleImport()}
+                disabled={!canImport || isImporting}
+                className="h-11 flex-1 gap-2"
               >
-                Job description *
-              </label>
-              <Textarea
-                id="draft-jobDescription"
-                value={draft.jobDescription}
-                onChange={(event) =>
-                  setDraft((prev) => ({
-                    ...prev,
-                    jobDescription: event.target.value,
-                  }))
-                }
-                placeholder="Paste the job description..."
-                className="min-h-[180px] font-mono text-sm leading-relaxed"
-              />
+                {isImporting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Sparkles className="h-4 w-4" />
+                )}
+                {isImporting ? "Importing..." : "Import job"}
+              </Button>
             </div>
-
-            <Button
-              onClick={() => void handleImport()}
-              disabled={!canImport || isImporting}
-              className="w-full h-10 gap-2"
-            >
-              {isImporting ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Sparkles className="h-4 w-4" />
-              )}
-              {isImporting ? "Importing..." : "Import job"}
-            </Button>
           </div>
         )}
       </div>
@@ -625,22 +667,107 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
   );
 };
 
-const FieldInput: React.FC<{
-  id: string;
-  label: string;
+const ReviewSection: React.FC<{
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}> = ({ icon: Icon, title, description, children }) => (
+  <section className="rounded-xl border border-border/80 bg-card/45 p-3 shadow-sm">
+    <div className="mb-3 flex items-start gap-3">
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border bg-background/80 text-muted-foreground">
+        <Icon className="h-4 w-4" />
+      </span>
+      <div className="min-w-0">
+        <h4 className="text-sm font-semibold text-foreground">{title}</h4>
+        <p className="text-xs leading-5 text-muted-foreground">{description}</p>
+      </div>
+    </div>
+    {children}
+  </section>
+);
+
+const ReviewField: React.FC<{
+  field: ReviewFieldConfig;
   value: string;
   onChange: (value: string) => void;
-  placeholder: string;
-}> = ({ id, label, value, onChange, placeholder }) => (
-  <div className="space-y-1">
-    <label htmlFor={id} className="text-xs font-medium text-muted-foreground">
-      {label}
-    </label>
-    <Input
-      id={id}
-      value={value}
-      onChange={(event) => onChange(event.target.value)}
-      placeholder={placeholder}
-    />
-  </div>
-);
+  compact?: boolean;
+}> = ({ field, value, onChange, compact = false }) => {
+  const hasValue = value.trim().length > 0;
+  const needsReview = Boolean(field.required) && !hasValue;
+  const Icon = field.icon;
+
+  return (
+    <div
+      className={
+        compact
+          ? "rounded-lg border border-border/70 bg-background/35 p-3"
+          : "py-3 first:pt-0 last:pb-0"
+      }
+    >
+      <div className="flex gap-3">
+        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/55 text-muted-foreground">
+          <Icon className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <label
+              htmlFor={field.id}
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {field.label}
+              {field.required ? " *" : ""}
+            </label>
+            <ReviewStatusBadge hasValue={hasValue} needsReview={needsReview} />
+          </div>
+          {field.multiline ? (
+            <Textarea
+              id={field.id}
+              value={value}
+              onChange={(event) => onChange(event.target.value)}
+              placeholder={field.placeholder}
+              className="min-h-[150px] resize-y border-border/70 bg-background/70 font-mono text-sm leading-relaxed"
+            />
+          ) : (
+            <Input
+              id={field.id}
+              value={value}
+              onChange={(event) => onChange(event.target.value)}
+              placeholder={field.placeholder}
+              className="h-9 border-border/70 bg-background/70 text-sm"
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ReviewStatusBadge: React.FC<{
+  hasValue: boolean;
+  needsReview: boolean;
+}> = ({ hasValue, needsReview }) => {
+  if (needsReview) {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-[11px] font-medium text-amber-200">
+        <CircleAlert className="h-3 w-3" />
+        Review
+      </span>
+    );
+  }
+
+  if (hasValue) {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-emerald-500/25 bg-emerald-500/10 px-2 py-1 text-[11px] font-medium text-emerald-200">
+        <CheckCircle2 className="h-3 w-3" />
+        Looks good
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex shrink-0 items-center rounded-full border border-border bg-muted/40 px-2 py-1 text-[11px] font-medium text-muted-foreground">
+      Add
+    </span>
+  );
+};

--- a/orchestrator/src/client/components/ManualImportFlow.tsx
+++ b/orchestrator/src/client/components/ManualImportFlow.tsx
@@ -1,12 +1,6 @@
 import * as api from "@client/api";
 import type { ManualJobDraft } from "@shared/types.js";
-import {
-  ArrowLeft,
-  ClipboardPaste,
-  Link,
-  Loader2,
-  Sparkles,
-} from "lucide-react";
+import { ArrowDown, ArrowLeft, Link, Loader2, Sparkles } from "lucide-react";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -144,10 +138,12 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
   const [draft, setDraft] = useState<ManualJobDraftState>(emptyDraft);
   const [warning, setWarning] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [fetchNotice, setFetchNotice] = useState<string | null>(null);
   const [isImporting, setIsImporting] = useState(false);
   const [importSource, setImportSource] =
     useState<ManualImportTrackingSource>("pasted_description");
   const [importSourceHost, setImportSourceHost] = useState<string | null>(null);
+  const [fetchedSourceUrl, setFetchedSourceUrl] = useState<string | null>(null);
 
   useEffect(() => {
     if (active) return;
@@ -158,15 +154,18 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
     setDraft(emptyDraft);
     setWarning(null);
     setError(null);
+    setFetchNotice(null);
     setIsImporting(false);
     setImportSource("pasted_description");
     setImportSourceHost(null);
+    setFetchedSourceUrl(null);
   }, [active]);
 
   const stepIndex = STEP_INDEX_BY_ID[step];
   const stepLabel = STEP_LABEL_BY_ID[step];
 
-  const canAnalyze = rawDescription.trim().length > 0 && step !== "loading";
+  const canAnalyze =
+    rawDescription.trim().length > 0 && step !== "loading" && !isFetching;
   const canFetch =
     fetchUrl.trim().length > 0 && !isFetching && step === "paste";
   const canImport = useMemo(() => {
@@ -184,34 +183,26 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
     try {
       setError(null);
       setWarning(null);
+      setFetchNotice(null);
       setIsFetching(true);
 
       const fetchResponse = await api.fetchJobFromUrl({ url: fetchUrl.trim() });
       const fetchedContent = fetchResponse.content;
       const fetchedUrl = fetchResponse.url;
 
-      setIsFetching(false);
-      setStep("loading");
-      const inferResponse = await api.inferManualJob({
-        jobDescription: fetchedContent,
-      });
-      const normalized = normalizeDraft(inferResponse.job);
-
-      if (!normalized.jobUrl) {
-        normalized.jobUrl = fetchedUrl;
-      }
-
-      setDraft(normalized);
-      setWarning(inferResponse.warning ?? null);
+      setRawDescription(fetchedContent);
+      setFetchedSourceUrl(fetchedUrl);
       setImportSource("fetched_url");
       setImportSourceHost(getSourceHost(fetchedUrl));
-      setStep("review");
+      setFetchUrl(fetchedUrl);
+      setFetchNotice("Fetched the page text. Review it below, then analyze.");
     } catch (err) {
       const message =
         err instanceof Error ? err.message : "Failed to fetch URL";
       setError(message);
-      setIsFetching(false);
       setStep("paste");
+    } finally {
+      setIsFetching(false);
     }
   };
 
@@ -229,14 +220,16 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
         jobDescription: rawDescription,
       });
       const normalized = normalizeDraft(response.job, rawDescription.trim());
-      if (draft.jobUrl && !normalized.jobUrl) {
-        normalized.jobUrl = draft.jobUrl;
+      if (fetchedSourceUrl && !normalized.jobUrl) {
+        normalized.jobUrl = fetchedSourceUrl;
       }
       setDraft(normalized);
       setWarning(response.warning ?? null);
-      setImportSource("pasted_description");
+      setImportSource(fetchedSourceUrl ? "fetched_url" : "pasted_description");
       setImportSourceHost(
-        getSourceHost(draft.jobUrl) ?? getSourceHost(draft.applicationLink),
+        getSourceHost(fetchedSourceUrl ?? "") ??
+          getSourceHost(normalized.jobUrl) ??
+          getSourceHost(normalized.applicationLink),
       );
       setStep("review");
     } catch (err) {
@@ -299,12 +292,17 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
         {step === "paste" && (
           <div className="space-y-4">
             <div className="space-y-2">
-              <label
-                htmlFor="fetch-url"
-                className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-              >
-                Job URL (optional)
-              </label>
+              <div className="flex items-center justify-between gap-3">
+                <label
+                  htmlFor="fetch-url"
+                  className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Job URL
+                </label>
+                <span className="text-[11px] text-muted-foreground">
+                  Optional helper
+                </span>
+              </div>
               <div className="flex gap-2">
                 <Input
                   id="fetch-url"
@@ -322,34 +320,29 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
                 <Button
                   type="button"
                   variant="secondary"
-                  disabled={isFetching}
+                  disabled={!canFetch}
                   className="gap-2 shrink-0"
-                  onClick={async () => {
-                    if (fetchUrl.trim()) {
-                      await handleFetch();
-                    } else {
-                      try {
-                        const text = await navigator.clipboard.readText();
-                        if (text) setFetchUrl(text.trim());
-                      } catch {
-                        // Clipboard access denied
-                      }
-                    }
-                  }}
+                  onClick={() => void handleFetch()}
                 >
                   {isFetching ? (
                     <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : fetchUrl.trim() ? (
-                    <Link className="h-4 w-4" />
                   ) : (
-                    <ClipboardPaste className="h-4 w-4" />
+                    <Link className="h-4 w-4" />
                   )}
-                  {isFetching
-                    ? "Fetching..."
-                    : fetchUrl.trim()
-                      ? "Fetch"
-                      : "Paste"}
+                  {isFetching ? "Fetching..." : "Fetch"}
                 </Button>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Fetch tries to copy the job text into the description field. If
+                the site blocks simple fetching, paste the description manually.
+              </p>
+            </div>
+
+            <div className="flex items-center justify-center text-muted-foreground">
+              <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide">
+                <span className="h-px w-10 bg-border" />
+                <ArrowDown className="h-3.5 w-3.5" />
+                <span className="h-px w-10 bg-border" />
               </div>
             </div>
 
@@ -363,11 +356,25 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
               <Textarea
                 id="raw-description"
                 value={rawDescription}
-                onChange={(event) => setRawDescription(event.target.value)}
-                placeholder="Paste the full job description here, or enter a URL above to fetch it..."
+                onChange={(event) => {
+                  setRawDescription(event.target.value);
+                  setFetchNotice(null);
+                  if (!event.target.value.trim()) {
+                    setFetchedSourceUrl(null);
+                    setImportSource("pasted_description");
+                    setImportSourceHost(null);
+                  }
+                }}
+                placeholder="Paste the full job description here, or fetch it from a URL above..."
                 className="min-h-[200px] font-mono text-sm leading-relaxed"
               />
             </div>
+
+            {fetchNotice && (
+              <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-200">
+                {fetchNotice}
+              </div>
+            )}
 
             {error && (
               <div className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
@@ -376,20 +383,12 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
             )}
 
             <Button
-              onClick={
-                fetchUrl.trim()
-                  ? () => void handleFetch()
-                  : () => void handleAnalyze()
-              }
-              disabled={isFetching || (!canFetch && !canAnalyze)}
+              onClick={() => void handleAnalyze()}
+              disabled={!canAnalyze}
               className="w-full h-10 gap-2"
             >
-              {isFetching ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <Sparkles className="h-4 w-4" />
-              )}
-              {isFetching ? "Fetching..." : "Analyze JD"}
+              <Sparkles className="h-4 w-4" />
+              Analyze JD
             </Button>
           </div>
         )}

--- a/orchestrator/src/client/components/ManualImportFlow.tsx
+++ b/orchestrator/src/client/components/ManualImportFlow.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 
 type ManualImportStep = "paste" | "loading" | "review";
+type ManualImportProgressStep = "paste" | "review";
 
 export type ManualImportTrackingSource = "pasted_description" | "fetched_url";
 
@@ -53,15 +54,13 @@ const emptyDraft: ManualJobDraftState = {
   starting: "",
 };
 
-const STEP_INDEX_BY_ID: Record<ManualImportStep, number> = {
+const STEP_INDEX_BY_ID: Record<ManualImportProgressStep, number> = {
   paste: 0,
-  loading: 1,
-  review: 2,
+  review: 1,
 };
 
-const STEP_LABEL_BY_ID: Record<ManualImportStep, string> = {
-  paste: "Paste JD",
-  loading: "Infer details",
+const STEP_LABEL_BY_ID: Record<ManualImportProgressStep, string> = {
+  paste: "Add JD",
   review: "Review & import",
 };
 
@@ -184,8 +183,10 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
     setFetchedSourceUrl(null);
   }, [active]);
 
-  const stepIndex = STEP_INDEX_BY_ID[step];
-  const stepLabel = STEP_LABEL_BY_ID[step];
+  const progressStep: ManualImportProgressStep =
+    step === "review" ? "review" : "paste";
+  const stepIndex = STEP_INDEX_BY_ID[progressStep];
+  const stepLabel = STEP_LABEL_BY_ID[progressStep];
 
   const canAnalyze =
     rawDescription.trim().length > 0 && step !== "loading" && !isFetching;
@@ -310,13 +311,13 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
       <div className="space-y-4">
         <div className="space-y-2">
           <div className="flex items-center justify-between text-xs text-muted-foreground">
-            <span>Step {stepIndex + 1} of 3</span>
+            <span>Step {stepIndex + 1} of 2</span>
             <span>{stepLabel}</span>
           </div>
           <div className="h-1 rounded-full bg-muted/40">
             <div
               className="h-1 rounded-full bg-primary/60 transition-all"
-              style={{ width: `${((stepIndex + 1) / 3) * 100}%` }}
+              style={{ width: `${((stepIndex + 1) / 2) * 100}%` }}
             />
           </div>
         </div>

--- a/orchestrator/src/client/components/ManualImportFlow.tsx
+++ b/orchestrator/src/client/components/ManualImportFlow.tsx
@@ -121,6 +121,14 @@ const REQUIRED_REVIEW_FIELDS: ReviewFieldConfig[] = [
     required: true,
     multiline: true,
   },
+  {
+    id: "draft-jobUrl",
+    key: "jobUrl",
+    label: "Job URL",
+    placeholder: "https://...",
+    icon: Link2,
+    required: true,
+  },
 ];
 
 const OTHER_REVIEW_FIELDS: ReviewFieldConfig[] = [
@@ -186,13 +194,6 @@ const OTHER_REVIEW_FIELDS: ReviewFieldConfig[] = [
     label: "Starting",
     placeholder: "e.g. September 2026",
     icon: Calendar,
-  },
-  {
-    id: "draft-jobUrl",
-    key: "jobUrl",
-    label: "Job URL",
-    placeholder: "https://...",
-    icon: Link2,
   },
   {
     id: "draft-applicationLink",
@@ -268,6 +269,7 @@ interface ManualImportFlowProps {
   active: boolean;
   onImported: (result: ManualImportResult) => void | Promise<void>;
   onClose: () => void;
+  showReviewIntro?: boolean;
 }
 
 function getSourceHost(value: string): string | null {
@@ -291,6 +293,7 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
   active,
   onImported,
   onClose,
+  showReviewIntro = true,
 }) => {
   const [step, setStep] = useState<ManualImportStep>("paste");
   const [rawDescription, setRawDescription] = useState("");
@@ -336,6 +339,7 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
     return (
       draft.title.trim().length > 0 &&
       draft.employer.trim().length > 0 &&
+      draft.jobUrl.trim().length > 0 &&
       draft.jobDescription.trim().length > 0
     );
   }, [draft, step]);
@@ -588,20 +592,22 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
               </div>
             )}
 
-            <div className="space-y-2">
-              <h3 className="text-2xl font-semibold tracking-tight">
-                Review job details
-              </h3>
-              <p className="max-w-lg text-sm leading-6 text-muted-foreground">
-                AI extracted these from the job description. Review anything
-                missing or odd before importing.
-              </p>
-            </div>
+            {showReviewIntro && (
+              <div className="space-y-2">
+                <h3 className="text-2xl font-semibold tracking-tight">
+                  Review job details
+                </h3>
+                <p className="max-w-lg text-sm leading-6 text-muted-foreground">
+                  AI extracted these from the job description. Review anything
+                  missing or odd before importing.
+                </p>
+              </div>
+            )}
 
             <ReviewSection
               icon={CheckCircle2}
               title="Required"
-              description="Title, employer, and description are needed to import."
+              description="Title, employer, job URL, and description are needed to import."
             >
               <div className="divide-y divide-border/70">
                 {REQUIRED_REVIEW_FIELDS.map((field) => (
@@ -622,7 +628,7 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
               title="Other details"
               description="Useful if available; blank fields can be added later."
             >
-              <div className="grid gap-2 sm:grid-cols-2">
+              <div className="grid gap-x-4 sm:grid-cols-2">
                 {OTHER_REVIEW_FIELDS.map((field) => (
                   <ReviewField
                     key={field.id}
@@ -700,9 +706,7 @@ const ReviewField: React.FC<{
   return (
     <div
       className={
-        compact
-          ? "rounded-lg border border-border/70 bg-background/35 p-3"
-          : "py-3 first:pt-0 last:pb-0"
+        compact ? "border-border/60 border-b py-3" : "py-3 first:pt-0 last:pb-0"
       }
     >
       <div className="flex gap-3">
@@ -726,7 +730,7 @@ const ReviewField: React.FC<{
               value={value}
               onChange={(event) => onChange(event.target.value)}
               placeholder={field.placeholder}
-              className="min-h-[150px] resize-y border-border/70 bg-background/70 font-mono text-sm leading-relaxed"
+              className="min-h-[150px] resize-y border-border/70 bg-background/60 font-mono text-sm leading-relaxed"
             />
           ) : (
             <Input
@@ -734,7 +738,7 @@ const ReviewField: React.FC<{
               value={value}
               onChange={(event) => onChange(event.target.value)}
               placeholder={field.placeholder}
-              className="h-9 border-border/70 bg-background/70 text-sm"
+              className="h-9 border-border/70 bg-background/60 text-sm"
             />
           )}
         </div>

--- a/orchestrator/src/client/components/ManualImportFlow.tsx
+++ b/orchestrator/src/client/components/ManualImportFlow.tsx
@@ -65,6 +65,22 @@ const STEP_LABEL_BY_ID: Record<ManualImportStep, string> = {
   review: "Review & import",
 };
 
+const BLOCKED_AUTOFETCH_HOSTS: Array<{
+  label: string;
+  match: (hostname: string) => boolean;
+}> = [
+  {
+    label: "LinkedIn",
+    match: (hostname) =>
+      hostname === "linkedin.com" || hostname.endsWith(".linkedin.com"),
+  },
+  {
+    label: "Indeed",
+    match: (hostname) =>
+      hostname === "indeed.com" || hostname.includes("indeed."),
+  },
+];
+
 const normalizeDraft = (
   draft?: ManualJobDraft | null,
   jd?: string,
@@ -126,6 +142,13 @@ function getSourceHost(value: string): string | null {
   }
 }
 
+function getBlockedAutofetchLabel(value: string): string | null {
+  const host = getSourceHost(value)?.toLowerCase();
+  if (!host) return null;
+  const blocked = BLOCKED_AUTOFETCH_HOSTS.find((entry) => entry.match(host));
+  return blocked?.label ?? null;
+}
+
 export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
   active,
   onImported,
@@ -178,7 +201,17 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
   }, [draft, step]);
 
   const handleFetch = async () => {
-    if (!fetchUrl.trim()) return;
+    const trimmedUrl = fetchUrl.trim();
+    if (!trimmedUrl) return;
+    const blockedLabel = getBlockedAutofetchLabel(trimmedUrl);
+    if (blockedLabel) {
+      setError(
+        `Auto-fetch is not supported for ${blockedLabel} links. Paste the job description manually.`,
+      );
+      setWarning(null);
+      setFetchNotice(null);
+      return;
+    }
 
     try {
       setError(null);
@@ -186,7 +219,7 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
       setFetchNotice(null);
       setIsFetching(true);
 
-      const fetchResponse = await api.fetchJobFromUrl({ url: fetchUrl.trim() });
+      const fetchResponse = await api.fetchJobFromUrl({ url: trimmedUrl });
       const fetchedContent = fetchResponse.content;
       const fetchedUrl = fetchResponse.url;
 
@@ -198,7 +231,9 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
       setFetchNotice("Fetched the page text. Review it below, then analyze.");
     } catch (err) {
       const message =
-        err instanceof Error ? err.message : "Failed to fetch URL";
+        err instanceof Error
+          ? err.message
+          : "Couldn't fetch this URL automatically. Paste the job description manually.";
       setError(message);
       setStep("paste");
     } finally {

--- a/orchestrator/src/client/components/ManualImportSheet.test.tsx
+++ b/orchestrator/src/client/components/ManualImportSheet.test.tsx
@@ -350,7 +350,9 @@ describe("ManualImportSheet", () => {
 
     it("shows error and returns to paste step when fetch fails", async () => {
       vi.mocked(api.fetchJobFromUrl).mockRejectedValue(
-        new Error("Failed to fetch URL"),
+        new Error(
+          "Couldn't fetch this URL automatically. Paste the job description manually.",
+        ),
       );
 
       render(
@@ -363,7 +365,9 @@ describe("ManualImportSheet", () => {
       );
       fireEvent.click(screen.getByRole("button", { name: /fetch/i }));
 
-      await screen.findByText("Failed to fetch URL");
+      await screen.findByText(
+        "Couldn't fetch this URL automatically. Paste the job description manually.",
+      );
 
       // Should still be on paste step
       expect(
@@ -371,6 +375,23 @@ describe("ManualImportSheet", () => {
           "Paste the full job description here, or fetch it from a URL above...",
         ),
       ).toBeInTheDocument();
+    });
+
+    it("rejects blocked autofetch domains before calling the API", async () => {
+      render(
+        <ManualImportSheet open onOpenChange={vi.fn()} onImported={vi.fn()} />,
+      );
+
+      fireEvent.change(
+        screen.getByPlaceholderText("https://example.com/job-posting"),
+        { target: { value: "https://www.linkedin.com/jobs/view/123" } },
+      );
+      fireEvent.click(screen.getByRole("button", { name: /fetch/i }));
+
+      await screen.findByText(
+        "Auto-fetch is not supported for LinkedIn links. Paste the job description manually.",
+      );
+      expect(api.fetchJobFromUrl).not.toHaveBeenCalled();
     });
 
     it("shows error when inference fails after fetch", async () => {

--- a/orchestrator/src/client/components/ManualImportSheet.test.tsx
+++ b/orchestrator/src/client/components/ManualImportSheet.test.tsx
@@ -46,7 +46,7 @@ describe("ManualImportSheet", () => {
 
     fireEvent.change(
       screen.getByPlaceholderText(
-        "Paste the full job description here, or enter a URL above to fetch it...",
+        "Paste the full job description here, or fetch it from a URL above...",
       ),
       { target: { value: rawDescription } },
     );
@@ -109,7 +109,7 @@ describe("ManualImportSheet", () => {
 
     fireEvent.change(
       screen.getByPlaceholderText(
-        "Paste the full job description here, or enter a URL above to fetch it...",
+        "Paste the full job description here, or fetch it from a URL above...",
       ),
       { target: { value: rawDescription } },
     );
@@ -146,7 +146,7 @@ describe("ManualImportSheet", () => {
 
     fireEvent.change(
       screen.getByPlaceholderText(
-        "Paste the full job description here, or enter a URL above to fetch it...",
+        "Paste the full job description here, or fetch it from a URL above...",
       ),
       { target: { value: rawDescription } },
     );
@@ -184,7 +184,7 @@ describe("ManualImportSheet", () => {
 
     fireEvent.change(
       screen.getByPlaceholderText(
-        "Paste the full job description here, or enter a URL above to fetch it...",
+        "Paste the full job description here, or fetch it from a URL above...",
       ),
       { target: { value: "Backend Engineer role." } },
     );
@@ -202,72 +202,69 @@ describe("ManualImportSheet", () => {
   });
 
   describe("URL fetch functionality", () => {
-    it("shows Paste button when URL field is empty, Fetch when URL is entered", async () => {
+    it("treats URL fetch as optional and only enables analyze when description is filled", async () => {
       render(
         <ManualImportSheet open onOpenChange={vi.fn()} onImported={vi.fn()} />,
       );
 
-      // Initially should show Paste button
-      expect(
-        screen.getByRole("button", { name: /paste/i }),
-      ).toBeInTheDocument();
+      const fetchButton = screen.getByRole("button", { name: /fetch/i });
+      const analyzeButton = screen.getByRole("button", { name: /analyze jd/i });
 
-      // Enter a URL
+      expect(fetchButton).toBeDisabled();
+      expect(analyzeButton).toBeDisabled();
+
       fireEvent.change(
         screen.getByPlaceholderText("https://example.com/job-posting"),
         { target: { value: "https://example.com/job" } },
       );
 
-      // Should now show Fetch button
-      expect(
-        screen.getByRole("button", { name: /fetch/i }),
-      ).toBeInTheDocument();
+      expect(fetchButton).toBeEnabled();
+      expect(analyzeButton).toBeDisabled();
+
+      fireEvent.change(
+        screen.getByPlaceholderText(
+          "Paste the full job description here, or fetch it from a URL above...",
+        ),
+        { target: { value: "Software Engineer role at Acme Corp" } },
+      );
+
+      expect(analyzeButton).toBeEnabled();
     });
 
-    it("fetches URL and proceeds to review on successful fetch", async () => {
+    it("fetches URL content into the job description without analyzing", async () => {
       vi.mocked(api.fetchJobFromUrl).mockResolvedValue({
         content: "Software Engineer role at Acme Corp",
         url: "https://example.com/job",
       });
-      vi.mocked(api.inferManualJob).mockResolvedValue({
-        job: {
-          title: "Software Engineer",
-          employer: "Acme Corp",
-          location: "Remote",
-          jobDescription: "Great opportunity to join our team.",
-        },
-      });
 
       render(
         <ManualImportSheet open onOpenChange={vi.fn()} onImported={vi.fn()} />,
       );
 
-      // Enter a URL
       fireEvent.change(
         screen.getByPlaceholderText("https://example.com/job-posting"),
         { target: { value: "https://example.com/job" } },
       );
 
-      // Click Fetch
       fireEvent.click(screen.getByRole("button", { name: /fetch/i }));
 
-      // Should show loading state then review
-      await screen.findByPlaceholderText("e.g. Junior Backend Engineer");
+      await screen.findByText(
+        "Fetched the page text. Review it below, then analyze.",
+      );
 
       expect(api.fetchJobFromUrl).toHaveBeenCalledWith({
         url: "https://example.com/job",
       });
-      expect(api.inferManualJob).toHaveBeenCalledWith({
-        jobDescription: "Software Engineer role at Acme Corp",
-      });
+      expect(api.inferManualJob).not.toHaveBeenCalled();
 
-      // Check inferred values are shown
       expect(
-        screen.getByPlaceholderText("e.g. Junior Backend Engineer"),
-      ).toHaveValue("Software Engineer");
-      expect(screen.getByPlaceholderText("e.g. Acme Labs")).toHaveValue(
-        "Acme Corp",
-      );
+        screen.getByPlaceholderText(
+          "Paste the full job description here, or fetch it from a URL above...",
+        ),
+      ).toHaveValue("Software Engineer role at Acme Corp");
+      expect(
+        screen.queryByPlaceholderText("e.g. Junior Backend Engineer"),
+      ).not.toBeInTheDocument();
     });
 
     it("preserves fetched URL in the job URL field", async () => {
@@ -291,6 +288,11 @@ describe("ManualImportSheet", () => {
         { target: { value: "https://example.com/job" } },
       );
       fireEvent.click(screen.getByRole("button", { name: /fetch/i }));
+
+      await screen.findByText(
+        "Fetched the page text. Review it below, then analyze.",
+      );
+      fireEvent.click(screen.getByRole("button", { name: /analyze jd/i }));
 
       await screen.findByPlaceholderText("e.g. Junior Backend Engineer");
 
@@ -329,6 +331,11 @@ describe("ManualImportSheet", () => {
       );
       fireEvent.click(screen.getByRole("button", { name: /fetch/i }));
 
+      await screen.findByText(
+        "Fetched the page text. Review it below, then analyze.",
+      );
+      fireEvent.click(screen.getByRole("button", { name: /analyze jd/i }));
+
       await screen.findByPlaceholderText("e.g. Junior Backend Engineer");
       fireEvent.click(screen.getByRole("button", { name: /import job/i }));
 
@@ -361,7 +368,7 @@ describe("ManualImportSheet", () => {
       // Should still be on paste step
       expect(
         screen.getByPlaceholderText(
-          "Paste the full job description here, or enter a URL above to fetch it...",
+          "Paste the full job description here, or fetch it from a URL above...",
         ),
       ).toBeInTheDocument();
     });
@@ -385,12 +392,17 @@ describe("ManualImportSheet", () => {
       );
       fireEvent.click(screen.getByRole("button", { name: /fetch/i }));
 
+      await screen.findByText(
+        "Fetched the page text. Review it below, then analyze.",
+      );
+      fireEvent.click(screen.getByRole("button", { name: /analyze jd/i }));
+
       await screen.findByText("Inference failed");
 
       // Should be back on paste step
       expect(
         screen.getByPlaceholderText(
-          "Paste the full job description here, or enter a URL above to fetch it...",
+          "Paste the full job description here, or fetch it from a URL above...",
         ),
       ).toBeInTheDocument();
     });

--- a/orchestrator/src/client/components/ManualImportSheet.test.tsx
+++ b/orchestrator/src/client/components/ManualImportSheet.test.tsx
@@ -31,6 +31,7 @@ describe("ManualImportSheet", () => {
       job: {
         title: "Backend Engineer",
         employer: "Acme Labs",
+        jobUrl: "https://example.com/jobs/backend-engineer",
         location: "London, UK",
       },
     });
@@ -73,6 +74,7 @@ describe("ManualImportSheet", () => {
       job: expect.objectContaining({
         title: "Backend Engineer",
         employer: "Acme Labs",
+        jobUrl: "https://example.com/jobs/backend-engineer",
         location: "London, UK",
         salary: "120k",
         jobDescription: rawDescription.trim(),
@@ -83,7 +85,7 @@ describe("ManualImportSheet", () => {
       expect(onImported).toHaveBeenCalledWith({
         jobId: "job-1",
         source: "pasted_description",
-        sourceHost: null,
+        sourceHost: "example.com",
       }),
     );
     expect(onOpenChange).toHaveBeenCalledWith(false);
@@ -130,6 +132,12 @@ describe("ManualImportSheet", () => {
       target: { value: "Acme Labs" },
     });
 
+    expect(importButton).toBeDisabled();
+
+    fireEvent.change(screen.getAllByPlaceholderText("https://...")[0], {
+      target: { value: "https://example.com/jobs/qa-engineer" },
+    });
+
     await waitFor(() => expect(importButton).toBeEnabled());
   });
 
@@ -166,6 +174,7 @@ describe("ManualImportSheet", () => {
       job: {
         title: "Backend Engineer",
         employer: "Acme Labs",
+        jobUrl: "https://example.com/jobs/backend-engineer",
       },
     });
     vi.mocked(api.importManualJob).mockRejectedValue(

--- a/orchestrator/src/client/pages/orchestrator/RunModeModal.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/RunModeModal.test.tsx
@@ -34,4 +34,30 @@ describe("RunModeModal", () => {
     expect(screen.getByTestId("automatic-tab")).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /manual/i })).toBeInTheDocument();
   });
+
+  it("uses the review header for manual import", () => {
+    render(
+      <RunModeModal
+        open
+        mode="manual"
+        settings={null}
+        enabledSources={["linkedin"]}
+        pipelineSources={["linkedin"]}
+        onToggleSource={vi.fn()}
+        onSetPipelineSources={vi.fn()}
+        isPipelineRunning={false}
+        onOpenChange={vi.fn()}
+        onModeChange={vi.fn()}
+        onSaveAndRunAutomatic={vi.fn().mockResolvedValue(undefined)}
+        onManualImported={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    expect(
+      screen.getByRole("heading", { name: /review job details/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/choose automatic pipeline run or manual import/i),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/orchestrator/src/client/pages/orchestrator/RunModeModal.tsx
+++ b/orchestrator/src/client/pages/orchestrator/RunModeModal.tsx
@@ -44,16 +44,20 @@ export const RunModeModal: React.FC<RunModeModalProps> = ({
   onSaveAndRunAutomatic,
   onManualImported,
 }) => {
+  const isManualMode = mode === "manual";
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="w-full sm:max-w-2xl">
         <div className="flex h-full flex-col">
           <SheetHeader>
             <SheetTitle className="flex items-center gap-2">
-              Run jobs
+              {isManualMode ? "Review job details" : "Run jobs"}
             </SheetTitle>
             <SheetDescription>
-              Choose Automatic pipeline run or Manual import.
+              {isManualMode
+                ? "Add a job description, review the extracted details, then import."
+                : "Configure an automatic pipeline run."}
             </SheetDescription>
           </SheetHeader>
 
@@ -87,6 +91,7 @@ export const RunModeModal: React.FC<RunModeModalProps> = ({
                 active={open && mode === "manual"}
                 onImported={onManualImported}
                 onClose={() => onOpenChange(false)}
+                showReviewIntro={false}
               />
             </TabsContent>
           </Tabs>

--- a/orchestrator/src/server/api/routes/jobs-tailoring.test.ts
+++ b/orchestrator/src/server/api/routes/jobs-tailoring.test.ts
@@ -27,6 +27,7 @@ describe.sequential("Jobs tailoring PATCH route", () => {
         job: {
           title: "Backend Engineer",
           employer: "Acme",
+          jobUrl: "https://example.com/jobs/backend-engineer",
           jobDescription: "Build backend systems",
         },
       }),

--- a/orchestrator/src/server/api/routes/manual-jobs.test.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.test.ts
@@ -79,7 +79,7 @@ describe.sequential("Manual jobs API routes", () => {
     expect(body.data.job.title).toBe("Backend Engineer");
   });
 
-  it("imports manual jobs and generates a fallback URL", async () => {
+  it("imports manual jobs with a required job URL", async () => {
     const { processJob } = await import("@server/pipeline/index");
     const { scoreJobSuitability } = await import("@server/services/scorer");
     vi.mocked(scoreJobSuitability).mockResolvedValue({
@@ -94,6 +94,7 @@ describe.sequential("Manual jobs API routes", () => {
         job: {
           title: "Backend Engineer",
           employer: "Acme",
+          jobUrl: "https://example.com/jobs/backend-engineer",
           jobDescription: "Great role",
         },
       }),
@@ -101,10 +102,26 @@ describe.sequential("Manual jobs API routes", () => {
     const body = await res.json();
     expect(body.ok).toBe(true);
     expect(body.data.source).toBe("manual");
-    expect(body.data.jobUrl).toMatch(/^manual:\/\//);
+    expect(body.data.jobUrl).toBe("https://example.com/jobs/backend-engineer");
     expect(vi.mocked(processJob)).toHaveBeenCalledWith(body.data.id, {
       analyticsOrigin: "manual_job_create",
     });
     await new Promise((resolve) => setTimeout(resolve, 25));
+  });
+
+  it("rejects manual imports without a job URL", async () => {
+    const res = await fetch(`${baseUrl}/api/manual-jobs/import`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        job: {
+          title: "Backend Engineer",
+          employer: "Acme",
+          jobDescription: "Great role",
+        },
+      }),
+    });
+
+    expect(res.status).toBe(400);
   });
 });

--- a/orchestrator/src/server/api/routes/manual-jobs.test.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.test.ts
@@ -36,6 +36,21 @@ describe.sequential("Manual jobs API routes", () => {
 
       expect(res.status).toBe(400);
     });
+
+    it("rejects known blocked autofetch domains", async () => {
+      const res = await fetch(`${baseUrl}/api/manual-jobs/fetch`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url: "https://www.linkedin.com/jobs/view/123" }),
+      });
+
+      expect(res.status).toBe(422);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.message).toContain(
+        "Auto-fetch is not supported for LinkedIn links",
+      );
+    });
   });
 
   it("infers manual jobs and rejects empty payloads", async () => {

--- a/orchestrator/src/server/api/routes/manual-jobs.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.ts
@@ -52,6 +52,49 @@ const cleanOptional = (value?: string | null) => {
   return trimmed.length > 0 ? trimmed : undefined;
 };
 
+const BLOCKED_AUTOFETCH_HOSTS: Array<{
+  label: string;
+  match: (hostname: string) => boolean;
+}> = [
+  {
+    label: "LinkedIn",
+    match: (hostname) =>
+      hostname === "linkedin.com" || hostname.endsWith(".linkedin.com"),
+  },
+  {
+    label: "Indeed",
+    match: (hostname) =>
+      hostname === "indeed.com" || hostname.includes("indeed."),
+  },
+];
+
+function getHostname(value: string): string | null {
+  try {
+    return new URL(value).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+function getBlockedAutofetchLabel(url: string): string | null {
+  const hostname = getHostname(url);
+  if (!hostname) return null;
+  const blocked = BLOCKED_AUTOFETCH_HOSTS.find((entry) =>
+    entry.match(hostname),
+  );
+  return blocked?.label ?? null;
+}
+
+function buildFetchFailureMessage(status: number): string {
+  if (status === 401 || status === 403 || status === 429) {
+    return "This site blocks automated fetch requests. Paste the job description manually.";
+  }
+  if (status === 404) {
+    return "We couldn't find that page. Check the URL or paste the job description manually.";
+  }
+  return "Couldn't fetch this URL automatically. Paste the job description manually.";
+}
+
 /**
  * POST /api/manual-jobs/fetch - Fetch and extract job content from a URL
  */
@@ -61,6 +104,17 @@ manualJobsRouter.post("/fetch", async (req: Request, res: Response) => {
 
   try {
     const input = manualJobFetchSchema.parse(req.body ?? {});
+    const blockedLabel = getBlockedAutofetchLabel(input.url);
+    if (blockedLabel) {
+      return fail(
+        res,
+        new AppError({
+          status: 422,
+          code: "UNPROCESSABLE_ENTITY",
+          message: `Auto-fetch is not supported for ${blockedLabel} links. Paste the job description manually.`,
+        }),
+      );
+    }
 
     const response = await fetch(input.url, {
       signal: controller.signal,
@@ -78,7 +132,8 @@ manualJobsRouter.post("/fetch", async (req: Request, res: Response) => {
         new AppError({
           status: 502,
           code: "UPSTREAM_ERROR",
-          message: `Failed to fetch URL: ${response.status} ${response.statusText}`,
+          message: buildFetchFailureMessage(response.status),
+          details: { upstreamStatus: response.status },
         }),
       );
     }

--- a/orchestrator/src/server/api/routes/manual-jobs.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from "node:crypto";
 import {
   AppError,
   badRequest,
@@ -31,7 +30,7 @@ const manualJobImportSchema = z.object({
   job: z.object({
     title: z.string().trim().min(1).max(500),
     employer: z.string().trim().min(1).max(500),
-    jobUrl: z.string().trim().url().max(2000).optional(),
+    jobUrl: z.string().trim().url().max(2000),
     applicationLink: z.string().trim().url().max(2000).optional(),
     location: z.string().trim().max(200).optional(),
     salary: z.string().trim().max(200).optional(),
@@ -261,16 +260,11 @@ manualJobsRouter.post("/import", async (req: Request, res: Response) => {
     const input = manualJobImportSchema.parse(req.body ?? {});
     const job = input.job;
 
-    const jobUrl =
-      cleanOptional(job.jobUrl) ||
-      cleanOptional(job.applicationLink) ||
-      `manual://${randomUUID()}`;
-
     const createdJob = await jobsRepo.createJob({
       source: "manual",
       title: job.title.trim(),
       employer: job.employer.trim(),
-      jobUrl,
+      jobUrl: job.jobUrl.trim(),
       applicationLink: cleanOptional(job.applicationLink) ?? undefined,
       location: cleanOptional(job.location) ?? undefined,
       salary: cleanOptional(job.salary) ?? undefined,


### PR DESCRIPTION
## Summary
- Promote the manual flow header to "Review job details" in manual mode and keep the chooser copy only for automatic runs.
- Require Job URL in the review step and in the import API, aligning the UI gate with backend validation.
- Flatten the review layout so the required and optional details read as structured rows instead of nested cards.
- Update tests to cover the new header behavior, required URL handling, and import validation.

## Testing
- ManualImportSheet UI tests
- RunModeModal UI tests
- manual-jobs API route tests