### PR TITLE
fix: force kanban columns to full viewport height

### DIFF
--- a/orchestrator/src/client/pages/InProgressBoardPage.tsx
+++ b/orchestrator/src/client/pages/InProgressBoardPage.tsx
@@ -262,14 +262,14 @@ export const InProgressBoardPage: React.FC = () => {
           </div>
         }
       />
-      <PageMain className="max-w-[1600px]">
+      <PageMain className="flex h-[calc(100dvh-5rem)] max-w-[1600px] flex-col">
         {isLoading ? (
           <div className="rounded-lg border border-dashed border-border/60 p-6 text-sm text-muted-foreground">
             Loading board...
           </div>
         ) : (
-          <div className="overflow-x-auto pb-2">
-            <div className="flex min-w-max items-start gap-4">
+          <div className="min-h-0 flex-1 overflow-x-auto pb-2">
+            <div className="flex h-full min-w-max items-stretch gap-4">
               {BOARD_STAGES.map((stage) => {
                 const laneCards = lanes[stage];
                 return (
@@ -291,7 +291,7 @@ export const InProgressBoardPage: React.FC = () => {
                       }
                     }}
                     className={cn(
-                      "w-[320px] self-start rounded-xl border border-border/70 bg-muted/30 shadow-[0_10px_24px_-20px_rgba(0,0,0,0.8)] transition-colors",
+                      "flex h-full w-[320px] flex-col rounded-xl border border-border/70 bg-muted/30 shadow-[0_10px_24px_-20px_rgba(0,0,0,0.8)] transition-colors",
                       dropTargetStage === stage &&
                         "border-sky-400/70 bg-sky-500/15",
                     )}
@@ -312,7 +312,7 @@ export const InProgressBoardPage: React.FC = () => {
                       </Badge>
                     </header>
 
-                    <div className="max-h-[calc(100vh-15rem)] space-y-2 overflow-y-auto p-2.5">
+                    <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2.5">
                       {laneCards.length === 0 ? (
                         <div className="rounded-md border border-dashed border-border/35 bg-background/20 px-2.5 py-2 text-[11px] text-muted-foreground/80">
                           Drop a card here or log a stage.


### PR DESCRIPTION
Fixes #472

## Problem
The kanban board columns used `items-start` and `self-start`, 
so columns shrank to fit their content. With few cards, the 
horizontal scrollbar collapsed into the middle of the screen, 
making it hard to scroll.

## Fix
- Made the board container take full viewport height
- Changed columns to use `items-stretch` so they always fill 
  the full height regardless of card count
- Cards area inside each column scrolls independently

## Tested
- Full test suite passed
- Build passed
- Biome lint passed on changed file

<img width="1873" height="922" alt="Screenshot_1" src="https://github.com/user-attachments/assets/7f060acf-7e6f-4407-9c40-f480045bdb25" />
