### PR TITLE
Fix flaky JobListPanel teardown race

### DIFF
--- a/orchestrator/src/client/lib/virtual-list.ts
+++ b/orchestrator/src/client/lib/virtual-list.ts
@@ -41,6 +41,154 @@ type ElementVirtualizedListOptions<TScrollElement extends Element> =
     scrollElement: TScrollElement | null;
   };
 
+type ScrollObserverCleanup = () => void;
+
+type DebouncedCallback = ((...args: []) => void) & {
+  cancel: () => void;
+};
+
+const addEventListenerOptions = {
+  passive: true,
+};
+
+const supportsScrollEnd =
+  typeof window === "undefined" ? true : "onscrollend" in window;
+
+const createDebouncedCallback = (
+  targetWindow: Window & typeof globalThis,
+  fn: () => void,
+  ms: number,
+): DebouncedCallback => {
+  let timeoutId: number | undefined;
+
+  const callback = (() => {
+    if (timeoutId !== undefined) {
+      targetWindow.clearTimeout(timeoutId);
+    }
+    timeoutId = targetWindow.setTimeout(() => {
+      timeoutId = undefined;
+      fn();
+    }, ms);
+  }) as DebouncedCallback;
+
+  callback.cancel = () => {
+    if (timeoutId !== undefined) {
+      targetWindow.clearTimeout(timeoutId);
+      timeoutId = undefined;
+    }
+  };
+
+  return callback;
+};
+
+const observeElementOffsetWithCleanup = <
+  TScrollElement extends Element,
+  TItemElement extends Element,
+>(
+  instance: Virtualizer<TScrollElement, TItemElement>,
+  cb: (offset: number, isScrolling: boolean) => void,
+): ScrollObserverCleanup | undefined => {
+  const scrollElement = instance.scrollElement;
+  if (!scrollElement) return;
+
+  const targetWindow = instance.targetWindow as
+    | (Window & typeof globalThis)
+    | null;
+  if (!targetWindow) return;
+
+  let offset = 0;
+  const fallback =
+    instance.options.useScrollendEvent && supportsScrollEnd
+      ? null
+      : createDebouncedCallback(
+          targetWindow,
+          () => cb(offset, false),
+          instance.options.isScrollingResetDelay,
+        );
+
+  const createHandler = (isScrolling: boolean) => () => {
+    const { horizontal, isRtl } = instance.options;
+    offset = horizontal
+      ? scrollElement.scrollLeft * ((isRtl && -1) || 1)
+      : scrollElement.scrollTop;
+    fallback?.();
+    cb(offset, isScrolling);
+  };
+
+  const handler = createHandler(true);
+  const endHandler = createHandler(false);
+  const registerScrollEndEvent =
+    instance.options.useScrollendEvent && supportsScrollEnd;
+
+  scrollElement.addEventListener("scroll", handler, addEventListenerOptions);
+  if (registerScrollEndEvent) {
+    scrollElement.addEventListener(
+      "scrollend",
+      endHandler,
+      addEventListenerOptions,
+    );
+  }
+
+  return () => {
+    scrollElement.removeEventListener("scroll", handler);
+    if (registerScrollEndEvent) {
+      scrollElement.removeEventListener("scrollend", endHandler);
+    }
+    fallback?.cancel();
+  };
+};
+
+const observeWindowOffsetWithCleanup = <TItemElement extends Element>(
+  instance: Virtualizer<Window, TItemElement>,
+  cb: (offset: number, isScrolling: boolean) => void,
+): ScrollObserverCleanup | undefined => {
+  const scrollElement = instance.scrollElement;
+  if (!scrollElement) return;
+
+  const targetWindow = instance.targetWindow as
+    | (Window & typeof globalThis)
+    | null;
+  if (!targetWindow) return;
+
+  let offset = 0;
+  const fallback =
+    instance.options.useScrollendEvent && supportsScrollEnd
+      ? null
+      : createDebouncedCallback(
+          targetWindow,
+          () => cb(offset, false),
+          instance.options.isScrollingResetDelay,
+        );
+
+  const createHandler = (isScrolling: boolean) => () => {
+    offset = scrollElement[instance.options.horizontal ? "scrollX" : "scrollY"];
+    fallback?.();
+    cb(offset, isScrolling);
+  };
+
+  const handler = createHandler(true);
+  const endHandler = createHandler(false);
+  const registerScrollEndEvent =
+    instance.options.useScrollendEvent && supportsScrollEnd;
+
+  scrollElement.addEventListener("scroll", handler, addEventListenerOptions);
+  if (registerScrollEndEvent) {
+    scrollElement.addEventListener(
+      "scrollend",
+      endHandler,
+      addEventListenerOptions,
+    );
+  }
+
+  return () => {
+    scrollElement.removeEventListener("scroll", handler);
+    if (registerScrollEndEvent) {
+      scrollElement.removeEventListener("scrollend", endHandler);
+    }
+    fallback?.cancel();
+  };
+};
+
 export function useVirtualizedList<
   TItemElement extends Element = HTMLDivElement,
 >(options: WindowVirtualizedListOptions): Virtualizer<Window, TItemElement>;
@@ -157,6 +305,7 @@ export function useVirtualizedList<
     initialRect,
     getScrollElement: () =>
       options.mode === "element" ? options.scrollElement : null,
+    observeElementOffset: observeElementOffsetWithCleanup,
     scrollToFn: scrollElement,
     useFlushSync: false,
   });
@@ -168,6 +317,7 @@ export function useVirtualizedList<
     overscan,
     enabled: enabled && !isElementMode,
     initialRect,
+    observeElementOffset: observeWindowOffsetWithCleanup,
     scrollToFn: scrollWindow,
     useFlushSync: false,
   });


### PR DESCRIPTION
## Summary
- Cancel pending virtualizer scroll-reset timers during cleanup in `useVirtualizedList`
- Keep window and element virtualized lists from firing updates after jsdom teardown
- Stabilize the `JobListPanel` test path that was intermittently throwing `window is not defined`

## Testing
- `vitest run src/client/pages/orchestrator/JobListPanel.test.tsx`
- `npm --workspace orchestrator run test:run`
- `npm --workspace orchestrator run check:types`
- `./orchestrator/node_modules/.bin/biome ci .`