### PR TITLE
Stop sign-in page from re-triggering demo and onboarding fetches

### DIFF
--- a/orchestrator/src/client/App.test.tsx
+++ b/orchestrator/src/client/App.test.tsx
@@ -110,6 +110,19 @@ describe("App demo banner", () => {
     expect(screen.queryByRole("link", { name: "try.jobops.app" })).toBeNull();
   });
 
+  it("does not fetch demo info while rendering the sign-in page", () => {
+    vi.mocked(useDemoInfo).mockReturnValue(null);
+
+    render(
+      <MemoryRouter initialEntries={["/sign-in"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("sign-in")).toBeInTheDocument();
+    expect(useDemoInfo).toHaveBeenCalledWith({ enabled: false });
+  });
+
   it("lets the user dismiss the waitlist banner and keeps it hidden", () => {
     vi.mocked(useDemoInfo).mockReturnValue({
       demoMode: true,

--- a/orchestrator/src/client/App.tsx
+++ b/orchestrator/src/client/App.tsx
@@ -55,7 +55,9 @@ export const App: React.FC = () => {
   const location = useLocation();
   const navigate = useNavigate();
   const nodeRef = useRef<HTMLDivElement>(null);
-  const demoInfo = useDemoInfo();
+  const isSignInPage = location.pathname === "/sign-in";
+  const demoInfo = useDemoInfo({ enabled: !isSignInPage });
+  const showDemoBanners = !isSignInPage && demoInfo?.demoMode;
   const [demoWaitlistBannerDismissed, setDemoWaitlistBannerDismissed] =
     useState(() => {
       try {
@@ -97,7 +99,7 @@ export const App: React.FC = () => {
   return (
     <>
       <OnboardingGate />
-      {demoInfo?.demoMode && !demoWaitlistBannerDismissed && (
+      {showDemoBanners && !demoWaitlistBannerDismissed && (
         <div className="sticky top-0 z-50 w-full border-b border-orange-400/60 bg-orange-500 px-4 py-2 text-xs text-orange-950 shadow-sm">
           <div className="mx-auto flex items-center justify-center gap-3">
             <p className="flex-1 text-center font-medium">
@@ -132,7 +134,7 @@ export const App: React.FC = () => {
           </div>
         </div>
       )}
-      {demoInfo?.demoMode && (
+      {showDemoBanners && (
         <div className="w-full border-b border-amber-400/50 bg-amber-500/20 px-4 py-2 text-center text-xs text-amber-100 backdrop-blur">
           Demo mode: integrations are simulated and data resets every{" "}
           {demoInfo.resetCadenceHours} hours.

--- a/orchestrator/src/client/components/OnboardingGate.test.tsx
+++ b/orchestrator/src/client/components/OnboardingGate.test.tsx
@@ -50,6 +50,20 @@ describe("OnboardingGate", () => {
     expect(screen.getByText("onboarding")).toBeInTheDocument();
   });
 
+  it("does not check onboarding while the user is on sign-in", () => {
+    render(
+      <MemoryRouter initialEntries={["/sign-in"]}>
+        <OnboardingGate />
+        <Routes>
+          <Route path="/sign-in" element={<div>sign-in</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("sign-in")).toBeInTheDocument();
+    expect(useOnboardingRequirement).not.toHaveBeenCalled();
+  });
+
   it("does not redirect once onboarding is complete", () => {
     vi.mocked(useOnboardingRequirement).mockReturnValue({
       checking: false,

--- a/orchestrator/src/client/components/OnboardingGate.tsx
+++ b/orchestrator/src/client/components/OnboardingGate.tsx
@@ -4,11 +4,16 @@ import { Navigate, useLocation } from "react-router-dom";
 
 export const OnboardingGate: React.FC = () => {
   const location = useLocation();
-  const { checking, complete } = useOnboardingRequirement();
 
   if (location.pathname === "/onboarding" || location.pathname === "/sign-in") {
     return null;
   }
+
+  return <OnboardingRedirect />;
+};
+
+const OnboardingRedirect: React.FC = () => {
+  const { checking, complete } = useOnboardingRequirement();
 
   if (checking || complete) {
     return null;

--- a/orchestrator/src/client/hooks/useDemoInfo.ts
+++ b/orchestrator/src/client/hooks/useDemoInfo.ts
@@ -3,9 +3,11 @@ import type { DemoInfoResponse } from "@shared/types";
 import { useQuery } from "@tanstack/react-query";
 import { queryKeys } from "@/client/lib/queryKeys";
 
-export function useDemoInfo() {
+export function useDemoInfo(options: { enabled?: boolean } = {}) {
+  const enabled = options.enabled ?? true;
   const { data } = useQuery<DemoInfoResponse | null>({
     queryKey: queryKeys.demo.info(),
+    enabled,
     queryFn: async () => {
       try {
         return await api.getDemoInfo();


### PR DESCRIPTION
## Summary
- Disable the global demo-info query on `/sign-in` and suppress demo banners there.
- Avoid mounting onboarding checks on the sign-in route so it does not fetch `/api/settings`.
- Add regression coverage for both paths.

## Testing
- Added unit tests covering the sign-in route behavior in `App` and `OnboardingGate`.
- Verified the targeted client tests and typecheck locally.