### PR TITLE
Add tracer-links migration repair for legacy databases

### DIFF
--- a/orchestrator/src/server/db/migrate.test.ts
+++ b/orchestrator/src/server/db/migrate.test.ts
@@ -142,4 +142,83 @@ describe.sequential("database migrations", () => {
       },
     );
   });
+
+  it("adds the tracer-link composite unique index to legacy tables", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-migrate-"));
+    const script = `
+      import { join } from "node:path";
+      import { pathToFileURL } from "node:url";
+      import Database from "better-sqlite3";
+
+      const dbPath = join(process.env.DATA_DIR, "jobs.db");
+      const sqlite = new Database(dbPath);
+      sqlite.exec(\`
+        CREATE TABLE tracer_links (
+          id TEXT PRIMARY KEY,
+          token TEXT NOT NULL UNIQUE,
+          job_id TEXT NOT NULL,
+          source_path TEXT NOT NULL,
+          source_label TEXT NOT NULL,
+          destination_url TEXT NOT NULL,
+          destination_url_hash TEXT NOT NULL,
+          is_active INTEGER NOT NULL DEFAULT 1,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+
+        CREATE TABLE tracer_click_events (
+          id TEXT PRIMARY KEY,
+          tracer_link_id TEXT NOT NULL,
+          clicked_at INTEGER NOT NULL,
+          is_likely_bot INTEGER NOT NULL DEFAULT 0,
+          unique_fingerprint_hash TEXT
+        );
+
+        INSERT INTO tracer_links(
+          id, token, job_id, source_path, source_label, destination_url,
+          destination_url_hash, created_at, updated_at
+        )
+        VALUES
+          ('link-1', 'acme-aa', 'job-1', 'basics.url.href', 'Portfolio', 'https://example.com', 'hash-1', '2026-01-01T00:00:00.000Z', '2026-01-01T00:00:00.000Z'),
+          ('link-2', 'acme-bb', 'job-1', 'basics.url.href', 'Portfolio', 'https://example.com', 'hash-1', '2026-01-02T00:00:00.000Z', '2026-01-02T00:00:00.000Z');
+
+        INSERT INTO tracer_click_events(id, tracer_link_id, clicked_at)
+        VALUES ('click-1', 'link-2', 1);
+      \`);
+      sqlite.close();
+
+      await import(pathToFileURL(join(process.cwd(), "src/server/db/migrate.ts")).href);
+
+      const migratedDb = new Database(dbPath, { readonly: true });
+      const indexes = migratedDb.prepare("PRAGMA index_list(tracer_links)").all();
+      const uniqueIndex = indexes.find((index) => index.name === "idx_tracer_links_tenant_job_source_destination_unique");
+      if (!uniqueIndex || !uniqueIndex.unique) {
+        throw new Error("tracer_links composite unique index missing after migration");
+      }
+
+      const linkCount = migratedDb.prepare("SELECT count(*) AS count FROM tracer_links").get();
+      if (linkCount.count !== 1) {
+        throw new Error(\`Expected duplicate tracer links to be merged, got \${linkCount.count}\`);
+      }
+
+      const click = migratedDb.prepare("SELECT tracer_link_id FROM tracer_click_events WHERE id = ?").get("click-1");
+      if (click?.tracer_link_id !== "link-1") {
+        throw new Error(\`Expected duplicate click to be reassigned to link-1, got \${click?.tracer_link_id}\`);
+      }
+
+      migratedDb.close();
+    `;
+
+    execFileSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", script],
+      {
+        env: {
+          ...process.env,
+          DATA_DIR: tempDir,
+        },
+        stdio: "pipe",
+      },
+    );
+  });
 });

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -1027,6 +1027,66 @@ function rebuildSettingsTable(): void {
   sqlite.exec("ALTER TABLE settings_new RENAME TO settings");
 }
 
+function ensureTracerLinksUniqueIndex(): void {
+  if (!tableExists("tracer_links")) return;
+
+  for (const columnName of [
+    "tenant_id",
+    "job_id",
+    "source_path",
+    "destination_url_hash",
+  ]) {
+    if (!tableHasColumn("tracer_links", columnName)) return;
+  }
+
+  if (tableExists("tracer_click_events")) {
+    sqlite.exec(`
+      WITH duplicate_links AS (
+        SELECT
+          id,
+          first_value(id) OVER (
+            PARTITION BY tenant_id, job_id, source_path, destination_url_hash
+            ORDER BY created_at ASC, id ASC
+          ) AS keep_id
+        FROM tracer_links
+      )
+      UPDATE tracer_click_events
+      SET tracer_link_id = (
+        SELECT keep_id
+        FROM duplicate_links
+        WHERE duplicate_links.id = tracer_click_events.tracer_link_id
+      )
+      WHERE tracer_link_id IN (
+        SELECT id
+        FROM duplicate_links
+        WHERE id <> keep_id
+      )
+    `);
+  }
+
+  sqlite.exec(`
+    WITH duplicate_links AS (
+      SELECT
+        id,
+        first_value(id) OVER (
+          PARTITION BY tenant_id, job_id, source_path, destination_url_hash
+          ORDER BY created_at ASC, id ASC
+        ) AS keep_id
+      FROM tracer_links
+    )
+    DELETE FROM tracer_links
+    WHERE id IN (
+      SELECT id
+      FROM duplicate_links
+      WHERE id <> keep_id
+    )
+  `);
+
+  sqlite.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracer_links_tenant_job_source_destination_unique ON tracer_links(tenant_id, job_id, source_path, destination_url_hash)",
+  );
+}
+
 function seedLegacyOwnerFromBasicAuth(): void {
   const existing = sqlite
     .prepare("SELECT count(*) AS count FROM users")
@@ -1071,6 +1131,7 @@ function seedLegacyOwnerFromBasicAuth(): void {
 console.log("🔐 Applying tenancy compatibility migrations...");
 ensureTenantColumns();
 rebuildSettingsTable();
+ensureTracerLinksUniqueIndex();
 sqlite.exec(
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_settings_tenant_key_unique ON settings(tenant_id, key)",
 );


### PR DESCRIPTION
## Summary
- Added a migration repair that creates the missing composite unique index on `tracer_links` for upgraded databases.
- Backfills legacy duplicates by reassigning click events to the oldest matching tracer link, then removes duplicate rows before creating the index.
- Added a regression test that reproduces the legacy table shape and verifies the index plus deduplication behavior.

## Testing
- `biome ci` passed.
- `check:types` passed for `shared`, `orchestrator`, `gradcracker-extractor`, and `ukvisajobs-extractor`.
- `build:client` passed.
- `test:run` passed for the full orchestrator suite.