### PR TITLE
Preserve skill accordion state across autosave

### DIFF
--- a/orchestrator/src/client/components/TailoringEditor.test.tsx
+++ b/orchestrator/src/client/components/TailoringEditor.test.tsx
@@ -262,6 +262,47 @@ describe("TailoringEditor", () => {
     );
   });
 
+  it("keeps the edited skill group open after autosave", async () => {
+    vi.mocked(api.updateJob).mockResolvedValueOnce(
+      createJob({
+        tailoredSkills: JSON.stringify([
+          { name: "Core", keywords: ["Node.js", "TypeScript"] },
+        ]),
+      }),
+    );
+
+    render(<TailoringEditor job={createJob()} onUpdate={vi.fn()} />);
+    await waitFor(() =>
+      expect(api.getResumeProjectsCatalog).toHaveBeenCalled(),
+    );
+    ensureAccordionOpen("Tailored Skills");
+    ensureAccordionOpen("Core");
+
+    fireEvent.change(screen.getByLabelText("Keywords (comma-separated)"), {
+      target: { value: "Node.js, TypeScript" },
+    });
+
+    await waitFor(
+      () =>
+        expect(api.updateJob).toHaveBeenCalledWith(
+          "job-1",
+          expect.objectContaining({
+            tailoredSkills:
+              '[{"name":"Core","keywords":["Node.js","TypeScript"]}]',
+          }),
+        ),
+      { timeout: 2000 },
+    );
+
+    expect(screen.getByRole("button", { name: "Core" })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
+    expect(screen.getByLabelText("Keywords (comma-separated)")).toHaveValue(
+      "Node.js, TypeScript",
+    );
+  });
+
   it("hydrates headline and skills after AI summarize", async () => {
     vi.mocked(api.summarizeJob).mockResolvedValueOnce({
       ...createJob(),

--- a/orchestrator/src/client/components/tailoring/TailoringWorkspace.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringWorkspace.tsx
@@ -165,6 +165,7 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
     isDirty,
     savedPayloadKey,
     applyIncomingDraft,
+    markSavedSnapshot,
     markSavedJob,
     handleToggleProject,
     handleAddSkillGroup,
@@ -303,13 +304,14 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
             getTailoringSavePayloadKey(latestPayloadRef.current) ===
               snapshotKey;
           if (latestStillMatchesSnapshot) {
-            applyIncomingDraft(updatedJob);
-            latestPayloadRef.current = updatedPayload;
+            markSavedSnapshot(snapshot);
+            latestPayloadRef.current = snapshot;
           } else {
             markSavedJob(updatedJob);
           }
-          persistedPayloadKeyRef.current =
-            getTailoringSavePayloadKey(updatedPayload);
+          persistedPayloadKeyRef.current = latestStillMatchesSnapshot
+            ? snapshotKey
+            : getTailoringSavePayloadKey(updatedPayload);
 
           const latestKey = latestPayloadRef.current
             ? getTailoringSavePayloadKey(latestPayloadRef.current)
@@ -337,7 +339,7 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
 
     saveInFlightRef.current = savePromise;
     await savePromise;
-  }, [applyIncomingDraft, editorProps, markSavedJob, props.job.id]);
+  }, [editorProps, markSavedJob, markSavedSnapshot, props.job.id]);
 
   const flushAutosave = useCallback(async () => {
     if (!editorProps) return;


### PR DESCRIPTION
## Summary
- Stop autosave from rehydrating the tailoring draft when the saved payload still matches the current local edit
- Preserve skill-group ids so the open accordion stays open after autosave
- Add a regression test that edits a skill group and verifies it remains expanded after the save completes

## Testing
- `TailoringEditor.test.tsx` regression coverage added for the autosave accordion case
- Full validation passed locally, including Biome, typecheck, client build, and the orchestrator test suite