### PR TITLE
Handle Reactive Resume PDF exports and resume import edge cases

### DIFF
--- a/orchestrator/src/client/components/design-resume/DesignResumePdfPreview.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumePdfPreview.tsx
@@ -37,6 +37,10 @@ export function DesignResumePdfPreview({
   useEffect(() => {
     if (saveState === "error") {
       setIsFrameLoading(false);
+      setPreviewState((current) =>
+        current === "waiting-for-save" ? "error" : current,
+      );
+      setPreviewError("Changes could not be saved. Please try again.");
       return;
     }
 

--- a/orchestrator/src/client/pages/DesignResumePage.tsx
+++ b/orchestrator/src/client/pages/DesignResumePage.tsx
@@ -250,15 +250,16 @@ export const DesignResumePage: React.FC = () => {
 
   const handleImport = async () => {
     try {
-      setSaveState("saving");
+      setResumeImporting(true);
       const imported = await api.importDesignResumeFromRxResume();
       setDesignResume(imported);
       setSaveState("saved");
       toast.success("Imported your resume.");
       notifyReadyPdfRefresh();
     } catch (importError) {
-      setSaveState("error");
       showErrorToast(importError, "Failed to import your resume.");
+    } finally {
+      setResumeImporting(false);
     }
   };
 
@@ -526,9 +527,14 @@ export const DesignResumePage: React.FC = () => {
                 type="button"
                 variant="outline"
                 onClick={handleImportWithConfirm}
+                disabled={resumeImporting}
               >
                 <Import className="mr-2 h-4 w-4" />
-                {status?.exists ? "Re-import RxResume" : "Import RxResume"}
+                {resumeImporting
+                  ? "Importing RxResume"
+                  : status?.exists
+                    ? "Re-import RxResume"
+                    : "Import RxResume"}
               </Button>
 
               <Button
@@ -572,9 +578,16 @@ export const DesignResumePage: React.FC = () => {
                   <Import className="mr-2 h-4 w-4" />
                   {resumeImporting ? "Importing File" : "Import File"}
                 </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => handleImportWithConfirm()}>
+                <DropdownMenuItem
+                  onSelect={() => handleImportWithConfirm()}
+                  disabled={resumeImporting}
+                >
                   <Import className="mr-2 h-4 w-4" />
-                  {status?.exists ? "Re-import RxResume" : "Import RxResume"}
+                  {resumeImporting
+                    ? "Importing RxResume"
+                    : status?.exists
+                      ? "Re-import RxResume"
+                      : "Import RxResume"}
                 </DropdownMenuItem>
                 <DropdownMenuItem
                   onSelect={() => handleDownloadPdf()}
@@ -611,9 +624,13 @@ export const DesignResumePage: React.FC = () => {
                 between tools.
               </p>
               <div className="flex justify-center gap-3">
-                <Button type="button" onClick={handleImport}>
+                <Button
+                  type="button"
+                  onClick={handleImport}
+                  disabled={resumeImporting}
+                >
                   <Import className="mr-2 h-4 w-4" />
-                  Import resume
+                  {resumeImporting ? "Importing resume" : "Import resume"}
                 </Button>
                 {error ? (
                   <div className="rounded-lg border border-rose-500/30 bg-rose-500/10 px-4 py-2 text-sm text-rose-300">

--- a/orchestrator/src/server/services/design-resume.test.ts
+++ b/orchestrator/src/server/services/design-resume.test.ts
@@ -165,6 +165,32 @@ describe("design resume service", () => {
     );
   });
 
+  it("imports Reactive Resume v5.1 data when metadata.css is absent", async () => {
+    const upstreamResume = makeValidResumeJson();
+    delete (upstreamResume.metadata as Record<string, unknown>).css;
+    vi.mocked(getResume).mockResolvedValueOnce({
+      id: "rx-1",
+      mode: "v5",
+      data: upstreamResume,
+    } as never);
+
+    const result = await importDesignResumeFromReactiveResume();
+
+    expect(result.resumeJson.metadata.css).toEqual({
+      enabled: false,
+      value: "",
+    });
+    expect(repo.upsertDesignResumeDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resumeJson: expect.objectContaining({
+          metadata: expect.objectContaining({
+            css: { enabled: false, value: "" },
+          }),
+        }),
+      }),
+    );
+  });
+
   it("localizes Reactive Resume relative picture URLs into design resume assets", async () => {
     vi.stubGlobal(
       "fetch",

--- a/orchestrator/src/server/services/pdf-tailoring.test.ts
+++ b/orchestrator/src/server/services/pdf-tailoring.test.ts
@@ -371,9 +371,10 @@ vi.mock("./rxresume", async () => {
   const projectSelectionModule = await import("./projectSelection");
   return {
     importResume: vi.fn().mockResolvedValue("temp-resume-id"),
-    exportResumePdf: vi
-      .fn()
-      .mockResolvedValue("https://pdf.rxresume.test/print/123"),
+    exportResumePdf: vi.fn().mockResolvedValue({
+      kind: "url",
+      url: "https://pdf.rxresume.test/print/123",
+    }),
     deleteResume: vi.fn().mockResolvedValue(undefined),
     getResume: vi.fn().mockResolvedValue({
       id: "base-resume-id",

--- a/orchestrator/src/server/services/pdf.ts
+++ b/orchestrator/src/server/services/pdf.ts
@@ -162,13 +162,12 @@ async function renderRxResumePdf(args: {
       data: importData,
     });
 
-    const downloadUrl = await exportRxResumePdf(importedResumeId);
-    if (!downloadUrl || typeof downloadUrl !== "string") {
-      throw new Error(
-        "Reactive Resume did not return a PDF download URL. Please ensure your Reactive Resume API key and instance URL are configured correctly in Settings.",
-      );
+    const exportResult = await exportRxResumePdf(importedResumeId);
+    if (exportResult.kind === "pdf") {
+      await writeFile(outputPath, exportResult.bytes);
+    } else {
+      await downloadRxResumePdf(exportResult.url, outputPath);
     }
-    await downloadRxResumePdf(downloadUrl, outputPath);
   } finally {
     if (importedResumeId) {
       try {

--- a/orchestrator/src/server/services/rxresume/index.test.ts
+++ b/orchestrator/src/server/services/rxresume/index.test.ts
@@ -214,7 +214,10 @@ describe("RxResume Service (index.ts)", () => {
 
   describe("exportResumePdf", () => {
     it("exports PDF using v5 upstream", async () => {
-      vi.mocked(v5.exportResumePdf).mockResolvedValueOnce("https://pdf.url");
+      vi.mocked(v5.exportResumePdf).mockResolvedValueOnce({
+        kind: "url",
+        url: "https://pdf.url",
+      });
 
       const result = await exportResumePdf("resume-1");
 
@@ -222,7 +225,7 @@ describe("RxResume Service (index.ts)", () => {
         apiKey: "test-api-key",
         baseUrl: "https://rxresu.me",
       });
-      expect(result).toBe("https://pdf.url");
+      expect(result).toEqual({ kind: "url", url: "https://pdf.url" });
     });
   });
 

--- a/orchestrator/src/server/services/rxresume/index.ts
+++ b/orchestrator/src/server/services/rxresume/index.ts
@@ -45,6 +45,8 @@ export type PreparedRxResumePdfPayload = {
   selectedProjectIds: string[];
 };
 
+export type RxResumeExportPdfResult = v5.RxResumeExportPdfResult;
+
 export class RxResumeAuthConfigError extends Error {
   constructor(message: string) {
     super(message);
@@ -512,7 +514,7 @@ export async function deleteResume(
 export async function exportResumePdf(
   resumeId: string,
   options: ResolveModeOptions = {},
-): Promise<string> {
+): Promise<RxResumeExportPdfResult> {
   try {
     const creds = await readV5Credentials(options.v5);
     return await v5.exportResumePdf(resumeId, {

--- a/orchestrator/src/server/services/rxresume/schema/v5.ts
+++ b/orchestrator/src/server/services/rxresume/schema/v5.ts
@@ -351,6 +351,8 @@ export const cssSchema = z.object({
   value: z.string(),
 });
 
+const defaultCss = { enabled: false, value: "" };
+
 export const pageSchema = z.object({
   gapX: z.number().min(0),
   gapY: z.number().min(0),
@@ -393,7 +395,7 @@ export const typographySchema = z.object({
 export const metadataSchema = z.object({
   template: templateSchema.catch("onyx"),
   layout: layoutSchema,
-  css: cssSchema,
+  css: cssSchema.catch(defaultCss),
   page: pageSchema,
   design: designSchema,
   typography: typographySchema,

--- a/orchestrator/src/server/services/rxresume/v5.test.ts
+++ b/orchestrator/src/server/services/rxresume/v5.test.ts
@@ -36,6 +36,23 @@ function jsonResponse(data: unknown, ok = true, status = 200) {
   };
 }
 
+function pdfResponse(bytes: Uint8Array, ok = true, status = 200) {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Error",
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === "content-type" ? "application/pdf" : null,
+    },
+    arrayBuffer: async () => bytes.buffer.slice(0),
+    json: async () => {
+      throw new Error("not json");
+    },
+    text: async () => Buffer.from(bytes).toString("latin1"),
+  };
+}
+
 describe("rxresume v5 endpoints", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -72,9 +89,7 @@ describe("rxresume v5 endpoints", () => {
       )
       .mockResolvedValueOnce(jsonResponse({ id: "imported-123" }))
       .mockResolvedValueOnce(jsonResponse({ ok: true }))
-      .mockResolvedValueOnce(
-        jsonResponse({ url: "https://rxresu.me/storage/resume-123.pdf" }),
-      );
+      .mockResolvedValueOnce(pdfResponse(new Uint8Array([37, 80, 68, 70])));
     vi.stubGlobal("fetch", mockFetch);
 
     const config = { baseUrl: "https://rxresu.me", apiKey: "test-key" };
@@ -83,7 +98,10 @@ describe("rxresume v5 endpoints", () => {
     await getResume("resume-123", config);
     await importResume({ data: sampleResume, name: "Imported Resume" }, config);
     await deleteResume("resume-123", config);
-    await exportResumePdf("resume-123", config);
+    await expect(exportResumePdf("resume-123", config)).resolves.toEqual({
+      kind: "pdf",
+      bytes: new Uint8Array([37, 80, 68, 70]),
+    });
 
     expect(mockFetch).toHaveBeenNthCalledWith(
       1,
@@ -112,6 +130,39 @@ describe("rxresume v5 endpoints", () => {
       5,
       "https://rxresu.me/api/openapi/resumes/resume-123/pdf",
       expect.any(Object),
+    );
+  });
+
+  it("supports older PDF export responses that return a download URL", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ url: "https://rxresu.me/storage/resume-123.pdf" }),
+      );
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(
+      exportResumePdf("resume-123", {
+        baseUrl: "https://rxresu.me",
+        apiKey: "test-key",
+      }),
+    ).resolves.toEqual({
+      kind: "url",
+      url: "https://rxresu.me/storage/resume-123.pdf",
+    });
+  });
+
+  it("rejects unexpected PDF export response shapes", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await expect(
+      exportResumePdf("resume-123", {
+        baseUrl: "https://rxresu.me",
+        apiKey: "test-key",
+      }),
+    ).rejects.toThrow(
+      "Reactive Resume returned an unexpected PDF export response shape.",
     );
   });
 

--- a/orchestrator/src/server/services/rxresume/v5.ts
+++ b/orchestrator/src/server/services/rxresume/v5.ts
@@ -36,9 +36,9 @@ export type RxResumeImportRequest = {
   slug?: string;
 };
 
-export type RxResumeExportPdfResponse = {
-  url: string;
-};
+export type RxResumeExportPdfResult =
+  | { kind: "pdf"; bytes: Uint8Array }
+  | { kind: "url"; url: string };
 
 export type VerifyApiKeyResult =
   | { ok: true }
@@ -130,6 +130,9 @@ async function executeWithKeyRetries(
     const contentType = response.headers.get("content-type");
     if (contentType?.includes("application/json")) {
       return response.json();
+    }
+    if (contentType?.includes("application/pdf")) {
+      return new Uint8Array(await response.arrayBuffer());
     }
     return response.text();
   }
@@ -246,18 +249,32 @@ export async function deleteResume(
 }
 
 /**
- * Export a resume as PDF. Returns the URL.
+ * Export a resume as PDF.
  */
 export async function exportResumePdf(
   id: string,
   config?: RxResumeApiConfig,
-): Promise<string> {
+): Promise<RxResumeExportPdfResult> {
   const result = (await fetchRxResume(
     `/resumes/${id}/pdf`,
     {},
     config,
-  )) as RxResumeExportPdfResponse;
-  return result.url;
+  )) as unknown;
+
+  if (result instanceof Uint8Array) {
+    return { kind: "pdf", bytes: result };
+  }
+
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    const url = (result as Record<string, unknown>).url;
+    if (typeof url === "string" && url.trim()) {
+      return { kind: "url", url };
+    }
+  }
+
+  throw new Error(
+    "Reactive Resume returned an unexpected PDF export response shape.",
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Support Reactive Resume PDF exports that return either a direct PDF payload or a download URL.
- Accept Reactive Resume v5.1 imports that omit `metadata.css` by applying a safe default.
- Improve resume import and preview states so the UI reflects in-progress and failed save/import flows more clearly.
- Add coverage for the new export response shapes and the missing CSS metadata fallback.

## Testing
- Added and updated server-side tests for Reactive Resume import/export behavior.
- Added coverage for PDF export responses returned as bytes, legacy URLs, and unexpected shapes.
- Updated client behavior around import/preview state handling.