### PR TITLE
Fix demo auth and pre-generate realistic demo PDFs

### DIFF
--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -128,9 +128,11 @@ Set `DEMO_MODE=true` for sandbox deployments.
 
 Behavior in demo mode:
 
-- Works locally: browsing/filtering/status/timeline edits
+- Anonymous read-only access to the seeded demo workspace
+- Works locally: browsing/filtering/viewing timelines
 - Simulated: pipeline run/summarize/process/rescore/pdf/apply
 - Blocked: settings writes, DB clear, backups
+- Disabled: first-run account setup
 - Auto-reset: every 6 hours
 
 ## Updating

--- a/orchestrator/src/client/App.test.tsx
+++ b/orchestrator/src/client/App.test.tsx
@@ -84,7 +84,7 @@ describe("App demo banner", () => {
       </MemoryRouter>,
     );
 
-    const link = screen.getByRole("link", { name: "try.jobops.app" });
+    const link = screen.getByRole("link", { name: "Join the waitlist." });
     expect(link).toHaveAttribute(
       "href",
       "https://try.jobops.app?utm_source=demo&utm_medium=banner&utm_campaign=waitlist",

--- a/orchestrator/src/client/App.tsx
+++ b/orchestrator/src/client/App.tsx
@@ -99,45 +99,53 @@ export const App: React.FC = () => {
   return (
     <>
       <OnboardingGate />
-      {showDemoBanners && !demoWaitlistBannerDismissed && (
-        <div className="sticky top-0 z-50 w-full border-b border-orange-400/60 bg-orange-500 px-4 py-2 text-xs text-orange-950 shadow-sm">
-          <div className="mx-auto flex items-center justify-center gap-3">
-            <p className="flex-1 text-center font-medium">
-              This is a read-only demo. Want JobOps without the Docker setup? ☁️{" "}
-              Cloud version coming soon — join the waitlist at{" "}
-              <a
-                className="font-semibold underline underline-offset-2 hover:text-orange-900"
-                href="https://try.jobops.app?utm_source=demo&utm_medium=banner&utm_campaign=waitlist"
-                target="_blank"
-                rel="noreferrer"
-              >
-                try.jobops.app
-              </a>
-            </p>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon"
-              className="h-7 w-7 shrink-0 rounded-full text-orange-950 hover:bg-orange-400/30 hover:text-orange-950"
-              onClick={() => {
-                setDemoWaitlistBannerDismissed(true);
-                try {
-                  localStorage.setItem(DEMO_WAITLIST_BANNER_DISMISSED_KEY, "1");
-                } catch {
-                  // Ignore storage errors in restricted browser contexts.
-                }
-              }}
-            >
-              <X className="h-4 w-4" />
-              <span className="sr-only">Dismiss demo waitlist banner</span>
-            </Button>
-          </div>
-        </div>
-      )}
       {showDemoBanners && (
-        <div className="w-full border-b border-amber-400/50 bg-amber-500/20 px-4 py-2 text-center text-xs text-amber-100 backdrop-blur">
-          Demo mode: integrations are simulated and data resets every{" "}
-          {demoInfo.resetCadenceHours} hours.
+        <div className="sticky top-0 z-50 w-full border-b border-amber-400/50 bg-amber-500/20 px-4 py-2 text-xs text-amber-100 shadow-sm backdrop-blur">
+          <div className="mx-auto flex items-center justify-center gap-3">
+            <p className="flex-1 text-center">
+              <span className="font-medium">
+                Demo mode: integrations are simulated and data resets every{" "}
+                {demoInfo.resetCadenceHours} hours.
+              </span>
+              {!demoWaitlistBannerDismissed && (
+                <>
+                  {" "}
+                  This is a read-only demo. Want JobOps without the Docker
+                  setup?{" "}
+                  <a
+                    className="font-semibold underline underline-offset-2 hover:text-amber-50"
+                    href="https://try.jobops.app?utm_source=demo&utm_medium=banner&utm_campaign=waitlist"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Join the waitlist.
+                  </a>
+                </>
+              )}
+            </p>
+            {!demoWaitlistBannerDismissed && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7 shrink-0 rounded-full text-amber-100 hover:bg-amber-400/20 hover:text-amber-50"
+                onClick={() => {
+                  setDemoWaitlistBannerDismissed(true);
+                  try {
+                    localStorage.setItem(
+                      DEMO_WAITLIST_BANNER_DISMISSED_KEY,
+                      "1",
+                    );
+                  } catch {
+                    // Ignore storage errors in restricted browser contexts.
+                  }
+                }}
+              >
+                <X className="h-4 w-4" />
+                <span className="sr-only">Dismiss demo waitlist banner</span>
+              </Button>
+            )}
+          </div>
         </div>
       )}
       <div>

--- a/orchestrator/src/server/api/routes/auth.test.ts
+++ b/orchestrator/src/server/api/routes/auth.test.ts
@@ -148,6 +148,51 @@ describe.sequential("Auth routes", () => {
     });
   });
 
+  describe("public demo auth behavior", () => {
+    beforeEach(async () => {
+      ({ server, baseUrl, closeDb, tempDir } = await startServer({
+        env: {
+          DEMO_MODE: "true",
+          JOBOPS_TEST_AUTH_BYPASS: "0",
+          BASIC_AUTH_USER: "",
+          BASIC_AUTH_PASSWORD: "",
+        },
+      }));
+    });
+
+    it("allows anonymous read access to demo-backed APIs", async () => {
+      const res = await fetch(`${baseUrl}/api/profile/projects`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(Array.isArray(body.data)).toBe(true);
+      expect(body.data.length).toBeGreaterThan(0);
+    });
+
+    it("does not allow creating the first admin in demo mode", async () => {
+      const bootstrapRes = await fetch(`${baseUrl}/api/auth/bootstrap-status`);
+      expect(bootstrapRes.status).toBe(200);
+      const bootstrapBody = await bootstrapRes.json();
+      expect(bootstrapBody.ok).toBe(true);
+      expect(bootstrapBody.data.setupRequired).toBe(false);
+
+      const setupRes = await fetch(`${baseUrl}/api/auth/setup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "admin",
+          password: "super-secret-password",
+        }),
+      });
+
+      expect(setupRes.status).toBe(503);
+      const setupBody = await setupRes.json();
+      expect(setupBody.ok).toBe(false);
+      expect(setupBody.error.message).toContain("disabled in the public demo");
+    });
+  });
+
   describe("POST /api/auth/logout", () => {
     beforeEach(async () => {
       ({ server, baseUrl, closeDb, tempDir } = await startServer({

--- a/orchestrator/src/server/api/routes/auth.ts
+++ b/orchestrator/src/server/api/routes/auth.ts
@@ -2,6 +2,7 @@ import { badRequest, serviceUnavailable, unauthorized } from "@infra/errors";
 import { asyncRoute, fail, ok } from "@infra/http";
 import { blacklistToken, signToken, verifyToken } from "@server/auth/jwt";
 import { verifyPassword } from "@server/auth/password";
+import { isDemoMode } from "@server/config/demo";
 import * as usersRepo from "@server/repositories/users";
 import type { Request, Response } from "express";
 import { Router } from "express";
@@ -79,6 +80,11 @@ authRouter.post(
 authRouter.get(
   "/bootstrap-status",
   asyncRoute(async (_req: Request, res: Response) => {
+    if (isDemoMode()) {
+      ok(res, { setupRequired: false });
+      return;
+    }
+
     ok(res, { setupRequired: (await usersRepo.countUsers()) === 0 });
   }),
 );
@@ -86,6 +92,14 @@ authRouter.get(
 authRouter.post(
   "/setup",
   asyncRoute(async (req: Request, res: Response) => {
+    if (isDemoMode()) {
+      fail(
+        res,
+        serviceUnavailable("First-run setup is disabled in the public demo."),
+      );
+      return;
+    }
+
     if ((await usersRepo.countUsers()) > 0) {
       fail(res, badRequest("Initial setup has already been completed"));
       return;

--- a/orchestrator/src/server/api/routes/demo-mode.test.ts
+++ b/orchestrator/src/server/api/routes/demo-mode.test.ts
@@ -1,11 +1,39 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import {
   DEMO_BASELINE_NAME,
   DEMO_BASELINE_VERSION,
 } from "@server/config/demo-defaults";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { startServer, stopServer } from "./test-utils";
 
+const pdfMocks = vi.hoisted(() => ({
+  generatePdf: vi.fn(),
+}));
+
+vi.mock("@server/services/pdf", async () => {
+  const actual = await vi.importActual<typeof import("@server/services/pdf")>(
+    "@server/services/pdf",
+  );
+  return {
+    ...actual,
+    generatePdf: pdfMocks.generatePdf,
+  };
+});
+
 describe.sequential("Demo mode API behavior", () => {
+  beforeEach(() => {
+    pdfMocks.generatePdf.mockImplementation(async (jobId: string) => {
+      const { getTenantJobPdfPath } = await import(
+        "@server/services/pdf-storage"
+      );
+      const pdfPath = getTenantJobPdfPath(jobId);
+      await mkdir(dirname(pdfPath), { recursive: true });
+      await writeFile(pdfPath, Buffer.from("%PDF-1.4\nDemo PDF\n%%EOF\n"));
+      return { success: true, pdfPath };
+    });
+  });
+
   it("returns demo info when demo mode is disabled", async () => {
     const { server, baseUrl, closeDb, tempDir } = await startServer();
     try {
@@ -129,6 +157,59 @@ describe.sequential("Demo mode API behavior", () => {
       expect(body.ok).toBe(true);
       expect(body.meta?.simulated).toBe(true);
       expect(body.data.status).toBe("applied");
+    } finally {
+      await stopServer({ server, closeDb, tempDir });
+    }
+  });
+
+  it("simulates PDF generation with a current demo artifact", async () => {
+    const { server, baseUrl, closeDb, tempDir } = await startServer({
+      env: {
+        DEMO_MODE: "true",
+        JOBOPS_TEST_AUTH_BYPASS: "0",
+      },
+    });
+
+    try {
+      const imported = await fetch(`${baseUrl}/api/manual-jobs/import`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          job: {
+            title: "Demo Imported Job",
+            employer: "Demo Corp",
+            jobDescription: "Demo description",
+            jobUrl: "https://demo.job-ops.local/jobs/imported-pdf",
+          },
+        }),
+      });
+      const importedBody = await imported.json();
+      expect(importedBody.ok).toBe(true);
+      const jobId = importedBody.data.id as string;
+
+      const response = await fetch(
+        `${baseUrl}/api/jobs/${jobId}/generate-pdf`,
+        {
+          method: "POST",
+        },
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.meta?.simulated).toBe(true);
+      expect(body.data.status).toBe("ready");
+      expect(body.data.pdfSource).toBe("generated");
+      expect(body.data.pdfFreshness).toBe("current");
+      expect(body.data.pdfPath).toContain(`resume_${jobId}.pdf`);
+
+      const pdfResponse = await fetch(`${baseUrl}/api/jobs/${jobId}/pdf`);
+      expect(pdfResponse.status).toBe(200);
+      expect(pdfResponse.headers.get("content-type")).toContain(
+        "application/pdf",
+      );
+      const pdfBytes = Buffer.from(await pdfResponse.arrayBuffer());
+      expect(pdfBytes.subarray(0, 5).toString()).toBe("%PDF-");
     } finally {
       await stopServer({ server, closeDb, tempDir });
     }

--- a/orchestrator/src/server/api/routes/demo-mode.test.ts
+++ b/orchestrator/src/server/api/routes/demo-mode.test.ts
@@ -48,6 +48,7 @@ describe.sequential("Demo mode API behavior", () => {
     const { server, baseUrl, closeDb, tempDir } = await startServer({
       env: {
         DEMO_MODE: "true",
+        JOBOPS_TEST_AUTH_BYPASS: "0",
         BASIC_AUTH_USER: "",
         BASIC_AUTH_PASSWORD: "",
       },
@@ -72,6 +73,7 @@ describe.sequential("Demo mode API behavior", () => {
     const { server, baseUrl, closeDb, tempDir } = await startServer({
       env: {
         DEMO_MODE: "true",
+        JOBOPS_TEST_AUTH_BYPASS: "0",
         BASIC_AUTH_USER: "",
         BASIC_AUTH_PASSWORD: "",
       },
@@ -95,7 +97,10 @@ describe.sequential("Demo mode API behavior", () => {
 
   it("simulates apply in demo mode", async () => {
     const { server, baseUrl, closeDb, tempDir } = await startServer({
-      env: { DEMO_MODE: "true" },
+      env: {
+        DEMO_MODE: "true",
+        JOBOPS_TEST_AUTH_BYPASS: "0",
+      },
     });
 
     try {
@@ -124,6 +129,28 @@ describe.sequential("Demo mode API behavior", () => {
       expect(body.ok).toBe(true);
       expect(body.meta?.simulated).toBe(true);
       expect(body.data.status).toBe("applied");
+    } finally {
+      await stopServer({ server, closeDb, tempDir });
+    }
+  });
+
+  it("keeps sensitive demo auth surfaces protected", async () => {
+    const { server, baseUrl, closeDb, tempDir } = await startServer({
+      env: {
+        DEMO_MODE: "true",
+        JOBOPS_TEST_AUTH_BYPASS: "0",
+        BASIC_AUTH_USER: "",
+        BASIC_AUTH_PASSWORD: "",
+      },
+    });
+
+    try {
+      const response = await fetch(`${baseUrl}/api/auth/me`);
+      const body = await response.json();
+
+      expect(response.status).toBe(401);
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("UNAUTHORIZED");
     } finally {
       await stopServer({ server, closeDb, tempDir });
     }

--- a/orchestrator/src/server/api/routes/extractor-health.test.ts
+++ b/orchestrator/src/server/api/routes/extractor-health.test.ts
@@ -78,6 +78,42 @@ describe.sequential("Extractor health API routes", () => {
     expect(typeof body.meta.requestId).toBe("string");
   });
 
+  it("remains publicly reachable when auth bypass is disabled", async () => {
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: {
+        JOBOPS_TEST_AUTH_BYPASS: "0",
+        BASIC_AUTH_USER: "admin",
+        BASIC_AUTH_PASSWORD: "secret",
+      },
+    }));
+
+    const manifest: ExtractorManifest = {
+      id: "jobspy",
+      displayName: "JobSpy",
+      providesSources: ["indeed", "linkedin", "glassdoor"],
+      run: vi.fn().mockResolvedValue({
+        success: true,
+        jobs: [
+          {
+            source: "linkedin",
+            title: "Software Engineer",
+            employer: "Acme",
+            jobUrl: "https://example.com/jobs/1",
+          },
+        ],
+      }),
+    };
+    mockGetExtractorRegistry.mockResolvedValue(createRegistry([manifest]));
+
+    const res = await fetch(`${baseUrl}/api/linkedin/health`);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe("healthy");
+  });
+
   it("returns service unavailable when the extractor run fails", async () => {
     const manifest: ExtractorManifest = {
       id: "gradcracker",

--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -20,6 +20,7 @@ import { logger } from "@infra/logger";
 import { runWithRequestContext } from "@infra/request-context";
 import { sanitizeUnknown } from "@infra/sanitize";
 import { verifyToken } from "@server/auth/jwt";
+import { isDemoMode } from "@server/config/demo";
 import * as usersRepo from "@server/repositories/users";
 import { proxyChallengeViewerRequest } from "@server/services/challenge-viewer";
 import { DEFAULT_TENANT_ID } from "@server/tenancy/constants";
@@ -203,8 +204,34 @@ export function createAuthGuard() {
     return false;
   }
 
+  function isProtectedDemoReadOnlyRoute(path: string): boolean {
+    const normalizedPath = path.split("?")[0] || path;
+
+    if (normalizedPath === "/api/auth/me") return true;
+    if (normalizedPath.startsWith("/api/workspaces")) return true;
+    if (normalizedPath === "/api/settings/codex-auth") return true;
+    if (normalizedPath === "/api/settings/rx-resumes") return true;
+    if (/^\/api\/settings\/rx-resumes\/[^/]+\/projects$/.test(normalizedPath)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  function isPublicDemoReadOnlyRoute(method: string, path: string): boolean {
+    if (!isDemoMode()) return false;
+
+    const normalizedMethod = method.toUpperCase();
+    const normalizedPath = path.split("?")[0] || path;
+    if (!["GET", "HEAD"].includes(normalizedMethod)) return false;
+    if (!normalizedPath.startsWith("/api/")) return false;
+
+    return !isProtectedDemoReadOnlyRoute(normalizedPath);
+  }
+
   function requiresAuth(method: string, path: string): boolean {
     if (isPublicReadOnlyRoute(method, path)) return false;
+    if (isPublicDemoReadOnlyRoute(method, path)) return false;
     // OPTIONS is always exempt for CORS preflight.
     if (method.toUpperCase() === "OPTIONS") return false;
 
@@ -254,7 +281,14 @@ export function createAuthGuard() {
 
       const userCount = await usersRepo.countUsers();
       if (userCount === 0) {
-        fail(res, unauthorized("Initial setup is required"));
+        fail(
+          res,
+          unauthorized(
+            isDemoMode()
+              ? "Authentication required"
+              : "Initial setup is required",
+          ),
+        );
         return;
       }
 

--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -200,6 +200,11 @@ export function createAuthGuard() {
       /^\/api\/design-resume\/assets\/[^/]+\/content$/.test(normalizedPath)
     )
       return true;
+    if (
+      ["GET", "HEAD"].includes(normalizedMethod) &&
+      /^\/api\/[^/]+\/health$/.test(normalizedPath)
+    )
+      return true;
 
     return false;
   }

--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -209,7 +209,7 @@ export function createAuthGuard() {
     return false;
   }
 
-  function isProtectedDemoReadOnlyRoute(path: string): boolean {
+  function isProtectedDemoRoute(path: string): boolean {
     const normalizedPath = path.split("?")[0] || path;
 
     if (normalizedPath === "/api/auth/me") return true;
@@ -223,20 +223,18 @@ export function createAuthGuard() {
     return false;
   }
 
-  function isPublicDemoReadOnlyRoute(method: string, path: string): boolean {
+  function isPublicDemoRoute(path: string): boolean {
     if (!isDemoMode()) return false;
 
-    const normalizedMethod = method.toUpperCase();
     const normalizedPath = path.split("?")[0] || path;
-    if (!["GET", "HEAD"].includes(normalizedMethod)) return false;
     if (!normalizedPath.startsWith("/api/")) return false;
 
-    return !isProtectedDemoReadOnlyRoute(normalizedPath);
+    return !isProtectedDemoRoute(normalizedPath);
   }
 
   function requiresAuth(method: string, path: string): boolean {
     if (isPublicReadOnlyRoute(method, path)) return false;
-    if (isPublicDemoReadOnlyRoute(method, path)) return false;
+    if (isPublicDemoRoute(path)) return false;
     // OPTIONS is always exempt for CORS preflight.
     if (method.toUpperCase() === "OPTIONS") return false;
 

--- a/orchestrator/src/server/basic-auth.test.ts
+++ b/orchestrator/src/server/basic-auth.test.ts
@@ -117,6 +117,51 @@ describe.sequential("Auth read-only enforcement", () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it("allows demo read APIs without auth", async () => {
+    process.env.DEMO_MODE = "true";
+
+    const { middleware } = createAuthGuard();
+    const req = createMockRequest({
+      method: "GET",
+      path: "/api/profile/projects",
+    });
+    const res = createMockResponse();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(countUsers).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("keeps sensitive demo read APIs behind auth", async () => {
+    process.env.DEMO_MODE = "true";
+    vi.mocked(countUsers).mockResolvedValue(0);
+
+    const { middleware } = createAuthGuard();
+    const req = createMockRequest({
+      method: "GET",
+      path: "/api/settings/codex-auth",
+    });
+    const res = createMockResponse();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(401);
+    expect(res.jsonBody).toMatchObject({
+      ok: false,
+      error: {
+        code: "UNAUTHORIZED",
+        message: "Authentication required",
+      },
+    });
+  });
+
   it("allows OPTIONS preflight without auth even for API routes", async () => {
     vi.mocked(countUsers).mockResolvedValue(1);
 

--- a/orchestrator/src/server/basic-auth.test.ts
+++ b/orchestrator/src/server/basic-auth.test.ts
@@ -117,6 +117,24 @@ describe.sequential("Auth read-only enforcement", () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it("allows extractor health APIs without auth", async () => {
+    vi.mocked(countUsers).mockResolvedValue(1);
+
+    const { middleware } = createAuthGuard();
+    const req = createMockRequest({
+      method: "GET",
+      path: "/api/linkedin/health",
+    });
+    const res = createMockResponse();
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
   it("allows demo read APIs without auth", async () => {
     process.env.DEMO_MODE = "true";
 

--- a/orchestrator/src/server/config/demo-defaults.data.ts
+++ b/orchestrator/src/server/config/demo-defaults.data.ts
@@ -15,6 +15,7 @@ export type DemoDefaultSettings = Partial<Record<SettingKey, string>>;
 export const DEMO_DEFAULT_SETTINGS: DemoDefaultSettings = {
   llmProvider: "openrouter",
   model: "google/gemini-3-flash-preview",
+  pdfRenderer: "latex",
   searchTerms: JSON.stringify([
     "software engineer",
     "backend engineer",

--- a/orchestrator/src/server/services/demo-pdf.ts
+++ b/orchestrator/src/server/services/demo-pdf.ts
@@ -1,0 +1,226 @@
+import { DEMO_PROJECT_CATALOG } from "@server/config/demo-defaults";
+import * as jobsRepo from "@server/repositories/jobs";
+import { replaceCurrentDesignResumeDocument } from "@server/services/design-resume";
+import { generatePdf, type TailoredPdfContent } from "@server/services/pdf";
+import {
+  createJobPdfFingerprint,
+  type PdfFingerprintContext,
+  resolvePdfFingerprintContext,
+} from "@server/services/pdf-fingerprint";
+import { clearProfileCache } from "@server/services/profile";
+import { buildDefaultReactiveResumeDocument } from "@server/services/rxresume/document";
+import type { DesignResumeJson, Job, JobStatus } from "@shared/types";
+
+function buildDemoDesignResume(): DesignResumeJson {
+  const document = structuredClone(
+    buildDefaultReactiveResumeDocument(),
+  ) as DesignResumeJson;
+
+  document.basics = {
+    ...document.basics,
+    name: "Avery Stone",
+    headline: "Senior Backend Engineer",
+    email: "avery@demo.jobops.local",
+    phone: "+1 (555) 010-2026",
+    location: "New York, NY",
+    website: {
+      url: "https://demo.jobops.local",
+      label: "jobops demo",
+    },
+    customFields: [],
+  };
+
+  document.summary = {
+    ...document.summary,
+    content:
+      "Backend and platform engineer focused on reliable TypeScript services, workflow automation, and observability-first systems design.",
+  };
+
+  document.sections = {
+    ...document.sections,
+    experience: {
+      ...document.sections.experience,
+      items: [
+        {
+          id: "demo-exp-1",
+          hidden: false,
+          company: "Northstar Systems",
+          position: "Senior Backend Engineer",
+          location: "Remote",
+          period: "2023 - Present",
+          website: { url: "https://demo.jobops.local", label: "company" },
+          description:
+            "Led tenant-safe workflow services, queue processing, and request tracing improvements across internal operations tooling.",
+          roles: [],
+        },
+        {
+          id: "demo-exp-2",
+          hidden: false,
+          company: "Beacon Labs",
+          position: "Software Engineer",
+          location: "Chicago, IL",
+          period: "2020 - 2023",
+          website: { url: "https://demo.jobops.local", label: "company" },
+          description:
+            "Built API integrations, operational dashboards, and incident-reduction tooling for customer support workflows.",
+          roles: [],
+        },
+      ],
+    },
+    education: {
+      ...document.sections.education,
+      items: [
+        {
+          id: "demo-edu-1",
+          hidden: false,
+          school: "University of Illinois",
+          degree: "B.S.",
+          area: "Computer Science",
+          grade: "",
+          location: "Urbana-Champaign, IL",
+          period: "2016 - 2020",
+          website: { url: "", label: "" },
+          description: "",
+        },
+      ],
+    },
+    projects: {
+      ...document.sections.projects,
+      items: DEMO_PROJECT_CATALOG.map((project) => ({
+        id: project.id,
+        hidden: !project.isVisibleInBase,
+        name: project.name,
+        period: project.date,
+        website: { url: "", label: "" },
+        description: project.description,
+        options: { showLinkInTitle: false },
+      })),
+    },
+    skills: {
+      ...document.sections.skills,
+      items: [
+        {
+          id: "demo-skill-1",
+          hidden: false,
+          icon: "",
+          name: "Backend",
+          proficiency: "",
+          level: 4,
+          keywords: ["TypeScript", "Node.js", "APIs", "SQL"],
+        },
+        {
+          id: "demo-skill-2",
+          hidden: false,
+          icon: "",
+          name: "Systems",
+          proficiency: "",
+          level: 4,
+          keywords: ["Reliability", "Queues", "Observability", "Automation"],
+        },
+      ],
+    },
+  };
+
+  return document;
+}
+
+function parseTailoredSkills(
+  raw: string | null,
+): Array<{ name: string; keywords: string[] }> {
+  if (!raw) return [];
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    if (
+      parsed.every(
+        (item) =>
+          item &&
+          typeof item === "object" &&
+          typeof (item as { name?: unknown }).name === "string" &&
+          Array.isArray((item as { keywords?: unknown }).keywords),
+      )
+    ) {
+      return parsed as Array<{ name: string; keywords: string[] }>;
+    }
+
+    const keywords = parsed.filter(
+      (item): item is string =>
+        typeof item === "string" && item.trim().length > 0,
+    );
+    return keywords.length > 0 ? [{ name: "Core Skills", keywords }] : [];
+  } catch {
+    return [];
+  }
+}
+
+function buildTailoredPdfContent(job: Job): TailoredPdfContent {
+  return {
+    summary: job.tailoredSummary ?? "",
+    headline: job.tailoredHeadline ?? "",
+    skills: parseTailoredSkills(job.tailoredSkills),
+  };
+}
+
+function resolveDemoPdfStatus(status: JobStatus): JobStatus {
+  if (status === "discovered" || status === "processing") return "ready";
+  return status;
+}
+
+export async function seedDemoDesignResume(): Promise<void> {
+  await replaceCurrentDesignResumeDocument({
+    importedAt: new Date().toISOString(),
+    resumeJson: buildDemoDesignResume(),
+    sourceResumeId: null,
+    sourceMode: null,
+  });
+  clearProfileCache();
+}
+
+export async function persistDemoGeneratedPdf(
+  job: Job,
+  fingerprintContext?: PdfFingerprintContext,
+  options?: { seedResume?: boolean },
+): Promise<Job> {
+  if (options?.seedResume ?? true) {
+    await seedDemoDesignResume();
+  }
+
+  const result = await generatePdf(
+    job.id,
+    buildTailoredPdfContent(job),
+    job.jobDescription ?? "",
+    undefined,
+    job.selectedProjectIds,
+    {
+      tracerLinksEnabled: job.tracerLinksEnabled,
+      tracerCompanyName: job.employer ?? null,
+      requestOrigin: null,
+    },
+  );
+
+  if (!result.success || !result.pdfPath) {
+    throw new Error(result.error ?? "Failed to generate demo PDF");
+  }
+
+  const context = fingerprintContext ?? (await resolvePdfFingerprintContext());
+  const pdfGeneratedAt = new Date().toISOString();
+  const pdfFingerprint = createJobPdfFingerprint(job, context);
+  const nextStatus = resolveDemoPdfStatus(job.status);
+  const updated = await jobsRepo.updateJob(job.id, {
+    ...(job.status === "ready" || nextStatus !== job.status
+      ? { status: nextStatus }
+      : {}),
+    pdfPath: result.pdfPath,
+    pdfSource: "generated",
+    pdfRegenerating: false,
+    pdfFingerprint,
+    pdfGeneratedAt,
+  });
+
+  if (!updated) {
+    throw new Error("Job not found");
+  }
+
+  return updated;
+}

--- a/orchestrator/src/server/services/demo-seed.test.ts
+++ b/orchestrator/src/server/services/demo-seed.test.ts
@@ -1,6 +1,13 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
   DEMO_DEFAULT_JOBS,
   DEMO_DEFAULT_PIPELINE_RUNS,
@@ -10,6 +17,17 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const originalEnv = { ...process.env };
+const pdfMocks = vi.hoisted(() => ({
+  generatePdf: vi.fn(),
+}));
+
+vi.mock("./pdf", async () => {
+  const actual = await vi.importActual<typeof import("./pdf")>("./pdf");
+  return {
+    ...actual,
+    generatePdf: pdfMocks.generatePdf,
+  };
+});
 
 function sortedPairs(map: Record<string, string>) {
   return Object.entries(map).sort(([a], [b]) => a.localeCompare(b));
@@ -21,6 +39,13 @@ describe.sequential("demo seed baseline", () => {
 
   beforeEach(async () => {
     vi.resetModules();
+    pdfMocks.generatePdf.mockImplementation(async (jobId: string) => {
+      const { getTenantJobPdfPath } = await import("./pdf-storage");
+      const pdfPath = getTenantJobPdfPath(jobId);
+      await mkdir(dirname(pdfPath), { recursive: true });
+      await writeFile(pdfPath, Buffer.from("%PDF-1.4\nDemo PDF\n%%EOF\n"));
+      return { success: true, pdfPath };
+    });
     tempDir = await mkdtemp(join(tmpdir(), "job-ops-demo-seed-test-"));
     process.env = {
       ...originalEnv,
@@ -39,6 +64,7 @@ describe.sequential("demo seed baseline", () => {
     if (closeDb) closeDb();
     await rm(tempDir, { recursive: true, force: true });
     process.env = { ...originalEnv };
+    pdfMocks.generatePdf.mockReset();
   });
 
   it("buildDemoBaseline returns deterministic, schema-shaped fixtures", async () => {
@@ -90,6 +116,43 @@ describe.sequential("demo seed baseline", () => {
     expect(sortedPairs(allSettings)).toEqual(
       sortedPairs(DEMO_DEFAULT_SETTINGS as Record<string, string>),
     );
+    expect(allSettings.pdfRenderer).toBe("latex");
+  });
+
+  it("resetDemoData generates fresh PDF artifacts for seeded ready and applied jobs", async () => {
+    const { resetDemoData } = await import("./demo-mode");
+    const { getAllJobs } = await import("../repositories/jobs");
+    const { getTenantJobPdfPath } = await import("./pdf-storage");
+    const { getJobPdfFreshness, resolvePdfFingerprintContext } = await import(
+      "./pdf-fingerprint"
+    );
+
+    await resetDemoData();
+
+    const allJobs = await getAllJobs();
+    const pdfJobs = allJobs.filter(
+      (job) => job.status === "ready" || job.status === "applied",
+    );
+    const fingerprintContext = await resolvePdfFingerprintContext();
+
+    expect(pdfJobs).toHaveLength(
+      DEMO_DEFAULT_JOBS.filter(
+        (job) => job.status === "ready" || job.status === "applied",
+      ).length,
+    );
+
+    for (const job of pdfJobs) {
+      const expectedPath = getTenantJobPdfPath(job.id);
+      expect(job.pdfPath).toBe(expectedPath);
+      expect(job.pdfSource).toBe("generated");
+      expect(job.pdfGeneratedAt).toEqual(expect.any(String));
+      expect(job.pdfFingerprint).toEqual(expect.any(String));
+      expect(getJobPdfFreshness(job, fingerprintContext)).toBe("current");
+
+      await expect(access(expectedPath)).resolves.toBeUndefined();
+      const pdfBytes = await readFile(expectedPath);
+      expect(pdfBytes.subarray(0, 5).toString()).toBe("%PDF-");
+    }
   });
 
   it("reset is idempotent for logical baseline content", async () => {

--- a/orchestrator/src/server/services/demo-seed.test.ts
+++ b/orchestrator/src/server/services/demo-seed.test.ts
@@ -21,8 +21,10 @@ const pdfMocks = vi.hoisted(() => ({
   generatePdf: vi.fn(),
 }));
 
-vi.mock("./pdf", async () => {
-  const actual = await vi.importActual<typeof import("./pdf")>("./pdf");
+vi.mock("@server/services/pdf", async () => {
+  const actual = await vi.importActual<typeof import("@server/services/pdf")>(
+    "@server/services/pdf",
+  );
   return {
     ...actual,
     generatePdf: pdfMocks.generatePdf,

--- a/orchestrator/src/server/services/demo-seed.ts
+++ b/orchestrator/src/server/services/demo-seed.ts
@@ -6,6 +6,12 @@ import {
   type DemoDefaultSettings,
 } from "@server/config/demo-defaults";
 import { db, schema } from "@server/db/index";
+import * as jobsRepo from "@server/repositories/jobs";
+import {
+  persistDemoGeneratedPdf,
+  seedDemoDesignResume,
+} from "@server/services/demo-pdf";
+import { resolvePdfFingerprintContext } from "@server/services/pdf-fingerprint";
 
 type BuiltDemoBaseline = {
   resetAt: string;
@@ -65,7 +71,7 @@ export function buildDemoBaseline(now: Date): BuiltDemoBaseline {
         ? JSON.stringify(job.tailoredSkills)
         : null,
       selectedProjectIds: job.selectedProjectIds ?? null,
-      pdfPath: job.pdfPath ?? null,
+      pdfPath: null,
       discoveredAt: toIsoFromOffset(now, job.discoveredOffsetMinutes),
       appliedAt:
         job.status === "applied" && typeof job.appliedOffsetMinutes === "number"
@@ -123,4 +129,20 @@ export async function applyDemoBaseline(
       tx.insert(stageEvents).values(baseline.stageEvents).run();
     }
   });
+
+  await seedDemoDesignResume();
+
+  const demoPdfJobIds = baseline.jobs
+    .filter((job) => job.status === "ready" || job.status === "applied")
+    .map((job) => job.id);
+  if (demoPdfJobIds.length === 0) return;
+
+  const fingerprintContext = await resolvePdfFingerprintContext();
+  for (const jobId of demoPdfJobIds) {
+    const job = await jobsRepo.getJobById(jobId);
+    if (!job) continue;
+    await persistDemoGeneratedPdf(job, fingerprintContext, {
+      seedResume: false,
+    });
+  }
 }

--- a/orchestrator/src/server/services/demo-simulator.ts
+++ b/orchestrator/src/server/services/demo-simulator.ts
@@ -4,6 +4,7 @@ import { buildPipelineRunSavedDetails } from "@server/pipeline/run-details";
 import * as jobsRepo from "@server/repositories/jobs";
 import * as pipelineRepo from "@server/repositories/pipeline";
 import { transitionStage } from "@server/services/applicationTracking";
+import { persistDemoGeneratedPdf } from "@server/services/demo-pdf";
 import type {
   Job,
   JobSource,
@@ -37,9 +38,13 @@ function ensureProjectIds(job: Job): string {
   return "demo-project-1,demo-project-2";
 }
 
-function samplePdfPath(job: Job): string {
-  const safeId = job.id.replace(/[^a-zA-Z0-9-_]/g, "");
-  return `/pdfs/demo-${safeId || "sample"}.pdf`;
+function makeDemoTailoredSkills(): string {
+  return JSON.stringify([
+    {
+      name: "Core Skills",
+      keywords: ["TypeScript", "System Design", "Communication"],
+    },
+  ]);
 }
 
 async function ensureJob(jobId: string): Promise<Job> {
@@ -116,11 +121,7 @@ export async function simulateSummarizeJob(
   await jobsRepo.updateJob(job.id, {
     tailoredSummary: makeDemoSummary(job),
     tailoredHeadline: `Demo Tailored Resume - ${job.title}`,
-    tailoredSkills: JSON.stringify([
-      "TypeScript",
-      "System Design",
-      "Communication",
-    ]),
+    tailoredSkills: makeDemoTailoredSkills(),
     selectedProjectIds: ensureProjectIds(job),
   });
   return { success: true };
@@ -130,13 +131,7 @@ export async function simulateGeneratePdf(
   jobId: string,
 ): Promise<{ success: boolean; error?: string }> {
   const job = await ensureJob(jobId);
-  await jobsRepo.updateJob(job.id, {
-    status: "ready",
-    pdfPath: samplePdfPath(job),
-    pdfSource: "generated",
-    pdfFingerprint: null,
-    pdfGeneratedAt: new Date().toISOString(),
-  });
+  await persistDemoGeneratedPdf(job);
   return { success: true };
 }
 

--- a/orchestrator/src/server/services/demo-simulator.ts
+++ b/orchestrator/src/server/services/demo-simulator.ts
@@ -130,9 +130,17 @@ export async function simulateSummarizeJob(
 export async function simulateGeneratePdf(
   jobId: string,
 ): Promise<{ success: boolean; error?: string }> {
-  const job = await ensureJob(jobId);
-  await persistDemoGeneratedPdf(job);
-  return { success: true };
+  try {
+    const job = await ensureJob(jobId);
+    await persistDemoGeneratedPdf(job);
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      error:
+        error instanceof Error ? error.message : "Failed to generate demo PDF",
+    };
+  }
 }
 
 export async function simulateProcessJob(


### PR DESCRIPTION
## Summary
- Allow anonymous read-only access in demo mode while keeping sensitive auth and settings routes protected.
- Fix demo actions so `Run pipeline`, `Mark applied`, and extractor health checks no longer redirect to sign-in.
- Replace placeholder demo PDFs with pre-generated LaTeX PDFs built from seeded fake resume data at demo startup/reset.
- Collapse the double demo banner UI into a single gold banner and update the self-hosting docs for the new demo behavior.

## Testing
- Added and updated unit/integration coverage for demo auth, extractor health, demo mode actions, and seeded PDF freshness.
- Ran formatting, type-checking, client build, and the full orchestrator test suite successfully.