### PR TITLE
Fix tenant-scoped caching and workspace-local pipeline prefs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,14 @@ Use consistent status/code mapping:
 - Include request ID in API responses (`meta.requestId`) and logs.
 - Propagate context into async flows (especially pipeline run and per-job work) so logs include `pipelineRunId` / `jobId` when available.
 
+## Multi-Tenancy Defaults
+
+- Treat every server-side change as multi-tenant by default.
+- Before adding or changing storage, caching, background work, API routes, SSE streams, files, or external payloads, confirm how tenant/workspace context is selected, propagated, and enforced.
+- Scope database reads/writes, filesystem paths, in-memory caches, queues, locks, rate limits, and long-lived process state by tenant/workspace unless the data is explicitly global.
+- Never let module-level caches or singleton state hold tenant-specific profile, settings, job, PDF, chat, or integration data unless the cache key includes the active tenant/workspace.
+- Include cross-tenant regression coverage when touching shared repositories, services, auth/session handling, profile/resume flows, PDF generation, Ghostwriter/tailoring, pipeline state, or settings.
+
 ## Logging Rules
 
 - Use the shared logger wrapper (`infra/logger.ts`) in core server paths.
@@ -62,6 +70,7 @@ Use consistent status/code mapping:
 - API responses follow `{ ok, data/error, meta.requestId }`.
 - Status/code mapping is correct and consistent.
 - Request/correlation IDs appear in logs and async workflows.
+- Tenant/workspace context is correctly scoped across storage, caches, async work, files, and external payloads.
 - No raw sensitive payload logging or raw upstream body throws.
 - New/changed webhook or LLM payloads are sanitized and documented.
 

--- a/orchestrator/src/client/api/client.auth.test.ts
+++ b/orchestrator/src/client/api/client.auth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { queryClient } from "@/client/lib/queryClient";
 import * as api from "./client";
 
 const { redirectToSignIn } = vi.hoisted(() => ({
@@ -146,6 +147,7 @@ describe("API client auth flow", () => {
       username: "legacy-user",
       password: "legacy-pass",
     });
+    const clearSpy = vi.spyOn(queryClient, "clear");
 
     vi.spyOn(global, "fetch").mockResolvedValueOnce(
       jwtLoginSuccess("fresh-token"),
@@ -155,10 +157,12 @@ describe("API client auth flow", () => {
       api.signInWithCredentials("legacy-user", "legacy-pass"),
     ).resolves.toBeUndefined();
     expect(api.getCachedAuthHeader()).toBe("Bearer fresh-token");
+    expect(clearSpy).toHaveBeenCalledTimes(1);
   });
 
   it("redirects after logout and clears the cached token", async () => {
     api.__setAuthTokenForTests("logout-token");
+    const clearSpy = vi.spyOn(queryClient, "clear");
 
     vi.spyOn(global, "fetch").mockResolvedValueOnce(
       createJsonResponse(200, {
@@ -171,6 +175,7 @@ describe("API client auth flow", () => {
     await api.logout();
 
     expect(api.getCachedAuthHeader()).toBeUndefined();
+    expect(clearSpy).toHaveBeenCalledTimes(1);
     expect(redirectToSignIn).toHaveBeenCalledTimes(1);
   });
 

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -153,6 +153,35 @@ const LEGACY_SESSION_JWT_KEY = "jobops.jwtToken";
 const SESSION_AUTH_TOKEN_KEY = "jobops.authToken";
 const LEGACY_SESSION_AUTH_TTL_MS = 5 * 60 * 1000;
 
+function decodeBase64UrlJsonSegment(
+  segment: string,
+): Record<string, unknown> | null {
+  try {
+    const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = normalized.padEnd(
+      normalized.length + ((4 - (normalized.length % 4)) % 4),
+      "=",
+    );
+    const decoded = globalThis.atob(padded);
+    const parsed = JSON.parse(decoded) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function getTenantIdFromAuthToken(token: string | null): string | null {
+  const payloadSegment = token?.split(".")[1];
+  if (!payloadSegment) return null;
+  const payload = decodeBase64UrlJsonSegment(payloadSegment);
+  const tenantId = payload?.tenantId;
+  return typeof tenantId === "string" && tenantId.trim().length > 0
+    ? tenantId.trim()
+    : null;
+}
+
 function loadStoredLegacyCredentials(): AuthCredentials | null {
   try {
     const stored = sessionStorage.getItem(LEGACY_SESSION_AUTH_KEY);
@@ -228,6 +257,16 @@ function storeAuthToken(token: string | null): void {
   } catch {
     // Ignore storage errors in restricted browser contexts.
   }
+}
+
+export function getCurrentAuthWorkspaceStorageScope(): string | null {
+  const tenantId = getTenantIdFromAuthToken(loadStoredAuthToken());
+  return tenantId ? `workspace:${tenantId}` : null;
+}
+
+export function getAuthScopedStorageKey(baseKey: string): string {
+  const scope = getCurrentAuthWorkspaceStorageScope();
+  return scope ? `${baseKey}:${scope}` : baseKey;
 }
 
 let cachedLegacyCredentials: AuthCredentials | null =

--- a/orchestrator/src/client/api/client.ts
+++ b/orchestrator/src/client/api/client.ts
@@ -65,6 +65,7 @@ import type {
   VisaSponsorStatusResponse,
 } from "@shared/types";
 import { formatUserFacingError } from "@/client/lib/error-format";
+import { queryClient } from "@/client/lib/queryClient";
 import {
   bucketQueryLength,
   getAnalyticsRequestHeaders,
@@ -234,7 +235,12 @@ let cachedLegacyCredentials: AuthCredentials | null =
 let cachedAuthToken: string | null = loadStoredAuthToken();
 let authMigrationInFlight: Promise<boolean> | null = null;
 
+function clearCachedAppData(): void {
+  queryClient.clear();
+}
+
 export function clearAuthSession(): void {
+  clearCachedAppData();
   cachedLegacyCredentials = null;
   cachedAuthToken = null;
   storeLegacyCredentials(null);
@@ -242,6 +248,7 @@ export function clearAuthSession(): void {
 }
 
 function setAuthenticatedSession(token: string): void {
+  clearCachedAppData();
   cachedAuthToken = token;
   storeAuthToken(token);
   cachedLegacyCredentials = null;

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.test.ts
@@ -260,6 +260,31 @@ describe("automatic-run utilities", () => {
     });
   });
 
+  it("migrates legacy run memory into the workspace-scoped key", () => {
+    const sessionStorage = ensureSessionStorage();
+    const localStorage = ensureStorage();
+    sessionStorage.setItem("jobops.authToken", makeAuthToken("tenant-one"));
+    localStorage.setItem(
+      RUN_MEMORY_STORAGE_KEY,
+      JSON.stringify({
+        topN: 8,
+        minSuitabilityScore: 65,
+        runBudget: 350,
+        presetId: "custom",
+      }),
+    );
+
+    expect(loadAutomaticRunMemory()).toEqual({
+      topN: 8,
+      minSuitabilityScore: 65,
+      runBudget: 350,
+      presetId: "custom",
+    });
+    expect(
+      localStorage.getItem(`${RUN_MEMORY_STORAGE_KEY}:workspace:tenant-one`),
+    ).toBe(localStorage.getItem(RUN_MEMORY_STORAGE_KEY));
+  });
+
   it("infers custom when legacy values do not match a preset", () => {
     expect(
       inferAutomaticPresetSelection({

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.test.ts
@@ -3,10 +3,12 @@ import {
   AUTOMATIC_PRESETS,
   calculateAutomaticEstimate,
   deriveExtractorLimits,
+  getRunMemoryStorageKey,
   inferAutomaticPresetSelection,
   loadAutomaticRunMemory,
   parseSearchTermsInput,
   RUN_MEMORY_STORAGE_KEY,
+  saveAutomaticRunMemory,
 } from "./automatic-run";
 
 function ensureStorage(): Storage {
@@ -54,9 +56,65 @@ function ensureStorage(): Storage {
   return storage;
 }
 
+function ensureSessionStorage(): Storage {
+  const existing = globalThis.sessionStorage as Partial<Storage> | undefined;
+  const hasStorageShape =
+    existing &&
+    typeof existing.getItem === "function" &&
+    typeof existing.setItem === "function" &&
+    typeof existing.removeItem === "function" &&
+    typeof existing.clear === "function";
+
+  if (hasStorageShape) {
+    return existing as Storage;
+  }
+
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      const value = store.get(key);
+      return value ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+
+  return storage;
+}
+
+function makeAuthToken(tenantId: string): string {
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+  return [
+    encode({ alg: "HS256", typ: "JWT" }),
+    encode({ tenantId }),
+    "signature",
+  ].join(".");
+}
+
 describe("automatic-run utilities", () => {
   beforeEach(() => {
     ensureStorage().clear();
+    ensureSessionStorage().clear();
   });
 
   it("exposes the expected preset values", () => {
@@ -162,6 +220,43 @@ describe("automatic-run utilities", () => {
       minSuitabilityScore: AUTOMATIC_PRESETS.balanced.minSuitabilityScore,
       runBudget: AUTOMATIC_PRESETS.balanced.runBudget,
       presetId: "custom",
+    });
+  });
+
+  it("scopes run memory to the authenticated workspace", () => {
+    const sessionStorage = ensureSessionStorage();
+    sessionStorage.setItem("jobops.authToken", makeAuthToken("tenant-one"));
+
+    saveAutomaticRunMemory({
+      topN: 6,
+      minSuitabilityScore: 70,
+      runBudget: 300,
+      presetId: "custom",
+    });
+
+    expect(getRunMemoryStorageKey()).toBe(
+      `${RUN_MEMORY_STORAGE_KEY}:workspace:tenant-one`,
+    );
+
+    sessionStorage.setItem("jobops.authToken", makeAuthToken("tenant-two"));
+    expect(loadAutomaticRunMemory()).toBeNull();
+
+    saveAutomaticRunMemory({
+      topN: 12,
+      minSuitabilityScore: 40,
+      runBudget: 600,
+      presetId: "custom",
+    });
+
+    expect(loadAutomaticRunMemory()).toMatchObject({
+      topN: 12,
+      minSuitabilityScore: 40,
+    });
+
+    sessionStorage.setItem("jobops.authToken", makeAuthToken("tenant-one"));
+    expect(loadAutomaticRunMemory()).toMatchObject({
+      topN: 6,
+      minSuitabilityScore: 70,
     });
   });
 

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.ts
@@ -10,6 +10,7 @@ import {
   serializeSearchCitiesSetting,
 } from "@shared/search-cities.js";
 import type { JobSource } from "@shared/types";
+import { getAuthScopedStorageKey } from "@/client/api/client";
 
 export type AutomaticPresetId = "fast" | "balanced" | "detailed";
 export type AutomaticPresetSelection = AutomaticPresetId | "custom";
@@ -83,6 +84,10 @@ export const AUTOMATIC_PRESETS: Record<
 };
 
 export const RUN_MEMORY_STORAGE_KEY = "jobops.pipeline.run-memory.v1";
+
+export function getRunMemoryStorageKey(): string {
+  return getAuthScopedStorageKey(RUN_MEMORY_STORAGE_KEY);
+}
 
 export const SEARCH_SCOPE_OPTIONS: Array<{
   value: LocationSearchScope;
@@ -397,7 +402,7 @@ export function calculateAutomaticEstimate(args: {
 
 export function loadAutomaticRunMemory(): AutomaticRunMemory | null {
   try {
-    const raw = localStorage.getItem(RUN_MEMORY_STORAGE_KEY);
+    const raw = localStorage.getItem(getRunMemoryStorageKey());
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     if (
@@ -467,7 +472,7 @@ export function loadAutomaticRunMemory(): AutomaticRunMemory | null {
 
 export function saveAutomaticRunMemory(memory: AutomaticRunMemory): void {
   try {
-    localStorage.setItem(RUN_MEMORY_STORAGE_KEY, JSON.stringify(memory));
+    localStorage.setItem(getRunMemoryStorageKey(), JSON.stringify(memory));
   } catch {
     // Ignore localStorage failures
   }

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.ts
@@ -89,6 +89,20 @@ export function getRunMemoryStorageKey(): string {
   return getAuthScopedStorageKey(RUN_MEMORY_STORAGE_KEY);
 }
 
+function readRunMemoryStorage(): string | null {
+  const storageKey = getRunMemoryStorageKey();
+  const scoped = localStorage.getItem(storageKey);
+  if (scoped || storageKey === RUN_MEMORY_STORAGE_KEY) return scoped;
+  return localStorage.getItem(RUN_MEMORY_STORAGE_KEY);
+}
+
+function migrateLegacyRunMemoryStorage(raw: string): void {
+  const storageKey = getRunMemoryStorageKey();
+  if (storageKey === RUN_MEMORY_STORAGE_KEY) return;
+  if (localStorage.getItem(storageKey)) return;
+  localStorage.setItem(storageKey, raw);
+}
+
 export const SEARCH_SCOPE_OPTIONS: Array<{
   value: LocationSearchScope;
   label: string;
@@ -402,7 +416,7 @@ export function calculateAutomaticEstimate(args: {
 
 export function loadAutomaticRunMemory(): AutomaticRunMemory | null {
   try {
-    const raw = localStorage.getItem(getRunMemoryStorageKey());
+    const raw = readRunMemoryStorage();
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     if (
@@ -423,6 +437,7 @@ export function loadAutomaticRunMemory(): AutomaticRunMemory | null {
     const explicitPresetId = isAutomaticPresetSelection(parsed.presetId)
       ? parsed.presetId
       : null;
+    migrateLegacyRunMemoryStorage(raw);
 
     if (explicitPresetId && explicitPresetId !== "custom") {
       const preset = AUTOMATIC_PRESETS[explicitPresetId];

--- a/orchestrator/src/client/pages/orchestrator/usePipelineSources.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineSources.test.ts
@@ -2,7 +2,10 @@ import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { PIPELINE_SOURCES_STORAGE_KEY } from "./constants";
-import { usePipelineSources } from "./usePipelineSources";
+import {
+  getPipelineSourcesStorageKey,
+  usePipelineSources,
+} from "./usePipelineSources";
 
 function ensureStorage(): Storage {
   const existing = globalThis.localStorage as Partial<Storage> | undefined;
@@ -49,9 +52,65 @@ function ensureStorage(): Storage {
   return storage;
 }
 
+function ensureSessionStorage(): Storage {
+  const existing = globalThis.sessionStorage as Partial<Storage> | undefined;
+  const hasStorageShape =
+    existing &&
+    typeof existing.getItem === "function" &&
+    typeof existing.setItem === "function" &&
+    typeof existing.removeItem === "function" &&
+    typeof existing.clear === "function";
+
+  if (hasStorageShape) {
+    return existing as Storage;
+  }
+
+  const store = new Map<string, string>();
+  const storage: Storage = {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string) {
+      const value = store.get(key);
+      return value ?? null;
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      store.delete(key);
+    },
+    setItem(key: string, value: string) {
+      store.set(key, value);
+    },
+  };
+
+  Object.defineProperty(globalThis, "sessionStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+
+  return storage;
+}
+
+function makeAuthToken(tenantId: string): string {
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value), "utf8").toString("base64url");
+  return [
+    encode({ alg: "HS256", typ: "JWT" }),
+    encode({ tenantId }),
+    "signature",
+  ].join(".");
+}
+
 describe("usePipelineSources", () => {
   beforeEach(() => {
     ensureStorage().clear();
+    ensureSessionStorage().clear();
   });
 
   it("filters stored sources to enabled sources", () => {
@@ -95,5 +154,48 @@ describe("usePipelineSources", () => {
     });
 
     expect(result.current.pipelineSources).toEqual(["gradcracker"]);
+  });
+
+  it("loads and saves sources using workspace-scoped storage keys", () => {
+    const sessionStorage = ensureSessionStorage();
+    sessionStorage.setItem("jobops.authToken", makeAuthToken("tenant-one"));
+    ensureStorage().setItem(
+      getPipelineSourcesStorageKey(),
+      JSON.stringify(["ukvisajobs"]),
+    );
+
+    sessionStorage.setItem("jobops.authToken", makeAuthToken("tenant-two"));
+    ensureStorage().setItem(
+      getPipelineSourcesStorageKey(),
+      JSON.stringify(["linkedin"]),
+    );
+
+    sessionStorage.setItem("jobops.authToken", makeAuthToken("tenant-one"));
+    const enabledSources = ["ukvisajobs", "linkedin"] as const;
+    const { result } = renderHook(() => usePipelineSources(enabledSources));
+
+    expect(getPipelineSourcesStorageKey()).toBe(
+      `${PIPELINE_SOURCES_STORAGE_KEY}:workspace:tenant-one`,
+    );
+    expect(result.current.pipelineSources).toEqual(["ukvisajobs"]);
+
+    act(() => {
+      result.current.toggleSource("linkedin", true);
+    });
+
+    expect(
+      JSON.parse(
+        ensureStorage().getItem(
+          `${PIPELINE_SOURCES_STORAGE_KEY}:workspace:tenant-one`,
+        ) ?? "[]",
+      ),
+    ).toEqual(["ukvisajobs", "linkedin"]);
+    expect(
+      JSON.parse(
+        ensureStorage().getItem(
+          `${PIPELINE_SOURCES_STORAGE_KEY}:workspace:tenant-two`,
+        ) ?? "[]",
+      ),
+    ).toEqual(["linkedin"]);
   });
 });

--- a/orchestrator/src/client/pages/orchestrator/usePipelineSources.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineSources.test.ts
@@ -198,4 +198,24 @@ describe("usePipelineSources", () => {
       ),
     ).toEqual(["linkedin"]);
   });
+
+  it("migrates legacy stored sources into the workspace-scoped key", () => {
+    const sessionStorage = ensureSessionStorage();
+    const localStorage = ensureStorage();
+    sessionStorage.setItem("jobops.authToken", makeAuthToken("tenant-one"));
+    localStorage.setItem(
+      PIPELINE_SOURCES_STORAGE_KEY,
+      JSON.stringify(["ukvisajobs"]),
+    );
+
+    const enabledSources = ["ukvisajobs", "linkedin"] as const;
+    const { result } = renderHook(() => usePipelineSources(enabledSources));
+
+    expect(result.current.pipelineSources).toEqual(["ukvisajobs"]);
+    expect(
+      localStorage.getItem(
+        `${PIPELINE_SOURCES_STORAGE_KEY}:workspace:tenant-one`,
+      ),
+    ).toBe(localStorage.getItem(PIPELINE_SOURCES_STORAGE_KEY));
+  });
 });

--- a/orchestrator/src/client/pages/orchestrator/usePipelineSources.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineSources.ts
@@ -1,10 +1,15 @@
 import type { JobSource } from "@shared/types";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { getAuthScopedStorageKey } from "@/client/api/client";
 import {
   DEFAULT_PIPELINE_SOURCES,
   orderedSources,
   PIPELINE_SOURCES_STORAGE_KEY,
 } from "./constants";
+
+export function getPipelineSourcesStorageKey(): string {
+  return getAuthScopedStorageKey(PIPELINE_SOURCES_STORAGE_KEY);
+}
 
 const resolveAllowedSources = (enabledSources?: readonly JobSource[]) =>
   enabledSources && enabledSources.length > 0
@@ -28,9 +33,10 @@ export const usePipelineSources = (enabledSources?: readonly JobSource[]) => {
     () => resolveAllowedSources(enabledSources),
     [enabledSources],
   );
+  const storageKey = useMemo(() => getPipelineSourcesStorageKey(), []);
   const [pipelineSources, setPipelineSources] = useState<JobSource[]>(() => {
     try {
-      const raw = localStorage.getItem(PIPELINE_SOURCES_STORAGE_KEY);
+      const raw = localStorage.getItem(storageKey);
       if (!raw) return normalizeSources(allowedSources, allowedSources);
       const parsed = JSON.parse(raw) as unknown;
       if (!Array.isArray(parsed))
@@ -53,14 +59,11 @@ export const usePipelineSources = (enabledSources?: readonly JobSource[]) => {
 
   useEffect(() => {
     try {
-      localStorage.setItem(
-        PIPELINE_SOURCES_STORAGE_KEY,
-        JSON.stringify(pipelineSources),
-      );
+      localStorage.setItem(storageKey, JSON.stringify(pipelineSources));
     } catch {
       // Ignore localStorage errors
     }
-  }, [pipelineSources]);
+  }, [pipelineSources, storageKey]);
 
   const toggleSource = useCallback(
     (source: JobSource, checked: boolean) => {

--- a/orchestrator/src/client/pages/orchestrator/usePipelineSources.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineSources.ts
@@ -11,6 +11,21 @@ export function getPipelineSourcesStorageKey(): string {
   return getAuthScopedStorageKey(PIPELINE_SOURCES_STORAGE_KEY);
 }
 
+function readPipelineSourcesStorage(storageKey: string): string | null {
+  const scoped = localStorage.getItem(storageKey);
+  if (scoped || storageKey === PIPELINE_SOURCES_STORAGE_KEY) return scoped;
+  return localStorage.getItem(PIPELINE_SOURCES_STORAGE_KEY);
+}
+
+function migrateLegacyPipelineSourcesStorage(
+  storageKey: string,
+  raw: string,
+): void {
+  if (storageKey === PIPELINE_SOURCES_STORAGE_KEY) return;
+  if (localStorage.getItem(storageKey)) return;
+  localStorage.setItem(storageKey, raw);
+}
+
 const resolveAllowedSources = (enabledSources?: readonly JobSource[]) =>
   enabledSources && enabledSources.length > 0
     ? (enabledSources as JobSource[])
@@ -36,7 +51,7 @@ export const usePipelineSources = (enabledSources?: readonly JobSource[]) => {
   const storageKey = useMemo(() => getPipelineSourcesStorageKey(), []);
   const [pipelineSources, setPipelineSources] = useState<JobSource[]>(() => {
     try {
-      const raw = localStorage.getItem(storageKey);
+      const raw = readPipelineSourcesStorage(storageKey);
       if (!raw) return normalizeSources(allowedSources, allowedSources);
       const parsed = JSON.parse(raw) as unknown;
       if (!Array.isArray(parsed))
@@ -44,6 +59,7 @@ export const usePipelineSources = (enabledSources?: readonly JobSource[]) => {
       const next = parsed.filter((value): value is JobSource =>
         orderedSources.includes(value as JobSource),
       );
+      migrateLegacyPipelineSourcesStorage(storageKey, raw);
       return normalizeSources(next, allowedSources);
     } catch {
       return normalizeSources(allowedSources, allowedSources);

--- a/orchestrator/src/server/services/profile.test.ts
+++ b/orchestrator/src/server/services/profile.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { clearProfileCache, getProfile } from "./profile";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  __getProfileCacheSizeForTests,
+  clearProfileCache,
+  getProfile,
+} from "./profile";
 
 // Mock the dependencies
 vi.mock("./design-resume", () => ({
@@ -40,6 +44,10 @@ describe("getProfile", () => {
     clearProfileCache();
     vi.mocked(designResumeToProfile).mockResolvedValue(null);
     vi.mocked(isLegacyDesignResumeError).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("should throw an error if rxresumeBaseResumeId is not configured", async () => {
@@ -101,6 +109,38 @@ describe("getProfile", () => {
     });
 
     expect(designResumeToProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it("should evict inactive tenant profile caches after the TTL", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-04T10:00:00.000Z"));
+
+    vi.mocked(designResumeToProfile)
+      .mockResolvedValueOnce({ basics: { name: "Tenant One" } } as any)
+      .mockResolvedValueOnce({ basics: { name: "Tenant Two" } } as any)
+      .mockResolvedValueOnce({
+        basics: { name: "Tenant One Reloaded" },
+      } as any);
+
+    vi.mocked(getActiveTenantId).mockReturnValue("tenant-one");
+    await expect(getProfile()).resolves.toEqual({
+      basics: { name: "Tenant One" },
+    });
+    expect(__getProfileCacheSizeForTests()).toBe(1);
+
+    vi.advanceTimersByTime(31 * 60 * 1000);
+    vi.mocked(getActiveTenantId).mockReturnValue("tenant-two");
+    await expect(getProfile()).resolves.toEqual({
+      basics: { name: "Tenant Two" },
+    });
+    expect(__getProfileCacheSizeForTests()).toBe(1);
+
+    vi.mocked(getActiveTenantId).mockReturnValue("tenant-one");
+    await expect(getProfile()).resolves.toEqual({
+      basics: { name: "Tenant One Reloaded" },
+    });
+
+    expect(designResumeToProfile).toHaveBeenCalledTimes(3);
   });
 
   it("should fetch profile from Reactive Resume when configured", async () => {

--- a/orchestrator/src/server/services/profile.test.ts
+++ b/orchestrator/src/server/services/profile.test.ts
@@ -21,6 +21,11 @@ vi.mock("./rxresume/baseResumeId", () => ({
   getConfiguredRxResumeBaseResumeId: vi.fn(),
 }));
 
+vi.mock("@server/tenancy/context", () => ({
+  getActiveTenantId: vi.fn(() => "tenant_default"),
+}));
+
+import { getActiveTenantId } from "@server/tenancy/context";
 import {
   designResumeToProfile,
   isLegacyDesignResumeError,
@@ -31,6 +36,7 @@ import { getConfiguredRxResumeBaseResumeId } from "./rxresume/baseResumeId";
 describe("getProfile", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    vi.mocked(getActiveTenantId).mockReturnValue("tenant_default");
     clearProfileCache();
     vi.mocked(designResumeToProfile).mockResolvedValue(null);
     vi.mocked(isLegacyDesignResumeError).mockReturnValue(false);
@@ -69,6 +75,32 @@ describe("getProfile", () => {
     expect(designResumeToProfile).toHaveBeenCalledTimes(1);
     expect(getConfiguredRxResumeBaseResumeId).not.toHaveBeenCalled();
     expect(getResume).not.toHaveBeenCalled();
+  });
+
+  it("should keep local Design Resume profiles scoped by tenant", async () => {
+    vi.mocked(designResumeToProfile)
+      .mockResolvedValueOnce({ basics: { name: "Tenant One" } } as any)
+      .mockResolvedValueOnce({ basics: { name: "Tenant Two" } } as any);
+
+    vi.mocked(getActiveTenantId).mockReturnValue("tenant-one");
+    await expect(getProfile()).resolves.toEqual({
+      basics: { name: "Tenant One" },
+    });
+    await expect(getProfile()).resolves.toEqual({
+      basics: { name: "Tenant One" },
+    });
+
+    vi.mocked(getActiveTenantId).mockReturnValue("tenant-two");
+    await expect(getProfile()).resolves.toEqual({
+      basics: { name: "Tenant Two" },
+    });
+
+    vi.mocked(getActiveTenantId).mockReturnValue("tenant-one");
+    await expect(getProfile()).resolves.toEqual({
+      basics: { name: "Tenant One" },
+    });
+
+    expect(designResumeToProfile).toHaveBeenCalledTimes(2);
   });
 
   it("should fetch profile from Reactive Resume when configured", async () => {

--- a/orchestrator/src/server/services/profile.ts
+++ b/orchestrator/src/server/services/profile.ts
@@ -1,4 +1,6 @@
 import { logger } from "@infra/logger";
+import { getTenantId } from "@infra/request-context";
+import { getActiveTenantId } from "@server/tenancy/context";
 import type { ResumeProfile } from "@shared/types";
 import {
   designResumeToProfile,
@@ -7,9 +9,27 @@ import {
 import { getResume, RxResumeAuthConfigError } from "./rxresume";
 import { getConfiguredRxResumeBaseResumeId } from "./rxresume/baseResumeId";
 
-let cachedProfile: ResumeProfile | null = null;
-let cachedResumeId: string | null = null;
-let cachedLocalProfile: ResumeProfile | null = null;
+type TenantProfileCache = {
+  profile: ResumeProfile | null;
+  resumeId: string | null;
+  localProfile: ResumeProfile | null;
+};
+
+const profileCacheByTenant = new Map<string, TenantProfileCache>();
+
+function getTenantProfileCache(): TenantProfileCache {
+  const tenantId = getActiveTenantId();
+  let cache = profileCacheByTenant.get(tenantId);
+  if (!cache) {
+    cache = {
+      profile: null,
+      resumeId: null,
+      localProfile: null,
+    };
+    profileCacheByTenant.set(tenantId, cache);
+  }
+  return cache;
+}
 
 /**
  * Get the base resume profile from RxResume.
@@ -21,14 +41,16 @@ let cachedLocalProfile: ResumeProfile | null = null;
  * @throws Error if rxresumeBaseResumeId is not configured or API call fails.
  */
 export async function getProfile(forceRefresh = false): Promise<ResumeProfile> {
-  if (cachedLocalProfile && !forceRefresh) {
-    return cachedLocalProfile;
+  const cache = getTenantProfileCache();
+
+  if (cache.localProfile && !forceRefresh) {
+    return cache.localProfile;
   }
 
   try {
     const localProfile = await designResumeToProfile();
     if (localProfile) {
-      cachedLocalProfile = localProfile;
+      cache.localProfile = localProfile;
       return localProfile;
     }
   } catch (error) {
@@ -54,11 +76,11 @@ export async function getProfile(forceRefresh = false): Promise<ResumeProfile> {
 
   // Return cached profile if valid
   if (
-    cachedProfile &&
-    cachedResumeId === rxresumeBaseResumeId &&
+    cache.profile &&
+    cache.resumeId === rxresumeBaseResumeId &&
     !forceRefresh
   ) {
-    return cachedProfile;
+    return cache.profile;
   }
 
   try {
@@ -73,12 +95,12 @@ export async function getProfile(forceRefresh = false): Promise<ResumeProfile> {
       throw new Error("Resume data is empty or invalid");
     }
 
-    cachedProfile = resume.data as unknown as ResumeProfile;
-    cachedResumeId = rxresumeBaseResumeId;
+    cache.profile = resume.data as unknown as ResumeProfile;
+    cache.resumeId = rxresumeBaseResumeId;
     logger.info("Profile loaded from Reactive Resume", {
       resumeId: rxresumeBaseResumeId,
     });
-    return cachedProfile;
+    return cache.profile;
   } catch (error) {
     if (error instanceof RxResumeAuthConfigError) {
       throw new Error(error.message);
@@ -103,7 +125,10 @@ export async function getPersonName(): Promise<string> {
  * Clear the profile cache.
  */
 export function clearProfileCache(): void {
-  cachedProfile = null;
-  cachedResumeId = null;
-  cachedLocalProfile = null;
+  const tenantId = getTenantId();
+  if (tenantId) {
+    profileCacheByTenant.delete(tenantId);
+    return;
+  }
+  profileCacheByTenant.clear();
 }

--- a/orchestrator/src/server/services/profile.ts
+++ b/orchestrator/src/server/services/profile.ts
@@ -13,11 +13,37 @@ type TenantProfileCache = {
   profile: ResumeProfile | null;
   resumeId: string | null;
   localProfile: ResumeProfile | null;
+  lastAccessedAt: number;
 };
 
+const PROFILE_CACHE_TTL_MS = 30 * 60 * 1000;
+const PROFILE_CACHE_MAX_TENANTS = 100;
 const profileCacheByTenant = new Map<string, TenantProfileCache>();
 
+function pruneProfileCache(now = Date.now()): void {
+  for (const [tenantId, cache] of profileCacheByTenant.entries()) {
+    if (now - cache.lastAccessedAt > PROFILE_CACHE_TTL_MS) {
+      profileCacheByTenant.delete(tenantId);
+    }
+  }
+
+  while (profileCacheByTenant.size >= PROFILE_CACHE_MAX_TENANTS) {
+    let oldestTenantId: string | null = null;
+    let oldestAccessedAt = Number.POSITIVE_INFINITY;
+    for (const [tenantId, cache] of profileCacheByTenant.entries()) {
+      if (cache.lastAccessedAt < oldestAccessedAt) {
+        oldestTenantId = tenantId;
+        oldestAccessedAt = cache.lastAccessedAt;
+      }
+    }
+    if (!oldestTenantId) return;
+    profileCacheByTenant.delete(oldestTenantId);
+  }
+}
+
 function getTenantProfileCache(): TenantProfileCache {
+  const now = Date.now();
+  pruneProfileCache(now);
   const tenantId = getActiveTenantId();
   let cache = profileCacheByTenant.get(tenantId);
   if (!cache) {
@@ -25,9 +51,11 @@ function getTenantProfileCache(): TenantProfileCache {
       profile: null,
       resumeId: null,
       localProfile: null,
+      lastAccessedAt: now,
     };
     profileCacheByTenant.set(tenantId, cache);
   }
+  cache.lastAccessedAt = now;
   return cache;
 }
 
@@ -131,4 +159,8 @@ export function clearProfileCache(): void {
     return;
   }
   profileCacheByTenant.clear();
+}
+
+export function __getProfileCacheSizeForTests(): number {
+  return profileCacheByTenant.size;
 }

--- a/orchestrator/src/server/services/rxresume/index.test.ts
+++ b/orchestrator/src/server/services/rxresume/index.test.ts
@@ -1,4 +1,5 @@
 import { getSetting } from "@server/repositories/settings";
+import { getActiveTenantId } from "@server/tenancy/context";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearRxResumeResumeCache,
@@ -12,6 +13,10 @@ import * as v5 from "./v5";
 
 vi.mock("@server/repositories/settings", () => ({
   getSetting: vi.fn(),
+}));
+
+vi.mock("@server/tenancy/context", () => ({
+  getActiveTenantId: vi.fn(() => "tenant-1"),
 }));
 
 vi.mock("./v5", () => ({
@@ -34,6 +39,7 @@ describe("RxResume Service (index.ts)", () => {
       if (key === "rxresumeUrl") return "https://rxresu.me";
       return null;
     });
+    vi.mocked(getActiveTenantId).mockReturnValue("tenant-1");
   });
 
   describe("listResumes", () => {
@@ -94,6 +100,34 @@ describe("RxResume Service (index.ts)", () => {
 
       await getResume("1", { forceRefresh: true });
       expect(v5.getResume).toHaveBeenCalledTimes(2);
+    });
+
+    it("keeps cached resumes scoped by tenant", async () => {
+      vi.mocked(v5.getResume)
+        .mockResolvedValueOnce({
+          id: "1",
+          name: "Tenant 1 Resume",
+          data: { basics: { name: "Tenant One" } },
+        } as any)
+        .mockResolvedValueOnce({
+          id: "1",
+          name: "Tenant 2 Resume",
+          data: { basics: { name: "Tenant Two" } },
+        } as any);
+
+      vi.mocked(getActiveTenantId).mockReturnValue("tenant-1");
+      const tenantOneResume = await getResume("1");
+
+      vi.mocked(getActiveTenantId).mockReturnValue("tenant-2");
+      const tenantTwoResume = await getResume("1");
+
+      vi.mocked(getActiveTenantId).mockReturnValue("tenant-1");
+      const tenantOneCachedResume = await getResume("1");
+
+      expect(v5.getResume).toHaveBeenCalledTimes(2);
+      expect(tenantOneResume.name).toBe("Tenant 1 Resume");
+      expect(tenantTwoResume.name).toBe("Tenant 2 Resume");
+      expect(tenantOneCachedResume).toEqual(tenantOneResume);
     });
 
     it("expires cache after TTL and refetches", async () => {

--- a/orchestrator/src/server/services/rxresume/index.ts
+++ b/orchestrator/src/server/services/rxresume/index.ts
@@ -7,6 +7,7 @@ import {
   resolveTracerPublicBaseUrl,
   rewriteResumeLinksWithTracer,
 } from "@server/services/tracer-links";
+import { getActiveTenantId } from "@server/tenancy/context";
 import type { ResumeProjectCatalogItem } from "@shared/types";
 import {
   getResumeSchemaValidationMessage,
@@ -129,6 +130,7 @@ function buildCredentialFingerprint(creds: V5Credentials): string {
 
 function buildResumeCacheKey(resumeId: string, creds: V5Credentials): string {
   return [
+    getActiveTenantId(),
     "v5",
     normalizeBaseUrlForCache(creds.baseUrl),
     resumeId.trim(),


### PR DESCRIPTION
## Summary
- Scope Reactive Resume resume caching by active tenant to prevent cross-workspace reuse
- Scope automatic run memory and pipeline source preferences to the authenticated workspace
- Add regression tests for tenant/workspace isolation and keep auth changes clearing app cache

## Testing
- Added unit tests covering tenant-scoped RxResume cache behavior
- Added unit tests covering workspace-scoped browser storage for run memory and pipeline sources
- Ran the focused Vitest suite for touched areas and the full orchestrator test run