### PR TITLE
docs: clarify rerunning pipeline for fresh jobs

### DIFF
--- a/docs-site/docs/features/pipeline-run.md
+++ b/docs-site/docs/features/pipeline-run.md
@@ -24,6 +24,7 @@ It helps you:
 - choose speed vs depth with presets
 - avoid invalid source/country combinations
 - understand estimated run cost before starting
+- refresh your job list when older discovered jobs have gone stale
 
 ## How to use it
 
@@ -127,6 +128,12 @@ For accepted input formats, inference behavior, and limits, see [Manual Import E
 - Reduce term count.
 - Use `Fast` preset or lower `Max jobs discovered`.
 - Disable high-cost source combinations where acceptable.
+
+### Older jobs look expired or stale
+
+- Run the pipeline again before reviewing or applying.
+- Existing discovered jobs are not automatically refreshed in the background.
+- A new run fetches current listings so you can work from fresher results.
 
 ### JobSpy results are broader than the selected workplace type
 

--- a/docs-site/docs/troubleshooting/common-problems.md
+++ b/docs-site/docs/troubleshooting/common-problems.md
@@ -30,6 +30,12 @@ npm --workspace docs-site run build
 - Validate `LLM_API_KEY` and provider settings.
 - Check settings page and API connectivity.
 
+## Older jobs look expired or stale
+
+- Run the pipeline again before reviewing or applying.
+- Existing discovered jobs are not automatically refreshed in the background.
+- A new run fetches current listings so you can work from fresher results.
+
 ## Codex sign-in shows device-code authorization error
 
 - Symptom: UI shows:

--- a/docs-site/docs/workflows/find-jobs-and-apply-workflow.md
+++ b/docs-site/docs/workflows/find-jobs-and-apply-workflow.md
@@ -27,6 +27,7 @@ Important:
 
 - Some scrapers are slower and can take significant time.
 - Larger scrape ranges and more sources increase run duration.
+- If you are returning after a few days, run the pipeline again before reviewing jobs. Existing results are not auto-refreshed, so older discovered jobs may be stale or expired.
 
 ### 2) Configure pipeline advanced settings
 
@@ -85,6 +86,7 @@ Once a job is marked `applied`, it becomes part of:
 ## Practical tips
 
 - Start with conservative run sizes while tuning sources.
+- Re-run the pipeline after time away when you want fresh listings.
 - Increase tailored-job count only after score thresholds feel calibrated.
 - Expect scraper runtime variance by source.
 - Keep resume/project context up to date so scoring/tailoring quality stays high.


### PR DESCRIPTION
Closes #396

## Summary

Clarifies that users should rerun the pipeline after a few days to fetch fresh jobs instead of relying on older discovered results.

## Changes

- added a refresh reminder to the Find Jobs and Apply workflow
- added an `Older jobs look expired or stale` entry to the Pipeline Run docs
- added the same guidance to Troubleshooting > Common Problems

## Docs updated

- `docs-site/docs/workflows/find-jobs-and-apply-workflow.md`
- `docs-site/docs/features/pipeline-run.md`
- `docs-site/docs/troubleshooting/common-problems.md`

## Screenshots

### Find Jobs and Apply Workflow
<img width="2031" height="1067" alt="image" src="https://github.com/user-attachments/assets/a4a0cf60-0d15-41fc-9429-d227954b471d" />

### Pipeline Run
<img width="1817" height="392" alt="image" src="https://github.com/user-attachments/assets/305fdc64-9bf5-4c3d-bc63-aa6bc98d27a4" />

### Common Problems
<img width="1817" height="392" alt="image" src="https://github.com/user-attachments/assets/ca6de3f2-d901-4193-b367-05f487f81b52" />

## Tradeoffs / Follow-up

- This PR updates documentation only. It does not change product behavior or add in-app messaging.
- If this continues to confuse users, a follow-up could add the same reminder in the Jobs page or pipeline modal.