### PR TITLE
Fix RxResume photo and template import handling

### DIFF
--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -1839,6 +1839,23 @@ export async function uploadDesignResumePicture(input: {
   });
 }
 
+export async function uploadDesignResumePictureFile(input: {
+  file: File;
+  baseRevision?: number;
+}): Promise<DesignResumeDocument> {
+  return fetchApi<DesignResumeDocument>("/design-resume/assets", {
+    method: "POST",
+    headers: {
+      "Content-Type": input.file.type || "application/octet-stream",
+      "x-file-name": encodeURIComponent(input.file.name || "picture"),
+      ...(input.baseRevision
+        ? { "x-base-revision": String(input.baseRevision) }
+        : {}),
+    },
+    body: await input.file.arrayBuffer(),
+  });
+}
+
 export async function deleteDesignResumePicture(input?: {
   baseRevision?: number;
   document?: DesignResumeJson;

--- a/orchestrator/src/client/components/JobDetailsEditDrawer.test.tsx
+++ b/orchestrator/src/client/components/JobDetailsEditDrawer.test.tsx
@@ -48,6 +48,7 @@ describe("JobDetailsEditDrawer", () => {
     _resetTracerReadinessCache();
     vi.mocked(api.getTracerReadiness).mockResolvedValue({
       status: "ready",
+      isPubliclyAvailable: true,
       canEnable: true,
       publicBaseUrl: "https://my-jobops.example.com",
       healthUrl: "https://my-jobops.example.com/health",

--- a/orchestrator/src/client/components/TailoringEditor.test.tsx
+++ b/orchestrator/src/client/components/TailoringEditor.test.tsx
@@ -56,6 +56,7 @@ describe("TailoringEditor", () => {
     _resetTracerReadinessCache();
     vi.mocked(api.getTracerReadiness).mockResolvedValue({
       status: "ready",
+      isPubliclyAvailable: true,
       canEnable: true,
       publicBaseUrl: "https://my-jobops.example.com",
       healthUrl: "https://my-jobops.example.com/health",

--- a/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.tsx
@@ -88,7 +88,7 @@ export function PictureSection({
   onDeletePicture,
   onUpdatePicture,
 }: PictureSectionProps) {
-  const disabled = !pictureEnabled;
+  const editDisabled = !pictureEnabled;
 
   return (
     <div className="grid gap-3">
@@ -115,7 +115,7 @@ export function PictureSection({
               type="button"
               variant="outline"
               onClick={onUploadPicture}
-              disabled={pictureUploading || disabled}
+              disabled={pictureUploading || editDisabled}
             >
               <ImagePlus className="mr-2 h-4 w-4" />
               Replace
@@ -125,7 +125,7 @@ export function PictureSection({
               variant="ghost"
               className="text-rose-400 hover:bg-rose-500/10 hover:text-rose-300"
               onClick={onDeletePicture}
-              disabled={disabled}
+              disabled={pictureUploading}
             >
               <Trash2 className="mr-2 h-4 w-4" />
               Delete
@@ -138,7 +138,7 @@ export function PictureSection({
           variant="outline"
           className="justify-start border-dashed"
           onClick={onUploadPicture}
-          disabled={pictureUploading || disabled}
+          disabled={pictureUploading || editDisabled}
         >
           <FileImage className="mr-2 h-4 w-4" />
           {pictureUploading ? "Uploading..." : "Upload image"}
@@ -156,7 +156,7 @@ export function PictureSection({
             onUpdatePicture("url", event.currentTarget.value)
           }
           className={fieldClassName}
-          disabled={disabled}
+          disabled={editDisabled}
         />
       </div>
 
@@ -174,7 +174,7 @@ export function PictureSection({
         <Switch
           checked={!toBoolean(picture.hidden, false)}
           onCheckedChange={(checked) => onUpdatePicture("hidden", !checked)}
-          disabled={disabled}
+          disabled={editDisabled}
         />
       </div>
 
@@ -199,7 +199,7 @@ export function PictureSection({
                 onUpdatePicture(key, Number(event.currentTarget.value || 0))
               }
               className={fieldClassName}
-              disabled={disabled}
+              disabled={editDisabled}
             />
           </div>
         ))}
@@ -212,7 +212,7 @@ export function PictureSection({
             id={fieldId("picture", key)}
             label={label}
             value={toText(picture[key])}
-            disabled={disabled}
+            disabled={editDisabled}
             onChange={(nextValue) => onUpdatePicture(key, nextValue)}
           />
         ))}

--- a/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.tsx
@@ -1,4 +1,5 @@
 import { FileImage, ImagePlus, Plus, Trash2 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -29,10 +30,17 @@ type ColorFieldProps = {
   id: string;
   label: string;
   value: string;
+  disabled?: boolean;
   onChange: (value: string) => void;
 };
 
-function ColorField({ id, label, value, onChange }: ColorFieldProps) {
+function ColorField({
+  id,
+  label,
+  value,
+  disabled = false,
+  onChange,
+}: ColorFieldProps) {
   const pickerValue = normalizeColorValue(value);
 
   return (
@@ -48,11 +56,13 @@ function ColorField({ id, label, value, onChange }: ColorFieldProps) {
           onChange={(event) => onChange(event.currentTarget.value)}
           className="h-10 w-12 cursor-pointer rounded-md border border-border/60 bg-background/60 p-1"
           aria-label={label}
+          disabled={disabled}
         />
         <Input
           value={value}
           onChange={(event) => onChange(event.currentTarget.value)}
           className={fieldClassName}
+          disabled={disabled}
         />
       </div>
     </div>
@@ -62,6 +72,8 @@ function ColorField({ id, label, value, onChange }: ColorFieldProps) {
 type PictureSectionProps = {
   picture: Record<string, unknown>;
   pictureUploading: boolean;
+  pictureEnabled: boolean;
+  pictureDisabledReason?: string | null;
   onUploadPicture: () => void;
   onDeletePicture: () => void;
   onUpdatePicture: (key: string, value: unknown) => void;
@@ -70,12 +82,25 @@ type PictureSectionProps = {
 export function PictureSection({
   picture,
   pictureUploading,
+  pictureEnabled,
+  pictureDisabledReason,
   onUploadPicture,
   onDeletePicture,
   onUpdatePicture,
 }: PictureSectionProps) {
+  const disabled = !pictureEnabled;
+
   return (
     <div className="grid gap-3">
+      {!pictureEnabled ? (
+        <Alert>
+          <AlertDescription>
+            {pictureDisabledReason ??
+              "Pictures require JobOps to be reachable at a public URL."}
+          </AlertDescription>
+        </Alert>
+      ) : null}
+
       {picture.url ? (
         <div
           className={`${insetPanelClassName} flex items-center gap-3 border-dashed p-3`}
@@ -90,7 +115,7 @@ export function PictureSection({
               type="button"
               variant="outline"
               onClick={onUploadPicture}
-              disabled={pictureUploading}
+              disabled={pictureUploading || disabled}
             >
               <ImagePlus className="mr-2 h-4 w-4" />
               Replace
@@ -100,6 +125,7 @@ export function PictureSection({
               variant="ghost"
               className="text-rose-400 hover:bg-rose-500/10 hover:text-rose-300"
               onClick={onDeletePicture}
+              disabled={disabled}
             >
               <Trash2 className="mr-2 h-4 w-4" />
               Delete
@@ -112,7 +138,7 @@ export function PictureSection({
           variant="outline"
           className="justify-start border-dashed"
           onClick={onUploadPicture}
-          disabled={pictureUploading}
+          disabled={pictureUploading || disabled}
         >
           <FileImage className="mr-2 h-4 w-4" />
           {pictureUploading ? "Uploading..." : "Upload image"}
@@ -130,6 +156,7 @@ export function PictureSection({
             onUpdatePicture("url", event.currentTarget.value)
           }
           className={fieldClassName}
+          disabled={disabled}
         />
       </div>
 
@@ -147,6 +174,7 @@ export function PictureSection({
         <Switch
           checked={!toBoolean(picture.hidden, false)}
           onCheckedChange={(checked) => onUpdatePicture("hidden", !checked)}
+          disabled={disabled}
         />
       </div>
 
@@ -171,6 +199,7 @@ export function PictureSection({
                 onUpdatePicture(key, Number(event.currentTarget.value || 0))
               }
               className={fieldClassName}
+              disabled={disabled}
             />
           </div>
         ))}
@@ -183,6 +212,7 @@ export function PictureSection({
             id={fieldId("picture", key)}
             label={label}
             value={toText(picture[key])}
+            disabled={disabled}
             onChange={(nextValue) => onUpdatePicture(key, nextValue)}
           />
         ))}

--- a/orchestrator/src/client/components/design-resume/DesignResumeRail.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeRail.tsx
@@ -20,6 +20,8 @@ type DesignResumeRailProps = {
   onUploadPicture: () => void;
   onDeletePicture: () => void;
   pictureUploading: boolean;
+  pictureEnabled: boolean;
+  pictureDisabledReason?: string | null;
 };
 
 export function DesignResumeRail({
@@ -29,6 +31,8 @@ export function DesignResumeRail({
   onUploadPicture,
   onDeletePicture,
   pictureUploading,
+  pictureEnabled,
+  pictureDisabledReason,
 }: DesignResumeRailProps) {
   const resumeJson = draft.resumeJson as Record<string, unknown>;
   const basics = (asRecord(resumeJson.basics) ?? {}) as Record<string, unknown>;
@@ -143,6 +147,8 @@ export function DesignResumeRail({
         <PictureSection
           picture={picture}
           pictureUploading={pictureUploading}
+          pictureEnabled={pictureEnabled}
+          pictureDisabledReason={pictureDisabledReason}
           onUploadPicture={onUploadPicture}
           onDeletePicture={onDeletePicture}
           onUpdatePicture={updatePicture}

--- a/orchestrator/src/client/components/discovered-panel/TailorMode.test.tsx
+++ b/orchestrator/src/client/components/discovered-panel/TailorMode.test.tsx
@@ -55,6 +55,7 @@ describe("TailorMode", () => {
     _resetTracerReadinessCache();
     vi.mocked(api.getTracerReadiness).mockResolvedValue({
       status: "ready",
+      isPubliclyAvailable: true,
       canEnable: true,
       publicBaseUrl: "https://my-jobops.example.com",
       healthUrl: "https://my-jobops.example.com/health",

--- a/orchestrator/src/client/pages/DesignResumePage.tsx
+++ b/orchestrator/src/client/pages/DesignResumePage.tsx
@@ -89,7 +89,7 @@ export const DesignResumePage: React.FC = () => {
 
   const pdfRenderer = settings?.pdfRenderer?.value ?? "rxresume";
   const canDownloadPdf = status?.exists && !pdfDownloading;
-  const pictureEnabled = Boolean(tracerReadiness?.canEnable);
+  const pictureEnabled = Boolean(tracerReadiness?.isPubliclyAvailable);
   const pictureDisabledReason =
     tracerReadiness?.reason ??
     "Pictures require JobOps to be reachable at a public URL.";

--- a/orchestrator/src/client/pages/DesignResumePage.tsx
+++ b/orchestrator/src/client/pages/DesignResumePage.tsx
@@ -313,13 +313,10 @@ export const DesignResumePage: React.FC = () => {
       const latestDraft = await ensureLatestPersistedDraft();
       if (!latestDraft) return;
 
-      const dataUrl = await fileToDataUrl(file);
       const editVersionAtStart = editVersionRef.current;
-      const updated = await api.uploadDesignResumePicture({
-        fileName: file.name,
-        dataUrl,
+      const updated = await api.uploadDesignResumePictureFile({
+        file,
         baseRevision: latestDraft.revision,
-        document: latestDraft.resumeJson,
       });
       if (editVersionRef.current === editVersionAtStart) {
         setDesignResume(updated);

--- a/orchestrator/src/client/pages/DesignResumePage.tsx
+++ b/orchestrator/src/client/pages/DesignResumePage.tsx
@@ -5,6 +5,7 @@ import { ItemDialog } from "@client/components/design-resume/ItemDialog";
 import { PageHeader, PageMain } from "@client/components/layout";
 import { useDesignResume } from "@client/hooks/useDesignResume";
 import { useSettings } from "@client/hooks/useSettings";
+import { useTracerReadiness } from "@client/hooks/useTracerReadiness";
 import type {
   DesignResumeDocument,
   DesignResumeJson,
@@ -63,6 +64,7 @@ export const DesignResumePage: React.FC = () => {
   const queryClient = useQueryClient();
   const { document, status, isLoading, error } = useDesignResume();
   const { settings, isLoading: settingsLoading } = useSettings();
+  const { readiness: tracerReadiness } = useTracerReadiness();
   const [draft, setDraft] = useState<DesignResumeDocument | null>(null);
   const [saveState, setSaveState] = useState<
     "idle" | "saving" | "saved" | "error"
@@ -87,6 +89,10 @@ export const DesignResumePage: React.FC = () => {
 
   const pdfRenderer = settings?.pdfRenderer?.value ?? "rxresume";
   const canDownloadPdf = status?.exists && !pdfDownloading;
+  const pictureEnabled = Boolean(tracerReadiness?.canEnable);
+  const pictureDisabledReason =
+    tracerReadiness?.reason ??
+    "Pictures require JobOps to be reachable at a public URL.";
 
   useEffect(() => {
     if (!document) return;
@@ -308,6 +314,14 @@ export const DesignResumePage: React.FC = () => {
   };
 
   const handleUploadPicture = async (file: File) => {
+    if (!pictureEnabled) {
+      toast.error(pictureDisabledReason);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+      return;
+    }
+
     try {
       setPictureUploading(true);
       const latestDraft = await ensureLatestPersistedDraft();
@@ -344,6 +358,11 @@ export const DesignResumePage: React.FC = () => {
   };
 
   const handleDeletePicture = async () => {
+    if (!pictureEnabled) {
+      toast.error(pictureDisabledReason);
+      return;
+    }
+
     try {
       const latestDraft = await ensureLatestPersistedDraft();
       if (!latestDraft) return;
@@ -428,6 +447,8 @@ export const DesignResumePage: React.FC = () => {
       onUploadPicture={() => fileInputRef.current?.click()}
       onDeletePicture={handleDeletePicture}
       pictureUploading={pictureUploading}
+      pictureEnabled={pictureEnabled}
+      pictureDisabledReason={pictureDisabledReason}
     />
   ) : null;
 

--- a/orchestrator/src/client/pages/DesignResumePage.tsx
+++ b/orchestrator/src/client/pages/DesignResumePage.tsx
@@ -358,11 +358,6 @@ export const DesignResumePage: React.FC = () => {
   };
 
   const handleDeletePicture = async () => {
-    if (!pictureEnabled) {
-      toast.error(pictureDisabledReason);
-      return;
-    }
-
     try {
       const latestDraft = await ensureLatestPersistedDraft();
       if (!latestDraft) return;

--- a/orchestrator/src/client/pages/SettingsPage.test.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.test.tsx
@@ -171,6 +171,7 @@ describe("SettingsPage", () => {
     _resetTracerReadinessCache();
     vi.mocked(api.getTracerReadiness).mockResolvedValue({
       status: "ready",
+      isPubliclyAvailable: true,
       canEnable: true,
       publicBaseUrl: "https://my-jobops.example.com",
       healthUrl: "https://my-jobops.example.com/health",

--- a/orchestrator/src/server/api/routes/design-resume.ts
+++ b/orchestrator/src/server/api/routes/design-resume.ts
@@ -9,6 +9,7 @@ import {
   readDesignResumeAssetContent,
   updateCurrentDesignResume,
   uploadDesignResumePicture,
+  uploadDesignResumePictureFile,
 } from "@server/services/design-resume";
 import { importDesignResumeFromFile } from "@server/services/design-resume/import-file";
 import { generateDesignResumePdf } from "@server/services/pdf";
@@ -164,6 +165,22 @@ const uploadSchema = pictureMutationSchema.extend({
   dataUrl: z.string().trim().min(1),
 });
 
+const rawUploadHeadersSchema = z.object({
+  fileName: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .transform((value) => {
+      try {
+        return decodeURIComponent(value);
+      } catch {
+        return value;
+      }
+    }),
+  baseRevision: z.coerce.number().int().min(1).optional(),
+});
+
 const importFileSchema = z.object({
   fileName: z.string().trim().min(1).max(255),
   mediaType: z.string().trim().min(1).max(200).optional(),
@@ -229,6 +246,22 @@ designResumeRouter.patch(
 designResumeRouter.post(
   "/assets",
   asyncRoute(async (req: Request, res: Response) => {
+    if (Buffer.isBuffer(req.body)) {
+      const input = rawUploadHeadersSchema.parse({
+        fileName: req.header("x-file-name"),
+        baseRevision: req.header("x-base-revision"),
+      });
+      const document = await uploadDesignResumePictureFile({
+        fileName: input.fileName,
+        mimeType: req.header("content-type"),
+        data: req.body,
+        baseRevision: input.baseRevision,
+      });
+      clearProfileCache();
+      ok(res, document, 201);
+      return;
+    }
+
     const input = uploadSchema.parse(req.body);
     const document = await uploadDesignResumePicture({
       fileName: input.fileName,

--- a/orchestrator/src/server/api/routes/design-resume.ts
+++ b/orchestrator/src/server/api/routes/design-resume.ts
@@ -293,8 +293,6 @@ designResumeRouter.post(
 designResumeRouter.delete(
   "/assets/picture",
   asyncRoute(async (req: Request, res: Response) => {
-    await assertPictureSupportEnabled(req);
-
     const input = pictureMutationSchema.parse(req.body ?? {});
     const document = await deleteDesignResumePicture({
       baseRevision: input.baseRevision,
@@ -314,7 +312,9 @@ designResumeRouter.get(
       return;
     }
 
-    const { asset, content } = await readDesignResumeAssetContent(assetId);
+    const { asset, content } = await readDesignResumeAssetContent(assetId, {
+      bypassTenantScope: true,
+    });
     res.setHeader("Content-Type", asset.mimeType);
     res.setHeader("Cache-Control", "private, max-age=60");
     res.send(content);

--- a/orchestrator/src/server/api/routes/design-resume.ts
+++ b/orchestrator/src/server/api/routes/design-resume.ts
@@ -15,7 +15,7 @@ import { importDesignResumeFromFile } from "@server/services/design-resume/impor
 import { generateDesignResumePdf } from "@server/services/pdf";
 import { getTenantDesignResumePdfPath } from "@server/services/pdf-storage";
 import { clearProfileCache } from "@server/services/profile";
-import { getTracerReadiness } from "@server/services/tracer-links";
+import { getJobOpsPublicAvailability } from "@server/services/tracer-links";
 import type { DesignResumeJson, DesignResumePatchRequest } from "@shared/types";
 import { type Request, type Response, Router } from "express";
 import { z } from "zod";
@@ -59,14 +59,14 @@ function resolveRequestOrigin(req: Request): string | null {
 }
 
 async function assertPictureSupportEnabled(req: Request): Promise<void> {
-  const readiness = await getTracerReadiness({
+  const availability = await getJobOpsPublicAvailability({
     requestOrigin: resolveRequestOrigin(req),
     force: false,
   });
-  if (readiness.canEnable) return;
+  if (availability.isPubliclyAvailable) return;
 
   throw conflict(
-    readiness.reason ??
+    availability.reason ??
       "Design Resume pictures require JobOps to be reachable at a public URL.",
   );
 }

--- a/orchestrator/src/server/api/routes/design-resume.ts
+++ b/orchestrator/src/server/api/routes/design-resume.ts
@@ -1,4 +1,4 @@
-import { badRequest, notFound, toAppError } from "@infra/errors";
+import { badRequest, conflict, notFound, toAppError } from "@infra/errors";
 import { asyncRoute, fail, ok } from "@infra/http";
 import {
   deleteDesignResumePicture,
@@ -15,6 +15,7 @@ import { importDesignResumeFromFile } from "@server/services/design-resume/impor
 import { generateDesignResumePdf } from "@server/services/pdf";
 import { getTenantDesignResumePdfPath } from "@server/services/pdf-storage";
 import { clearProfileCache } from "@server/services/profile";
+import { getTracerReadiness } from "@server/services/tracer-links";
 import type { DesignResumeJson, DesignResumePatchRequest } from "@shared/types";
 import { type Request, type Response, Router } from "express";
 import { z } from "zod";
@@ -55,6 +56,19 @@ function resolveRequestOrigin(req: Request): string | null {
 
   if (!host || !protocol) return null;
   return `${protocol}://${host}`;
+}
+
+async function assertPictureSupportEnabled(req: Request): Promise<void> {
+  const readiness = await getTracerReadiness({
+    requestOrigin: resolveRequestOrigin(req),
+    force: false,
+  });
+  if (readiness.canEnable) return;
+
+  throw conflict(
+    readiness.reason ??
+      "Design Resume pictures require JobOps to be reachable at a public URL.",
+  );
 }
 
 const addOperationSchema = z
@@ -246,6 +260,8 @@ designResumeRouter.patch(
 designResumeRouter.post(
   "/assets",
   asyncRoute(async (req: Request, res: Response) => {
+    await assertPictureSupportEnabled(req);
+
     if (Buffer.isBuffer(req.body)) {
       const input = rawUploadHeadersSchema.parse({
         fileName: req.header("x-file-name"),
@@ -277,6 +293,8 @@ designResumeRouter.post(
 designResumeRouter.delete(
   "/assets/picture",
   asyncRoute(async (req: Request, res: Response) => {
+    await assertPictureSupportEnabled(req);
+
     const input = pictureMutationSchema.parse(req.body ?? {});
     const document = await deleteDesignResumePicture({
       baseRevision: input.baseRevision,

--- a/orchestrator/src/server/api/routes/tracer-links.test.ts
+++ b/orchestrator/src/server/api/routes/tracer-links.test.ts
@@ -202,6 +202,7 @@ describe.sequential("Tracer links routes", () => {
         ok: boolean;
         data?: {
           status: string;
+          isPubliclyAvailable: boolean;
           canEnable: boolean;
           publicBaseUrl: string | null;
         };
@@ -211,6 +212,7 @@ describe.sequential("Tracer links routes", () => {
       expect(body.ok).toBe(true);
       expect(body.meta?.requestId).toBeTruthy();
       expect(body.data?.status).toBe("ready");
+      expect(body.data?.isPubliclyAvailable).toBe(true);
       expect(body.data?.canEnable).toBe(true);
       expect(body.data?.publicBaseUrl).toBe("https://my-jobops.example.com");
     } finally {

--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -194,6 +194,11 @@ export function createAuthGuard() {
       normalizedPath === "/api/auth/bootstrap-status"
     )
       return true;
+    if (
+      ["GET", "HEAD"].includes(normalizedMethod) &&
+      /^\/api\/design-resume\/assets\/[^/]+\/content$/.test(normalizedPath)
+    )
+      return true;
 
     return false;
   }
@@ -326,6 +331,18 @@ export function createApp() {
   });
   app.use(requestContextMiddleware());
   app.use("/stats", express.raw({ limit: "1mb", type: "*/*" }));
+  app.use(
+    "/api/design-resume/assets",
+    express.raw({
+      limit: "10mb",
+      type: [
+        "image/png",
+        "image/jpeg",
+        "image/webp",
+        "application/octet-stream",
+      ],
+    }),
+  );
   // Resume file import sends base64 JSON payloads, which expand beyond the raw
   // file size. Scope the larger JSON limit to that endpoint only.
   app.use("/api/design-resume/import/file", express.json({ limit: "15mb" }));

--- a/orchestrator/src/server/basic-auth.test.ts
+++ b/orchestrator/src/server/basic-auth.test.ts
@@ -99,6 +99,24 @@ describe.sequential("Auth read-only enforcement", () => {
     expect(res.statusCode).toBe(401);
   });
 
+  it("allows Design Resume asset content without auth for PDF rendering", async () => {
+    vi.mocked(countUsers).mockResolvedValue(1);
+
+    const { middleware } = createAuthGuard();
+    const req = createMockRequest({
+      method: "GET",
+      path: "/api/design-resume/assets/asset-1/content",
+    });
+    const res = createMockResponse();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
   it("allows OPTIONS preflight without auth even for API routes", async () => {
     vi.mocked(countUsers).mockResolvedValue(1);
 

--- a/orchestrator/src/server/repositories/design-resume.ts
+++ b/orchestrator/src/server/repositories/design-resume.ts
@@ -59,6 +59,15 @@ export async function getDesignResumeAssetById(id: string) {
   return row ?? null;
 }
 
+export async function getDesignResumeAssetByIdAnyTenant(id: string) {
+  const [row] = await db
+    .select()
+    .from(designResumeAssets)
+    .where(eq(designResumeAssets.id, id))
+    .limit(1);
+  return row ?? null;
+}
+
 export async function upsertDesignResumeDocument(input: {
   id: string;
   title: string;

--- a/orchestrator/src/server/services/design-resume.test.ts
+++ b/orchestrator/src/server/services/design-resume.test.ts
@@ -5,6 +5,7 @@ import { buildDefaultReactiveResumeDocument } from "./rxresume/document";
 const repo = vi.hoisted(() => ({
   getLatestDesignResumeDocument: vi.fn(),
   getDesignResumeAssetById: vi.fn(),
+  getDesignResumeAssetByIdAnyTenant: vi.fn(),
   listDesignResumeAssets: vi.fn(),
   upsertDesignResumeDocument: vi.fn(),
   insertDesignResumeAsset: vi.fn(),
@@ -110,6 +111,7 @@ describe("design resume service", () => {
     repo.getLatestDesignResumeDocument.mockResolvedValue(makeDocumentRow());
     repo.listDesignResumeAssets.mockResolvedValue([]);
     repo.getDesignResumeAssetById.mockResolvedValue(null);
+    repo.getDesignResumeAssetByIdAnyTenant.mockResolvedValue(null);
     repo.upsertDesignResumeDocument.mockImplementation(async (input) =>
       makeDocumentRow({
         ...input,
@@ -210,6 +212,37 @@ describe("design resume service", () => {
         kind: "picture",
         mimeType: "image/webp",
       }),
+    );
+  });
+
+  it("does not fetch imported picture URLs from private hosts", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const upstreamResume = makeValidResumeJson({
+      picture: {
+        ...(buildDefaultReactiveResumeDocument().picture as Record<
+          string,
+          unknown
+        >),
+        hidden: false,
+        url: "/uploads/profile-photo.png",
+      },
+    });
+    vi.mocked(getSetting).mockImplementation(async (key) =>
+      key === "rxresumeUrl" ? "http://127.0.0.1:3000/api/openapi" : null,
+    );
+    vi.mocked(getResume).mockResolvedValueOnce({
+      id: "rx-1",
+      mode: "v5",
+      data: upstreamResume,
+    } as never);
+
+    const result = await importDesignResumeFromReactiveResume();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(repo.insertDesignResumeAsset).not.toHaveBeenCalled();
+    expect(result.resumeJson.picture.url).toBe(
+      "http://127.0.0.1:3000/uploads/profile-photo.png",
     );
   });
 
@@ -567,6 +600,30 @@ describe("design resume service", () => {
     const { asset } = await readDesignResumeAssetContent("asset-1");
 
     expect(asset).not.toHaveProperty("storagePath");
+    expect(asset.contentUrl).toBe("/api/design-resume/assets/asset-1/content");
+  });
+
+  it("can read asset content without tenant scoping for public preview fetches", async () => {
+    repo.getDesignResumeAssetByIdAnyTenant.mockResolvedValueOnce({
+      id: "asset-1",
+      documentId: "primary",
+      kind: "picture",
+      originalName: "photo.png",
+      mimeType: "image/png",
+      byteSize: 123,
+      storagePath: "/tmp/job-ops-test/design-resume/assets/photo.png",
+      createdAt: "2026-04-07T00:00:00.000Z",
+      updatedAt: "2026-04-07T00:00:00.000Z",
+    });
+    fsMocks.readFile.mockResolvedValueOnce(Buffer.from("hello"));
+
+    const { asset } = await readDesignResumeAssetContent("asset-1", {
+      bypassTenantScope: true,
+    });
+
+    expect(repo.getDesignResumeAssetByIdAnyTenant).toHaveBeenCalledWith(
+      "asset-1",
+    );
     expect(asset.contentUrl).toBe("/api/design-resume/assets/asset-1/content");
   });
 

--- a/orchestrator/src/server/services/design-resume.test.ts
+++ b/orchestrator/src/server/services/design-resume.test.ts
@@ -25,8 +25,14 @@ vi.mock("@server/repositories/design-resume", () => repo);
 vi.mock("@server/config/dataDir", () => ({
   getDataDir: vi.fn(() => "/tmp/job-ops-test"),
 }));
+vi.mock("@server/repositories/settings", () => ({
+  getSetting: vi.fn(),
+}));
 vi.mock("@paralleldrive/cuid2", () => ({
   createId: vi.fn(() => "asset-1"),
+}));
+vi.mock("@server/services/envSettings", () => ({
+  getOriginalEnvValue: vi.fn(),
 }));
 vi.mock("@server/services/rxresume/baseResumeId", () => ({
   getConfiguredRxResumeBaseResumeId: vi.fn(),
@@ -51,6 +57,8 @@ vi.mock("node:fs/promises", () => ({
   default: fsMocks,
 }));
 
+import { getSetting } from "@server/repositories/settings";
+import { getOriginalEnvValue } from "@server/services/envSettings";
 import { getResume } from "@server/services/rxresume";
 import { getConfiguredRxResumeBaseResumeId } from "@server/services/rxresume/baseResumeId";
 import {
@@ -109,6 +117,8 @@ describe("design resume service", () => {
       mode: "v5",
       resumeId: "rx-1",
     });
+    vi.mocked(getSetting).mockResolvedValue(null);
+    vi.mocked(getOriginalEnvValue).mockReturnValue(undefined);
     vi.mocked(getResume).mockResolvedValue({
       id: "rx-1",
       mode: "v5",
@@ -146,6 +156,34 @@ describe("design resume service", () => {
         id: "primary_tenant-test-2",
       }),
     );
+  });
+
+  it("stores Reactive Resume relative picture URLs as absolute upstream URLs", async () => {
+    const upstreamResume = makeValidResumeJson({
+      picture: {
+        ...(buildDefaultReactiveResumeDocument().picture as Record<
+          string,
+          unknown
+        >),
+        hidden: false,
+        url: "/uploads/profile-photo.png",
+      },
+    });
+    vi.mocked(getSetting).mockImplementation(async (key) =>
+      key === "rxresumeUrl" ? "https://resume.example.com/api/openapi" : null,
+    );
+    vi.mocked(getResume).mockResolvedValueOnce({
+      id: "rx-1",
+      mode: "v5",
+      data: upstreamResume,
+    } as never);
+
+    const result = await importDesignResumeFromReactiveResume();
+
+    expect(result.resumeJson.picture.url).toBe(
+      "https://resume.example.com/uploads/profile-photo.png",
+    );
+    expect(result.resumeJson.picture.hidden).toBe(false);
   });
 
   it("preserves an explicit picture hidden flag during updates", async () => {

--- a/orchestrator/src/server/services/design-resume.test.ts
+++ b/orchestrator/src/server/services/design-resume.test.ts
@@ -1,5 +1,5 @@
 import type { DesignResumeJson } from "@shared/types";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildDefaultReactiveResumeDocument } from "./rxresume/document";
 
 const repo = vi.hoisted(() => ({
@@ -70,6 +70,7 @@ import {
   replaceCurrentDesignResumeDocument,
   updateCurrentDesignResume,
   uploadDesignResumePicture,
+  uploadDesignResumePictureFile,
 } from "./design-resume";
 
 function makeDocumentRow(overrides?: Partial<Record<string, unknown>>) {
@@ -100,6 +101,10 @@ function makeValidResumeJson(
 }
 
 describe("design resume service", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     repo.getLatestDesignResumeDocument.mockResolvedValue(makeDocumentRow());
@@ -158,7 +163,18 @@ describe("design resume service", () => {
     );
   });
 
-  it("stores Reactive Resume relative picture URLs as absolute upstream URLs", async () => {
+  it("localizes Reactive Resume relative picture URLs into design resume assets", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        headers: {
+          get: (name: string) =>
+            name.toLowerCase() === "content-type" ? "image/webp" : null,
+        },
+        arrayBuffer: async () => Buffer.from("webp-bytes").buffer,
+      }),
+    );
     const upstreamResume = makeValidResumeJson({
       picture: {
         ...(buildDefaultReactiveResumeDocument().picture as Record<
@@ -181,9 +197,20 @@ describe("design resume service", () => {
     const result = await importDesignResumeFromReactiveResume();
 
     expect(result.resumeJson.picture.url).toBe(
-      "https://resume.example.com/uploads/profile-photo.png",
+      "/api/design-resume/assets/asset-1/content",
     );
     expect(result.resumeJson.picture.hidden).toBe(false);
+    expect(fetch).toHaveBeenCalledWith(
+      "https://resume.example.com/uploads/profile-photo.png",
+      expect.any(Object),
+    );
+    expect(repo.insertDesignResumeAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "asset-1",
+        kind: "picture",
+        mimeType: "image/webp",
+      }),
+    );
   });
 
   it("preserves an explicit picture hidden flag during updates", async () => {
@@ -488,6 +515,33 @@ describe("design resume service", () => {
           summary: expect.objectContaining({
             content: "Unsaved summary edit",
           }),
+          picture: expect.objectContaining({
+            url: "/api/design-resume/assets/asset-1/content",
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("accepts raw picture uploads up to 10 MB", async () => {
+    const data = Buffer.alloc(10 * 1024 * 1024, 0);
+
+    await uploadDesignResumePictureFile({
+      fileName: "photo.webp",
+      mimeType: "image/webp",
+      data,
+      baseRevision: 1,
+    });
+
+    expect(repo.insertDesignResumeAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        byteSize: 10 * 1024 * 1024,
+        mimeType: "image/webp",
+      }),
+    );
+    expect(repo.upsertDesignResumeDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeJson: expect.objectContaining({
           picture: expect.objectContaining({
             url: "/api/design-resume/assets/asset-1/content",
           }),

--- a/orchestrator/src/server/services/design-resume/index.ts
+++ b/orchestrator/src/server/services/design-resume/index.ts
@@ -8,6 +8,8 @@ import { sanitizeUnknown } from "@infra/sanitize";
 import { createId } from "@paralleldrive/cuid2";
 import { getDataDir } from "@server/config/dataDir";
 import * as designResumeRepo from "@server/repositories/design-resume";
+import { getSetting } from "@server/repositories/settings";
+import { getOriginalEnvValue } from "@server/services/envSettings";
 import { getResume } from "@server/services/rxresume";
 import { getConfiguredRxResumeBaseResumeId } from "@server/services/rxresume/baseResumeId";
 import { getResumeSchemaValidationMessage } from "@server/services/rxresume/schema";
@@ -104,6 +106,46 @@ function buildDocumentTitle(document: DesignResumeJson): string {
 
 function contentUrlForAsset(assetId: string): string {
   return `/api/design-resume/assets/${encodeURIComponent(assetId)}/content`;
+}
+
+function absolutizeUrl(value: string, baseUrl: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+
+  try {
+    return new URL(trimmed).toString();
+  } catch {
+    try {
+      return new URL(trimmed, baseUrl).toString();
+    } catch {
+      return trimmed;
+    }
+  }
+}
+
+async function resolveReactiveResumePublicBaseUrl(): Promise<string> {
+  return (
+    (await getSetting("rxresumeUrl"))?.trim() ||
+    getOriginalEnvValue("RXRESUME_URL")?.trim() ||
+    "https://rxresu.me"
+  );
+}
+
+function withReactiveResumePictureUrl(
+  document: DesignResumeJson,
+  baseUrl: string,
+): DesignResumeJson {
+  const picture = asRecord(document.picture);
+  const pictureUrl = toText(picture?.url);
+  if (!pictureUrl) return document;
+
+  return {
+    ...document,
+    picture: {
+      ...document.picture,
+      url: absolutizeUrl(pictureUrl, baseUrl),
+    } as DesignResumeJson["picture"],
+  };
 }
 
 function toDesignResumeAsset(
@@ -461,7 +503,10 @@ export async function importDesignResumeFromReactiveResume(): Promise<DesignResu
     throw badRequest("Reactive Resume base resume is empty or invalid.");
   }
 
-  const validated = validateIncomingDesignResumeDocument(upstreamResume.data);
+  const validated = withReactiveResumePictureUrl(
+    validateIncomingDesignResumeDocument(upstreamResume.data),
+    await resolveReactiveResumePublicBaseUrl(),
+  );
   return replaceCurrentDesignResumeDocument({
     resumeJson: validated,
     sourceResumeId: resumeId,

--- a/orchestrator/src/server/services/design-resume/index.ts
+++ b/orchestrator/src/server/services/design-resume/index.ts
@@ -33,6 +33,7 @@ const DESIGN_RESUME_ASSET_DIR = join(DESIGN_RESUME_DIR, "assets");
 const DESIGN_RESUME_DEFAULT_ID = "primary";
 const IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
 const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+const MAX_PICTURE_FETCH_REDIRECTS = 3;
 const LEGACY_REIMPORT_MESSAGE =
   "Stored Design Resume is no longer compatible. Re-import from Reactive Resume v5 to continue.";
 const INVALID_V5_PREFIX =
@@ -174,6 +175,78 @@ function assertImageByteSize(byteLength: number): void {
   }
 }
 
+function isLocalOrPrivateHostname(hostnameRaw: string): boolean {
+  const hostname = hostnameRaw.trim().toLowerCase();
+  if (!hostname) return true;
+
+  if (
+    hostname === "localhost" ||
+    hostname.endsWith(".localhost") ||
+    hostname.endsWith(".local")
+  ) {
+    return true;
+  }
+
+  const ipv4Match = hostname.match(
+    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
+  );
+  if (ipv4Match) {
+    const octets = ipv4Match.slice(1).map((part) => Number(part));
+    if (octets.some((octet) => Number.isNaN(octet) || octet > 255)) return true;
+    const [first, second] = octets;
+    if (
+      first === 10 ||
+      first === 127 ||
+      first === 0 ||
+      (first === 169 && second === 254) ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168)
+    ) {
+      return true;
+    }
+  }
+
+  if (hostname.includes(":")) {
+    if (
+      hostname === "::1" ||
+      hostname.startsWith("fe80:") ||
+      hostname.startsWith("fc") ||
+      hostname.startsWith("fd")
+    ) {
+      return true;
+    }
+  }
+
+  if (!hostname.includes(".") && !hostname.includes(":")) {
+    return true;
+  }
+
+  return false;
+}
+
+function parsePublicPictureUrl(value: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw badRequest("Design Resume pictures must use a valid absolute URL.");
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw badRequest("Design Resume pictures must use HTTP or HTTPS URLs.");
+  }
+  if (parsed.username || parsed.password) {
+    throw badRequest("Design Resume picture URLs cannot include credentials.");
+  }
+  if (isLocalOrPrivateHostname(parsed.hostname)) {
+    throw badRequest(
+      "Design Resume picture URLs must point to a publicly reachable host.",
+    );
+  }
+
+  return parsed;
+}
+
 function originalNameFromUrl(url: string, mimeType: string): string {
   try {
     const pathname = new URL(url).pathname;
@@ -223,14 +296,32 @@ async function storeDesignResumePictureAsset(input: {
   return { assetId, storagePath };
 }
 
-async function fetchPictureFromUrl(url: string): Promise<{
+async function fetchPictureFromUrl(
+  url: string,
+  redirectCount = 0,
+): Promise<{
   data: Buffer;
   fileName: string;
   mimeType: string;
 }> {
-  const response = await fetch(url, {
+  const parsedUrl = parsePublicPictureUrl(url);
+  const response = await fetch(parsedUrl.toString(), {
     signal: AbortSignal.timeout(15_000),
+    redirect: "manual",
   });
+  if (
+    response.status >= 300 &&
+    response.status < 400 &&
+    response.headers.get("location")
+  ) {
+    if (redirectCount >= MAX_PICTURE_FETCH_REDIRECTS) {
+      throw new Error(
+        "Reactive Resume picture download redirected too many times.",
+      );
+    }
+    const nextUrl = new URL(response.headers.get("location") ?? "", parsedUrl);
+    return fetchPictureFromUrl(nextUrl.toString(), redirectCount + 1);
+  }
   if (!response.ok) {
     throw new Error(
       `Reactive Resume picture download failed with HTTP ${response.status}.`,
@@ -887,11 +978,16 @@ export async function deleteDesignResumePicture(input?: {
   return updated;
 }
 
-export async function readDesignResumeAssetContent(assetId: string): Promise<{
+export async function readDesignResumeAssetContent(
+  assetId: string,
+  options?: { bypassTenantScope?: boolean },
+): Promise<{
   asset: DesignResumeAsset;
   content: Buffer;
 }> {
-  const row = await designResumeRepo.getDesignResumeAssetById(assetId);
+  const row = options?.bypassTenantScope
+    ? await designResumeRepo.getDesignResumeAssetByIdAnyTenant(assetId)
+    : await designResumeRepo.getDesignResumeAssetById(assetId);
   if (!row) {
     throw notFound("Design Resume asset not found.");
   }

--- a/orchestrator/src/server/services/design-resume/index.ts
+++ b/orchestrator/src/server/services/design-resume/index.ts
@@ -32,7 +32,7 @@ const DESIGN_RESUME_DIR = join(getDataDir(), "design-resume");
 const DESIGN_RESUME_ASSET_DIR = join(DESIGN_RESUME_DIR, "assets");
 const DESIGN_RESUME_DEFAULT_ID = "primary";
 const IMAGE_MIME_TYPES = new Set(["image/png", "image/jpeg", "image/webp"]);
-const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
 const LEGACY_REIMPORT_MESSAGE =
   "Stored Design Resume is no longer compatible. Re-import from Reactive Resume v5 to continue.";
 const INVALID_V5_PREFIX =
@@ -148,6 +148,115 @@ function withReactiveResumePictureUrl(
   };
 }
 
+function normalizeImageMimeType(input: {
+  mimeType?: string | null;
+  fileName?: string | null;
+}): string {
+  const normalizedMimeType = input.mimeType
+    ?.split(";")[0]
+    ?.trim()
+    .toLowerCase();
+  if (normalizedMimeType && IMAGE_MIME_TYPES.has(normalizedMimeType)) {
+    return normalizedMimeType;
+  }
+
+  const extension = input.fileName?.toLowerCase().split(".").pop() ?? "";
+  if (extension === "png") return "image/png";
+  if (extension === "jpg" || extension === "jpeg") return "image/jpeg";
+  if (extension === "webp") return "image/webp";
+
+  throw badRequest("Only PNG, JPEG, and WebP images are supported.");
+}
+
+function assertImageByteSize(byteLength: number): void {
+  if (byteLength > MAX_IMAGE_BYTES) {
+    throw badRequest("Images must be 10 MB or smaller.");
+  }
+}
+
+function originalNameFromUrl(url: string, mimeType: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    const name = basename(decodeURIComponent(pathname));
+    if (name) return name;
+  } catch {
+    // Fall back to a deterministic generated name below.
+  }
+  return `picture${extensionForMimeType(mimeType)}`;
+}
+
+async function storeDesignResumePictureAsset(input: {
+  documentId: string;
+  fileName: string;
+  mimeType: string;
+  data: Buffer;
+  updatedAt: string;
+}) {
+  await ensureStorageDirs();
+  assertImageByteSize(input.data.byteLength);
+
+  const assetId = createId();
+  const storagePath = join(
+    DESIGN_RESUME_ASSET_DIR,
+    `${assetId}${extensionForMimeType(input.mimeType)}`,
+  );
+
+  try {
+    await writeFile(storagePath, input.data);
+    await designResumeRepo.insertDesignResumeAsset({
+      id: assetId,
+      documentId: input.documentId,
+      kind: "picture",
+      originalName: basename(
+        input.fileName || `picture${extname(storagePath)}`,
+      ),
+      mimeType: input.mimeType,
+      byteSize: input.data.byteLength,
+      storagePath,
+      updatedAt: input.updatedAt,
+    });
+  } catch (error) {
+    await deleteAssetFile(storagePath);
+    throw error;
+  }
+
+  return { assetId, storagePath };
+}
+
+async function fetchPictureFromUrl(url: string): Promise<{
+  data: Buffer;
+  fileName: string;
+  mimeType: string;
+}> {
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Reactive Resume picture download failed with HTTP ${response.status}.`,
+    );
+  }
+
+  const mimeType = normalizeImageMimeType({
+    mimeType: response.headers.get("content-type"),
+    fileName: url,
+  });
+  const contentLength = Number(response.headers.get("content-length") ?? 0);
+  if (contentLength > 0) assertImageByteSize(contentLength);
+
+  const data = Buffer.from(await response.arrayBuffer());
+  if (data.byteLength === 0) {
+    throw new Error("Reactive Resume picture download returned an empty file.");
+  }
+  assertImageByteSize(data.byteLength);
+
+  return {
+    data,
+    fileName: originalNameFromUrl(url, mimeType),
+    mimeType,
+  };
+}
+
 function toDesignResumeAsset(
   row: Awaited<
     ReturnType<typeof designResumeRepo.getDesignResumeAssetById>
@@ -195,22 +304,15 @@ function parseDataUrl(input: string): { mimeType: string; data: Buffer } {
     throw badRequest("Image payload must be a base64 data URL.");
   }
 
-  const mimeType = match[1].toLowerCase();
-  if (!IMAGE_MIME_TYPES.has(mimeType)) {
-    throw badRequest("Only PNG, JPEG, and WebP images are supported.");
-  }
+  const mimeType = normalizeImageMimeType({ mimeType: match[1] });
 
   // Base64 expands by roughly 4/3, so we can reject oversized payloads
   // before decoding the entire string into memory.
   const estimatedByteLength = Math.floor((match[2].length * 3) / 4);
-  if (estimatedByteLength > MAX_IMAGE_BYTES) {
-    throw badRequest("Images must be 5 MB or smaller.");
-  }
+  assertImageByteSize(estimatedByteLength);
 
   const data = Buffer.from(match[2], "base64");
-  if (data.byteLength > MAX_IMAGE_BYTES) {
-    throw badRequest("Images must be 5 MB or smaller.");
-  }
+  assertImageByteSize(data.byteLength);
 
   return {
     mimeType,
@@ -507,12 +609,63 @@ export async function importDesignResumeFromReactiveResume(): Promise<DesignResu
     validateIncomingDesignResumeDocument(upstreamResume.data),
     await resolveReactiveResumePublicBaseUrl(),
   );
-  return replaceCurrentDesignResumeDocument({
+  const imported = await replaceCurrentDesignResumeDocument({
     resumeJson: validated,
     sourceResumeId: resumeId,
     sourceMode: "v5",
     importedAt: new Date().toISOString(),
   });
+
+  return localizeImportedDesignResumePicture(imported);
+}
+
+async function localizeImportedDesignResumePicture(
+  document: DesignResumeDocument,
+): Promise<DesignResumeDocument> {
+  const picture = asRecord(document.resumeJson.picture);
+  const pictureUrl = toText(picture?.url).trim();
+  if (!pictureUrl || pictureUrl.startsWith("/api/design-resume/assets/")) {
+    return document;
+  }
+
+  let downloaded: Awaited<ReturnType<typeof fetchPictureFromUrl>>;
+  try {
+    downloaded = await fetchPictureFromUrl(pictureUrl);
+  } catch (error) {
+    logger.warn("Failed to localize Reactive Resume picture", {
+      documentId: document.id,
+      sourceResumeId: document.sourceResumeId,
+      pictureUrl,
+      error: sanitizeUnknown(error),
+    });
+    return document;
+  }
+
+  const now = new Date().toISOString();
+  const { assetId, storagePath } = await storeDesignResumePictureAsset({
+    documentId: document.id,
+    fileName: downloaded.fileName,
+    mimeType: downloaded.mimeType,
+    data: downloaded.data,
+    updatedAt: now,
+  });
+
+  const nextDocument = structuredClone(document.resumeJson) as DesignResumeJson;
+  nextDocument.picture = {
+    ...(asRecord(nextDocument.picture) ?? {}),
+    url: contentUrlForAsset(assetId),
+  } as DesignResumeJson["picture"];
+
+  try {
+    return await updateCurrentDesignResume({
+      baseRevision: document.revision,
+      document: nextDocument,
+    });
+  } catch (error) {
+    await designResumeRepo.deleteDesignResumeAsset(assetId);
+    await deleteAssetFile(storagePath);
+    throw error;
+  }
 }
 
 export async function updateCurrentDesignResume(
@@ -565,14 +718,79 @@ export async function uploadDesignResumePicture(input: {
   document?: DesignResumeJson;
 }): Promise<DesignResumeDocument> {
   const current = await requireCurrentDesignResume();
-  await ensureStorageDirs();
-
   const parsed = parseDataUrl(input.dataUrl);
-  const assetId = createId();
-  const storagePath = join(
-    DESIGN_RESUME_ASSET_DIR,
-    `${assetId}${extensionForMimeType(parsed.mimeType)}`,
+  const existingAsset = await designResumeRepo.findDesignResumeAssetForDocument(
+    {
+      documentId: current.id,
+      kind: "picture",
+    },
   );
+
+  const now = new Date().toISOString();
+  const { assetId, storagePath } = await storeDesignResumePictureAsset({
+    documentId: current.id,
+    fileName: input.fileName,
+    mimeType: parsed.mimeType,
+    data: parsed.data,
+    updatedAt: now,
+  });
+
+  const baseDocument = input.document
+    ? validatePatchedDocument(
+        structuredClone(input.document) as Record<string, unknown>,
+      )
+    : current.resumeJson;
+  const nextDocument = structuredClone(baseDocument) as DesignResumeJson;
+  const picture = asRecord(nextDocument.picture) ?? {};
+  nextDocument.picture = {
+    ...picture,
+    url: contentUrlForAsset(assetId),
+    hidden: false,
+  } as DesignResumeJson["picture"];
+
+  let updated: DesignResumeDocument;
+  try {
+    updated = await updateCurrentDesignResume({
+      baseRevision: input.baseRevision ?? current.revision,
+      document: nextDocument,
+    });
+  } catch (error) {
+    await designResumeRepo.deleteDesignResumeAsset(assetId);
+    await deleteAssetFile(storagePath);
+    throw error;
+  }
+
+  if (existingAsset) {
+    try {
+      await designResumeRepo.deleteDesignResumeAsset(existingAsset.id);
+      await deleteAssetFile(existingAsset.storagePath);
+    } catch (error) {
+      logger.warn("Failed to delete replaced design resume asset", {
+        assetId: existingAsset.id,
+        documentId: current.id,
+        error: sanitizeUnknown(error),
+      });
+    }
+  }
+
+  return updated;
+}
+
+export async function uploadDesignResumePictureFile(input: {
+  fileName: string;
+  mimeType?: string | null;
+  data: Buffer;
+  baseRevision?: number;
+}): Promise<DesignResumeDocument> {
+  const current = await requireCurrentDesignResume();
+  const mimeType = normalizeImageMimeType({
+    mimeType: input.mimeType,
+    fileName: input.fileName,
+  });
+  if (input.data.byteLength === 0) {
+    throw badRequest("Image payload must not be empty.");
+  }
+  assertImageByteSize(input.data.byteLength);
 
   const existingAsset = await designResumeRepo.findDesignResumeAssetForDocument(
     {
@@ -582,31 +800,15 @@ export async function uploadDesignResumePicture(input: {
   );
 
   const now = new Date().toISOString();
-  try {
-    await writeFile(storagePath, parsed.data);
-    await designResumeRepo.insertDesignResumeAsset({
-      id: assetId,
-      documentId: current.id,
-      kind: "picture",
-      originalName: basename(
-        input.fileName || `picture${extname(storagePath)}`,
-      ),
-      mimeType: parsed.mimeType,
-      byteSize: parsed.data.byteLength,
-      storagePath,
-      updatedAt: now,
-    });
-  } catch (error) {
-    await deleteAssetFile(storagePath);
-    throw error;
-  }
+  const { assetId, storagePath } = await storeDesignResumePictureAsset({
+    documentId: current.id,
+    fileName: input.fileName,
+    mimeType,
+    data: input.data,
+    updatedAt: now,
+  });
 
-  const baseDocument = input.document
-    ? validatePatchedDocument(
-        structuredClone(input.document) as Record<string, unknown>,
-      )
-    : current.resumeJson;
-  const nextDocument = structuredClone(baseDocument) as DesignResumeJson;
+  const nextDocument = structuredClone(current.resumeJson) as DesignResumeJson;
   const picture = asRecord(nextDocument.picture) ?? {};
   nextDocument.picture = {
     ...picture,

--- a/orchestrator/src/server/services/pdf-skills-validation.test.ts
+++ b/orchestrator/src/server/services/pdf-skills-validation.test.ts
@@ -129,6 +129,7 @@ vi.mock("./projectSelection", () => ({
 vi.mock("./tracer-links", () => ({
   getTracerReadiness: vi.fn().mockResolvedValue({
     status: "ready",
+    isPubliclyAvailable: true,
     canEnable: true,
     publicBaseUrl: "https://jobops.example",
     healthUrl: "https://jobops.example/health",

--- a/orchestrator/src/server/services/pdf-skills-validation.test.ts
+++ b/orchestrator/src/server/services/pdf-skills-validation.test.ts
@@ -127,6 +127,15 @@ vi.mock("./projectSelection", () => ({
 }));
 
 vi.mock("./tracer-links", () => ({
+  getTracerReadiness: vi.fn().mockResolvedValue({
+    status: "ready",
+    canEnable: true,
+    publicBaseUrl: "https://jobops.example",
+    healthUrl: "https://jobops.example/health",
+    checkedAt: 1,
+    lastSuccessAt: 1,
+    reason: null,
+  }),
   resolveTracerPublicBaseUrl: vi.fn().mockReturnValue("https://jobops.example"),
   rewriteResumeLinksWithTracer: vi
     .fn()

--- a/orchestrator/src/server/services/pdf-tailoring.test.ts
+++ b/orchestrator/src/server/services/pdf-tailoring.test.ts
@@ -708,4 +708,62 @@ describe("PDF Service Tailoring Logic", () => {
       vi.unstubAllGlobals();
     }
   });
+
+  it("keeps externally hosted pictures in RxResume export when JobOps is not hosted", async () => {
+    currentPdfRenderer.value = "rxresume";
+    mockTracerLinks.getJobOpsPublicAvailability.mockResolvedValue({
+      status: "unavailable",
+      isPubliclyAvailable: false,
+      publicBaseUrl: "http://localhost:3005",
+      healthUrl: "http://localhost:3005/health",
+      checkedAt: 1,
+      lastSuccessAt: null,
+      reason:
+        "Configured public URL must be internet-reachable (not localhost/private network).",
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new TextEncoder().encode("pdf-bytes").buffer,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const designResume = await import("./design-resume");
+    vi.mocked(designResume.getCurrentDesignResume).mockResolvedValueOnce({
+      id: "design-resume-1",
+      title: "Design Resume",
+      sourceResumeId: null,
+      sourceMode: "v5",
+      importedAt: "2026-05-02T00:00:00.000Z",
+      updatedAt: "2026-05-02T00:00:00.000Z",
+      revision: 1,
+      resumeJson: {
+        ...mockProfile,
+        picture: {
+          ...mockProfile.picture,
+          hidden: false,
+          url: "https://cdn.example.com/photo.png",
+        },
+      },
+    } as any);
+
+    const rxresume = await import("./rxresume");
+
+    try {
+      await generateDesignResumePdf({
+        requestOrigin: "http://localhost:3005",
+      });
+
+      expect(rxresume.importResume).toHaveBeenCalledWith({
+        name: "Design Resume",
+        data: expect.objectContaining({
+          picture: expect.objectContaining({
+            hidden: false,
+            url: "https://cdn.example.com/photo.png",
+          }),
+        }),
+      });
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });

--- a/orchestrator/src/server/services/pdf-tailoring.test.ts
+++ b/orchestrator/src/server/services/pdf-tailoring.test.ts
@@ -324,8 +324,18 @@ vi.mock("./resume-renderer", () => ({
 
 const mockTracerLinks = vi.hoisted(() => ({
   resolveTracerPublicBaseUrl: vi.fn().mockReturnValue("https://jobops.example"),
+  getJobOpsPublicAvailability: vi.fn().mockResolvedValue({
+    status: "ready",
+    isPubliclyAvailable: true,
+    publicBaseUrl: "https://jobops.example",
+    healthUrl: "https://jobops.example/health",
+    checkedAt: 1,
+    lastSuccessAt: 1,
+    reason: null,
+  }),
   getTracerReadiness: vi.fn().mockResolvedValue({
     status: "ready",
+    isPubliclyAvailable: true,
     canEnable: true,
     publicBaseUrl: "https://jobops.example",
     healthUrl: "https://jobops.example/health",
@@ -339,6 +349,7 @@ const mockTracerLinks = vi.hoisted(() => ({
 }));
 
 vi.mock("./tracer-links", () => ({
+  getJobOpsPublicAvailability: mockTracerLinks.getJobOpsPublicAvailability,
   getTracerReadiness: mockTracerLinks.getTracerReadiness,
   resolveTracerPublicBaseUrl: mockTracerLinks.resolveTracerPublicBaseUrl,
   rewriteResumeLinksWithTracer: mockTracerLinks.rewriteResumeLinksWithTracer,
@@ -437,8 +448,18 @@ describe("PDF Service Tailoring Logic", () => {
     mockTracerLinks.resolveTracerPublicBaseUrl.mockReturnValue(
       "https://jobops.example",
     );
+    mockTracerLinks.getJobOpsPublicAvailability.mockResolvedValue({
+      status: "ready",
+      isPubliclyAvailable: true,
+      publicBaseUrl: "https://jobops.example",
+      healthUrl: "https://jobops.example/health",
+      checkedAt: 1,
+      lastSuccessAt: 1,
+      reason: null,
+    });
     mockTracerLinks.getTracerReadiness.mockResolvedValue({
       status: "ready",
+      isPubliclyAvailable: true,
       canEnable: true,
       publicBaseUrl: "https://jobops.example",
       healthUrl: "https://jobops.example/health",
@@ -621,8 +642,19 @@ describe("PDF Service Tailoring Logic", () => {
     mockTracerLinks.resolveTracerPublicBaseUrl.mockReturnValue(
       "http://localhost:3005",
     );
+    mockTracerLinks.getJobOpsPublicAvailability.mockResolvedValue({
+      status: "unavailable",
+      isPubliclyAvailable: false,
+      publicBaseUrl: "http://localhost:3005",
+      healthUrl: "http://localhost:3005/health",
+      checkedAt: 1,
+      lastSuccessAt: null,
+      reason:
+        "Configured public URL must be internet-reachable (not localhost/private network).",
+    });
     mockTracerLinks.getTracerReadiness.mockResolvedValue({
       status: "unavailable",
+      isPubliclyAvailable: false,
       canEnable: false,
       publicBaseUrl: "http://localhost:3005",
       healthUrl: "http://localhost:3005/health",

--- a/orchestrator/src/server/services/pdf-tailoring.test.ts
+++ b/orchestrator/src/server/services/pdf-tailoring.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { generatePdf } from "./pdf";
+import { generateDesignResumePdf, generatePdf } from "./pdf";
 import * as projectSelection from "./projectSelection";
 
 // Define mock data in hoisted block
@@ -324,12 +324,22 @@ vi.mock("./resume-renderer", () => ({
 
 const mockTracerLinks = vi.hoisted(() => ({
   resolveTracerPublicBaseUrl: vi.fn().mockReturnValue("https://jobops.example"),
+  getTracerReadiness: vi.fn().mockResolvedValue({
+    status: "ready",
+    canEnable: true,
+    publicBaseUrl: "https://jobops.example",
+    healthUrl: "https://jobops.example/health",
+    checkedAt: 1,
+    lastSuccessAt: 1,
+    reason: null,
+  }),
   rewriteResumeLinksWithTracer: vi
     .fn()
     .mockResolvedValue({ rewrittenLinks: 2 }),
 }));
 
 vi.mock("./tracer-links", () => ({
+  getTracerReadiness: mockTracerLinks.getTracerReadiness,
   resolveTracerPublicBaseUrl: mockTracerLinks.resolveTracerPublicBaseUrl,
   rewriteResumeLinksWithTracer: mockTracerLinks.rewriteResumeLinksWithTracer,
 }));
@@ -427,6 +437,15 @@ describe("PDF Service Tailoring Logic", () => {
     mockTracerLinks.resolveTracerPublicBaseUrl.mockReturnValue(
       "https://jobops.example",
     );
+    mockTracerLinks.getTracerReadiness.mockResolvedValue({
+      status: "ready",
+      canEnable: true,
+      publicBaseUrl: "https://jobops.example",
+      healthUrl: "https://jobops.example/health",
+      checkedAt: 1,
+      lastSuccessAt: 1,
+      reason: null,
+    });
     mockTracerLinks.rewriteResumeLinksWithTracer.mockResolvedValue({
       rewrittenLinks: 2,
     });
@@ -592,6 +611,67 @@ describe("PDF Service Tailoring Logic", () => {
         expect.any(Uint8Array),
       );
       expect(rxresume.deleteResume).toHaveBeenCalledWith("temp-resume-id");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("strips Design Resume pictures from RxResume export when JobOps is not hosted", async () => {
+    currentPdfRenderer.value = "rxresume";
+    mockTracerLinks.resolveTracerPublicBaseUrl.mockReturnValue(
+      "http://localhost:3005",
+    );
+    mockTracerLinks.getTracerReadiness.mockResolvedValue({
+      status: "unavailable",
+      canEnable: false,
+      publicBaseUrl: "http://localhost:3005",
+      healthUrl: "http://localhost:3005/health",
+      checkedAt: 1,
+      lastSuccessAt: null,
+      reason:
+        "Configured public URL must be internet-reachable (not localhost/private network).",
+    });
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new TextEncoder().encode("pdf-bytes").buffer,
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const designResume = await import("./design-resume");
+    vi.mocked(designResume.getCurrentDesignResume).mockResolvedValueOnce({
+      id: "design-resume-1",
+      title: "Design Resume",
+      sourceResumeId: null,
+      sourceMode: "v5",
+      importedAt: "2026-05-02T00:00:00.000Z",
+      updatedAt: "2026-05-02T00:00:00.000Z",
+      revision: 1,
+      resumeJson: {
+        ...mockProfile,
+        picture: {
+          ...mockProfile.picture,
+          hidden: false,
+          url: "/api/design-resume/assets/photo-1/content",
+        },
+      },
+    } as any);
+
+    const rxresume = await import("./rxresume");
+
+    try {
+      await generateDesignResumePdf({
+        requestOrigin: "http://localhost:3005",
+      });
+
+      expect(rxresume.importResume).toHaveBeenCalledWith({
+        name: "Design Resume",
+        data: expect.objectContaining({
+          picture: expect.objectContaining({
+            hidden: true,
+            url: "",
+          }),
+        }),
+      });
     } finally {
       vi.unstubAllGlobals();
     }

--- a/orchestrator/src/server/services/pdf.ts
+++ b/orchestrator/src/server/services/pdf.ts
@@ -8,6 +8,7 @@ import { access, mkdir, writeFile } from "node:fs/promises";
 import { AppError, type AppErrorCode, notFound } from "@infra/errors";
 import { logger } from "@infra/logger";
 import { getSetting } from "@server/repositories/settings";
+import { getTracerReadiness } from "@server/services/tracer-links";
 import { settingsRegistry } from "@shared/settings-registry";
 import type { DesignResumePdfResponse, PdfRenderer } from "@shared/types";
 import { getCurrentDesignResume } from "./design-resume";
@@ -101,6 +102,36 @@ async function downloadRxResumePdf(
   await writeFile(outputPath, bytes);
 }
 
+async function stripPictureWhenJobOpsIsNotHosted(args: {
+  data: Record<string, unknown>;
+  requestOrigin?: string | null;
+}): Promise<Record<string, unknown>> {
+  const readiness = await getTracerReadiness({
+    requestOrigin: args.requestOrigin ?? null,
+    force: false,
+  });
+  if (readiness.canEnable) {
+    return args.data;
+  }
+
+  const picture =
+    args.data.picture &&
+    typeof args.data.picture === "object" &&
+    !Array.isArray(args.data.picture)
+      ? (args.data.picture as Record<string, unknown>)
+      : null;
+  if (!picture) return args.data;
+
+  return {
+    ...args.data,
+    picture: {
+      ...picture,
+      hidden: true,
+      url: "",
+    },
+  };
+}
+
 async function renderRxResumePdf(args: {
   preparedResume: PreparedRxResumePdfPayload;
   outputPath: string;
@@ -111,7 +142,10 @@ async function renderRxResumePdf(args: {
   const { preparedResume, outputPath, jobId } = args;
   let importedResumeId: string | null = null;
   const importData = prepareReactiveResumeV5DocumentForExternalUse(
-    preparedResume.data,
+    await stripPictureWhenJobOpsIsNotHosted({
+      data: preparedResume.data,
+      requestOrigin: args.requestOrigin ?? null,
+    }),
     {
       requestOrigin: args.requestOrigin ?? null,
     },

--- a/orchestrator/src/server/services/pdf.ts
+++ b/orchestrator/src/server/services/pdf.ts
@@ -106,14 +106,6 @@ async function stripPictureWhenJobOpsIsNotHosted(args: {
   data: Record<string, unknown>;
   requestOrigin?: string | null;
 }): Promise<Record<string, unknown>> {
-  const availability = await getJobOpsPublicAvailability({
-    requestOrigin: args.requestOrigin ?? null,
-    force: false,
-  });
-  if (availability.isPubliclyAvailable) {
-    return args.data;
-  }
-
   const picture =
     args.data.picture &&
     typeof args.data.picture === "object" &&
@@ -121,6 +113,19 @@ async function stripPictureWhenJobOpsIsNotHosted(args: {
       ? (args.data.picture as Record<string, unknown>)
       : null;
   if (!picture) return args.data;
+
+  const pictureUrl = typeof picture.url === "string" ? picture.url.trim() : "";
+  if (!/^\/api\/design-resume\/assets\/[^/]+\/content$/.test(pictureUrl)) {
+    return args.data;
+  }
+
+  const availability = await getJobOpsPublicAvailability({
+    requestOrigin: args.requestOrigin ?? null,
+    force: false,
+  });
+  if (availability.isPubliclyAvailable) {
+    return args.data;
+  }
 
   return {
     ...args.data,

--- a/orchestrator/src/server/services/pdf.ts
+++ b/orchestrator/src/server/services/pdf.ts
@@ -8,7 +8,7 @@ import { access, mkdir, writeFile } from "node:fs/promises";
 import { AppError, type AppErrorCode, notFound } from "@infra/errors";
 import { logger } from "@infra/logger";
 import { getSetting } from "@server/repositories/settings";
-import { getTracerReadiness } from "@server/services/tracer-links";
+import { getJobOpsPublicAvailability } from "@server/services/tracer-links";
 import { settingsRegistry } from "@shared/settings-registry";
 import type { DesignResumePdfResponse, PdfRenderer } from "@shared/types";
 import { getCurrentDesignResume } from "./design-resume";
@@ -106,11 +106,11 @@ async function stripPictureWhenJobOpsIsNotHosted(args: {
   data: Record<string, unknown>;
   requestOrigin?: string | null;
 }): Promise<Record<string, unknown>> {
-  const readiness = await getTracerReadiness({
+  const availability = await getJobOpsPublicAvailability({
     requestOrigin: args.requestOrigin ?? null,
     force: false,
   });
-  if (readiness.canEnable) {
+  if (availability.isPubliclyAvailable) {
     return args.data;
   }
 

--- a/orchestrator/src/server/services/rxresume/document.ts
+++ b/orchestrator/src/server/services/rxresume/document.ts
@@ -15,6 +15,7 @@ const VALID_TEMPLATES = new Set([
   "kakuna",
   "lapras",
   "leafish",
+  "meowth",
   "onyx",
   "pikachu",
   "rhyhorn",

--- a/orchestrator/src/server/services/rxresume/schema/v5.ts
+++ b/orchestrator/src/server/services/rxresume/schema/v5.ts
@@ -11,6 +11,7 @@ const templateNames = [
   "kakuna",
   "lapras",
   "leafish",
+  "meowth",
   "onyx",
   "pikachu",
   "rhyhorn",

--- a/orchestrator/src/server/services/rxresume/v5.test.ts
+++ b/orchestrator/src/server/services/rxresume/v5.test.ts
@@ -115,6 +115,21 @@ describe("rxresume v5 endpoints", () => {
     );
   });
 
+  it("preserves current v5 templates during import", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ id: "meowth" }));
+    vi.stubGlobal("fetch", mockFetch);
+    const resume = structuredClone(sampleResume);
+    (resume.metadata as Record<string, unknown>).template = "meowth";
+
+    await importResume(
+      { data: resume, name: "Meowth Resume" },
+      { baseUrl: "https://rxresu.me", apiKey: "test-key" },
+    );
+
+    const body = JSON.parse(String(mockFetch.mock.calls[0][1].body));
+    expect(body.data.metadata.template).toBe("meowth");
+  });
+
   it("logs sanitized upstream validation details when a request fails", async () => {
     const { logger } = await import("@infra/logger");
     const errorPayload = {

--- a/orchestrator/src/server/services/tracer-links.test.ts
+++ b/orchestrator/src/server/services/tracer-links.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as tracerLinksRepo from "../repositories/tracer-links";
 import {
   _resetTracerReadinessCacheForTests,
+  getJobOpsPublicAvailability,
   getTracerReadiness,
   resolveTracerPublicBaseUrl,
   resolveTracerRedirect,
@@ -205,6 +206,7 @@ describe("tracer-links service", () => {
     const readiness = await getTracerReadiness({ requestOrigin: null });
 
     expect(readiness.status).toBe("unconfigured");
+    expect(readiness.isPubliclyAvailable).toBe(false);
     expect(readiness.canEnable).toBe(false);
     expect(readiness.publicBaseUrl).toBeNull();
     expect(readiness.reason).toMatch(/no public jobops base url/i);
@@ -216,6 +218,7 @@ describe("tracer-links service", () => {
     });
 
     expect(readiness.status).toBe("unavailable");
+    expect(readiness.isPubliclyAvailable).toBe(false);
     expect(readiness.canEnable).toBe(false);
     expect(readiness.reason).toMatch(/internet-reachable/i);
   });
@@ -243,6 +246,7 @@ describe("tracer-links service", () => {
     });
 
     expect(readiness.status).toBe("ready");
+    expect(readiness.isPubliclyAvailable).toBe(true);
     expect(readiness.canEnable).toBe(true);
     expect(readiness.publicBaseUrl).toBe("https://my-jobops.example.com");
     expect(mockFetch).toHaveBeenCalledWith(
@@ -251,6 +255,30 @@ describe("tracer-links service", () => {
         method: "GET",
       }),
     );
+  });
+
+  it("exposes public availability as a reusable helper", async () => {
+    process.env.JOBOPS_PUBLIC_BASE_URL = "https://my-jobops.example.com";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ status: "ok" }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+          },
+        }),
+      ),
+    );
+
+    const availability = await getJobOpsPublicAvailability({
+      requestOrigin: null,
+      force: true,
+    });
+
+    expect(availability.status).toBe("ready");
+    expect(availability.isPubliclyAvailable).toBe(true);
+    expect(availability.publicBaseUrl).toBe("https://my-jobops.example.com");
   });
 
   it("classifies browser-like bot user agents as bot family", async () => {

--- a/orchestrator/src/server/services/tracer-links.ts
+++ b/orchestrator/src/server/services/tracer-links.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { logger } from "@infra/logger";
 import { trackServerProductEvent } from "@infra/product-analytics";
 import type {
+  JobOpsPublicAvailabilityResponse,
   JobTracerLinksResponse,
   TracerAnalyticsResponse,
   TracerReadinessResponse,
@@ -28,7 +29,7 @@ const TRACER_READINESS_CACHE_TTL_MS = 5 * 60_000;
 type TracerReadinessCacheEntry = {
   baseUrl: string | null;
   checkedAt: number;
-  response: TracerReadinessResponse;
+  response: JobOpsPublicAvailabilityResponse;
 };
 
 let tracerReadinessCache: TracerReadinessCacheEntry | null = null;
@@ -133,17 +134,17 @@ function resolveTracerReadinessBaseUrl(args: {
   return normalizeBaseUrl(args.requestOrigin);
 }
 
-function makeTracerReadinessResponse(
-  status: TracerReadinessResponse["status"],
+function makePublicAvailabilityResponse(
+  status: JobOpsPublicAvailabilityResponse["status"],
   args: {
     baseUrl: string | null;
     checkedAt: number;
     reason: string | null;
   },
-): TracerReadinessResponse {
+): JobOpsPublicAvailabilityResponse {
   return {
     status,
-    canEnable: status === "ready",
+    isPubliclyAvailable: status === "ready",
     publicBaseUrl: args.baseUrl,
     healthUrl: args.baseUrl ? `${args.baseUrl}/health` : null,
     checkedAt: args.checkedAt,
@@ -383,9 +384,9 @@ export function resolveTracerPublicBaseUrl(args: {
   return normalizeBaseUrl(process.env.JOBOPS_PUBLIC_BASE_URL ?? null);
 }
 
-export async function getTracerReadiness(
+export async function getJobOpsPublicAvailability(
   args: { requestOrigin?: string | null; force?: boolean } = {},
-): Promise<TracerReadinessResponse> {
+): Promise<JobOpsPublicAvailabilityResponse> {
   const baseUrl = resolveTracerReadinessBaseUrl({
     requestOrigin: args.requestOrigin,
   });
@@ -402,10 +403,10 @@ export async function getTracerReadiness(
     return cached.response;
   }
 
-  let response: TracerReadinessResponse;
+  let response: JobOpsPublicAvailabilityResponse;
 
   if (!baseUrl) {
-    response = makeTracerReadinessResponse("unconfigured", {
+    response = makePublicAvailabilityResponse("unconfigured", {
       baseUrl: null,
       checkedAt,
       reason:
@@ -420,7 +421,7 @@ export async function getTracerReadiness(
     }
 
     if (!hostname || isLocalOrPrivateHostname(hostname)) {
-      response = makeTracerReadinessResponse("unavailable", {
+      response = makePublicAvailabilityResponse("unavailable", {
         baseUrl,
         checkedAt,
         reason:
@@ -436,14 +437,14 @@ export async function getTracerReadiness(
         );
 
         if (!healthResponse.ok) {
-          response = makeTracerReadinessResponse("unavailable", {
+          response = makePublicAvailabilityResponse("unavailable", {
             baseUrl,
             checkedAt,
             reason: `Health check returned HTTP ${healthResponse.status}.`,
           });
         } else {
           tracerReadinessLastSuccessAt = checkedAt;
-          response = makeTracerReadinessResponse("ready", {
+          response = makePublicAvailabilityResponse("ready", {
             baseUrl,
             checkedAt,
             reason: null,
@@ -457,7 +458,7 @@ export async function getTracerReadiness(
               ? `Health check failed: ${error.message}.`
               : "Health check failed.";
 
-        response = makeTracerReadinessResponse("unavailable", {
+        response = makePublicAvailabilityResponse("unavailable", {
           baseUrl,
           checkedAt,
           reason,
@@ -489,6 +490,16 @@ export async function getTracerReadiness(
   }
 
   return response;
+}
+
+export async function getTracerReadiness(
+  args: { requestOrigin?: string | null; force?: boolean } = {},
+): Promise<TracerReadinessResponse> {
+  const availability = await getJobOpsPublicAvailability(args);
+  return {
+    ...availability,
+    canEnable: availability.isPubliclyAvailable,
+  };
 }
 
 export function _resetTracerReadinessCacheForTests(): void {

--- a/shared/src/types/api.ts
+++ b/shared/src/types/api.ts
@@ -111,14 +111,19 @@ export interface JobTracerLinksResponse {
 
 export type TracerReadinessStatus = "ready" | "unconfigured" | "unavailable";
 
-export interface TracerReadinessResponse {
+export interface JobOpsPublicAvailabilityResponse {
   status: TracerReadinessStatus;
-  canEnable: boolean;
+  isPubliclyAvailable: boolean;
   publicBaseUrl: string | null;
   healthUrl: string | null;
   checkedAt: number;
   lastSuccessAt: number | null;
   reason: string | null;
+}
+
+export interface TracerReadinessResponse
+  extends JobOpsPublicAvailabilityResponse {
+  canEnable: boolean;
 }
 
 export type ExtractorHealthStatus = "healthy" | "unhealthy";


### PR DESCRIPTION
## Summary
- Preserve RxResume-relative profile image URLs when importing Design Resume data so the PDF exporter can fetch the photo.
- Accept the current RxResume v5 `meowth` template instead of downgrading it during normalization/import.
- Add regression coverage for both behaviors.

## Testing
- Added unit tests for Design Resume import URL handling and RxResume v5 template preservation.
- Ran the orchestrator test suite, client build, and repository CI-parity checks successfully.