### PR TITLE
Redesign Job Page

### DIFF
--- a/orchestrator/src/client/App.tsx
+++ b/orchestrator/src/client/App.tsx
@@ -165,6 +165,7 @@ export const App: React.FC = () => {
                   element={<GmailOauthCallbackPage />}
                 />
                 <Route path="/job/:id" element={<JobPage />} />
+                <Route path="/job/:id/:view" element={<JobPage />} />
                 <Route
                   path="/applications/in-progress"
                   element={<InProgressBoardPage />}

--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -213,8 +213,12 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
   const jobStatus = getJobStatusIndicator(job.status);
   const tracerStatus = getTracerStatusIndicator(job.tracerLinksEnabled);
   const { showSponsorInfo } = useSettings();
-  const { pathname } = useLocation();
+  const location = useLocation();
+  const { pathname } = location;
   const isJobPage = pathname.startsWith("/job/");
+  const jobPageLinkState = isJobPage
+    ? undefined
+    : { jobPageBackTo: `${location.pathname}${location.search}` };
   const deadline = formatDate(job.deadline);
   const jobStatusTooltip =
     job.status === "discovered" ? (
@@ -242,6 +246,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
         <div className="min-w-0 w-full sm:w-auto sm:flex-1">
           <Link
             to={`/job/${job.id}`}
+            state={jobPageLinkState}
             className="block text-base font-semibold leading-snug text-foreground/90 underline-offset-2 break-words hover:underline"
           >
             {job.title}
@@ -272,7 +277,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
               variant="ghost"
               className="h-6 px-2 text-[10px] uppercase tracking-wide"
             >
-              <Link to={`/job/${job.id}`}>
+              <Link to={`/job/${job.id}`} state={jobPageLinkState}>
                 View
                 <ArrowUpRight className="h-3 w-3" />
               </Link>

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterPanel.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterPanel.tsx
@@ -28,9 +28,15 @@ import { MessageList } from "./MessageList";
 
 type GhostwriterPanelProps = {
   job: Job;
+  initialPrompt?: string | null;
+  onInitialPromptConsumed?: () => void;
 };
 
-export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({ job }) => {
+export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
+  job,
+  initialPrompt,
+  onInitialPromptConsumed,
+}) => {
   const [messages, setMessages] = useState<JobChatMessage[]>([]);
   const [branches, setBranches] = useState<BranchInfo[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -44,6 +50,7 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({ job }) => {
 
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const streamAbortRef = useRef<AbortController | null>(null);
+  const consumedInitialPromptRef = useRef<string | null>(null);
   const runTriggerRef = useRef<"new_prompt" | "regenerate" | "edit">(
     "new_prompt",
   );
@@ -341,6 +348,22 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({ job }) => {
   const canReset = useMemo(() => {
     return !isStreaming && messages.length > 0;
   }, [isStreaming, messages]);
+
+  useEffect(() => {
+    const content = initialPrompt?.trim();
+    if (!content || isLoading || isStreaming) return;
+    if (consumedInitialPromptRef.current === content) return;
+
+    consumedInitialPromptRef.current = content;
+    onInitialPromptConsumed?.();
+    void sendMessage(content);
+  }, [
+    initialPrompt,
+    isLoading,
+    isStreaming,
+    onInitialPromptConsumed,
+    sendMessage,
+  ]);
 
   const resetConversation = useCallback(async () => {
     try {

--- a/orchestrator/src/client/pages/InProgressBoardPage.tsx
+++ b/orchestrator/src/client/pages/InProgressBoardPage.tsx
@@ -9,7 +9,7 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowDownAZ, Columns3, ExternalLink, Plus } from "lucide-react";
 import React from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { useQueryErrorToast } from "@/client/hooks/useQueryErrorToast";
 import { showErrorToast } from "@/client/lib/error-toast";
@@ -81,7 +81,12 @@ const resolveCurrentStage = (
 
 export const InProgressBoardPage: React.FC = () => {
   const queryClient = useQueryClient();
+  const location = useLocation();
   const navigate = useNavigate();
+  const jobPageLinkState = React.useMemo(
+    () => ({ jobPageBackTo: `${location.pathname}${location.search}` }),
+    [location.pathname, location.search],
+  );
 
   const [dragging, setDragging] = React.useState<{
     jobId: string;
@@ -317,6 +322,7 @@ export const InProgressBoardPage: React.FC = () => {
                           <Link
                             key={job.id}
                             to={`/job/${job.id}`}
+                            state={jobPageLinkState}
                             draggable={movingJobId !== job.id}
                             onDragStart={(event) => {
                               setDragging({ jobId: job.id, fromStage: stage });

--- a/orchestrator/src/client/pages/JobPage.test.tsx
+++ b/orchestrator/src/client/pages/JobPage.test.tsx
@@ -107,6 +107,10 @@ vi.mock("../components/LogEventModal", () => ({
   LogEventModal: () => null,
 }));
 
+vi.mock("./job-page/JobPageRightSidebar", () => ({
+  JobPageRightSidebar: () => <div data-testid="job-right-sidebar" />,
+}));
+
 vi.mock("../components/ConfirmDelete", () => ({
   ConfirmDelete: ({
     isOpen,
@@ -350,6 +354,36 @@ describe("JobPage notes", () => {
     expect(toast.success).toHaveBeenCalledWith("Note deleted");
     await waitFor(() =>
       expect(screen.queryByText("Why this company")).toBeNull(),
+    );
+  });
+});
+
+describe("JobPage timeline actions", () => {
+  it("shows a log event button on the overview page when stage logging is available", async () => {
+    vi.mocked(api.getJob).mockResolvedValue(
+      createJob({ status: "in_progress" }) as Job,
+    );
+
+    renderJobPage("/job/job-1");
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /log event/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("shows a log event button on the timeline page when stage logging is available", async () => {
+    vi.mocked(api.getJob).mockResolvedValue(
+      createJob({ status: "in_progress" }) as Job,
+    );
+
+    renderJobPage("/job/job-1/timeline");
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: /log event/i }),
+      ).toBeInTheDocument(),
     );
   });
 });

--- a/orchestrator/src/client/pages/JobPage.test.tsx
+++ b/orchestrator/src/client/pages/JobPage.test.tsx
@@ -2,7 +2,7 @@ import { createJob } from "@shared/testing/factories.js";
 import type { Job, JobNote } from "@shared/types.js";
 import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { editorHtmlToMarkdown } from "@/client/lib/jobNoteContent";
@@ -97,6 +97,10 @@ vi.mock("../components/JobHeader", () => ({
 
 vi.mock("../components/ghostwriter/GhostwriterDrawer", () => ({
   GhostwriterDrawer: () => <div data-testid="ghostwriter-drawer" />,
+}));
+
+vi.mock("../components/ghostwriter/GhostwriterPanel", () => ({
+  GhostwriterPanel: () => <div data-testid="ghostwriter-panel" />,
 }));
 
 vi.mock("../components/JobDetailsEditDrawer", () => ({
@@ -209,16 +213,59 @@ beforeEach(() => {
   });
 });
 
-const renderJobPage = (initialEntry = "/job/job-1/note") =>
+const LocationProbe = () => {
+  const location = useLocation();
+  return (
+    <div data-testid="location-probe">
+      {location.pathname}
+      {location.search}
+    </div>
+  );
+};
+
+type RouterInitialEntry = NonNullable<
+  Parameters<typeof MemoryRouter>[0]["initialEntries"]
+>[number];
+
+const renderJobPage = (initialEntry: RouterInitialEntry = "/job/job-1/notes") =>
   render(
     <MemoryRouter initialEntries={[initialEntry]}>
+      <LocationProbe />
       <Routes>
         <Route path="/job/:id/:view?" element={<JobPage />} />
+        <Route path="/jobs/ready" element={<div>Ready jobs</div>} />
+        <Route path="/jobs/discovered" element={<div>Discovered jobs</div>} />
+        <Route path="/jobs/applied" element={<div>Applied jobs</div>} />
+        <Route path="/jobs/all" element={<div>All jobs</div>} />
+        <Route
+          path="/applications/in-progress"
+          element={<div>In progress board</div>}
+        />
       </Routes>
     </MemoryRouter>,
   );
 
 describe("JobPage notes", () => {
+  it("renders notes at the public /notes URL", async () => {
+    renderJobPage("/job/job-1/notes");
+
+    expect(await screen.findByTestId("job-notes-section")).toBeInTheDocument();
+    expect(screen.getByTestId("location-probe")).toHaveTextContent(
+      "/job/job-1/notes",
+    );
+  });
+
+  it("normalizes the legacy /note URL to /notes", async () => {
+    renderJobPage("/job/job-1/note?draft=1");
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        "/job/job-1/notes?draft=1",
+      ),
+    );
+    expect(await screen.findByTestId("job-notes-section")).toBeInTheDocument();
+  });
+
   it("renders the full-width notes section and defaults to markdown preview", async () => {
     notesStore = [
       makeNote({
@@ -386,6 +433,70 @@ describe("JobPage timeline actions", () => {
       expect(
         screen.getByRole("button", { name: /log event/i }),
       ).toBeInTheDocument(),
+    );
+  });
+});
+
+describe("JobPage back navigation", () => {
+  it("returns to the entry page instead of stepping through job memory views", async () => {
+    renderJobPage({
+      pathname: "/job/job-1/ghostwriter",
+      state: { jobPageBackTo: "/jobs/ready?q=backend" },
+    });
+
+    expect(await screen.findByTestId("ghostwriter-panel")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        "/jobs/ready?q=backend",
+      ),
+    );
+    expect(screen.getByText("Ready jobs")).toBeInTheDocument();
+  });
+
+  it("falls back to the status page when there is no entry page state", async () => {
+    vi.mocked(api.getJob).mockResolvedValue(
+      createJob({ status: "in_progress" }) as Job,
+    );
+
+    renderJobPage("/job/job-1/timeline");
+
+    expect(await screen.findByTestId("job-timeline")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        "/applications/in-progress",
+      ),
+    );
+    expect(screen.getByText("In progress board")).toBeInTheDocument();
+  });
+
+  it("preserves the entry page state across internal job view links", async () => {
+    renderJobPage({
+      pathname: "/job/job-1",
+      state: { jobPageBackTo: "/jobs/ready?source=naukri" },
+    });
+
+    await screen.findByRole("heading", { name: "Acme Labs" });
+
+    fireEvent.click(screen.getByRole("link", { name: /^notes$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        "/job/job-1/notes",
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^back$/i }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("location-probe")).toHaveTextContent(
+        "/jobs/ready?source=naukri",
+      ),
     );
   });
 });

--- a/orchestrator/src/client/pages/JobPage.test.tsx
+++ b/orchestrator/src/client/pages/JobPage.test.tsx
@@ -205,11 +205,11 @@ beforeEach(() => {
   });
 });
 
-const renderJobPage = () =>
+const renderJobPage = (initialEntry = "/job/job-1/note") =>
   render(
-    <MemoryRouter initialEntries={["/job/job-1"]}>
+    <MemoryRouter initialEntries={[initialEntry]}>
       <Routes>
-        <Route path="/job/:id" element={<JobPage />} />
+        <Route path="/job/:id/:view?" element={<JobPage />} />
       </Routes>
     </MemoryRouter>,
   );
@@ -235,27 +235,14 @@ describe("JobPage notes", () => {
     renderJobPage();
 
     await waitFor(() => {
-      expect(screen.getByTestId("job-header")).toHaveTextContent(
-        "Backend Engineer",
-      );
+      expect(
+        screen.getByRole("heading", { name: "Acme Labs" }),
+      ).toBeInTheDocument();
     });
 
     expect(screen.getByTestId("job-notes-section")).toHaveClass("w-full");
     expect(screen.getByTestId("job-notes-list")).toBeInTheDocument();
     expect(screen.getByTestId("job-notes-detail")).toBeInTheDocument();
-
-    const applicationDetails = screen.getByText("Application details");
-    const notesHeading = screen.getByText("Notes");
-    const upcomingTasks = screen.getByText("Upcoming tasks");
-
-    expect(
-      applicationDetails.compareDocumentPosition(notesHeading) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
-    expect(
-      upcomingTasks.compareDocumentPosition(notesHeading) &
-        Node.DOCUMENT_POSITION_FOLLOWING,
-    ).toBeTruthy();
 
     expect(
       await screen.findByRole("heading", { name: "Strong fit" }),

--- a/orchestrator/src/client/pages/JobPage.test.tsx
+++ b/orchestrator/src/client/pages/JobPage.test.tsx
@@ -366,6 +366,7 @@ describe("JobPage timeline actions", () => {
 
     renderJobPage("/job/job-1");
 
+    expect(await screen.findByTestId("job-right-sidebar")).toBeInTheDocument();
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /log event/i }),
@@ -380,6 +381,7 @@ describe("JobPage timeline actions", () => {
 
     renderJobPage("/job/job-1/timeline");
 
+    expect(screen.queryByTestId("job-right-sidebar")).not.toBeInTheDocument();
     await waitFor(() =>
       expect(
         screen.getByRole("button", { name: /log event/i }),

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -125,12 +125,10 @@ const parseSelectedProjectIds = (value: string | null | undefined) =>
     .filter(Boolean) ?? [];
 
 const getGhostwriterSuggestions = (job: Job, hasNotes: boolean) => [
-  "What projects did I use for this application?",
   hasNotes
     ? "Summarize the latest interview notes."
     : "What should I remember if a recruiter calls?",
   `What should I know before speaking with ${job.employer}?`,
-  "Draft a concise follow-up message for this role.",
 ];
 
 const OverviewGhostwriterComposer: React.FC<{
@@ -155,9 +153,8 @@ const OverviewGhostwriterComposer: React.FC<{
 
   return (
     <section className="rounded-xl border border-border/50 bg-card/85 p-4">
-      <div className="rounded-lg border border-border/60 bg-background/30 p-3 shadow-sm transition focus-within:border-orange-400/50 focus-within:bg-background/45">
         <div className="flex items-start gap-3">
-          <Sparkles className="mt-2 h-4 w-4 shrink-0 text-orange-300" />
+          <Sparkles className="mt-1.5 h-4 w-4 shrink-0 text-orange-300" />
           <Textarea
             value={prompt}
             onChange={(event) => setPrompt(event.target.value)}
@@ -168,37 +165,35 @@ const OverviewGhostwriterComposer: React.FC<{
               }
             }}
             placeholder="Ask Ghostwriter anything about this application..."
-            className="min-h-[84px] resize-none border-0 bg-transparent px-0 py-1 text-base shadow-none focus-visible:ring-0 md:text-sm"
+            className="min-h-[30px] resize-none border-0 bg-transparent px-0 py-1 text-base shadow-none focus-visible:ring-0 md:text-sm"
           />
         </div>
-        <div className="mt-3 flex items-center justify-between gap-3 border-t border-border/50 pt-3">
-          <div className="text-[10px] text-muted-foreground">
-            Enter to send / Shift Enter for a new line
+        <div className="mt-3 flex items-center justify-between gap-3 border-t border-border/50">
+          <div className="mt-3 flex flex-wrap gap-2">
+            {suggestions.map((suggestion) => (
+              <Button
+                key={suggestion}
+                type="button"
+                size="sm"
+                variant="outline"
+                className="h-auto border-border/60 bg-background/25 px-3 py-1.5 text-left text-xs text-muted-foreground hover:border-orange-400/40 hover:bg-orange-500/10 hover:text-orange-100"
+                onClick={() => setPrompt(suggestion)}
+              >
+                {suggestion}
+              </Button>
+            ))}
           </div>
+
           <Button
             size="sm"
             onClick={submitPrompt}
             disabled={!prompt.trim()}
-            className="border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+            className="mt-3"
           >
             <Send className="mr-1.5 h-3.5 w-3.5" />
             Go
           </Button>
         </div>
-      </div>
-
-      <div className="mt-3 flex flex-wrap gap-2">
-        {suggestions.map((suggestion) => (
-          <button
-            key={suggestion}
-            type="button"
-            className="rounded-md border border-border/60 bg-background/25 px-3 py-1.5 text-left text-xs text-muted-foreground transition hover:border-orange-400/40 hover:bg-orange-500/10 hover:text-orange-100"
-            onClick={() => setPrompt(suggestion)}
-          >
-            {suggestion}
-          </button>
-        ))}
-      </div>
     </section>
   );
 };
@@ -405,11 +400,12 @@ const JobNotesCard: React.FC<{ jobId: string }> = ({ jobId }) => {
                       formatDateTime(note.updatedAt) ?? note.updatedAt;
                     const isSelected = note.id === selectedNoteId;
                     return (
-                      <button
+                      <Button
                         key={note.id}
                         type="button"
+                        variant="ghost"
                         className={cn(
-                          "w-full rounded-xl border px-4 py-3 text-left transition",
+                          "h-auto w-full justify-start whitespace-normal rounded-xl border px-4 py-3 text-left font-normal transition",
                           isSelected
                             ? "border-primary/40 bg-primary/5 shadow-sm"
                             : "border-border/60 bg-background/70 hover:border-border hover:bg-muted/40",
@@ -433,7 +429,7 @@ const JobNotesCard: React.FC<{ jobId: string }> = ({ jobId }) => {
                             </Badge>
                           )}
                         </div>
-                      </button>
+                      </Button>
                     );
                   })}
                 </div>
@@ -1137,26 +1133,21 @@ export const JobPage: React.FC = () => {
                     icon: Sparkles,
                   },
                 ].map(({ id: linkView, label, path, icon: Icon }) => (
-                  <Link
-                    to={path}
+                  <Button
+                    asChild
                     key={linkView}
+                    variant={activeMemoryView === linkView ? "outline" : "ghost"}
                     className={cn(
-                      "flex h-9 w-full items-center justify-between rounded-md px-2 text-left text-sm transition",
-                      activeMemoryView === linkView
-                        ? "border border-orange-400/30 bg-orange-500/10 text-orange-100"
-                        : "text-muted-foreground hover:bg-muted/30 hover:text-foreground",
+                      "h-9 w-full justify-between px-2 text-left text-sm",
                     )}
                   >
-                    <span className="flex min-w-0 items-center gap-2">
-                      <Icon className="h-4 w-4 shrink-0" />
-                      <span className="truncate">{label}</span>
-                    </span>
-                    {activeMemoryView === linkView && (
-                      <Badge variant="secondary" className="text-[10px]">
-                        Open
-                      </Badge>
-                    )}
-                  </Link>
+                    <Link to={path}>
+                      <span className="flex min-w-0 items-center gap-2">
+                        <Icon className="h-4 w-4 shrink-0" />
+                        <span className="truncate">{label}</span>
+                      </span>
+                    </Link>
+                  </Button>
                 ))}
               </div>
             </section>
@@ -1165,19 +1156,6 @@ export const JobPage: React.FC = () => {
           <div className="space-y-4">
             {activeMemoryView === "overview" && (
               <section className="space-y-4">
-                <div className="rounded-xl border border-border/50 bg-card/85 p-4">
-                  <div className="flex flex-wrap items-start justify-between gap-4">
-                    <div>
-                      <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                        Overview
-                      </div>
-                      <h2 className="mt-1 text-xl font-semibold">
-                        Application memory
-                      </h2>
-                    </div>
-                  </div>
-                </div>
-
                 <OverviewGhostwriterComposer
                   job={job}
                   baseJobPath={baseJobPath}
@@ -1478,15 +1456,14 @@ export const JobPage: React.FC = () => {
           <aside className="space-y-4 xl:sticky xl:top-5">
             <section className="rounded-xl border border-border/50 bg-card/85 p-3">
               <div className="mb-3 flex items-center gap-2 px-1 text-sm font-semibold">
-                <Sparkles className="h-4 w-4" />
-                Next actions
+                Actions
               </div>
               <div className="space-y-2">
                 {jobLink && (
                   <Button
                     asChild
                     size="sm"
-                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    className="w-full"
                   >
                     <a href={jobLink} target="_blank" rel="noopener noreferrer">
                       <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
@@ -1498,7 +1475,7 @@ export const JobPage: React.FC = () => {
                 {isDiscovered && (
                   <Button
                     size="sm"
-                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    className="w-full"
                     onClick={() => navigate(`/jobs/discovered/${job.id}`)}
                     disabled={isBusy}
                   >
@@ -1510,7 +1487,7 @@ export const JobPage: React.FC = () => {
                 {isReady && (
                   <Button
                     size="sm"
-                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    className="w-full"
                     onClick={() => void handleMarkApplied()}
                     disabled={isBusy}
                   >
@@ -1522,7 +1499,7 @@ export const JobPage: React.FC = () => {
                 {isApplied && (
                   <Button
                     size="sm"
-                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    className="w-full"
                     onClick={() => void handleMoveToInProgress()}
                     disabled={isBusy}
                   >
@@ -1534,7 +1511,7 @@ export const JobPage: React.FC = () => {
                 {isInProgress && (
                   <Button
                     size="sm"
-                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    className="w-full"
                     onClick={() => setIsLogModalOpen(true)}
                     disabled={!canLogEvents || isBusy}
                   >

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -24,6 +24,7 @@ import {
 import React from "react";
 import {
   Link,
+  useLocation,
   useNavigate,
   useParams,
   useSearchParams,
@@ -78,6 +79,28 @@ const normalizeMemoryView = (view: string | undefined): JobMemoryView => {
   return "overview";
 };
 
+type JobPageLocationState = {
+  jobPageBackTo?: string;
+};
+
+const isValidJobPageBackTarget = (value: unknown): value is string =>
+  typeof value === "string" &&
+  value.startsWith("/") &&
+  !value.startsWith("/job/");
+
+const getFallbackBackTarget = (job: Job | null): string => {
+  if (job?.status === "ready" || job?.status === "discovered") {
+    return `/jobs/${job.status}`;
+  }
+  if (job?.status === "applied") {
+    return "/jobs/applied";
+  }
+  if (job?.status === "in_progress") {
+    return "/applications/in-progress";
+  }
+  return "/jobs/all";
+};
+
 const sortNotesByUpdatedAtDesc = (notes: JobNote[]) =>
   [...notes].sort(
     (left, right) =>
@@ -97,6 +120,7 @@ const parseSelectedProjectIds = (value: string | null | undefined) =>
 
 export const JobPage: React.FC = () => {
   const { id, view } = useParams<{ id: string; view?: string }>();
+  const location = useLocation();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
@@ -188,6 +212,25 @@ export const JobPage: React.FC = () => {
     () => formatSourceLabel(job?.source ?? ""),
     [job?.source],
   );
+  const jobPageBackTo = React.useMemo(() => {
+    const state = location.state as JobPageLocationState | null;
+    return isValidJobPageBackTarget(state?.jobPageBackTo)
+      ? state.jobPageBackTo
+      : null;
+  }, [location.state]);
+  const jobPageNavigationState = React.useMemo(
+    () => (jobPageBackTo ? { jobPageBackTo } : undefined),
+    [jobPageBackTo],
+  );
+
+  React.useEffect(() => {
+    if (!id || view !== "note") return;
+    const search = location.search;
+    navigate(`/job/${id}/notes${search}`, {
+      replace: true,
+      state: jobPageNavigationState,
+    });
+  }, [id, jobPageNavigationState, location.search, navigate, view]);
 
   React.useEffect(() => {
     let isCancelled = false;
@@ -462,8 +505,14 @@ export const JobPage: React.FC = () => {
   const initialGhostwriterPrompt =
     activeMemoryView === "ghostwriter" ? searchParams.get("prompt") : null;
   const clearInitialGhostwriterPrompt = React.useCallback(() => {
-    navigate(`${baseJobPath}/ghostwriter`, { replace: true });
-  }, [baseJobPath, navigate]);
+    navigate(`${baseJobPath}/ghostwriter`, {
+      replace: true,
+      state: jobPageNavigationState,
+    });
+  }, [baseJobPath, jobPageNavigationState, navigate]);
+  const handleBack = React.useCallback(() => {
+    navigate(jobPageBackTo ?? getFallbackBackTarget(job));
+  }, [job, jobPageBackTo, navigate]);
   const pageGridClass =
     activeMemoryView === "overview"
       ? "grid items-start gap-4 xl:grid-cols-[18rem_minmax(0,1fr)_18rem]"
@@ -476,7 +525,7 @@ export const JobPage: React.FC = () => {
   return (
     <main className="mx-auto max-w-[92rem] px-4 py-5">
       <div className="mb-4 flex items-center justify-between gap-4">
-        <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
+        <Button variant="ghost" size="sm" onClick={handleBack}>
           <ArrowLeft className="h-4 w-4" />
           Back
         </Button>
@@ -504,6 +553,7 @@ export const JobPage: React.FC = () => {
             job={job}
             activeMemoryView={activeMemoryView}
             baseJobPath={baseJobPath}
+            navigationState={jobPageNavigationState}
             selectedProjects={selectedProjects}
             sourceLabel={sourceLabel}
           />
@@ -515,6 +565,7 @@ export const JobPage: React.FC = () => {
                   job={job}
                   baseJobPath={baseJobPath}
                   hasNotes={notes.length > 0}
+                  navigationState={jobPageNavigationState}
                 />
 
                 <div className="grid gap-4 lg:grid-cols-2">
@@ -559,7 +610,10 @@ export const JobPage: React.FC = () => {
                       variant="outline"
                       className="mt-4 w-full justify-between"
                     >
-                      <Link to={`${baseJobPath}/note`}>
+                      <Link
+                        to={`${baseJobPath}/notes`}
+                        state={jobPageNavigationState}
+                      >
                         Open notes
                         <ExternalLink className="h-3.5 w-3.5" />
                       </Link>
@@ -605,7 +659,10 @@ export const JobPage: React.FC = () => {
                       variant="outline"
                       className="mt-4 w-full justify-between"
                     >
-                      <Link to={`${baseJobPath}/documents`}>
+                      <Link
+                        to={`${baseJobPath}/documents`}
+                        state={jobPageNavigationState}
+                      >
                         Open documents
                         <ExternalLink className="h-3.5 w-3.5" />
                       </Link>
@@ -668,7 +725,10 @@ export const JobPage: React.FC = () => {
                         variant="outline"
                         className="mt-4 w-full justify-between"
                       >
-                        <Link to={`${baseJobPath}/timeline`}>
+                        <Link
+                          to={`${baseJobPath}/timeline`}
+                          state={jobPageNavigationState}
+                        >
                           Open timeline
                           <ExternalLink className="h-3.5 w-3.5" />
                         </Link>

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -12,24 +12,13 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import confetti from "canvas-confetti";
 import {
   ArrowLeft,
-  CalendarClock,
-  CheckCircle2,
   ClipboardList,
-  Copy,
   DollarSign,
-  Edit2,
   ExternalLink,
   FileText,
-  FolderKanban,
   MessageSquareText,
-  MoreHorizontal,
-  PlusCircle,
-  RefreshCcw,
-  Send,
   Sparkles,
-  Trash2,
   Upload,
-  XCircle,
 } from "lucide-react";
 import React from "react";
 import {
@@ -39,44 +28,25 @@ import {
   useSearchParams,
 } from "react-router-dom";
 import { toast } from "sonner";
-import { RichTextEditor } from "@/client/components/design-resume/RichTextEditor";
 import { JobDescriptionMarkdown } from "@/client/components/JobDescriptionMarkdown";
 import { invalidateJobData } from "@/client/hooks/queries/invalidate";
 import {
   useCheckSponsorMutation,
-  useCreateJobNoteMutation,
-  useDeleteJobNoteMutation,
   useGenerateJobPdfMutation,
   useMarkAsAppliedMutation,
   useRescoreJobMutation,
   useSkipJobMutation,
   useUpdateJobMutation,
-  useUpdateJobNoteMutation,
 } from "@/client/hooks/queries/useJobMutations";
 import { useQueryErrorToast } from "@/client/hooks/useQueryErrorToast";
 import { showErrorToast } from "@/client/lib/error-toast";
 import { uploadJobPdfFromFile } from "@/client/lib/job-pdf-upload";
 import { getRenderableJobDescription } from "@/client/lib/jobDescription";
-import {
-  markdownToEditorHtml as markdownToTipTapHtml,
-  editorHtmlToMarkdown as tipTapHtmlToMarkdown,
-} from "@/client/lib/jobNoteContent";
 import { openJobPdf } from "@/client/lib/private-pdf";
 import { queryKeys } from "@/client/lib/queryKeys";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  cn,
   copyTextToClipboard,
   formatDateTime,
   formatJobForWebhook,
@@ -91,13 +61,13 @@ import {
   LogEventModal,
 } from "../components/LogEventModal";
 import { JobTimeline } from "./job/Timeline";
-
-type JobMemoryView =
-  | "overview"
-  | "note"
-  | "documents"
-  | "timeline"
-  | "ghostwriter";
+import { JobNotesCard } from "./job-page/JobNotesCard";
+import {
+  type JobMemoryView,
+  JobPageLeftSidebar,
+} from "./job-page/JobPageLeftSidebar";
+import { JobPageRightSidebar } from "./job-page/JobPageRightSidebar";
+import { OverviewGhostwriterComposer } from "./job-page/OverviewGhostwriterComposer";
 
 const normalizeMemoryView = (view: string | undefined): JobMemoryView => {
   if (view === "notes" || view === "note") return "note";
@@ -123,510 +93,6 @@ const parseSelectedProjectIds = (value: string | null | undefined) =>
     ?.split(",")
     .map((id) => id.trim())
     .filter(Boolean) ?? [];
-
-const getGhostwriterSuggestions = (job: Job, hasNotes: boolean) => [
-  hasNotes
-    ? "Summarize the latest interview notes."
-    : "What should I remember if a recruiter calls?",
-  `What should I know before speaking with ${job.employer}?`,
-];
-
-const OverviewGhostwriterComposer: React.FC<{
-  job: Job;
-  baseJobPath: string;
-  hasNotes: boolean;
-}> = ({ job, baseJobPath, hasNotes }) => {
-  const navigate = useNavigate();
-  const [prompt, setPrompt] = React.useState("");
-  const suggestions = React.useMemo(
-    () => getGhostwriterSuggestions(job, hasNotes),
-    [hasNotes, job],
-  );
-
-  const submitPrompt = React.useCallback(() => {
-    const content = prompt.trim();
-    if (!content) return;
-    navigate(
-      `${baseJobPath}/ghostwriter?prompt=${encodeURIComponent(content)}`,
-    );
-  }, [baseJobPath, navigate, prompt]);
-
-  return (
-    <section className="rounded-xl border border-border/50 bg-card/85 p-4">
-        <div className="flex items-start gap-3">
-          <Sparkles className="mt-1.5 h-4 w-4 shrink-0 text-primary" />
-          <Textarea
-            value={prompt}
-            onChange={(event) => setPrompt(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter" && !event.shiftKey) {
-                event.preventDefault();
-                submitPrompt();
-              }
-            }}
-            placeholder="Ask Ghostwriter anything about this application..."
-            className="min-h-[30px] resize-none border-0 bg-transparent px-0 py-1 text-base shadow-none focus-visible:ring-0 md:text-sm"
-          />
-        </div>
-        <div className="mt-3 flex items-center justify-between gap-3 border-t border-border/50">
-          <div className="mt-3 flex flex-wrap gap-2">
-            {suggestions.map((suggestion) => (
-              <Button
-                key={suggestion}
-                type="button"
-                size="sm"
-                variant="outline"
-                className="h-auto px-3 py-1.5 text-left text-xs"
-                onClick={() => setPrompt(suggestion)}
-              >
-                {suggestion}
-              </Button>
-            ))}
-          </div>
-
-          <Button
-            size="sm"
-            onClick={submitPrompt}
-            disabled={!prompt.trim()}
-            className="mt-3"
-          >
-            <Send className="mr-1.5 h-3.5 w-3.5" />
-            Go
-          </Button>
-        </div>
-    </section>
-  );
-};
-
-const JobNotesCard: React.FC<{ jobId: string }> = ({ jobId }) => {
-  const [editorState, setEditorState] = React.useState<
-    { mode: "create" } | { mode: "edit"; noteId: string } | null
-  >(null);
-  const [selectedNoteId, setSelectedNoteId] = React.useState<string | null>(
-    null,
-  );
-  const [draftTitle, setDraftTitle] = React.useState("");
-  const [draftContent, setDraftContent] = React.useState("");
-  const [editorError, setEditorError] = React.useState<string | null>(null);
-  const [noteToDelete, setNoteToDelete] = React.useState<JobNote | null>(null);
-
-  const notesQuery = useQuery<JobNote[]>({
-    queryKey: queryKeys.jobs.notes(jobId),
-    queryFn: () => api.getJobNotes(jobId),
-    enabled: Boolean(jobId),
-  });
-  const createNoteMutation = useCreateJobNoteMutation();
-  const updateNoteMutation = useUpdateJobNoteMutation();
-  const deleteNoteMutation = useDeleteJobNoteMutation();
-
-  useQueryErrorToast(
-    notesQuery.error,
-    "Failed to load notes. Please try again.",
-  );
-
-  const notes = React.useMemo(
-    () => sortNotesByUpdatedAtDesc(notesQuery.data ?? []),
-    [notesQuery.data],
-  );
-  const selectedNote = React.useMemo(
-    () => notes.find((note) => note.id === selectedNoteId) ?? notes[0] ?? null,
-    [notes, selectedNoteId],
-  );
-  const isSaving = createNoteMutation.isPending || updateNoteMutation.isPending;
-  const isDeleting = deleteNoteMutation.isPending;
-
-  const resetEditor = React.useCallback(() => {
-    setEditorState(null);
-    setDraftTitle("");
-    setDraftContent("");
-    setEditorError(null);
-  }, []);
-
-  const openCreateEditor = React.useCallback(() => {
-    setEditorState({ mode: "create" });
-    setSelectedNoteId(null);
-    setDraftTitle("");
-    setDraftContent("");
-    setEditorError(null);
-  }, []);
-
-  const openEditEditor = React.useCallback((note: JobNote) => {
-    setEditorState({ mode: "edit", noteId: note.id });
-    setDraftTitle(note.title);
-    setDraftContent(markdownToTipTapHtml(note.content));
-    setEditorError(null);
-    setSelectedNoteId(note.id);
-  }, []);
-
-  const confirmDeleteNote = React.useCallback((note: JobNote) => {
-    setNoteToDelete(note);
-  }, []);
-
-  const saveNote = React.useCallback(async () => {
-    const title = draftTitle.trim();
-    const content = tipTapHtmlToMarkdown(draftContent).trim();
-
-    if (!title || !content) {
-      setEditorError("Title and note content are required.");
-      return;
-    }
-
-    try {
-      const savedNote =
-        editorState?.mode === "edit"
-          ? await updateNoteMutation.mutateAsync({
-              jobId,
-              noteId: editorState.noteId,
-              input: { title, content },
-            })
-          : await createNoteMutation.mutateAsync({
-              jobId,
-              input: { title, content },
-            });
-
-      toast.success("Note saved");
-      setSelectedNoteId(savedNote.id);
-      resetEditor();
-    } catch (error) {
-      showErrorToast(error, "Failed to save note");
-    }
-  }, [
-    createNoteMutation,
-    draftContent,
-    draftTitle,
-    editorState,
-    jobId,
-    resetEditor,
-    updateNoteMutation,
-  ]);
-
-  const handleDeleteNote = React.useCallback(async () => {
-    if (!noteToDelete) return;
-
-    try {
-      await deleteNoteMutation.mutateAsync({
-        jobId,
-        noteId: noteToDelete.id,
-      });
-      toast.success("Note deleted");
-      if (selectedNoteId === noteToDelete.id) {
-        const nextNote = notes.find((note) => note.id !== noteToDelete.id);
-        setSelectedNoteId(nextNote?.id ?? null);
-      }
-      if (
-        editorState?.mode === "edit" &&
-        editorState.noteId === noteToDelete.id
-      ) {
-        resetEditor();
-      }
-    } catch (error) {
-      showErrorToast(error, "Failed to delete note");
-    } finally {
-      setNoteToDelete(null);
-    }
-  }, [
-    deleteNoteMutation,
-    editorState,
-    jobId,
-    noteToDelete,
-    notes,
-    resetEditor,
-    selectedNoteId,
-  ]);
-
-  const canEditOtherNotes = editorState === null;
-
-  React.useEffect(() => {
-    if (editorState) return;
-    if (notes.length === 0) {
-      setSelectedNoteId(null);
-      return;
-    }
-
-    if (!selectedNoteId || !notes.some((note) => note.id === selectedNoteId)) {
-      setSelectedNoteId(notes[0]?.id ?? null);
-    }
-  }, [editorState, notes, selectedNoteId]);
-
-  const startViewingNote = React.useCallback(
-    (note: JobNote) => {
-      if (editorState) return;
-      setSelectedNoteId(note.id);
-    },
-    [editorState],
-  );
-
-  const selectedTimestamp = selectedNote
-    ? (formatDateTime(selectedNote.updatedAt) ?? selectedNote.updatedAt)
-    : null;
-
-  return (
-    <section data-testid="job-notes-section" className="w-full">
-      <Card className="border-border/50">
-        <CardHeader>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <CardTitle className="flex items-center gap-2 text-base">
-              <FileText className="h-4 w-4" />
-              Notes
-            </CardTitle>
-            {!editorState && (
-              <Button size="sm" variant="outline" onClick={openCreateEditor}>
-                <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
-                Add note
-              </Button>
-            )}
-          </div>
-        </CardHeader>
-        <CardContent>
-          <div className="grid gap-6 lg:grid-cols-[minmax(14rem,0.7fr)_minmax(0,1.3fr)]">
-            <aside data-testid="job-notes-list" className="space-y-3">
-              {!editorState && notesQuery.isLoading && notes.length === 0 && (
-                <div className="rounded-xl border border-dashed border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
-                  Loading notes...
-                </div>
-              )}
-
-              {!editorState && !notesQuery.isLoading && notes.length === 0 && (
-                <div className="rounded-xl border border-dashed border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
-                  No notes yet. Capture reminders, interview prep, or links in
-                  markdown.
-                </div>
-              )}
-
-              {notes.length > 0 && (
-                <div className="space-y-2">
-                  {notes.map((note) => {
-                    const noteTimestamp =
-                      formatDateTime(note.updatedAt) ?? note.updatedAt;
-                    const isSelected = note.id === selectedNoteId;
-                    return (
-                      <Button
-                        key={note.id}
-                        type="button"
-                        variant="ghost"
-                        className={cn(
-                          "h-auto w-full justify-start whitespace-normal rounded-xl border px-4 py-3 text-left font-normal transition",
-                          isSelected
-                            ? "border-primary/40 bg-primary/5 shadow-sm"
-                            : "border-border/60 bg-background/70 hover:border-border hover:bg-muted/40",
-                          editorState && "cursor-default opacity-70",
-                        )}
-                        onClick={() => startViewingNote(note)}
-                        disabled={Boolean(editorState)}
-                      >
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-semibold">
-                              {note.title}
-                            </div>
-                            <div className="mt-1 text-xs text-muted-foreground">
-                              Updated {noteTimestamp}
-                            </div>
-                          </div>
-                          {isSelected && !editorState && (
-                            <Badge variant="secondary" className="text-[10px]">
-                              Selected
-                            </Badge>
-                          )}
-                        </div>
-                      </Button>
-                    );
-                  })}
-                </div>
-              )}
-            </aside>
-
-            <div
-              data-testid="job-notes-detail"
-              className="min-w-0 rounded-2xl border border-border/60 bg-muted/10 p-4 shadow-sm"
-            >
-              {editorState ? (
-                <form
-                  className="space-y-4"
-                  onSubmit={(event) => {
-                    event.preventDefault();
-                    void saveNote();
-                  }}
-                >
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
-                        {editorState.mode === "create"
-                          ? "New note"
-                          : "Editing note"}
-                      </div>
-                      <div className="mt-1 text-lg font-semibold">
-                        {editorState.mode === "create"
-                          ? "Draft a note"
-                          : draftTitle || selectedNote?.title || "Edit note"}
-                      </div>
-                    </div>
-                    {editorState.mode === "edit" && selectedNote && (
-                      <Badge variant="secondary" className="text-[10px]">
-                        Updated {selectedTimestamp}
-                      </Badge>
-                    )}
-                  </div>
-
-                  <div className="space-y-2">
-                    <label
-                      htmlFor="job-note-title"
-                      className="text-[10px] uppercase tracking-wide text-muted-foreground"
-                    >
-                      Title
-                    </label>
-                    <Input
-                      id="job-note-title"
-                      autoFocus
-                      value={draftTitle}
-                      onChange={(event) => {
-                        setDraftTitle(event.target.value);
-                        setEditorError(null);
-                      }}
-                      placeholder="Why I am applying"
-                      disabled={isSaving || isDeleting}
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                        Content
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        TipTap editor
-                      </div>
-                    </div>
-                    <RichTextEditor
-                      key={
-                        editorState.mode === "edit"
-                          ? editorState.noteId
-                          : "create-note"
-                      }
-                      value={draftContent}
-                      onChange={(next) => {
-                        setDraftContent(next);
-                        setEditorError(null);
-                      }}
-                      placeholder="Capture answers, reminders, interview notes, and useful links."
-                      className="bg-background/20"
-                    />
-                  </div>
-
-                  {editorError && (
-                    <div className="text-sm text-destructive">
-                      {editorError}
-                    </div>
-                  )}
-
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button type="submit" disabled={isSaving || isDeleting}>
-                      {isSaving ? "Saving..." : "Save note"}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      onClick={resetEditor}
-                      disabled={isSaving || isDeleting}
-                    >
-                      Cancel
-                    </Button>
-                    {editorState.mode === "edit" && selectedNote && (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        className="text-destructive hover:text-destructive"
-                        onClick={() => confirmDeleteNote(selectedNote)}
-                        disabled={isSaving || isDeleting}
-                      >
-                        Delete note
-                      </Button>
-                    )}
-                  </div>
-                </form>
-              ) : selectedNote ? (
-                <div className="space-y-4">
-                  <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <div className="text-lg font-semibold">
-                        {selectedNote.title}
-                      </div>
-                      <div className="mt-1 text-sm text-muted-foreground">
-                        Updated {selectedTimestamp}
-                      </div>
-                    </div>
-                    <div className="flex flex-wrap items-center gap-2">
-                      <Button
-                        size="icon"
-                        variant="outline"
-                        onClick={() => openEditEditor(selectedNote)}
-                        disabled={!canEditOtherNotes}
-                        aria-label="Edit note"
-                        title="Edit note"
-                      >
-                        <Edit2 className="h-4 w-4" />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        className="text-destructive hover:text-destructive"
-                        onClick={() => confirmDeleteNote(selectedNote)}
-                        disabled={!canEditOtherNotes}
-                        aria-label="Delete note"
-                        title="Delete note"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </div>
-
-                  <div className="rounded-xl border border-border/60 bg-card/70 p-4">
-                    <JobDescriptionMarkdown
-                      description={getRenderableJobDescription(
-                        selectedNote.content,
-                      )}
-                    />
-                  </div>
-                </div>
-              ) : (
-                <div className="flex min-h-[280px] flex-col items-start justify-between gap-4 rounded-xl border border-dashed border-border/60 bg-background/60 p-5">
-                  <div className="space-y-2">
-                    <div className="text-lg font-semibold">
-                      No note selected
-                    </div>
-                    <div className="max-w-xl text-sm text-muted-foreground">
-                      Notes you add here can hold interview answers, contact
-                      details, and application-specific reminders. Select a note
-                      on the left or create a new one to get started.
-                    </div>
-                  </div>
-                  {!editorState && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={openCreateEditor}
-                    >
-                      <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
-                      Add note
-                    </Button>
-                  )}
-                </div>
-              )}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      <ConfirmDelete
-        isOpen={noteToDelete !== null}
-        onClose={() => setNoteToDelete(null)}
-        onConfirm={() => void handleDeleteNote()}
-        title="Delete note?"
-        description="This will permanently delete this note from the job."
-      />
-    </section>
-  );
-};
 
 export const JobPage: React.FC = () => {
   const { id, view } = useParams<{ id: string; view?: string }>();
@@ -716,6 +182,10 @@ export const JobPage: React.FC = () => {
           projectId,
       ),
     [catalog, selectedProjectIds],
+  );
+  const sourceLabel = React.useMemo(
+    () => formatSourceLabel(job?.source ?? ""),
+    [job?.source],
   );
 
   React.useEffect(() => {
@@ -1025,118 +495,13 @@ export const JobPage: React.FC = () => {
 
       {job && (
         <div className="grid items-start gap-4 xl:grid-cols-[18rem_minmax(0,1fr)_18rem]">
-          <aside className="space-y-4 xl:sticky xl:top-5">
-            <section className="rounded-xl border border-border/50 bg-card/85 p-4">
-              <div className="space-y-1">
-                <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                  Application dossier
-                </div>
-                <h1 className="text-2xl font-semibold leading-tight">
-                  {job.employer}
-                </h1>
-                <div className="text-sm text-muted-foreground">{job.title}</div>
-              </div>
-
-              <div className="mt-5 space-y-3 text-sm">
-                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
-                  <span className="text-muted-foreground">Source</span>
-                  <span className="text-right font-medium">
-                    {formatSourceLabel(job.source)}
-                  </span>
-                </div>
-                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
-                  <span className="text-muted-foreground">Location</span>
-                  <span className="text-right font-medium">
-                    {job.location || "Unknown"}
-                  </span>
-                </div>
-                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
-                  <span className="text-muted-foreground">Found</span>
-                  <span className="text-right font-medium">
-                    {formatDateTime(job.discoveredAt) ?? job.discoveredAt}
-                  </span>
-                </div>
-                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
-                  <span className="text-muted-foreground">Applied</span>
-                  <span className="text-right font-medium">
-                    {job.appliedAt
-                      ? (formatDateTime(job.appliedAt) ?? job.appliedAt)
-                      : "Not marked"}
-                  </span>
-                </div>
-                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
-                  <span className="text-muted-foreground">Outcome</span>
-                  <span className="text-right font-medium">
-                    {job.outcome ? job.outcome.replace(/_/g, " ") : "Open"}
-                  </span>
-                </div>
-                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
-                  <span className="text-muted-foreground">Projects Chosen</span>
-                  <span className="text-right font-medium">
-                    {selectedProjects.length > 0
-                      ? selectedProjects.length
-                      : "No projects"}
-                  </span>
-                </div>
-              </div>
-            </section>
-
-            <section className="rounded-xl border border-border/50 bg-card/70 p-3">
-              <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-                Links
-              </div>
-              <div className="space-y-1">
-                {[
-                  {
-                    id: "overview" as const,
-                    label: "Overview",
-                    path: baseJobPath,
-                    icon: FolderKanban,
-                  },
-                  {
-                    id: "note" as const,
-                    label: "Notes",
-                    path: `${baseJobPath}/note`,
-                    icon: MessageSquareText,
-                  },
-                  {
-                    id: "documents" as const,
-                    label: "Documents",
-                    path: `${baseJobPath}/documents`,
-                    icon: FileText,
-                  },
-                  {
-                    id: "timeline" as const,
-                    label: "Timeline",
-                    path: `${baseJobPath}/timeline`,
-                    icon: ClipboardList,
-                  },
-                  {
-                    id: "ghostwriter" as const,
-                    label: "Ghostwriter",
-                    path: `${baseJobPath}/ghostwriter`,
-                    icon: Sparkles,
-                  },
-                ].map(({ id: linkView, label, path, icon: Icon }) => (
-                  <Button
-                    asChild
-                    key={linkView}
-                    variant={activeMemoryView === linkView ? "outline" : "ghost"}
-                    className={cn(
-                      "h-9 w-full justify-between px-2 text-left text-sm",
-                    )}
-                  >
-                    <Link to={path}>
-                      <span className="flex min-w-0 items-center gap-2">
-                        <Icon className="h-4 w-4 shrink-0" />
-                        <span className="truncate">{label}</span>
-                      </span>
-                    </Link>
-                  </Button>
-                ))}
-              </div>
-            </section>
-          </aside>
+          <JobPageLeftSidebar
+            job={job}
+            activeMemoryView={activeMemoryView}
+            baseJobPath={baseJobPath}
+            selectedProjects={selectedProjects}
+            sourceLabel={sourceLabel}
+          />
 
           <div className="space-y-4">
             {activeMemoryView === "overview" && (
@@ -1438,216 +803,37 @@ export const JobPage: React.FC = () => {
             )}
           </div>
 
-          <aside className="space-y-4 xl:sticky xl:top-5">
-            <section className="rounded-xl border border-border/50 bg-card/85 p-3">
-              <div className="mb-3 flex items-center gap-2 px-1 text-sm font-semibold">
-                Actions
-              </div>
-              <div className="space-y-2">
-                {jobLink && (
-                  <Button
-                    asChild
-                    size="sm"
-                    variant="outline"
-                    className="w-full justify-start"
-                  >
-                    <a href={jobLink} target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
-                      Open Job Listing
-                    </a>
-                  </Button>
-                )}
-
-                {isDiscovered && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="w-full justify-start"
-                    onClick={() => navigate(`/jobs/discovered/${job.id}`)}
-                    disabled={isBusy}
-                  >
-                    <Sparkles className="mr-1.5 h-3.5 w-3.5" />
-                    Start Tailoring
-                  </Button>
-                )}
-
-                {isReady && (
-                  <Button
-                    size="sm"
-                    className="w-full justify-start"
-                    variant="outline"
-                    onClick={() => void handleMarkApplied()}
-                    disabled={isBusy}
-                  >
-                    <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
-                    Mark Applied
-                  </Button>
-                )}
-
-                {isApplied && (
-                  <Button
-                    size="sm"
-                    className="w-full justify-start"
-                    variant="outline"
-                    onClick={() => void handleMoveToInProgress()}
-                    disabled={isBusy}
-                  >
-                    <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
-                    Move to In Progress
-                  </Button>
-                )}
-
-                {isInProgress && (
-                  <Button
-                    size="sm"
-                    className="w-full justify-start"
-                    variant="outline"
-                    onClick={() => setIsLogModalOpen(true)}
-                    disabled={!canLogEvents || isBusy}
-                  >
-                    <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
-                    Log Event
-                  </Button>
-                )}
-
-                {isReady && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-9 w-full justify-start"
-                    onClick={() => navigate(`/jobs/ready/${job.id}`)}
-                    disabled={isBusy}
-                  >
-                    <Sparkles className="mr-1.5 h-3.5 w-3.5" />
-                    Edit Tailoring
-                  </Button>
-                )}
-
-                {job.pdfPath && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-9 w-full justify-start"
-                    onClick={() => {
-                      void openJobPdf(job.id).catch((error) => {
-                        toast.error(
-                          error instanceof Error
-                            ? error.message
-                            : "Could not open PDF",
-                        );
-                      });
-                    }}
-                  >
-                    <FileText className="mr-1.5 h-3.5 w-3.5" />
-                    View PDF
-                  </Button>
-                )}
-
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-9 w-full justify-start"
-                  onClick={() => uploadPdfInputRef.current?.click()}
-                  disabled={isUploadingPdf}
-                >
-                  <Upload className="mr-1.5 h-3.5 w-3.5" />
-                  {isUploadingPdf
-                    ? "Uploading PDF"
-                    : job.pdfPath
-                      ? "Replace PDF"
-                      : "Upload PDF"}
-                </Button>
-
-                {isReady && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-9 w-full justify-start"
-                    onClick={() => void handleRegeneratePdf()}
-                    disabled={isBusy}
-                  >
-                    <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
-                    Regenerate PDF
-                  </Button>
-                )}
-
-                {(isReady || isDiscovered) && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-9 w-full justify-start"
-                    onClick={() => void handleSkip()}
-                    disabled={isBusy}
-                  >
-                    <XCircle className="mr-1.5 h-3.5 w-3.5" />
-                    Skip Job
-                  </Button>
-                )}
-
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-9 w-full justify-start text-muted-foreground"
-                    >
-                      <MoreHorizontal className="mr-1.5 h-3.5 w-3.5" />
-                      More actions
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem onSelect={openEditDetails}>
-                      <Edit2 className="mr-2 h-4 w-4" />
-                      Edit details
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => void handleCopyJobInfo()}>
-                      <Copy className="mr-2 h-4 w-4" />
-                      Copy job info
-                    </DropdownMenuItem>
-                    {(isReady || isDiscovered) && (
-                      <DropdownMenuItem onSelect={() => void handleRescore()}>
-                        <RefreshCcw className="mr-2 h-4 w-4" />
-                        Recalculate match
-                      </DropdownMenuItem>
-                    )}
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onSelect={() => void handleCheckSponsor()}
-                    >
-                      Check sponsorship status
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            </section>
-
-            {tasks.length > 0 && (
-              <section className="rounded-xl border border-border/50 bg-card/70 p-4">
-                <div className="mb-3 flex items-center gap-2 text-sm font-semibold">
-                  <CalendarClock className="h-4 w-4" />
-                  Upcoming tasks
-                </div>
-                <div className="space-y-3">
-                  {tasks.map((task) => (
-                    <div key={task.id} className="space-y-1">
-                      <div className="text-sm font-medium">{task.title}</div>
-                      {task.notes && (
-                        <div className="text-xs text-muted-foreground">
-                          {task.notes}
-                        </div>
-                      )}
-                      <Badge
-                        variant="outline"
-                        className="text-[10px] uppercase tracking-wide"
-                      >
-                        {formatTimestamp(task.dueDate)}
-                      </Badge>
-                    </div>
-                  ))}
-                </div>
-              </section>
-            )}
-          </aside>
+          <JobPageRightSidebar
+            job={job}
+            tasks={tasks}
+            jobLink={jobLink}
+            isDiscovered={Boolean(isDiscovered)}
+            isReady={Boolean(isReady)}
+            isApplied={Boolean(isApplied)}
+            isInProgress={Boolean(isInProgress)}
+            canLogEvents={canLogEvents}
+            isBusy={isBusy}
+            isUploadingPdf={isUploadingPdf}
+            onStartTailoring={() => navigate(`/jobs/discovered/${job.id}`)}
+            onMarkApplied={() => void handleMarkApplied()}
+            onMoveToInProgress={() => void handleMoveToInProgress()}
+            onOpenLogEvent={() => setIsLogModalOpen(true)}
+            onEditTailoring={() => navigate(`/jobs/ready/${job.id}`)}
+            onViewPdf={() => {
+              void openJobPdf(job.id).catch((error) => {
+                toast.error(
+                  error instanceof Error ? error.message : "Could not open PDF",
+                );
+              });
+            }}
+            onUploadPdf={() => uploadPdfInputRef.current?.click()}
+            onRegeneratePdf={() => void handleRegeneratePdf()}
+            onSkip={() => void handleSkip()}
+            onOpenEditDetails={openEditDetails}
+            onCopyJobInfo={() => void handleCopyJobInfo()}
+            onRescore={() => void handleRescore()}
+            onCheckSponsor={() => void handleCheckSponsor()}
+          />
         </div>
       )}
 

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -17,6 +17,7 @@ import {
   ExternalLink,
   FileText,
   MessageSquareText,
+  PlusCircle,
   Sparkles,
   Upload,
 } from "lucide-react";
@@ -644,17 +645,31 @@ export const JobPage: React.FC = () => {
                         </div>
                       )}
                     </div>
-                    <Button
-                      asChild
-                      size="sm"
-                      variant="outline"
-                      className="mt-4 w-full justify-between"
-                    >
-                      <Link to={`${baseJobPath}/timeline`}>
-                        Open timeline
-                        <ExternalLink className="h-3.5 w-3.5" />
-                      </Link>
-                    </Button>
+                    {canLogEvents ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="mt-4 w-full justify-between"
+                        onClick={() => setIsLogModalOpen(true)}
+                      >
+                        <span className="flex items-center gap-2">
+                          <PlusCircle className="h-3.5 w-3.5" />
+                          Log event
+                        </span>
+                      </Button>
+                    ) : (
+                      <Button
+                        asChild
+                        size="sm"
+                        variant="outline"
+                        className="mt-4 w-full justify-between"
+                      >
+                        <Link to={`${baseJobPath}/timeline`}>
+                          Open timeline
+                          <ExternalLink className="h-3.5 w-3.5" />
+                        </Link>
+                      </Button>
+                    )}
                   </article>
                 </div>
               </section>
@@ -760,6 +775,17 @@ export const JobPage: React.FC = () => {
                           {STAGE_LABELS[currentStage as ApplicationStage] ||
                             currentStage}
                         </Badge>
+                      )}
+                      {canLogEvents && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="h-8"
+                          onClick={() => setIsLogModalOpen(true)}
+                        >
+                          <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
+                          Log event
+                        </Button>
                       )}
                     </div>
                   </div>

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -31,7 +31,7 @@ import {
   XCircle,
 } from "lucide-react";
 import React from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { RichTextEditor } from "@/client/components/design-resume/RichTextEditor";
 import { JobDescriptionMarkdown } from "@/client/components/JobDescriptionMarkdown";
@@ -85,7 +85,20 @@ import {
 } from "../components/LogEventModal";
 import { JobTimeline } from "./job/Timeline";
 
-type JobMemoryView = "notes" | "documents" | "timeline" | "ghostwriter";
+type JobMemoryView =
+  | "overview"
+  | "note"
+  | "documents"
+  | "timeline"
+  | "ghostwriter";
+
+const normalizeMemoryView = (view: string | undefined): JobMemoryView => {
+  if (view === "notes" || view === "note") return "note";
+  if (view === "documents" || view === "timeline" || view === "ghostwriter") {
+    return view;
+  }
+  return "overview";
+};
 
 const sortNotesByUpdatedAtDesc = (notes: JobNote[]) =>
   [...notes].sort(
@@ -534,7 +547,7 @@ const JobNotesCard: React.FC<{ jobId: string }> = ({ jobId }) => {
 };
 
 export const JobPage: React.FC = () => {
-  const { id } = useParams<{ id: string }>();
+  const { id, view } = useParams<{ id: string; view?: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const [isLogModalOpen, setIsLogModalOpen] = React.useState(false);
@@ -542,8 +555,6 @@ export const JobPage: React.FC = () => {
   const [isEditDetailsOpen, setIsEditDetailsOpen] = React.useState(false);
   const [isUploadingPdf, setIsUploadingPdf] = React.useState(false);
   const [activeAction, setActiveAction] = React.useState<string | null>(null);
-  const [activeMemoryView, setActiveMemoryView] =
-    React.useState<JobMemoryView>("notes");
   const [eventToDelete, setEventToDelete] = React.useState<string | null>(null);
   const [editingEvent, setEditingEvent] = React.useState<StageEvent | null>(
     null,
@@ -565,6 +576,11 @@ export const JobPage: React.FC = () => {
     queryFn: () => (id ? api.getJobStageEvents(id) : Promise.resolve([])),
     enabled: Boolean(id),
   });
+  const notesQuery = useQuery<JobNote[]>({
+    queryKey: queryKeys.jobs.notes(id ?? ""),
+    queryFn: () => (id ? api.getJobNotes(id) : Promise.resolve([])),
+    enabled: Boolean(id),
+  });
   const tasksQuery = useQuery<ApplicationTask[]>({
     queryKey: ["jobs", "tasks", id ?? null] as const,
     queryFn: () => (id ? api.getJobTasks(id) : Promise.resolve([])),
@@ -580,6 +596,10 @@ export const JobPage: React.FC = () => {
     "Failed to load job timeline. Please try again.",
   );
   useQueryErrorToast(
+    notesQuery.error,
+    "Failed to load notes. Please try again.",
+  );
+  useQueryErrorToast(
     tasksQuery.error,
     "Failed to load job tasks. Please try again.",
   );
@@ -593,9 +613,14 @@ export const JobPage: React.FC = () => {
 
   const job = jobQuery.data ?? null;
   const events = mergeEvents(eventsQuery.data ?? [], pendingEventRef.current);
+  const notes = React.useMemo(
+    () => sortNotesByUpdatedAtDesc(notesQuery.data ?? []),
+    [notesQuery.data],
+  );
   const tasks = tasksQuery.data ?? [];
   const isLoading =
     jobQuery.isLoading || eventsQuery.isLoading || tasksQuery.isLoading;
+  const activeMemoryView = normalizeMemoryView(view);
   const selectedProjectIds = React.useMemo(
     () => parseSelectedProjectIds(job?.selectedProjectIds),
     [job?.selectedProjectIds],
@@ -873,6 +898,13 @@ export const JobPage: React.FC = () => {
   const isReady = job?.status === "ready";
   const isApplied = job?.status === "applied";
   const isInProgress = job?.status === "in_progress";
+  const baseJobPath = id ? `/job/${id}` : "";
+  const latestNote = notes[0] ?? null;
+  const latestEvent = events.at(-1) ?? null;
+  const latestEventTitle =
+    latestEvent?.metadata?.eventLabel || latestEvent?.title || null;
+  const jobDescriptionPreview = summarizeMemoryText(job?.jobDescription, 260);
+  const latestNotePreview = summarizeMemoryText(latestNote?.content, 180);
 
   if (!id) {
     return null;
@@ -983,54 +1015,261 @@ export const JobPage: React.FC = () => {
               <div className="space-y-1">
                 {[
                   {
-                    id: "notes" as const,
+                    id: "overview" as const,
+                    label: "Overview",
+                    path: baseJobPath,
+                    icon: FolderKanban,
+                  },
+                  {
+                    id: "note" as const,
                     label: "Notes",
+                    path: `${baseJobPath}/note`,
                     icon: MessageSquareText,
                   },
                   {
                     id: "documents" as const,
                     label: "Documents",
+                    path: `${baseJobPath}/documents`,
                     icon: FileText,
                   },
                   {
                     id: "timeline" as const,
                     label: "Timeline",
+                    path: `${baseJobPath}/timeline`,
                     icon: ClipboardList,
                   },
                   {
                     id: "ghostwriter" as const,
                     label: "Ghostwriter",
+                    path: `${baseJobPath}/ghostwriter`,
                     icon: Sparkles,
                   },
-                ].map(({ id: view, label, icon: Icon }) => (
-                  <button
-                    key={view}
-                    type="button"
+                ].map(({ id: linkView, label, path, icon: Icon }) => (
+                  <Link
+                    to={path}
+                    key={linkView}
                     className={cn(
                       "flex h-9 w-full items-center justify-between rounded-md px-2 text-left text-sm transition",
-                      activeMemoryView === view
+                      activeMemoryView === linkView
                         ? "border border-orange-400/30 bg-orange-500/10 text-orange-100"
                         : "text-muted-foreground hover:bg-muted/30 hover:text-foreground",
                     )}
-                    onClick={() => setActiveMemoryView(view)}
                   >
                     <span className="flex min-w-0 items-center gap-2">
                       <Icon className="h-4 w-4 shrink-0" />
                       <span className="truncate">{label}</span>
                     </span>
-                    {activeMemoryView === view && (
+                    {activeMemoryView === linkView && (
                       <Badge variant="secondary" className="text-[10px]">
                         Open
                       </Badge>
                     )}
-                  </button>
+                  </Link>
                 ))}
               </div>
             </section>
           </aside>
 
-          <div>
-            {activeMemoryView === "notes" && job.id && (
+          <div className="space-y-4">
+            {activeMemoryView === "overview" && (
+              <section className="space-y-4">
+                <div className="rounded-xl border border-border/50 bg-card/85 p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-4">
+                    <div>
+                      <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                        Overview
+                      </div>
+                      <h2 className="mt-1 text-xl font-semibold">
+                        Application memory
+                      </h2>
+                    </div>
+                    <Button asChild size="sm" variant="outline">
+                      <Link to={`${baseJobPath}/ghostwriter`}>
+                        <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+                        Ask Ghostwriter
+                      </Link>
+                    </Button>
+                  </div>
+                </div>
+
+                <div className="grid gap-4 lg:grid-cols-2">
+                  <article className="rounded-xl border border-border/50 bg-card/75 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-2 text-sm font-semibold">
+                        <MessageSquareText className="h-4 w-4 text-orange-300" />
+                        Notes
+                      </div>
+                      <Badge variant="secondary" className="text-[10px]">
+                        {notesQuery.isLoading
+                          ? "Loading"
+                          : `${notes.length} saved`}
+                      </Badge>
+                    </div>
+                    <div className="mt-4 min-h-[5.5rem] rounded-lg border border-border/50 bg-background/25 p-3">
+                      {latestNote ? (
+                        <div>
+                          <div className="text-sm font-medium">
+                            {latestNote.title}
+                          </div>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            Updated{" "}
+                            {formatDateTime(latestNote.updatedAt) ??
+                              latestNote.updatedAt}
+                          </div>
+                          {latestNotePreview && (
+                            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                              {latestNotePreview}
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="text-sm text-muted-foreground">
+                          No notes or transcripts captured yet.
+                        </div>
+                      )}
+                    </div>
+                    <Button
+                      asChild
+                      size="sm"
+                      variant="outline"
+                      className="mt-4 w-full justify-between"
+                    >
+                      <Link to={`${baseJobPath}/note`}>
+                        Open notes
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Link>
+                    </Button>
+                  </article>
+
+                  <article className="rounded-xl border border-border/50 bg-card/75 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-2 text-sm font-semibold">
+                        <FileText className="h-4 w-4 text-sky-300" />
+                        Documents
+                      </div>
+                      <Badge variant="secondary" className="text-[10px]">
+                        {job.pdfPath ? "Resume ready" : "No resume PDF"}
+                      </Badge>
+                    </div>
+                    <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                      <div className="rounded-lg border border-border/50 bg-background/25 p-3">
+                        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                          Resume PDF
+                        </div>
+                        <div className="mt-2 text-sm font-medium">
+                          {job.pdfPath ? "Stored for this job" : "Missing"}
+                        </div>
+                      </div>
+                      <div className="rounded-lg border border-border/50 bg-background/25 p-3">
+                        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                          Job description
+                        </div>
+                        <div className="mt-2 text-sm font-medium">
+                          {job.jobDescription ? "Saved" : "Missing"}
+                        </div>
+                      </div>
+                    </div>
+                    {jobDescriptionPreview && (
+                      <p className="mt-4 line-clamp-3 text-sm leading-6 text-muted-foreground">
+                        {jobDescriptionPreview}
+                      </p>
+                    )}
+                    <Button
+                      asChild
+                      size="sm"
+                      variant="outline"
+                      className="mt-4 w-full justify-between"
+                    >
+                      <Link to={`${baseJobPath}/documents`}>
+                        Open documents
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Link>
+                    </Button>
+                  </article>
+
+                  <article className="rounded-xl border border-border/50 bg-card/75 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-2 text-sm font-semibold">
+                        <ClipboardList className="h-4 w-4 text-emerald-300" />
+                        Timeline
+                      </div>
+                      {currentStage && (
+                        <Badge variant="secondary" className="text-[10px]">
+                          {STAGE_LABELS[currentStage as ApplicationStage] ||
+                            currentStage}
+                        </Badge>
+                      )}
+                    </div>
+                    <div className="mt-4 min-h-[5.5rem] rounded-lg border border-border/50 bg-background/25 p-3">
+                      {latestEvent ? (
+                        <div>
+                          <div className="text-sm font-medium">
+                            {latestEventTitle}
+                          </div>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            {formatTimestamp(latestEvent.occurredAt)}
+                          </div>
+                          {latestEvent.metadata?.note && (
+                            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+                              {summarizeMemoryText(
+                                latestEvent.metadata.note,
+                                160,
+                              )}
+                            </p>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="text-sm text-muted-foreground">
+                          No timeline events yet.
+                        </div>
+                      )}
+                    </div>
+                    <Button
+                      asChild
+                      size="sm"
+                      variant="outline"
+                      className="mt-4 w-full justify-between"
+                    >
+                      <Link to={`${baseJobPath}/timeline`}>
+                        Open timeline
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Link>
+                    </Button>
+                  </article>
+
+                  <article className="rounded-xl border border-orange-400/20 bg-orange-500/5 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-2 text-sm font-semibold">
+                        <Sparkles className="h-4 w-4 text-orange-300" />
+                        Ghostwriter
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className="border-orange-400/30 bg-orange-500/10 text-orange-100"
+                      >
+                        AI
+                      </Badge>
+                    </div>
+                    <div className="mt-4 min-h-[5.5rem] rounded-lg border border-orange-400/20 bg-background/25 p-3 text-sm leading-6 text-muted-foreground">
+                      Ask what CV context was used, what happened in the last
+                      call, or what to say before the next recruiter touchpoint.
+                    </div>
+                    <Button
+                      asChild
+                      size="sm"
+                      className="mt-4 w-full justify-between border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    >
+                      <Link to={`${baseJobPath}/ghostwriter`}>
+                        Open Ghostwriter
+                        <ExternalLink className="h-3.5 w-3.5" />
+                      </Link>
+                    </Button>
+                  </article>
+                </div>
+              </section>
+            )}
+
+            {activeMemoryView === "note" && job.id && (
               <JobNotesCard jobId={job.id} />
             )}
 
@@ -1431,4 +1670,19 @@ const mergeEvents = (events: StageEvent[], pending: StageEvent | null) => {
   if (!pending) return events;
   if (events.some((event) => event.id === pending.id)) return events;
   return [...events, pending].sort((a, b) => a.occurredAt - b.occurredAt);
+};
+
+const summarizeMemoryText = (
+  value: string | null | undefined,
+  maxLength: number,
+) => {
+  const text = getRenderableJobDescription(value ?? "")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/[#*_`>[\](){}-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  if (!text) return "";
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength).trim()}...`;
 };

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -515,8 +515,8 @@ export const JobPage: React.FC = () => {
   }, [job, jobPageBackTo, navigate]);
   const pageGridClass =
     activeMemoryView === "overview"
-      ? "grid items-start gap-4 xl:grid-cols-[18rem_minmax(0,1fr)_18rem]"
-      : "grid items-start gap-4 xl:grid-cols-[18rem_minmax(0,1fr)]";
+      ? "grid items-start gap-4 grid-cols-1 xl:grid-cols-[18rem_minmax(0,1fr)_18rem]"
+      : "grid items-start gap-4 grid-cols-1 xl:grid-cols-[18rem_minmax(0,1fr)]";
 
   if (!id) {
     return null;

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -77,13 +77,15 @@ import {
 } from "@/lib/utils";
 import * as api from "../api";
 import { ConfirmDelete } from "../components/ConfirmDelete";
-import { GhostwriterDrawer } from "../components/ghostwriter/GhostwriterDrawer";
+import { GhostwriterPanel } from "../components/ghostwriter/GhostwriterPanel";
 import { JobDetailsEditDrawer } from "../components/JobDetailsEditDrawer";
 import {
   type LogEventFormValues,
   LogEventModal,
 } from "../components/LogEventModal";
 import { JobTimeline } from "./job/Timeline";
+
+type JobMemoryView = "notes" | "documents" | "timeline" | "ghostwriter";
 
 const sortNotesByUpdatedAtDesc = (notes: JobNote[]) =>
   [...notes].sort(
@@ -540,6 +542,8 @@ export const JobPage: React.FC = () => {
   const [isEditDetailsOpen, setIsEditDetailsOpen] = React.useState(false);
   const [isUploadingPdf, setIsUploadingPdf] = React.useState(false);
   const [activeAction, setActiveAction] = React.useState<string | null>(null);
+  const [activeMemoryView, setActiveMemoryView] =
+    React.useState<JobMemoryView>("notes");
   const [eventToDelete, setEventToDelete] = React.useState<string | null>(null);
   const [editingEvent, setEditingEvent] = React.useState<StageEvent | null>(
     null,
@@ -971,100 +975,195 @@ export const JobPage: React.FC = () => {
                 </div>
               )}
             </section>
+
+            <section className="rounded-xl border border-border/50 bg-card/70 p-3">
+              <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                Links
+              </div>
+              <div className="space-y-1">
+                {[
+                  {
+                    id: "notes" as const,
+                    label: "Notes",
+                    icon: MessageSquareText,
+                  },
+                  {
+                    id: "documents" as const,
+                    label: "Documents",
+                    icon: FileText,
+                  },
+                  {
+                    id: "timeline" as const,
+                    label: "Timeline",
+                    icon: ClipboardList,
+                  },
+                  {
+                    id: "ghostwriter" as const,
+                    label: "Ghostwriter",
+                    icon: Sparkles,
+                  },
+                ].map(({ id: view, label, icon: Icon }) => (
+                  <button
+                    key={view}
+                    type="button"
+                    className={cn(
+                      "flex h-9 w-full items-center justify-between rounded-md px-2 text-left text-sm transition",
+                      activeMemoryView === view
+                        ? "border border-orange-400/30 bg-orange-500/10 text-orange-100"
+                        : "text-muted-foreground hover:bg-muted/30 hover:text-foreground",
+                    )}
+                    onClick={() => setActiveMemoryView(view)}
+                  >
+                    <span className="flex min-w-0 items-center gap-2">
+                      <Icon className="h-4 w-4 shrink-0" />
+                      <span className="truncate">{label}</span>
+                    </span>
+                    {activeMemoryView === view && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        Open
+                      </Badge>
+                    )}
+                  </button>
+                ))}
+              </div>
+            </section>
           </aside>
 
-          <div className="space-y-4">
-            <section className="rounded-xl border border-orange-400/20 bg-orange-500/[0.06] p-4">
-              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
-                <div className="min-w-0">
-                  <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-orange-100">
-                    <MessageSquareText className="h-4 w-4" />
-                    Ghostwriter recall
-                  </div>
-                  <div className="rounded-lg border border-orange-300/20 bg-background/50 px-4 py-3 text-sm text-muted-foreground">
-                    Ask Ghostwriter about this application...
-                  </div>
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {[
-                      "What projects did I use?",
-                      "Summarize interview notes",
-                      "What should I remember?",
-                    ].map((prompt) => (
-                      <Badge
-                        key={prompt}
-                        variant="outline"
-                        className="border-orange-300/20 bg-background/25 text-[11px] font-normal text-orange-100/80"
-                      >
-                        {prompt}
-                      </Badge>
-                    ))}
-                  </div>
-                </div>
-                <GhostwriterDrawer job={job} />
-              </div>
-            </section>
+          <div>
+            {activeMemoryView === "notes" && job.id && (
+              <JobNotesCard jobId={job.id} />
+            )}
 
-            <section className="rounded-xl border border-border/50 bg-card/85">
-              <div className="border-b border-border/50 px-4 py-3">
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div className="flex items-center gap-2 text-base font-semibold">
-                    <ClipboardList className="h-4 w-4" />
-                    Memory stream
-                  </div>
-                  <div className="flex flex-wrap items-center gap-2">
-                    {job.salary && (
-                      <Badge
-                        variant="outline"
-                        className="border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
-                      >
-                        <DollarSign className="mr-1 h-3.5 w-3.5" />
-                        {job.salary}
-                      </Badge>
-                    )}
-                    {currentStage && (
-                      <Badge variant="secondary">
-                        {STAGE_LABELS[currentStage as ApplicationStage] ||
-                          currentStage}
-                      </Badge>
-                    )}
-                  </div>
-                </div>
-              </div>
-              <div className="p-4">
-                {!canTrackStages && (
-                  <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
-                    Move this job to In Progress to track application stages.
-                  </div>
-                )}
-                {canTrackStages && isClosedStage && (
-                  <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
-                    This application is closed. Stage logging is disabled.
-                  </div>
-                )}
-                <JobTimeline
-                  events={events}
-                  onEdit={canLogEvents ? handleEditEvent : undefined}
-                  onDelete={canLogEvents ? confirmDeleteEvent : undefined}
-                />
-              </div>
-            </section>
-
-            {job.id && <JobNotesCard jobId={job.id} />}
-
-            {job.jobDescription && (
+            {activeMemoryView === "documents" && (
               <section className="rounded-xl border border-border/50 bg-card/75">
                 <div className="border-b border-border/50 px-4 py-3">
                   <div className="flex items-center gap-2 text-base font-semibold">
                     <FileText className="h-4 w-4" />
-                    Source document
+                    Documents
+                  </div>
+                </div>
+                <div className="space-y-4 p-4">
+                  <div className="rounded-lg border border-border/60 bg-background/25 p-4">
+                    <div className="flex flex-wrap items-center justify-between gap-3">
+                      <div>
+                        <div className="text-sm font-semibold">Resume PDF</div>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          Generated or uploaded application material for this
+                          job.
+                        </div>
+                      </div>
+                      {job.pdfPath ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            void openJobPdf(job.id).catch((error) => {
+                              toast.error(
+                                error instanceof Error
+                                  ? error.message
+                                  : "Could not open PDF",
+                              );
+                            });
+                          }}
+                        >
+                          <FileText className="mr-1.5 h-3.5 w-3.5" />
+                          View PDF
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => uploadPdfInputRef.current?.click()}
+                          disabled={isUploadingPdf}
+                        >
+                          <Upload className="mr-1.5 h-3.5 w-3.5" />
+                          Upload PDF
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="rounded-lg border border-border/60 bg-background/25">
+                    <div className="border-b border-border/50 px-4 py-3">
+                      <div className="text-sm font-semibold">
+                        Job description
+                      </div>
+                    </div>
+                    <div className="p-4">
+                      {job.jobDescription ? (
+                        <JobDescriptionMarkdown
+                          description={getRenderableJobDescription(
+                            job.jobDescription,
+                          )}
+                        />
+                      ) : (
+                        <div className="text-sm text-muted-foreground">
+                          No job description stored.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </section>
+            )}
+
+            {activeMemoryView === "timeline" && (
+              <section className="rounded-xl border border-border/50 bg-card/85">
+                <div className="border-b border-border/50 px-4 py-3">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div className="flex items-center gap-2 text-base font-semibold">
+                      <ClipboardList className="h-4 w-4" />
+                      Timeline
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      {job.salary && (
+                        <Badge
+                          variant="outline"
+                          className="border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                        >
+                          <DollarSign className="mr-1 h-3.5 w-3.5" />
+                          {job.salary}
+                        </Badge>
+                      )}
+                      {currentStage && (
+                        <Badge variant="secondary">
+                          {STAGE_LABELS[currentStage as ApplicationStage] ||
+                            currentStage}
+                        </Badge>
+                      )}
+                    </div>
                   </div>
                 </div>
                 <div className="p-4">
-                  <JobDescriptionMarkdown
-                    description={getRenderableJobDescription(
-                      job.jobDescription,
-                    )}
+                  {!canTrackStages && (
+                    <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
+                      Move this job to In Progress to track application stages.
+                    </div>
+                  )}
+                  {canTrackStages && isClosedStage && (
+                    <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
+                      This application is closed. Stage logging is disabled.
+                    </div>
+                  )}
+                  <JobTimeline
+                    events={events}
+                    onEdit={canLogEvents ? handleEditEvent : undefined}
+                    onDelete={canLogEvents ? confirmDeleteEvent : undefined}
                   />
+                </div>
+              </section>
+            )}
+
+            {activeMemoryView === "ghostwriter" && (
+              <section className="overflow-hidden rounded-xl border border-border/50 bg-card/85">
+                <div className="border-b border-border/50 px-4 py-3">
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <Sparkles className="h-4 w-4" />
+                    Ghostwriter
+                  </div>
+                </div>
+                <div className="h-[720px] min-h-0">
+                  <GhostwriterPanel job={job} />
                 </div>
               </section>
             )}

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -4,6 +4,7 @@ import {
   type Job,
   type JobNote,
   type JobOutcome,
+  type ResumeProjectCatalogItem,
   STAGE_LABELS,
   type StageEvent,
 } from "@shared/types.js";
@@ -19,6 +20,8 @@ import {
   Edit2,
   ExternalLink,
   FileText,
+  FolderKanban,
+  MessageSquareText,
   MoreHorizontal,
   PlusCircle,
   RefreshCcw,
@@ -76,7 +79,6 @@ import * as api from "../api";
 import { ConfirmDelete } from "../components/ConfirmDelete";
 import { GhostwriterDrawer } from "../components/ghostwriter/GhostwriterDrawer";
 import { JobDetailsEditDrawer } from "../components/JobDetailsEditDrawer";
-import { JobHeader } from "../components/JobHeader";
 import {
   type LogEventFormValues,
   LogEventModal,
@@ -88,6 +90,17 @@ const sortNotesByUpdatedAtDesc = (notes: JobNote[]) =>
     (left, right) =>
       new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
   );
+
+const formatSourceLabel = (source: string) =>
+  source
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+
+const parseSelectedProjectIds = (value: string | null | undefined) =>
+  value
+    ?.split(",")
+    .map((id) => id.trim())
+    .filter(Boolean) ?? [];
 
 const JobNotesCard: React.FC<{ jobId: string }> = ({ jobId }) => {
   const [editorState, setEditorState] = React.useState<
@@ -531,6 +544,7 @@ export const JobPage: React.FC = () => {
   const [editingEvent, setEditingEvent] = React.useState<StageEvent | null>(
     null,
   );
+  const [catalog, setCatalog] = React.useState<ResumeProjectCatalogItem[]>([]);
   const pendingEventRef = React.useRef<StageEvent | null>(null);
   const uploadPdfInputRef = React.useRef<HTMLInputElement | null>(null);
   const openEditDetails = React.useCallback(() => {
@@ -578,6 +592,47 @@ export const JobPage: React.FC = () => {
   const tasks = tasksQuery.data ?? [];
   const isLoading =
     jobQuery.isLoading || eventsQuery.isLoading || tasksQuery.isLoading;
+  const selectedProjectIds = React.useMemo(
+    () => parseSelectedProjectIds(job?.selectedProjectIds),
+    [job?.selectedProjectIds],
+  );
+  const selectedProjects = React.useMemo(
+    () =>
+      selectedProjectIds.map(
+        (projectId) =>
+          catalog.find((project) => project.id === projectId)?.name ??
+          projectId,
+      ),
+    [catalog, selectedProjectIds],
+  );
+
+  React.useEffect(() => {
+    let isCancelled = false;
+
+    if (selectedProjectIds.length === 0) {
+      setCatalog([]);
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    void api
+      .getResumeProjectsCatalog()
+      .then((nextCatalog) => {
+        if (!isCancelled) {
+          setCatalog(nextCatalog);
+        }
+      })
+      .catch(() => {
+        if (!isCancelled) {
+          setCatalog([]);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [selectedProjectIds.length]);
 
   const loadData = React.useCallback(async () => {
     if (!id) return;
@@ -820,349 +875,395 @@ export const JobPage: React.FC = () => {
   }
 
   return (
-    <main className="container mx-auto max-w-6xl space-y-6 px-4 py-6 pb-12">
-      <div className="flex items-center justify-between gap-4">
+    <main className="mx-auto max-w-[92rem] px-4 py-5 pb-12">
+      <div className="mb-4 flex items-center justify-between gap-4">
         <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
           <ArrowLeft className="h-4 w-4" />
           Back
         </Button>
+        {job && (
+          <Badge
+            variant="outline"
+            className="border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+          >
+            {currentStage
+              ? STAGE_LABELS[currentStage as ApplicationStage] || currentStage
+              : job.status}
+          </Badge>
+        )}
       </div>
 
-      {job ? (
-        <JobHeader
-          job={job}
-          className="rounded-lg border border-border/40 bg-muted/5 p-4"
-          onCheckSponsor={handleCheckSponsor}
-        />
-      ) : (
+      {!job && (
         <div className="rounded-lg border border-dashed border-border/40 p-6 text-sm text-muted-foreground">
           {isLoading ? "Loading application..." : "Application not found."}
         </div>
       )}
 
       {job && (
-        <div className="rounded-xl border border-border/60 bg-card/80 p-2 shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/65">
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="flex flex-wrap items-center gap-2">
-              {jobLink && (
-                <Button
-                  asChild
-                  size="sm"
-                  className="h-9 border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
-                >
-                  <a href={jobLink} target="_blank" rel="noopener noreferrer">
-                    <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
-                    Open Job Listing
-                  </a>
-                </Button>
-              )}
+        <div className="grid items-start gap-4 xl:grid-cols-[18rem_minmax(0,1fr)_18rem]">
+          <aside className="space-y-4 xl:sticky xl:top-5">
+            <section className="rounded-xl border border-border/50 bg-card/85 p-4">
+              <div className="space-y-1">
+                <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+                  Application dossier
+                </div>
+                <h1 className="text-2xl font-semibold leading-tight">
+                  {job.employer}
+                </h1>
+                <div className="text-sm text-muted-foreground">{job.title}</div>
+              </div>
 
-              {isReady && (
-                <>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-9 border-orange-400/50 bg-orange-500/10 text-orange-100 hover:bg-orange-500/20"
-                    onClick={() => void handleMarkApplied()}
-                    disabled={isBusy}
-                  >
-                    <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
-                    Mark Applied
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    className="h-9 border-border/60 bg-background/30"
-                    onClick={() => void handleSkip()}
-                    disabled={isBusy}
-                  >
-                    <XCircle className="mr-1.5 h-3.5 w-3.5" />
-                    Skip Job
-                  </Button>
-                </>
-              )}
+              <div className="mt-5 space-y-3 text-sm">
+                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+                  <span className="text-muted-foreground">Source</span>
+                  <span className="text-right font-medium">
+                    {formatSourceLabel(job.source)}
+                  </span>
+                </div>
+                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+                  <span className="text-muted-foreground">Location</span>
+                  <span className="text-right font-medium">
+                    {job.location || "Unknown"}
+                  </span>
+                </div>
+                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+                  <span className="text-muted-foreground">Found</span>
+                  <span className="text-right font-medium">
+                    {formatDateTime(job.discoveredAt) ?? job.discoveredAt}
+                  </span>
+                </div>
+                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+                  <span className="text-muted-foreground">Applied</span>
+                  <span className="text-right font-medium">
+                    {job.appliedAt
+                      ? (formatDateTime(job.appliedAt) ?? job.appliedAt)
+                      : "Not marked"}
+                  </span>
+                </div>
+                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+                  <span className="text-muted-foreground">Outcome</span>
+                  <span className="text-right font-medium">
+                    {job.outcome ? job.outcome.replace(/_/g, " ") : "Open"}
+                  </span>
+                </div>
+              </div>
+            </section>
 
-              {isDiscovered && (
-                <>
+            <section className="rounded-xl border border-border/50 bg-card/70 p-4">
+              <div className="mb-3 flex items-center gap-2 text-sm font-semibold">
+                <FolderKanban className="h-4 w-4 text-emerald-400" />
+                Applied with
+              </div>
+              {selectedProjects.length > 0 ? (
+                <div className="space-y-2">
+                  {selectedProjects.map((project) => (
+                    <div
+                      key={project}
+                      className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100"
+                    >
+                      {project}
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
+                  No selected projects stored.
+                </div>
+              )}
+            </section>
+          </aside>
+
+          <div className="space-y-4">
+            <section className="rounded-xl border border-orange-400/20 bg-orange-500/[0.06] p-4">
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center">
+                <div className="min-w-0">
+                  <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-orange-100">
+                    <MessageSquareText className="h-4 w-4" />
+                    Ghostwriter recall
+                  </div>
+                  <div className="rounded-lg border border-orange-300/20 bg-background/50 px-4 py-3 text-sm text-muted-foreground">
+                    Ask Ghostwriter about this application...
+                  </div>
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {[
+                      "What projects did I use?",
+                      "Summarize interview notes",
+                      "What should I remember?",
+                    ].map((prompt) => (
+                      <Badge
+                        key={prompt}
+                        variant="outline"
+                        className="border-orange-300/20 bg-background/25 text-[11px] font-normal text-orange-100/80"
+                      >
+                        {prompt}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                <GhostwriterDrawer job={job} />
+              </div>
+            </section>
+
+            <section className="rounded-xl border border-border/50 bg-card/85">
+              <div className="border-b border-border/50 px-4 py-3">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <ClipboardList className="h-4 w-4" />
+                    Memory stream
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {job.salary && (
+                      <Badge
+                        variant="outline"
+                        className="border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                      >
+                        <DollarSign className="mr-1 h-3.5 w-3.5" />
+                        {job.salary}
+                      </Badge>
+                    )}
+                    {currentStage && (
+                      <Badge variant="secondary">
+                        {STAGE_LABELS[currentStage as ApplicationStage] ||
+                          currentStage}
+                      </Badge>
+                    )}
+                  </div>
+                </div>
+              </div>
+              <div className="p-4">
+                {!canTrackStages && (
+                  <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
+                    Move this job to In Progress to track application stages.
+                  </div>
+                )}
+                {canTrackStages && isClosedStage && (
+                  <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
+                    This application is closed. Stage logging is disabled.
+                  </div>
+                )}
+                <JobTimeline
+                  events={events}
+                  onEdit={canLogEvents ? handleEditEvent : undefined}
+                  onDelete={canLogEvents ? confirmDeleteEvent : undefined}
+                />
+              </div>
+            </section>
+
+            {job.id && <JobNotesCard jobId={job.id} />}
+
+            {job.jobDescription && (
+              <section className="rounded-xl border border-border/50 bg-card/75">
+                <div className="border-b border-border/50 px-4 py-3">
+                  <div className="flex items-center gap-2 text-base font-semibold">
+                    <FileText className="h-4 w-4" />
+                    Source document
+                  </div>
+                </div>
+                <div className="p-4">
+                  <JobDescriptionMarkdown
+                    description={getRenderableJobDescription(
+                      job.jobDescription,
+                    )}
+                  />
+                </div>
+              </section>
+            )}
+          </div>
+
+          <aside className="space-y-4 xl:sticky xl:top-5">
+            <section className="rounded-xl border border-border/50 bg-card/85 p-3">
+              <div className="mb-3 flex items-center gap-2 px-1 text-sm font-semibold">
+                <Sparkles className="h-4 w-4" />
+                Next actions
+              </div>
+              <div className="space-y-2">
+                {jobLink && (
+                  <Button
+                    asChild
+                    size="sm"
+                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                  >
+                    <a href={jobLink} target="_blank" rel="noopener noreferrer">
+                      <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                      Open Job Listing
+                    </a>
+                  </Button>
+                )}
+
+                {isDiscovered && (
                   <Button
                     size="sm"
-                    className="h-9 border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
                     onClick={() => navigate(`/jobs/discovered/${job.id}`)}
                     disabled={isBusy}
                   >
                     <Sparkles className="mr-1.5 h-3.5 w-3.5" />
                     Start Tailoring
                   </Button>
+                )}
+
+                {isReady && (
+                  <Button
+                    size="sm"
+                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    onClick={() => void handleMarkApplied()}
+                    disabled={isBusy}
+                  >
+                    <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
+                    Mark Applied
+                  </Button>
+                )}
+
+                {isApplied && (
+                  <Button
+                    size="sm"
+                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    onClick={() => void handleMoveToInProgress()}
+                    disabled={isBusy}
+                  >
+                    <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
+                    Move to In Progress
+                  </Button>
+                )}
+
+                {isInProgress && (
+                  <Button
+                    size="sm"
+                    className="h-9 w-full justify-start border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+                    onClick={() => setIsLogModalOpen(true)}
+                    disabled={!canLogEvents || isBusy}
+                  >
+                    <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
+                    Log Event
+                  </Button>
+                )}
+
+                {isReady && (
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-9 border-border/60 bg-background/30"
+                    className="h-9 w-full justify-start border-border/60 bg-background/30"
+                    onClick={() => navigate(`/jobs/ready/${job.id}`)}
+                    disabled={isBusy}
+                  >
+                    <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+                    Edit Tailoring
+                  </Button>
+                )}
+
+                {job.pdfPath && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-9 w-full justify-start border-border/60 bg-background/30"
+                    onClick={() => {
+                      void openJobPdf(job.id).catch((error) => {
+                        toast.error(
+                          error instanceof Error
+                            ? error.message
+                            : "Could not open PDF",
+                        );
+                      });
+                    }}
+                  >
+                    <FileText className="mr-1.5 h-3.5 w-3.5" />
+                    View PDF
+                  </Button>
+                )}
+
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="h-9 w-full justify-start border-border/60 bg-background/30"
+                  onClick={() => uploadPdfInputRef.current?.click()}
+                  disabled={isUploadingPdf}
+                >
+                  <Upload className="mr-1.5 h-3.5 w-3.5" />
+                  {isUploadingPdf
+                    ? "Uploading PDF"
+                    : job.pdfPath
+                      ? "Replace PDF"
+                      : "Upload PDF"}
+                </Button>
+
+                {isReady && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-9 w-full justify-start border-border/60 bg-background/30"
+                    onClick={() => void handleRegeneratePdf()}
+                    disabled={isBusy}
+                  >
+                    <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
+                    Regenerate PDF
+                  </Button>
+                )}
+
+                {(isReady || isDiscovered) && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-9 w-full justify-start border-border/60 bg-background/30"
                     onClick={() => void handleSkip()}
                     disabled={isBusy}
                   >
                     <XCircle className="mr-1.5 h-3.5 w-3.5" />
                     Skip Job
                   </Button>
-                </>
-              )}
+                )}
 
-              {isApplied && (
-                <Button
-                  size="sm"
-                  className="h-9 border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
-                  onClick={() => void handleMoveToInProgress()}
-                  disabled={isBusy}
-                >
-                  <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
-                  Move to In Progress
-                </Button>
-              )}
-
-              {isInProgress && (
-                <Button
-                  size="sm"
-                  className="h-9 border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
-                  onClick={() => setIsLogModalOpen(true)}
-                  disabled={!canLogEvents || isBusy}
-                >
-                  <PlusCircle className="mr-2 h-4 w-4" />
-                  Log Event
-                </Button>
-              )}
-            </div>
-
-            <div className="flex flex-wrap items-center gap-2">
-              {isReady && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-9 border-border/60 bg-background/30"
-                  onClick={() => navigate(`/jobs/ready/${job.id}`)}
-                  disabled={isBusy}
-                >
-                  <Sparkles className="mr-1.5 h-3.5 w-3.5" />
-                  Edit Tailoring
-                </Button>
-              )}
-
-              {job?.pdfPath && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-9 border-border/60 bg-background/30"
-                  onClick={() => {
-                    void openJobPdf(job.id).catch((error) => {
-                      toast.error(
-                        error instanceof Error
-                          ? error.message
-                          : "Could not open PDF",
-                      );
-                    });
-                  }}
-                >
-                  <FileText className="mr-1.5 h-3.5 w-3.5" />
-                  View PDF
-                </Button>
-              )}
-
-              <Button
-                size="sm"
-                variant="outline"
-                className="h-9 border-border/60 bg-background/30"
-                onClick={() => uploadPdfInputRef.current?.click()}
-                disabled={isUploadingPdf}
-              >
-                <Upload className="mr-1.5 h-3.5 w-3.5" />
-                {isUploadingPdf
-                  ? "Uploading PDF"
-                  : job?.pdfPath
-                    ? "Replace PDF"
-                    : "Upload PDF"}
-              </Button>
-
-              {isReady && (
-                <Button
-                  size="sm"
-                  variant="outline"
-                  className="h-9 border-border/60 bg-background/30"
-                  onClick={() => void handleRegeneratePdf()}
-                  disabled={isBusy}
-                >
-                  <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
-                  Regenerate PDF
-                </Button>
-              )}
-
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    size="icon"
-                    variant="outline"
-                    className="h-9 w-9 border-border/60 bg-background/30"
-                    aria-label="More actions"
-                  >
-                    <MoreHorizontal className="h-4 w-4" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem onSelect={openEditDetails}>
-                    <Edit2 className="mr-2 h-4 w-4" />
-                    Edit details
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => void handleCopyJobInfo()}>
-                    <Copy className="mr-2 h-4 w-4" />
-                    Copy job info
-                  </DropdownMenuItem>
-                  {(isReady || isDiscovered) && (
-                    <DropdownMenuItem onSelect={() => void handleRescore()}>
-                      <RefreshCcw className="mr-2 h-4 w-4" />
-                      Recalculate match
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-9 w-full justify-start text-muted-foreground"
+                    >
+                      <MoreHorizontal className="mr-1.5 h-3.5 w-3.5" />
+                      More actions
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onSelect={openEditDetails}>
+                      <Edit2 className="mr-2 h-4 w-4" />
+                      Edit details
                     </DropdownMenuItem>
-                  )}
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem onSelect={() => void handleCheckSponsor()}>
-                    Check sponsorship status
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-            </div>
-          </div>
-        </div>
-      )}
-      {job?.jobDescription && (
-        <Card className="border-border/50">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base">
-              <FileText className="h-4 w-4" />
-              Job description
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <JobDescriptionMarkdown
-              description={getRenderableJobDescription(job.jobDescription)}
-            />
-          </CardContent>
-        </Card>
-      )}
+                    <DropdownMenuItem onSelect={() => void handleCopyJobInfo()}>
+                      <Copy className="mr-2 h-4 w-4" />
+                      Copy job info
+                    </DropdownMenuItem>
+                    {(isReady || isDiscovered) && (
+                      <DropdownMenuItem onSelect={() => void handleRescore()}>
+                        <RefreshCcw className="mr-2 h-4 w-4" />
+                        Recalculate match
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      onSelect={() => void handleCheckSponsor()}
+                    >
+                      Check sponsorship status
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            </section>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
-        <Card className="border-border/50">
-          <CardHeader>
-            <div className="flex flex-wrap items-center justify-between gap-4">
-              <CardTitle className="flex items-center gap-2 text-base">
-                <ClipboardList className="h-4 w-4" />
-                Stage timeline
-              </CardTitle>
-              <div className="flex items-center gap-2">
-                {job?.salary && (
-                  <Badge
-                    variant="outline"
-                    className="border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-600 dark:text-emerald-400"
-                  >
-                    <DollarSign className="mr-1 h-3.5 w-3.5" />
-                    {job.salary}
-                  </Badge>
-                )}
-                {currentStage && (
-                  <Badge
-                    variant="secondary"
-                    className="px-3 py-1 text-xs font-medium uppercase tracking-wider"
-                  >
-                    {STAGE_LABELS[currentStage as ApplicationStage] ||
-                      currentStage}
-                  </Badge>
-                )}
-              </div>
-            </div>
-          </CardHeader>
-          <CardContent>
-            {!canTrackStages && (
-              <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
-                Move this job to In Progress to track application stages.
-              </div>
-            )}
-            {canTrackStages && isClosedStage && (
-              <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
-                This application is closed. Stage logging is disabled.
-              </div>
-            )}
-            <JobTimeline
-              events={events}
-              onEdit={canLogEvents ? handleEditEvent : undefined}
-              onDelete={canLogEvents ? confirmDeleteEvent : undefined}
-            />
-          </CardContent>
-        </Card>
-
-        <div className="space-y-4">
-          <Card className="border-border/50">
-            <CardHeader>
-              <div className="flex items-center justify-between gap-3">
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <CalendarClock className="h-4 w-4" />
-                  Application details
-                </CardTitle>
-                <GhostwriterDrawer job={job} />
-              </div>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div>
-                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  Current Stage
-                </div>
-                <div className="mt-1 text-sm font-medium">
-                  {currentStage
-                    ? STAGE_LABELS[currentStage as ApplicationStage] ||
-                      currentStage
-                    : job?.status}
-                </div>
-              </div>
-              <div>
-                <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                  Outcome
-                </div>
-                <div className="mt-1 text-sm font-medium">
-                  {job?.outcome ? job.outcome.replace(/_/g, " ") : "Open"}
-                </div>
-              </div>
-              {job?.closedAt && (
-                <div>
-                  <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
-                    Closed On
-                  </div>
-                  <div className="mt-1 text-sm font-medium">
-                    {formatTimestamp(job.closedAt)}
-                  </div>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-
-          {tasks.length > 0 && (
-            <Card className="border-border/50">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
+            {tasks.length > 0 && (
+              <section className="rounded-xl border border-border/50 bg-card/70 p-4">
+                <div className="mb-3 flex items-center gap-2 text-sm font-semibold">
                   <CalendarClock className="h-4 w-4" />
                   Upcoming tasks
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+                </div>
                 <div className="space-y-3">
                   {tasks.map((task) => (
-                    <div
-                      key={task.id}
-                      className="flex items-start justify-between gap-4"
-                    >
-                      <div className="space-y-1">
-                        <div className="text-sm font-medium text-foreground/90">
-                          {task.title}
+                    <div key={task.id} className="space-y-1">
+                      <div className="text-sm font-medium">{task.title}</div>
+                      {task.notes && (
+                        <div className="text-xs text-muted-foreground">
+                          {task.notes}
                         </div>
-                        {task.notes && (
-                          <div className="text-xs text-muted-foreground">
-                            {task.notes}
-                          </div>
-                        )}
-                      </div>
+                      )}
                       <Badge
                         variant="outline"
                         className="text-[10px] uppercase tracking-wide"
@@ -1172,13 +1273,11 @@ export const JobPage: React.FC = () => {
                     </div>
                   ))}
                 </div>
-              </CardContent>
-            </Card>
-          )}
+              </section>
+            )}
+          </aside>
         </div>
-      </div>
-
-      {job?.id && <JobNotesCard jobId={job.id} />}
+      )}
 
       <LogEventModal
         isOpen={isLogModalOpen}

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -464,13 +464,17 @@ export const JobPage: React.FC = () => {
   const clearInitialGhostwriterPrompt = React.useCallback(() => {
     navigate(`${baseJobPath}/ghostwriter`, { replace: true });
   }, [baseJobPath, navigate]);
+  const pageGridClass =
+    activeMemoryView === "overview"
+      ? "grid items-start gap-4 xl:grid-cols-[18rem_minmax(0,1fr)_18rem]"
+      : "grid items-start gap-4 xl:grid-cols-[18rem_minmax(0,1fr)]";
 
   if (!id) {
     return null;
   }
 
   return (
-    <main className="mx-auto max-w-[92rem] px-4 py-5 pb-12">
+    <main className="mx-auto max-w-[92rem] px-4 py-5">
       <div className="mb-4 flex items-center justify-between gap-4">
         <Button variant="ghost" size="sm" onClick={() => navigate(-1)}>
           <ArrowLeft className="h-4 w-4" />
@@ -495,7 +499,7 @@ export const JobPage: React.FC = () => {
       )}
 
       {job && (
-        <div className="grid items-start gap-4 xl:grid-cols-[18rem_minmax(0,1fr)_18rem]">
+        <div className={pageGridClass}>
           <JobPageLeftSidebar
             job={job}
             activeMemoryView={activeMemoryView}
@@ -811,14 +815,14 @@ export const JobPage: React.FC = () => {
             )}
 
             {activeMemoryView === "ghostwriter" && (
-              <section className="overflow-hidden rounded-xl border border-border/50 bg-card/85">
+              <section className="">
                 <div className="border-b border-border/50 px-4 py-3">
                   <div className="flex items-center gap-2 text-base font-semibold">
                     <Sparkles className="h-4 w-4" />
                     Ghostwriter
                   </div>
                 </div>
-                <div className="h-[720px] min-h-0">
+                <div className="h-[calc(100vh-140px)] px-4">
                   <GhostwriterPanel
                     job={job}
                     initialPrompt={initialGhostwriterPrompt}
@@ -829,37 +833,41 @@ export const JobPage: React.FC = () => {
             )}
           </div>
 
-          <JobPageRightSidebar
-            job={job}
-            tasks={tasks}
-            jobLink={jobLink}
-            isDiscovered={Boolean(isDiscovered)}
-            isReady={Boolean(isReady)}
-            isApplied={Boolean(isApplied)}
-            isInProgress={Boolean(isInProgress)}
-            canLogEvents={canLogEvents}
-            isBusy={isBusy}
-            isUploadingPdf={isUploadingPdf}
-            onStartTailoring={() => navigate(`/jobs/discovered/${job.id}`)}
-            onMarkApplied={() => void handleMarkApplied()}
-            onMoveToInProgress={() => void handleMoveToInProgress()}
-            onOpenLogEvent={() => setIsLogModalOpen(true)}
-            onEditTailoring={() => navigate(`/jobs/ready/${job.id}`)}
-            onViewPdf={() => {
-              void openJobPdf(job.id).catch((error) => {
-                toast.error(
-                  error instanceof Error ? error.message : "Could not open PDF",
-                );
-              });
-            }}
-            onUploadPdf={() => uploadPdfInputRef.current?.click()}
-            onRegeneratePdf={() => void handleRegeneratePdf()}
-            onSkip={() => void handleSkip()}
-            onOpenEditDetails={openEditDetails}
-            onCopyJobInfo={() => void handleCopyJobInfo()}
-            onRescore={() => void handleRescore()}
-            onCheckSponsor={() => void handleCheckSponsor()}
-          />
+          {activeMemoryView === "overview" && (
+            <JobPageRightSidebar
+              job={job}
+              tasks={tasks}
+              jobLink={jobLink}
+              isDiscovered={Boolean(isDiscovered)}
+              isReady={Boolean(isReady)}
+              isApplied={Boolean(isApplied)}
+              isInProgress={Boolean(isInProgress)}
+              canLogEvents={canLogEvents}
+              isBusy={isBusy}
+              isUploadingPdf={isUploadingPdf}
+              onStartTailoring={() => navigate(`/jobs/discovered/${job.id}`)}
+              onMarkApplied={() => void handleMarkApplied()}
+              onMoveToInProgress={() => void handleMoveToInProgress()}
+              onOpenLogEvent={() => setIsLogModalOpen(true)}
+              onEditTailoring={() => navigate(`/jobs/ready/${job.id}`)}
+              onViewPdf={() => {
+                void openJobPdf(job.id).catch((error) => {
+                  toast.error(
+                    error instanceof Error
+                      ? error.message
+                      : "Could not open PDF",
+                  );
+                });
+              }}
+              onUploadPdf={() => uploadPdfInputRef.current?.click()}
+              onRegeneratePdf={() => void handleRegeneratePdf()}
+              onSkip={() => void handleSkip()}
+              onOpenEditDetails={openEditDetails}
+              onCopyJobInfo={() => void handleCopyJobInfo()}
+              onRescore={() => void handleRescore()}
+              onCheckSponsor={() => void handleCheckSponsor()}
+            />
+          )}
         </div>
       )}
 

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -25,13 +25,19 @@ import {
   MoreHorizontal,
   PlusCircle,
   RefreshCcw,
+  Send,
   Sparkles,
   Trash2,
   Upload,
   XCircle,
 } from "lucide-react";
 import React from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  Link,
+  useNavigate,
+  useParams,
+  useSearchParams,
+} from "react-router-dom";
 import { toast } from "sonner";
 import { RichTextEditor } from "@/client/components/design-resume/RichTextEditor";
 import { JobDescriptionMarkdown } from "@/client/components/JobDescriptionMarkdown";
@@ -68,6 +74,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import {
   cn,
   copyTextToClipboard,
@@ -116,6 +123,85 @@ const parseSelectedProjectIds = (value: string | null | undefined) =>
     ?.split(",")
     .map((id) => id.trim())
     .filter(Boolean) ?? [];
+
+const getGhostwriterSuggestions = (job: Job, hasNotes: boolean) => [
+  "What projects did I use for this application?",
+  hasNotes
+    ? "Summarize the latest interview notes."
+    : "What should I remember if a recruiter calls?",
+  `What should I know before speaking with ${job.employer}?`,
+  "Draft a concise follow-up message for this role.",
+];
+
+const OverviewGhostwriterComposer: React.FC<{
+  job: Job;
+  baseJobPath: string;
+  hasNotes: boolean;
+}> = ({ job, baseJobPath, hasNotes }) => {
+  const navigate = useNavigate();
+  const [prompt, setPrompt] = React.useState("");
+  const suggestions = React.useMemo(
+    () => getGhostwriterSuggestions(job, hasNotes),
+    [hasNotes, job],
+  );
+
+  const submitPrompt = React.useCallback(() => {
+    const content = prompt.trim();
+    if (!content) return;
+    navigate(
+      `${baseJobPath}/ghostwriter?prompt=${encodeURIComponent(content)}`,
+    );
+  }, [baseJobPath, navigate, prompt]);
+
+  return (
+    <section className="rounded-xl border border-border/50 bg-card/85 p-4">
+      <div className="rounded-lg border border-border/60 bg-background/30 p-3 shadow-sm transition focus-within:border-orange-400/50 focus-within:bg-background/45">
+        <div className="flex items-start gap-3">
+          <Sparkles className="mt-2 h-4 w-4 shrink-0 text-orange-300" />
+          <Textarea
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter" && !event.shiftKey) {
+                event.preventDefault();
+                submitPrompt();
+              }
+            }}
+            placeholder="Ask Ghostwriter anything about this application..."
+            className="min-h-[84px] resize-none border-0 bg-transparent px-0 py-1 text-base shadow-none focus-visible:ring-0 md:text-sm"
+          />
+        </div>
+        <div className="mt-3 flex items-center justify-between gap-3 border-t border-border/50 pt-3">
+          <div className="text-[10px] text-muted-foreground">
+            Enter to send / Shift Enter for a new line
+          </div>
+          <Button
+            size="sm"
+            onClick={submitPrompt}
+            disabled={!prompt.trim()}
+            className="border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
+          >
+            <Send className="mr-1.5 h-3.5 w-3.5" />
+            Go
+          </Button>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {suggestions.map((suggestion) => (
+          <button
+            key={suggestion}
+            type="button"
+            className="rounded-md border border-border/60 bg-background/25 px-3 py-1.5 text-left text-xs text-muted-foreground transition hover:border-orange-400/40 hover:bg-orange-500/10 hover:text-orange-100"
+            onClick={() => setPrompt(suggestion)}
+          >
+            {suggestion}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+};
 
 const JobNotesCard: React.FC<{ jobId: string }> = ({ jobId }) => {
   const [editorState, setEditorState] = React.useState<
@@ -549,6 +635,7 @@ const JobNotesCard: React.FC<{ jobId: string }> = ({ jobId }) => {
 export const JobPage: React.FC = () => {
   const { id, view } = useParams<{ id: string; view?: string }>();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const [isLogModalOpen, setIsLogModalOpen] = React.useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
@@ -905,6 +992,11 @@ export const JobPage: React.FC = () => {
     latestEvent?.metadata?.eventLabel || latestEvent?.title || null;
   const jobDescriptionPreview = summarizeMemoryText(job?.jobDescription, 260);
   const latestNotePreview = summarizeMemoryText(latestNote?.content, 180);
+  const initialGhostwriterPrompt =
+    activeMemoryView === "ghostwriter" ? searchParams.get("prompt") : null;
+  const clearInitialGhostwriterPrompt = React.useCallback(() => {
+    navigate(`${baseJobPath}/ghostwriter`, { replace: true });
+  }, [baseJobPath, navigate]);
 
   if (!id) {
     return null;
@@ -1083,14 +1175,14 @@ export const JobPage: React.FC = () => {
                         Application memory
                       </h2>
                     </div>
-                    <Button asChild size="sm" variant="outline">
-                      <Link to={`${baseJobPath}/ghostwriter`}>
-                        <Sparkles className="mr-1.5 h-3.5 w-3.5" />
-                        Ask Ghostwriter
-                      </Link>
-                    </Button>
                   </div>
                 </div>
+
+                <OverviewGhostwriterComposer
+                  job={job}
+                  baseJobPath={baseJobPath}
+                  hasNotes={notes.length > 0}
+                />
 
                 <div className="grid gap-4 lg:grid-cols-2">
                   <article className="rounded-xl border border-border/50 bg-card/75 p-4">
@@ -1236,35 +1328,6 @@ export const JobPage: React.FC = () => {
                       </Link>
                     </Button>
                   </article>
-
-                  <article className="rounded-xl border border-orange-400/20 bg-orange-500/5 p-4">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="flex items-center gap-2 text-sm font-semibold">
-                        <Sparkles className="h-4 w-4 text-orange-300" />
-                        Ghostwriter
-                      </div>
-                      <Badge
-                        variant="outline"
-                        className="border-orange-400/30 bg-orange-500/10 text-orange-100"
-                      >
-                        AI
-                      </Badge>
-                    </div>
-                    <div className="mt-4 min-h-[5.5rem] rounded-lg border border-orange-400/20 bg-background/25 p-3 text-sm leading-6 text-muted-foreground">
-                      Ask what CV context was used, what happened in the last
-                      call, or what to say before the next recruiter touchpoint.
-                    </div>
-                    <Button
-                      asChild
-                      size="sm"
-                      className="mt-4 w-full justify-between border border-orange-400/50 bg-orange-500/20 text-orange-100 hover:bg-orange-500/30"
-                    >
-                      <Link to={`${baseJobPath}/ghostwriter`}>
-                        Open Ghostwriter
-                        <ExternalLink className="h-3.5 w-3.5" />
-                      </Link>
-                    </Button>
-                  </article>
                 </div>
               </section>
             )}
@@ -1402,7 +1465,11 @@ export const JobPage: React.FC = () => {
                   </div>
                 </div>
                 <div className="h-[720px] min-h-0">
-                  <GhostwriterPanel job={job} />
+                  <GhostwriterPanel
+                    job={job}
+                    initialPrompt={initialGhostwriterPrompt}
+                    onInitialPromptConsumed={clearInitialGhostwriterPrompt}
+                  />
                 </div>
               </section>
             )}

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -154,7 +154,7 @@ const OverviewGhostwriterComposer: React.FC<{
   return (
     <section className="rounded-xl border border-border/50 bg-card/85 p-4">
         <div className="flex items-start gap-3">
-          <Sparkles className="mt-1.5 h-4 w-4 shrink-0 text-orange-300" />
+          <Sparkles className="mt-1.5 h-4 w-4 shrink-0 text-primary" />
           <Textarea
             value={prompt}
             onChange={(event) => setPrompt(event.target.value)}
@@ -176,7 +176,7 @@ const OverviewGhostwriterComposer: React.FC<{
                 type="button"
                 size="sm"
                 variant="outline"
-                className="h-auto border-border/60 bg-background/25 px-3 py-1.5 text-left text-xs text-muted-foreground hover:border-orange-400/40 hover:bg-orange-500/10 hover:text-orange-100"
+                className="h-auto px-3 py-1.5 text-left text-xs"
                 onClick={() => setPrompt(suggestion)}
               >
                 {suggestion}
@@ -1070,30 +1070,15 @@ export const JobPage: React.FC = () => {
                     {job.outcome ? job.outcome.replace(/_/g, " ") : "Open"}
                   </span>
                 </div>
-              </div>
-            </section>
-
-            <section className="rounded-xl border border-border/50 bg-card/70 p-4">
-              <div className="mb-3 flex items-center gap-2 text-sm font-semibold">
-                <FolderKanban className="h-4 w-4 text-emerald-400" />
-                Applied with
-              </div>
-              {selectedProjects.length > 0 ? (
-                <div className="space-y-2">
-                  {selectedProjects.map((project) => (
-                    <div
-                      key={project}
-                      className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-3 py-2 text-sm text-emerald-100"
-                    >
-                      {project}
-                    </div>
-                  ))}
+                <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+                  <span className="text-muted-foreground">Projects Chosen</span>
+                  <span className="text-right font-medium">
+                    {selectedProjects.length > 0
+                      ? selectedProjects.length
+                      : "No projects"}
+                  </span>
                 </div>
-              ) : (
-                <div className="rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
-                  No selected projects stored.
-                </div>
-              )}
+              </div>
             </section>
 
             <section className="rounded-xl border border-border/50 bg-card/70 p-3">
@@ -1166,7 +1151,7 @@ export const JobPage: React.FC = () => {
                   <article className="rounded-xl border border-border/50 bg-card/75 p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex items-center gap-2 text-sm font-semibold">
-                        <MessageSquareText className="h-4 w-4 text-orange-300" />
+                        <MessageSquareText className="h-4 w-4 text-primary" />
                         Notes
                       </div>
                       <Badge variant="secondary" className="text-[10px]">
@@ -1214,7 +1199,7 @@ export const JobPage: React.FC = () => {
                   <article className="rounded-xl border border-border/50 bg-card/75 p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex items-center gap-2 text-sm font-semibold">
-                        <FileText className="h-4 w-4 text-sky-300" />
+                        <FileText className="h-4 w-4 text-primary" />
                         Documents
                       </div>
                       <Badge variant="secondary" className="text-[10px]">
@@ -1260,7 +1245,7 @@ export const JobPage: React.FC = () => {
                   <article className="rounded-xl border border-border/50 bg-card/75 p-4">
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex items-center gap-2 text-sm font-semibold">
-                        <ClipboardList className="h-4 w-4 text-emerald-300" />
+                        <ClipboardList className="h-4 w-4 text-primary" />
                         Timeline
                       </div>
                       {currentStage && (
@@ -1463,7 +1448,8 @@ export const JobPage: React.FC = () => {
                   <Button
                     asChild
                     size="sm"
-                    className="w-full"
+                    variant="outline"
+                    className="w-full justify-start"
                   >
                     <a href={jobLink} target="_blank" rel="noopener noreferrer">
                       <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
@@ -1475,7 +1461,8 @@ export const JobPage: React.FC = () => {
                 {isDiscovered && (
                   <Button
                     size="sm"
-                    className="w-full"
+                    variant="outline"
+                    className="w-full justify-start"
                     onClick={() => navigate(`/jobs/discovered/${job.id}`)}
                     disabled={isBusy}
                   >
@@ -1487,7 +1474,8 @@ export const JobPage: React.FC = () => {
                 {isReady && (
                   <Button
                     size="sm"
-                    className="w-full"
+                    className="w-full justify-start"
+                    variant="outline"
                     onClick={() => void handleMarkApplied()}
                     disabled={isBusy}
                   >
@@ -1499,7 +1487,8 @@ export const JobPage: React.FC = () => {
                 {isApplied && (
                   <Button
                     size="sm"
-                    className="w-full"
+                    className="w-full justify-start"
+                    variant="outline"
                     onClick={() => void handleMoveToInProgress()}
                     disabled={isBusy}
                   >
@@ -1511,7 +1500,8 @@ export const JobPage: React.FC = () => {
                 {isInProgress && (
                   <Button
                     size="sm"
-                    className="w-full"
+                    className="w-full justify-start"
+                    variant="outline"
                     onClick={() => setIsLogModalOpen(true)}
                     disabled={!canLogEvents || isBusy}
                   >
@@ -1524,7 +1514,7 @@ export const JobPage: React.FC = () => {
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-9 w-full justify-start border-border/60 bg-background/30"
+                    className="h-9 w-full justify-start"
                     onClick={() => navigate(`/jobs/ready/${job.id}`)}
                     disabled={isBusy}
                   >
@@ -1537,7 +1527,7 @@ export const JobPage: React.FC = () => {
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-9 w-full justify-start border-border/60 bg-background/30"
+                    className="h-9 w-full justify-start"
                     onClick={() => {
                       void openJobPdf(job.id).catch((error) => {
                         toast.error(
@@ -1556,7 +1546,7 @@ export const JobPage: React.FC = () => {
                 <Button
                   size="sm"
                   variant="outline"
-                  className="h-9 w-full justify-start border-border/60 bg-background/30"
+                  className="h-9 w-full justify-start"
                   onClick={() => uploadPdfInputRef.current?.click()}
                   disabled={isUploadingPdf}
                 >
@@ -1572,7 +1562,7 @@ export const JobPage: React.FC = () => {
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-9 w-full justify-start border-border/60 bg-background/30"
+                    className="h-9 w-full justify-start"
                     onClick={() => void handleRegeneratePdf()}
                     disabled={isBusy}
                   >
@@ -1585,7 +1575,7 @@ export const JobPage: React.FC = () => {
                   <Button
                     size="sm"
                     variant="outline"
-                    className="h-9 w-full justify-start border-border/60 bg-background/30"
+                    className="h-9 w-full justify-start"
                     onClick={() => void handleSkip()}
                     disabled={isBusy}
                   >

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -53,6 +53,7 @@ import {
   formatDateTime,
   formatJobForWebhook,
   formatTimestamp,
+  sourceLabel as sourceLabels,
 } from "@/lib/utils";
 import * as api from "../api";
 import { ConfirmDelete } from "../components/ConfirmDelete";
@@ -106,11 +107,6 @@ const sortNotesByUpdatedAtDesc = (notes: JobNote[]) =>
     (left, right) =>
       new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
   );
-
-const formatSourceLabel = (source: string) =>
-  source
-    .replace(/[-_]/g, " ")
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
 
 const parseSelectedProjectIds = (value: string | null | undefined) =>
   value
@@ -170,10 +166,6 @@ export const JobPage: React.FC = () => {
     "Failed to load job timeline. Please try again.",
   );
   useQueryErrorToast(
-    notesQuery.error,
-    "Failed to load notes. Please try again.",
-  );
-  useQueryErrorToast(
     tasksQuery.error,
     "Failed to load job tasks. Please try again.",
   );
@@ -195,10 +187,15 @@ export const JobPage: React.FC = () => {
   const isLoading =
     jobQuery.isLoading || eventsQuery.isLoading || tasksQuery.isLoading;
   const activeMemoryView = normalizeMemoryView(view);
+  useQueryErrorToast(
+    activeMemoryView === "note" ? null : notesQuery.error,
+    "Failed to load notes. Please try again.",
+  );
   const selectedProjectIds = React.useMemo(
     () => parseSelectedProjectIds(job?.selectedProjectIds),
     [job?.selectedProjectIds],
   );
+  const selectedProjectIdsKey = selectedProjectIds.join(",");
   const selectedProjects = React.useMemo(
     () =>
       selectedProjectIds.map(
@@ -208,10 +205,7 @@ export const JobPage: React.FC = () => {
       ),
     [catalog, selectedProjectIds],
   );
-  const sourceLabel = React.useMemo(
-    () => formatSourceLabel(job?.source ?? ""),
-    [job?.source],
-  );
+  const sourceLabel = job ? sourceLabels[job.source] : "";
   const jobPageBackTo = React.useMemo(() => {
     const state = location.state as JobPageLocationState | null;
     return isValidJobPageBackTarget(state?.jobPageBackTo)
@@ -235,7 +229,7 @@ export const JobPage: React.FC = () => {
   React.useEffect(() => {
     let isCancelled = false;
 
-    if (selectedProjectIds.length === 0) {
+    if (selectedProjectIdsKey.length === 0) {
       setCatalog([]);
       return () => {
         isCancelled = true;
@@ -258,7 +252,7 @@ export const JobPage: React.FC = () => {
     return () => {
       isCancelled = true;
     };
-  }, [selectedProjectIds.length]);
+  }, [selectedProjectIdsKey]);
 
   const loadData = React.useCallback(async () => {
     if (!id) return;

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -70,6 +70,7 @@ let mockAutomaticRunValues: AutomaticRunValues = {
   matchStrictness: "exact_only",
 };
 const mockJobListScrollToIndex = vi.fn();
+let mockIsLoading = false;
 
 const jobFixture = createJob({
   id: "job-1",
@@ -127,7 +128,7 @@ vi.mock("./orchestrator/useOrchestratorData", () => ({
       skipped: 0,
       expired: 0,
     },
-    isLoading: false,
+    isLoading: mockIsLoading,
     isPipelineRunning: mockIsPipelineRunning,
     setIsPipelineRunning: vi.fn(),
     pipelineTerminalEvent: mockPipelineTerminalEvent,
@@ -439,6 +440,7 @@ describe("OrchestratorPage", () => {
     mockDemoMode = false;
     mockIsPipelineRunning = false;
     mockPipelineTerminalEvent = null;
+    mockIsLoading = false;
     mockPipelineSources = ["linkedin"];
     mockJobs = [jobFixture, job2, processingJob];
     mockSelectedJob = jobFixture;
@@ -530,6 +532,30 @@ describe("OrchestratorPage", () => {
     await waitFor(() => {
       expect(locationText()).toContain("/all/job-2");
     });
+  });
+
+  it("keeps a direct job URL while jobs are still loading", () => {
+    mockIsLoading = true;
+    mockJobs = [];
+    mockSelectedJob = null;
+    window.matchMedia = createMatchMedia(
+      true,
+    ) as unknown as typeof window.matchMedia;
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/discovered/job-2"]}>
+        <LocationWatcher />
+        <Routes>
+          <Route path="/jobs/:tab" element={<OrchestratorPage />} />
+          <Route path="/jobs/:tab/:jobId" element={<OrchestratorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/jobs/discovered/job-2",
+    );
+    expect(screen.getByTestId("selected-job")).toHaveTextContent("job-2");
   });
 
   it("surfaces applied duplicate warnings for reposted jobs in the orchestrator flow", () => {

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -295,6 +295,7 @@ export const OrchestratorPage: React.FC = () => {
   );
 
   useEffect(() => {
+    if (isLoading) return;
     if (activeJobs.length === 0) {
       if (selectedJobId) handleSelectJobId(null);
       return;
@@ -307,6 +308,7 @@ export const OrchestratorPage: React.FC = () => {
     }
   }, [
     activeJobs,
+    isLoading,
     selectedJobId,
     isDesktop,
     activeTab,

--- a/orchestrator/src/client/pages/job-page/JobNotesCard.tsx
+++ b/orchestrator/src/client/pages/job-page/JobNotesCard.tsx
@@ -1,0 +1,467 @@
+import type { JobNote } from "@shared/types.js";
+import { useQuery } from "@tanstack/react-query";
+import { Edit2, FileText, PlusCircle, Trash2 } from "lucide-react";
+import React from "react";
+import { toast } from "sonner";
+import * as api from "@/client/api";
+import { ConfirmDelete } from "@/client/components/ConfirmDelete";
+import { RichTextEditor } from "@/client/components/design-resume/RichTextEditor";
+import { JobDescriptionMarkdown } from "@/client/components/JobDescriptionMarkdown";
+import {
+  useCreateJobNoteMutation,
+  useDeleteJobNoteMutation,
+  useUpdateJobNoteMutation,
+} from "@/client/hooks/queries/useJobMutations";
+import { useQueryErrorToast } from "@/client/hooks/useQueryErrorToast";
+import { showErrorToast } from "@/client/lib/error-toast";
+import { getRenderableJobDescription } from "@/client/lib/jobDescription";
+import {
+  markdownToEditorHtml as markdownToTipTapHtml,
+  editorHtmlToMarkdown as tipTapHtmlToMarkdown,
+} from "@/client/lib/jobNoteContent";
+import { queryKeys } from "@/client/lib/queryKeys";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { cn, formatDateTime } from "@/lib/utils";
+
+const sortNotesByUpdatedAtDesc = (notes: JobNote[]) =>
+  [...notes].sort(
+    (left, right) =>
+      new Date(right.updatedAt).getTime() - new Date(left.updatedAt).getTime(),
+  );
+
+type JobNotesCardProps = {
+  jobId: string;
+};
+
+export const JobNotesCard: React.FC<JobNotesCardProps> = ({ jobId }) => {
+  const [editorState, setEditorState] = React.useState<
+    { mode: "create" } | { mode: "edit"; noteId: string } | null
+  >(null);
+  const [selectedNoteId, setSelectedNoteId] = React.useState<string | null>(
+    null,
+  );
+  const [draftTitle, setDraftTitle] = React.useState("");
+  const [draftContent, setDraftContent] = React.useState("");
+  const [editorError, setEditorError] = React.useState<string | null>(null);
+  const [noteToDelete, setNoteToDelete] = React.useState<JobNote | null>(null);
+
+  const notesQuery = useQuery<JobNote[]>({
+    queryKey: queryKeys.jobs.notes(jobId),
+    queryFn: () => api.getJobNotes(jobId),
+    enabled: Boolean(jobId),
+  });
+  const createNoteMutation = useCreateJobNoteMutation();
+  const updateNoteMutation = useUpdateJobNoteMutation();
+  const deleteNoteMutation = useDeleteJobNoteMutation();
+
+  useQueryErrorToast(
+    notesQuery.error,
+    "Failed to load notes. Please try again.",
+  );
+
+  const notes = React.useMemo(
+    () => sortNotesByUpdatedAtDesc(notesQuery.data ?? []),
+    [notesQuery.data],
+  );
+  const selectedNote = React.useMemo(
+    () => notes.find((note) => note.id === selectedNoteId) ?? notes[0] ?? null,
+    [notes, selectedNoteId],
+  );
+  const isSaving = createNoteMutation.isPending || updateNoteMutation.isPending;
+  const isDeleting = deleteNoteMutation.isPending;
+
+  const resetEditor = React.useCallback(() => {
+    setEditorState(null);
+    setDraftTitle("");
+    setDraftContent("");
+    setEditorError(null);
+  }, []);
+
+  const openCreateEditor = React.useCallback(() => {
+    setEditorState({ mode: "create" });
+    setSelectedNoteId(null);
+    setDraftTitle("");
+    setDraftContent("");
+    setEditorError(null);
+  }, []);
+
+  const openEditEditor = React.useCallback((note: JobNote) => {
+    setEditorState({ mode: "edit", noteId: note.id });
+    setDraftTitle(note.title);
+    setDraftContent(markdownToTipTapHtml(note.content));
+    setEditorError(null);
+    setSelectedNoteId(note.id);
+  }, []);
+
+  const confirmDeleteNote = React.useCallback((note: JobNote) => {
+    setNoteToDelete(note);
+  }, []);
+
+  const saveNote = React.useCallback(async () => {
+    const title = draftTitle.trim();
+    const content = tipTapHtmlToMarkdown(draftContent).trim();
+
+    if (!title || !content) {
+      setEditorError("Title and note content are required.");
+      return;
+    }
+
+    try {
+      const savedNote =
+        editorState?.mode === "edit"
+          ? await updateNoteMutation.mutateAsync({
+              jobId,
+              noteId: editorState.noteId,
+              input: { title, content },
+            })
+          : await createNoteMutation.mutateAsync({
+              jobId,
+              input: { title, content },
+            });
+
+      toast.success("Note saved");
+      setSelectedNoteId(savedNote.id);
+      resetEditor();
+    } catch (error) {
+      showErrorToast(error, "Failed to save note");
+    }
+  }, [
+    createNoteMutation,
+    draftContent,
+    draftTitle,
+    editorState,
+    jobId,
+    resetEditor,
+    updateNoteMutation,
+  ]);
+
+  const handleDeleteNote = React.useCallback(async () => {
+    if (!noteToDelete) return;
+
+    try {
+      await deleteNoteMutation.mutateAsync({
+        jobId,
+        noteId: noteToDelete.id,
+      });
+      toast.success("Note deleted");
+      if (selectedNoteId === noteToDelete.id) {
+        const nextNote = notes.find((note) => note.id !== noteToDelete.id);
+        setSelectedNoteId(nextNote?.id ?? null);
+      }
+      if (
+        editorState?.mode === "edit" &&
+        editorState.noteId === noteToDelete.id
+      ) {
+        resetEditor();
+      }
+    } catch (error) {
+      showErrorToast(error, "Failed to delete note");
+    } finally {
+      setNoteToDelete(null);
+    }
+  }, [
+    deleteNoteMutation,
+    editorState,
+    jobId,
+    noteToDelete,
+    notes,
+    resetEditor,
+    selectedNoteId,
+  ]);
+
+  const canEditOtherNotes = editorState === null;
+
+  React.useEffect(() => {
+    if (editorState) return;
+    if (notes.length === 0) {
+      setSelectedNoteId(null);
+      return;
+    }
+
+    if (!selectedNoteId || !notes.some((note) => note.id === selectedNoteId)) {
+      setSelectedNoteId(notes[0]?.id ?? null);
+    }
+  }, [editorState, notes, selectedNoteId]);
+
+  const startViewingNote = React.useCallback(
+    (note: JobNote) => {
+      if (editorState) return;
+      setSelectedNoteId(note.id);
+    },
+    [editorState],
+  );
+
+  const selectedTimestamp = selectedNote
+    ? (formatDateTime(selectedNote.updatedAt) ?? selectedNote.updatedAt)
+    : null;
+
+  return (
+    <section data-testid="job-notes-section" className="w-full">
+      <Card className="border-border/50">
+        <CardHeader>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <FileText className="h-4 w-4" />
+              Notes
+            </CardTitle>
+            {!editorState && (
+              <Button size="sm" variant="outline" onClick={openCreateEditor}>
+                <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
+                Add note
+              </Button>
+            )}
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-6 lg:grid-cols-[minmax(14rem,0.7fr)_minmax(0,1.3fr)]">
+            <aside data-testid="job-notes-list" className="space-y-3">
+              {!editorState && notesQuery.isLoading && notes.length === 0 && (
+                <div className="rounded-xl border border-dashed border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
+                  Loading notes...
+                </div>
+              )}
+
+              {!editorState && !notesQuery.isLoading && notes.length === 0 && (
+                <div className="rounded-xl border border-dashed border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
+                  No notes yet. Capture reminders, interview prep, or links in
+                  markdown.
+                </div>
+              )}
+
+              {notes.length > 0 && (
+                <div className="space-y-2">
+                  {notes.map((note) => {
+                    const noteTimestamp =
+                      formatDateTime(note.updatedAt) ?? note.updatedAt;
+                    const isSelected = note.id === selectedNoteId;
+                    return (
+                      <Button
+                        key={note.id}
+                        type="button"
+                        variant="ghost"
+                        className={cn(
+                          "h-auto w-full justify-start whitespace-normal rounded-xl border px-4 py-3 text-left font-normal transition",
+                          isSelected
+                            ? "border-primary/40 bg-primary/5 shadow-sm"
+                            : "border-border/60 bg-background/70 hover:border-border hover:bg-muted/40",
+                          editorState && "cursor-default opacity-70",
+                        )}
+                        onClick={() => startViewingNote(note)}
+                        disabled={Boolean(editorState)}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-semibold">
+                              {note.title}
+                            </div>
+                            <div className="mt-1 text-xs text-muted-foreground">
+                              Updated {noteTimestamp}
+                            </div>
+                          </div>
+                          {isSelected && !editorState && (
+                            <Badge variant="secondary" className="text-[10px]">
+                              Selected
+                            </Badge>
+                          )}
+                        </div>
+                      </Button>
+                    );
+                  })}
+                </div>
+              )}
+            </aside>
+
+            <div
+              data-testid="job-notes-detail"
+              className="min-w-0 rounded-2xl border border-border/60 bg-muted/10 p-4 shadow-sm"
+            >
+              {editorState ? (
+                <form
+                  className="space-y-4"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void saveNote();
+                  }}
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-[10px] uppercase tracking-[0.24em] text-muted-foreground">
+                        {editorState.mode === "create"
+                          ? "New note"
+                          : "Editing note"}
+                      </div>
+                      <div className="mt-1 text-lg font-semibold">
+                        {editorState.mode === "create"
+                          ? "Draft a note"
+                          : draftTitle || selectedNote?.title || "Edit note"}
+                      </div>
+                    </div>
+                    {editorState.mode === "edit" && selectedNote && (
+                      <Badge variant="secondary" className="text-[10px]">
+                        Updated {selectedTimestamp}
+                      </Badge>
+                    )}
+                  </div>
+
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="job-note-title"
+                      className="text-[10px] uppercase tracking-wide text-muted-foreground"
+                    >
+                      Title
+                    </label>
+                    <Input
+                      id="job-note-title"
+                      autoFocus
+                      value={draftTitle}
+                      onChange={(event) => {
+                        setDraftTitle(event.target.value);
+                        setEditorError(null);
+                      }}
+                      placeholder="Why I am applying"
+                      disabled={isSaving || isDeleting}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center justify-between gap-3">
+                      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                        Content
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        TipTap editor
+                      </div>
+                    </div>
+                    <RichTextEditor
+                      key={
+                        editorState.mode === "edit"
+                          ? editorState.noteId
+                          : "create-note"
+                      }
+                      value={draftContent}
+                      onChange={(next) => {
+                        setDraftContent(next);
+                        setEditorError(null);
+                      }}
+                      placeholder="Capture answers, reminders, interview notes, and useful links."
+                      className="bg-background/20"
+                    />
+                  </div>
+
+                  {editorError && (
+                    <div className="text-sm text-destructive">
+                      {editorError}
+                    </div>
+                  )}
+
+                  <div className="flex flex-wrap items-center gap-2">
+                    <Button type="submit" disabled={isSaving || isDeleting}>
+                      {isSaving ? "Saving..." : "Save note"}
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={resetEditor}
+                      disabled={isSaving || isDeleting}
+                    >
+                      Cancel
+                    </Button>
+                    {editorState.mode === "edit" && selectedNote && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => confirmDeleteNote(selectedNote)}
+                        disabled={isSaving || isDeleting}
+                      >
+                        Delete note
+                      </Button>
+                    )}
+                  </div>
+                </form>
+              ) : selectedNote ? (
+                <div className="space-y-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-lg font-semibold">
+                        {selectedNote.title}
+                      </div>
+                      <div className="mt-1 text-sm text-muted-foreground">
+                        Updated {selectedTimestamp}
+                      </div>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button
+                        size="icon"
+                        variant="outline"
+                        onClick={() => openEditEditor(selectedNote)}
+                        disabled={!canEditOtherNotes}
+                        aria-label="Edit note"
+                        title="Edit note"
+                      >
+                        <Edit2 className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => confirmDeleteNote(selectedNote)}
+                        disabled={!canEditOtherNotes}
+                        aria-label="Delete note"
+                        title="Delete note"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+
+                  <div className="rounded-xl border border-border/60 bg-card/70 p-4">
+                    <JobDescriptionMarkdown
+                      description={getRenderableJobDescription(
+                        selectedNote.content,
+                      )}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <div className="flex min-h-[280px] flex-col items-start justify-between gap-4 rounded-xl border border-dashed border-border/60 bg-background/60 p-5">
+                  <div className="space-y-2">
+                    <div className="text-lg font-semibold">
+                      No note selected
+                    </div>
+                    <div className="max-w-xl text-sm text-muted-foreground">
+                      Notes you add here can hold interview answers, contact
+                      details, and application-specific reminders. Select a note
+                      on the left or create a new one to get started.
+                    </div>
+                  </div>
+                  {!editorState && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={openCreateEditor}
+                    >
+                      <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
+                      Add note
+                    </Button>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <ConfirmDelete
+        isOpen={noteToDelete !== null}
+        onClose={() => setNoteToDelete(null)}
+        onConfirm={() => void handleDeleteNote()}
+        title="Delete note?"
+        description="This will permanently delete this note from the job."
+      />
+    </section>
+  );
+};

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.test.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { createJob } from "../../../../../shared/src/testing/factories";
+import { JobPageLeftSidebar } from "./JobPageLeftSidebar";
+
+const renderSidebar = (score: number | null) =>
+  render(
+    <MemoryRouter>
+      <JobPageLeftSidebar
+        job={createJob({ suitabilityScore: score })}
+        activeMemoryView="overview"
+        baseJobPath="/job/job-1"
+        selectedProjects={[]}
+        sourceLabel="Manual"
+      />
+    </MemoryRouter>,
+  );
+
+describe("JobPageLeftSidebar score ring", () => {
+  it.each([
+    [70, "border-emerald-400/60"],
+    [65, "border-amber-400/60"],
+    [59, "border-slate-500/55"],
+    [null, "border-border/60"],
+  ])("uses the expected band for score %s", (score, expectedClass) => {
+    renderSidebar(score);
+
+    const ring = screen.getByRole("img", {
+      name:
+        score === null
+          ? "Suitability score not available"
+          : `Suitability score ${score}`,
+    });
+
+    expect(ring).toHaveClass(expectedClass);
+    expect(
+      within(ring).getByText(score === null ? "—" : String(score)),
+    ).toBeInTheDocument();
+  });
+});

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.test.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.test.tsx
@@ -1,7 +1,7 @@
+import { createJob } from "@shared/testing/factories.js";
 import { render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { describe, expect, it } from "vitest";
-import { createJob } from "../../../../../shared/src/testing/factories";
 import { JobPageLeftSidebar } from "./JobPageLeftSidebar";
 
 type JobOverrides = Parameters<typeof createJob>[0];
@@ -51,7 +51,7 @@ describe("JobPageLeftSidebar application details", () => {
   });
 
   it("shows the applied row when the job has an applied timestamp", () => {
-    renderSidebar({ appliedAt: "2026-05-01T22:17:00.000Z" });
+    renderSidebar({ appliedAt: "2026-05-01T12:00:00.000Z" });
 
     expect(screen.getByText("Applied")).toBeInTheDocument();
     expect(screen.getByText(/1 May 2026/)).toBeInTheDocument();

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.test.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.test.tsx
@@ -4,11 +4,13 @@ import { describe, expect, it } from "vitest";
 import { createJob } from "../../../../../shared/src/testing/factories";
 import { JobPageLeftSidebar } from "./JobPageLeftSidebar";
 
-const renderSidebar = (score: number | null) =>
+type JobOverrides = Parameters<typeof createJob>[0];
+
+const renderSidebar = (jobOverrides: JobOverrides = {}) =>
   render(
     <MemoryRouter>
       <JobPageLeftSidebar
-        job={createJob({ suitabilityScore: score })}
+        job={createJob(jobOverrides)}
         activeMemoryView="overview"
         baseJobPath="/job/job-1"
         selectedProjects={[]}
@@ -24,7 +26,7 @@ describe("JobPageLeftSidebar score ring", () => {
     [59, "border-slate-500/55"],
     [null, "border-border/60"],
   ])("uses the expected band for score %s", (score, expectedClass) => {
-    renderSidebar(score);
+    renderSidebar({ suitabilityScore: score });
 
     const ring = screen.getByRole("img", {
       name:
@@ -37,5 +39,21 @@ describe("JobPageLeftSidebar score ring", () => {
     expect(
       within(ring).getByText(score === null ? "—" : String(score)),
     ).toBeInTheDocument();
+  });
+});
+
+describe("JobPageLeftSidebar application details", () => {
+  it("hides the applied row when the job has not been applied to yet", () => {
+    renderSidebar({ appliedAt: null });
+
+    expect(screen.queryByText("Applied")).not.toBeInTheDocument();
+    expect(screen.queryByText("Not marked")).not.toBeInTheDocument();
+  });
+
+  it("shows the applied row when the job has an applied timestamp", () => {
+    renderSidebar({ appliedAt: "2026-05-01T22:17:00.000Z" });
+
+    expect(screen.getByText("Applied")).toBeInTheDocument();
+    expect(screen.getByText(/1 May 2026/)).toBeInTheDocument();
   });
 });

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
@@ -1,0 +1,147 @@
+import type { Job } from "@shared/types.js";
+import {
+  ClipboardList,
+  FileText,
+  FolderKanban,
+  MessageSquareText,
+  Sparkles,
+} from "lucide-react";
+import type React from "react";
+import { Link } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { cn, formatDateTime } from "@/lib/utils";
+
+export type JobMemoryView =
+  | "overview"
+  | "note"
+  | "documents"
+  | "timeline"
+  | "ghostwriter";
+
+type JobPageLeftSidebarProps = {
+  job: Job;
+  activeMemoryView: JobMemoryView;
+  baseJobPath: string;
+  selectedProjects: string[];
+  sourceLabel: string;
+};
+
+const memoryLinks = [
+  {
+    id: "overview" as const,
+    label: "Overview",
+    icon: FolderKanban,
+  },
+  {
+    id: "note" as const,
+    label: "Notes",
+    icon: MessageSquareText,
+  },
+  {
+    id: "documents" as const,
+    label: "Documents",
+    icon: FileText,
+  },
+  {
+    id: "timeline" as const,
+    label: "Timeline",
+    icon: ClipboardList,
+  },
+  {
+    id: "ghostwriter" as const,
+    label: "Ghostwriter",
+    icon: Sparkles,
+  },
+];
+
+export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
+  job,
+  activeMemoryView,
+  baseJobPath,
+  selectedProjects,
+  sourceLabel,
+}) => (
+  <aside className="space-y-4 xl:sticky xl:top-5">
+    <section className="rounded-xl border border-border/50 bg-card/85 p-4">
+      <div className="space-y-1">
+        <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+          Application dossier
+        </div>
+        <h1 className="text-2xl font-semibold leading-tight">{job.employer}</h1>
+        <div className="text-sm text-muted-foreground">{job.title}</div>
+      </div>
+
+      <div className="mt-5 space-y-3 text-sm">
+        <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+          <span className="text-muted-foreground">Source</span>
+          <span className="text-right font-medium">{sourceLabel}</span>
+        </div>
+        <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+          <span className="text-muted-foreground">Location</span>
+          <span className="text-right font-medium">
+            {job.location || "Unknown"}
+          </span>
+        </div>
+        <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+          <span className="text-muted-foreground">Found</span>
+          <span className="text-right font-medium">
+            {formatDateTime(job.discoveredAt) ?? job.discoveredAt}
+          </span>
+        </div>
+        <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+          <span className="text-muted-foreground">Applied</span>
+          <span className="text-right font-medium">
+            {job.appliedAt
+              ? (formatDateTime(job.appliedAt) ?? job.appliedAt)
+              : "Not marked"}
+          </span>
+        </div>
+        <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+          <span className="text-muted-foreground">Outcome</span>
+          <span className="text-right font-medium">
+            {job.outcome ? job.outcome.replace(/_/g, " ") : "Open"}
+          </span>
+        </div>
+        <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+          <span className="text-muted-foreground">Projects Chosen</span>
+          <span className="text-right font-medium">
+            {selectedProjects.length > 0
+              ? selectedProjects.length
+              : "No projects"}
+          </span>
+        </div>
+      </div>
+    </section>
+
+    <section className="rounded-xl border border-border/50 bg-card/70 p-3">
+      <div className="mb-2 px-1 text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+        Links
+      </div>
+      <div className="space-y-1">
+        {memoryLinks.map(({ id: linkView, label, icon: Icon }) => {
+          const path =
+            linkView === "overview"
+              ? baseJobPath
+              : `${baseJobPath}/${linkView}`;
+          return (
+            <Button
+              asChild
+              key={linkView}
+              variant={activeMemoryView === linkView ? "outline" : "ghost"}
+              className={cn(
+                "h-9 w-full justify-between px-2 text-left text-sm",
+              )}
+            >
+              <Link to={path}>
+                <span className="flex min-w-0 items-center gap-2">
+                  <Icon className="h-4 w-4 shrink-0" />
+                  <span className="truncate">{label}</span>
+                </span>
+              </Link>
+            </Button>
+          );
+        })}
+      </div>
+    </section>
+  </aside>
+);

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
@@ -54,6 +54,62 @@ const memoryLinks = [
   },
 ];
 
+const getSuitabilityScoreTokens = (score: number | null) => {
+  if (score === null) {
+    return {
+      shell: "border-border/60 bg-muted/15 text-muted-foreground",
+      value: "—",
+      label: "Suitability score not available",
+    };
+  }
+
+  if (score >= 70) {
+    return {
+      shell: "border-emerald-400/60 bg-emerald-500/10 text-emerald-100",
+      value: `${Math.round(score)}`,
+      label: `Suitability score ${Math.round(score)}`,
+    };
+  }
+
+  if (score >= 60) {
+    return {
+      shell: "border-amber-400/60 bg-amber-500/10 text-amber-100",
+      value: `${Math.round(score)}`,
+      label: `Suitability score ${Math.round(score)}`,
+    };
+  }
+
+  return {
+    shell: "border-slate-500/55 bg-slate-500/10 text-slate-200",
+    value: `${Math.round(score)}`,
+    label: `Suitability score ${Math.round(score)}`,
+  };
+};
+
+const ScoreRing: React.FC<{ score: number | null }> = ({ score }) => {
+  const tokens = getSuitabilityScoreTokens(score);
+
+  return (
+    <div
+      role="img"
+      aria-label={tokens.label}
+      className={cn(
+        "flex h-20 w-20 shrink-0 items-center justify-center rounded-full border-2 p-1",
+        tokens.shell,
+      )}
+    >
+      <div className="flex h-full w-full flex-col items-center justify-center rounded-full border border-white/5 bg-background/70 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
+        <div className="text-2xl font-semibold leading-none tabular-nums">
+          {tokens.value}
+        </div>
+        <div className="mt-0.5 text-[9px] uppercase tracking-[0.22em] text-current/70">
+          score
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
   job,
   activeMemoryView,
@@ -63,12 +119,19 @@ export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
 }) => (
   <aside className="space-y-4 xl:sticky xl:top-5">
     <section className="rounded-xl border border-border/50 bg-card/85 p-4">
-      <div className="space-y-1">
-        <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
-          Application dossier
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
+            Application dossier
+          </div>
+          <h1 className="text-2xl font-semibold leading-tight">
+            {job.employer}
+          </h1>
+          <div className="text-sm text-muted-foreground">{job.title}</div>
         </div>
-        <h1 className="text-2xl font-semibold leading-tight">{job.employer}</h1>
-        <div className="text-sm text-muted-foreground">{job.title}</div>
+        <div className="flex justify-start sm:justify-end">
+          <ScoreRing score={job.suitabilityScore} />
+        </div>
       </div>
 
       <div className="mt-5 space-y-3 text-sm">

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
@@ -151,14 +151,14 @@ export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
             {formatDateTime(job.discoveredAt) ?? job.discoveredAt}
           </span>
         </div>
-        <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
-          <span className="text-muted-foreground">Applied</span>
-          <span className="text-right font-medium">
-            {job.appliedAt
-              ? (formatDateTime(job.appliedAt) ?? job.appliedAt)
-              : "Not marked"}
-          </span>
-        </div>
+        {job.appliedAt && (
+          <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+            <span className="text-muted-foreground">Applied</span>
+            <span className="text-right font-medium">
+              {formatDateTime(job.appliedAt) ?? job.appliedAt}
+            </span>
+          </div>
+        )}
         <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
           <span className="text-muted-foreground">Outcome</span>
           <span className="text-right font-medium">

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
@@ -121,7 +121,7 @@ export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
 }) => (
   <aside className="space-y-4 xl:sticky xl:top-5">
     <section className="rounded-xl border border-border/50 bg-card/85 p-4">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="flex gap-4 flex-row items-start justify-between">
         <div className="min-w-0 space-y-1">
           <div className="text-[10px] uppercase tracking-[0.22em] text-muted-foreground">
             Application dossier

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
@@ -22,6 +22,7 @@ type JobPageLeftSidebarProps = {
   job: Job;
   activeMemoryView: JobMemoryView;
   baseJobPath: string;
+  navigationState?: { jobPageBackTo: string };
   selectedProjects: string[];
   sourceLabel: string;
 };
@@ -114,6 +115,7 @@ export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
   job,
   activeMemoryView,
   baseJobPath,
+  navigationState,
   selectedProjects,
   sourceLabel,
 }) => (
@@ -185,7 +187,7 @@ export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
           const path =
             linkView === "overview"
               ? baseJobPath
-              : `${baseJobPath}/${linkView}`;
+              : `${baseJobPath}/${linkView === "note" ? "notes" : linkView}`;
           return (
             <Button
               asChild
@@ -195,7 +197,7 @@ export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
                 "h-9 w-full justify-between px-2 text-left text-sm",
               )}
             >
-              <Link to={path}>
+              <Link to={path} state={navigationState}>
                 <span className="flex min-w-0 items-center gap-2">
                   <Icon className="h-4 w-4 shrink-0" />
                   <span className="truncate">{label}</span>

--- a/orchestrator/src/client/pages/job-page/JobPageRightSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageRightSidebar.tsx
@@ -1,0 +1,279 @@
+import type { ApplicationTask, Job } from "@shared/types.js";
+import {
+  CalendarClock,
+  CheckCircle2,
+  Copy,
+  Edit2,
+  ExternalLink,
+  FileText,
+  MoreHorizontal,
+  PlusCircle,
+  RefreshCcw,
+  Sparkles,
+  Upload,
+  XCircle,
+} from "lucide-react";
+import type React from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { formatTimestamp } from "@/lib/utils";
+
+type JobPageRightSidebarProps = {
+  job: Job;
+  tasks: ApplicationTask[];
+  jobLink: string | null;
+  isDiscovered: boolean;
+  isReady: boolean;
+  isApplied: boolean;
+  isInProgress: boolean;
+  canLogEvents: boolean;
+  isBusy: boolean;
+  isUploadingPdf: boolean;
+  onStartTailoring: () => void;
+  onMarkApplied: () => void;
+  onMoveToInProgress: () => void;
+  onOpenLogEvent: () => void;
+  onEditTailoring: () => void;
+  onViewPdf: () => void;
+  onUploadPdf: () => void;
+  onRegeneratePdf: () => void;
+  onSkip: () => void;
+  onOpenEditDetails: () => void;
+  onCopyJobInfo: () => void;
+  onRescore: () => void;
+  onCheckSponsor: () => void;
+};
+
+export const JobPageRightSidebar: React.FC<JobPageRightSidebarProps> = ({
+  job,
+  tasks,
+  jobLink,
+  isDiscovered,
+  isReady,
+  isApplied,
+  isInProgress,
+  canLogEvents,
+  isBusy,
+  isUploadingPdf,
+  onStartTailoring,
+  onMarkApplied,
+  onMoveToInProgress,
+  onOpenLogEvent,
+  onEditTailoring,
+  onViewPdf,
+  onUploadPdf,
+  onRegeneratePdf,
+  onSkip,
+  onOpenEditDetails,
+  onCopyJobInfo,
+  onRescore,
+  onCheckSponsor,
+}) => (
+  <aside className="space-y-4 xl:sticky xl:top-5">
+    <section className="rounded-xl border border-border/50 bg-card/85 p-3">
+      <div className="mb-3 flex items-center gap-2 px-1 text-sm font-semibold">
+        Actions
+      </div>
+      <div className="space-y-2">
+        {jobLink && (
+          <Button
+            asChild
+            size="sm"
+            variant="outline"
+            className="w-full justify-start"
+          >
+            <a href={jobLink} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+              Open Job Listing
+            </a>
+          </Button>
+        )}
+
+        {isDiscovered && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="w-full justify-start"
+            onClick={onStartTailoring}
+            disabled={isBusy}
+          >
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+            Start Tailoring
+          </Button>
+        )}
+
+        {isReady && (
+          <Button
+            size="sm"
+            className="w-full justify-start"
+            variant="outline"
+            onClick={onMarkApplied}
+            disabled={isBusy}
+          >
+            <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
+            Mark Applied
+          </Button>
+        )}
+
+        {isApplied && (
+          <Button
+            size="sm"
+            className="w-full justify-start"
+            variant="outline"
+            onClick={onMoveToInProgress}
+            disabled={isBusy}
+          >
+            <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
+            Move to In Progress
+          </Button>
+        )}
+
+        {isInProgress && (
+          <Button
+            size="sm"
+            className="w-full justify-start"
+            variant="outline"
+            onClick={onOpenLogEvent}
+            disabled={!canLogEvents || isBusy}
+          >
+            <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
+            Log Event
+          </Button>
+        )}
+
+        {isReady && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-9 w-full justify-start"
+            onClick={onEditTailoring}
+            disabled={isBusy}
+          >
+            <Sparkles className="mr-1.5 h-3.5 w-3.5" />
+            Edit Tailoring
+          </Button>
+        )}
+
+        {job.pdfPath && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-9 w-full justify-start"
+            onClick={onViewPdf}
+          >
+            <FileText className="mr-1.5 h-3.5 w-3.5" />
+            View PDF
+          </Button>
+        )}
+
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-9 w-full justify-start"
+          onClick={onUploadPdf}
+          disabled={isUploadingPdf}
+        >
+          <Upload className="mr-1.5 h-3.5 w-3.5" />
+          {isUploadingPdf
+            ? "Uploading PDF"
+            : job.pdfPath
+              ? "Replace PDF"
+              : "Upload PDF"}
+        </Button>
+
+        {isReady && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-9 w-full justify-start"
+            onClick={onRegeneratePdf}
+            disabled={isBusy}
+          >
+            <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
+            Regenerate PDF
+          </Button>
+        )}
+
+        {(isReady || isDiscovered) && (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-9 w-full justify-start"
+            onClick={onSkip}
+            disabled={isBusy}
+          >
+            <XCircle className="mr-1.5 h-3.5 w-3.5" />
+            Skip Job
+          </Button>
+        )}
+
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              size="sm"
+              variant="ghost"
+              className="h-9 w-full justify-start text-muted-foreground"
+            >
+              <MoreHorizontal className="mr-1.5 h-3.5 w-3.5" />
+              More actions
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onSelect={onOpenEditDetails}>
+              <Edit2 className="mr-2 h-4 w-4" />
+              Edit details
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onCopyJobInfo}>
+              <Copy className="mr-2 h-4 w-4" />
+              Copy job info
+            </DropdownMenuItem>
+            {(isReady || isDiscovered) && (
+              <DropdownMenuItem onSelect={onRescore}>
+                <RefreshCcw className="mr-2 h-4 w-4" />
+                Recalculate match
+              </DropdownMenuItem>
+            )}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onCheckSponsor}>
+              Check sponsorship status
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </section>
+
+    {tasks.length > 0 && (
+      <section className="rounded-xl border border-border/50 bg-card/70 p-4">
+        <div className="mb-3 flex items-center gap-2 text-sm font-semibold">
+          <CalendarClock className="h-4 w-4" />
+          Upcoming tasks
+        </div>
+        <div className="space-y-3">
+          {tasks.map((task) => (
+            <div key={task.id} className="space-y-1">
+              <div className="text-sm font-medium">{task.title}</div>
+              {task.notes && (
+                <div className="text-xs text-muted-foreground">
+                  {task.notes}
+                </div>
+              )}
+              <Badge
+                variant="outline"
+                className="text-[10px] uppercase tracking-wide"
+              >
+                {formatTimestamp(task.dueDate)}
+              </Badge>
+            </div>
+          ))}
+        </div>
+      </section>
+    )}
+  </aside>
+);

--- a/orchestrator/src/client/pages/job-page/JobPageRightSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageRightSidebar.tsx
@@ -144,7 +144,7 @@ export const JobPageRightSidebar: React.FC<JobPageRightSidebarProps> = ({
             disabled={!canLogEvents || isBusy}
           >
             <PlusCircle className="mr-1.5 h-3.5 w-3.5" />
-            Log Event
+            Log event
           </Button>
         )}
 

--- a/orchestrator/src/client/pages/job-page/OverviewGhostwriterComposer.tsx
+++ b/orchestrator/src/client/pages/job-page/OverviewGhostwriterComposer.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 const getGhostwriterSuggestions = (job: Job, hasNotes: boolean) => [
   hasNotes
@@ -52,7 +53,7 @@ export const OverviewGhostwriterComposer: React.FC<
             }
           }}
           placeholder="Ask Ghostwriter anything about this application..."
-          className="min-h-[30px] resize-none border-0 bg-transparent px-0 py-1 text-base shadow-none focus-visible:ring-0 md:text-sm"
+          className="min-h-[30px] resize-none border-0 bg-transparent px-0 py-1 text-xs shadow-none focus-visible:ring-0 md:text-sm"
         />
       </div>
       <div className="mt-3 flex items-center justify-between gap-3 border-t border-border/50">
@@ -63,7 +64,7 @@ export const OverviewGhostwriterComposer: React.FC<
               type="button"
               size="sm"
               variant="outline"
-              className="h-auto px-3 py-1.5 text-left text-xs"
+              className={"h-auto md:px-3 md:py-1.5 text-left hidden md:inline-flex"}
               onClick={() => setPrompt(suggestion)}
             >
               {suggestion}

--- a/orchestrator/src/client/pages/job-page/OverviewGhostwriterComposer.tsx
+++ b/orchestrator/src/client/pages/job-page/OverviewGhostwriterComposer.tsx
@@ -16,11 +16,12 @@ type OverviewGhostwriterComposerProps = {
   job: Job;
   baseJobPath: string;
   hasNotes: boolean;
+  navigationState?: { jobPageBackTo: string };
 };
 
 export const OverviewGhostwriterComposer: React.FC<
   OverviewGhostwriterComposerProps
-> = ({ job, baseJobPath, hasNotes }) => {
+> = ({ job, baseJobPath, hasNotes, navigationState }) => {
   const navigate = useNavigate();
   const [prompt, setPrompt] = React.useState("");
   const suggestions = React.useMemo(
@@ -33,8 +34,9 @@ export const OverviewGhostwriterComposer: React.FC<
     if (!content) return;
     navigate(
       `${baseJobPath}/ghostwriter?prompt=${encodeURIComponent(content)}`,
+      { state: navigationState },
     );
-  }, [baseJobPath, navigate, prompt]);
+  }, [baseJobPath, navigate, navigationState, prompt]);
 
   return (
     <section className="rounded-xl border border-border/50 bg-card/85 p-4">

--- a/orchestrator/src/client/pages/job-page/OverviewGhostwriterComposer.tsx
+++ b/orchestrator/src/client/pages/job-page/OverviewGhostwriterComposer.tsx
@@ -1,0 +1,84 @@
+import type { Job } from "@shared/types.js";
+import { Send, Sparkles } from "lucide-react";
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+const getGhostwriterSuggestions = (job: Job, hasNotes: boolean) => [
+  hasNotes
+    ? "Summarize the latest interview notes."
+    : "What should I remember if a recruiter calls?",
+  `What should I know before speaking with ${job.employer}?`,
+];
+
+type OverviewGhostwriterComposerProps = {
+  job: Job;
+  baseJobPath: string;
+  hasNotes: boolean;
+};
+
+export const OverviewGhostwriterComposer: React.FC<
+  OverviewGhostwriterComposerProps
+> = ({ job, baseJobPath, hasNotes }) => {
+  const navigate = useNavigate();
+  const [prompt, setPrompt] = React.useState("");
+  const suggestions = React.useMemo(
+    () => getGhostwriterSuggestions(job, hasNotes),
+    [hasNotes, job],
+  );
+
+  const submitPrompt = React.useCallback(() => {
+    const content = prompt.trim();
+    if (!content) return;
+    navigate(
+      `${baseJobPath}/ghostwriter?prompt=${encodeURIComponent(content)}`,
+    );
+  }, [baseJobPath, navigate, prompt]);
+
+  return (
+    <section className="rounded-xl border border-border/50 bg-card/85 p-4">
+      <div className="flex items-start gap-3">
+        <Sparkles className="mt-1.5 h-4 w-4 shrink-0 text-primary" />
+        <Textarea
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              submitPrompt();
+            }
+          }}
+          placeholder="Ask Ghostwriter anything about this application..."
+          className="min-h-[30px] resize-none border-0 bg-transparent px-0 py-1 text-base shadow-none focus-visible:ring-0 md:text-sm"
+        />
+      </div>
+      <div className="mt-3 flex items-center justify-between gap-3 border-t border-border/50">
+        <div className="mt-3 flex flex-wrap gap-2">
+          {suggestions.map((suggestion) => (
+            <Button
+              key={suggestion}
+              type="button"
+              size="sm"
+              variant="outline"
+              className="h-auto px-3 py-1.5 text-left text-xs"
+              onClick={() => setPrompt(suggestion)}
+            >
+              {suggestion}
+            </Button>
+          ))}
+        </div>
+
+        <Button
+          size="sm"
+          onClick={submitPrompt}
+          disabled={!prompt.trim()}
+          className="mt-3"
+        >
+          <Send className="mr-1.5 h-3.5 w-3.5" />
+          Go
+        </Button>
+      </div>
+    </section>
+  );
+};

--- a/orchestrator/src/client/pages/job-page/OverviewGhostwriterComposer.tsx
+++ b/orchestrator/src/client/pages/job-page/OverviewGhostwriterComposer.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { cn } from "@/lib/utils";
 
 const getGhostwriterSuggestions = (job: Job, hasNotes: boolean) => [
   hasNotes
@@ -64,7 +63,7 @@ export const OverviewGhostwriterComposer: React.FC<
               type="button"
               size="sm"
               variant="outline"
-              className={"h-auto md:px-3 md:py-1.5 text-left hidden md:inline-flex"}
+              className="hidden h-auto text-left md:inline-flex md:px-3 md:py-1.5"
               onClick={() => setPrompt(suggestion)}
             >
               {suggestion}


### PR DESCRIPTION
## Summary
- Rename the job notes URL from `/job/:id/note` to `/job/:id/notes` and keep the legacy path working via redirect
- Replace browser-history back behavior on job pages with an explicit return target that exits the job page
- Preserve the entry page state across job subviews and update entry links from the orchestrator and in-progress board
- Adjust job-page tests to cover direct deep links, legacy URL normalization, and back-navigation fallbacks

## Testing
- Added and updated unit tests for job-page notes routing, back behavior, and orchestrator deep-link selection
- Ran targeted client test suites and type checks locally
- Full orchestrator test suite passed after rebuilding the native SQLite module for the local Node version