### PR TITLE
fix(auth): exempt extractor health endpoints from auth (#465)

### DIFF
--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -200,6 +200,16 @@ export function createAuthGuard() {
     )
       return true;
 
+    // Extractor health endpoints (/api/<source>/health) report runtime
+    // availability and must remain reachable to uptime probes that cannot
+    // present a JWT. The route handler still returns 404 for unknown
+    // <source> values, so this exemption does not widen the surface.
+    if (
+      ["GET", "HEAD"].includes(normalizedMethod) &&
+      /^\/api\/[^/]+\/health$/.test(normalizedPath)
+    )
+      return true;
+
     return false;
   }
 

--- a/orchestrator/src/server/basic-auth.test.ts
+++ b/orchestrator/src/server/basic-auth.test.ts
@@ -117,6 +117,46 @@ describe.sequential("Auth read-only enforcement", () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it("allows GET extractor health endpoints without auth (issue #465)", async () => {
+    vi.mocked(countUsers).mockResolvedValue(1);
+
+    const { middleware } = createAuthGuard();
+    for (const path of [
+      "/api/linkedin/health",
+      "/api/jobspy/health",
+      "/api/not-a-source/health",
+    ]) {
+      const req = createMockRequest({ method: "GET", path });
+      const res = createMockResponse();
+      const next = vi.fn() as NextFunction;
+
+      middleware(req, res, next);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(next).toHaveBeenCalledOnce();
+      expect(res.status).not.toHaveBeenCalled();
+    }
+  });
+
+  it("still requires auth for nested or non-GET extractor health URLs", async () => {
+    vi.mocked(countUsers).mockResolvedValue(1);
+
+    const { middleware } = createAuthGuard();
+    for (const request of [
+      createMockRequest({ method: "POST", path: "/api/linkedin/health" }),
+      createMockRequest({ method: "GET", path: "/api/linkedin/health/extra" }),
+    ]) {
+      const res = createMockResponse();
+      const next = vi.fn() as NextFunction;
+
+      middleware(request, res, next);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+    }
+  });
+
   it("allows OPTIONS preflight without auth even for API routes", async () => {
     vi.mocked(countUsers).mockResolvedValue(1);
 


### PR DESCRIPTION
Fixes #465.

## Problem

`createAuthGuard` in `orchestrator/src/server/app.ts` requires JWT auth for every `/api/*` request that isn't explicitly exempt. The `/api/<source>/health` routes registered by `extractorHealthRouter` fall under that blanket rule, so uptime probes and the in-app extractor status panel get a 401 instead of the 200/503 the route handler is designed to return.

## Change

Add a single regex exemption to `isPublicReadOnlyRoute` matching `^/api/[^/]+/health$` for `GET`/`HEAD`. The exemption is intentionally narrow:

- Method-restricted (POST/PATCH/DELETE on the same path still require auth).
- Single-segment under `/api/`, so nested paths like `/api/linkedin/health/extra` still require auth.
- The route handler in `extractor-health.ts` already validates `<source>` via `isExtractorSourceId` and returns 404 for unknown values, so this exemption does not widen the response surface.

## Tests

Two new cases in `orchestrator/src/server/basic-auth.test.ts`:

- `allows GET extractor health endpoints without auth` — covers a known source, a manifest id that maps to a source, and an unknown source (which should still reach the handler and 404 there).
- `still requires auth for nested or non-GET extractor health URLs` — guards against the regex over-matching.

Also exercised the existing `extractor-health.test.ts` suite to confirm the route handler behavior is unchanged.

```
npm --workspace orchestrator run test -- basic-auth        # 13 passed
npm --workspace orchestrator run test -- extractor-health  # 8 passed
npm run check:types                                         # clean
biome check (touched files)                                 # clean
```
