### PR TITLE
Convert Reactive Resume rich-text fields to HTML before export

### DIFF
--- a/orchestrator/src/server/services/rxresume/document.test.ts
+++ b/orchestrator/src/server/services/rxresume/document.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDefaultReactiveResumeDocument,
+  prepareReactiveResumeV5DocumentForExternalUse,
+} from "./document";
+
+describe("prepareReactiveResumeV5DocumentForExternalUse", () => {
+  it("wraps plain rich-text fields in HTML paragraphs for Reactive Resume", () => {
+    const document = buildDefaultReactiveResumeDocument();
+    document.summary = {
+      ...(document.summary as Record<string, unknown>),
+      content: "Plain summary",
+    };
+    document.sections = {
+      ...(document.sections as Record<string, unknown>),
+      experience: {
+        title: "Experience",
+        columns: 1,
+        hidden: false,
+        items: [
+          {
+            id: "experience-1",
+            hidden: false,
+            company: "Acme",
+            position: "Engineer",
+            location: "",
+            period: "",
+            website: { url: "", label: "" },
+            description: "Built things",
+            roles: [
+              {
+                id: "role-1",
+                position: "Platform",
+                period: "",
+                description: "Owned APIs",
+              },
+            ],
+          },
+        ],
+      },
+      education: {
+        title: "Education",
+        columns: 1,
+        hidden: false,
+        items: [
+          {
+            id: "education-1",
+            hidden: false,
+            school: "University",
+            degree: "",
+            area: "",
+            grade: "",
+            location: "",
+            period: "",
+            website: { url: "", label: "" },
+            description: "Relevant Modules: Web Apps",
+          },
+        ],
+      },
+    };
+
+    const prepared = prepareReactiveResumeV5DocumentForExternalUse(document);
+    const sections = prepared.sections as Record<string, any>;
+
+    expect((prepared.summary as Record<string, unknown>).content).toBe(
+      "<p>Plain summary</p>",
+    );
+    expect(sections.experience.items[0].description).toBe(
+      "<p>Built things</p>",
+    );
+    expect(sections.experience.items[0].roles[0].description).toBe(
+      "<p>Owned APIs</p>",
+    );
+    expect(sections.education.items[0].description).toBe(
+      "<p>Relevant Modules: Web Apps</p>",
+    );
+  });
+
+  it("preserves existing HTML and escapes plain text before wrapping", () => {
+    const document = buildDefaultReactiveResumeDocument();
+    document.summary = {
+      ...(document.summary as Record<string, unknown>),
+      content: "<p>Already HTML</p>",
+    };
+    document.sections = {
+      ...(document.sections as Record<string, unknown>),
+      projects: {
+        title: "Projects",
+        columns: 1,
+        hidden: false,
+        items: [
+          {
+            id: "project-1",
+            hidden: false,
+            name: "Parser",
+            period: "",
+            website: { url: "", label: "" },
+            description: "Used A&B < C\nThen shipped",
+          },
+        ],
+      },
+    };
+
+    const prepared = prepareReactiveResumeV5DocumentForExternalUse(document);
+    const sections = prepared.sections as Record<string, any>;
+
+    expect((prepared.summary as Record<string, unknown>).content).toBe(
+      "<p>Already HTML</p>",
+    );
+    expect(sections.projects.items[0].description).toBe(
+      "<p>Used A&amp;B &lt; C<br>Then shipped</p>",
+    );
+  });
+
+  it("prepares custom section rich text without changing local storage shape", () => {
+    const document = buildDefaultReactiveResumeDocument();
+    document.customSections = [
+      {
+        id: "custom-1",
+        type: "summary",
+        title: "More",
+        columns: 1,
+        hidden: false,
+        items: [
+          {
+            id: "summary-item-1",
+            hidden: false,
+            content: "Extra note",
+          },
+        ],
+      },
+    ];
+
+    const prepared = prepareReactiveResumeV5DocumentForExternalUse(document);
+    const customSections = prepared.customSections as Array<
+      Record<string, any>
+    >;
+
+    expect(customSections[0].items[0].content).toBe("<p>Extra note</p>");
+    expect(
+      (document.customSections as Array<Record<string, any>>)[0].items[0]
+        .content,
+    ).toBe("Extra note");
+  });
+});

--- a/orchestrator/src/server/services/rxresume/document.ts
+++ b/orchestrator/src/server/services/rxresume/document.ts
@@ -251,6 +251,76 @@ function absolutizeSectionWebsites(
   };
 }
 
+function escapeHtmlText(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function looksLikeHtml(value: string): boolean {
+  return /<\/?[a-z][\s\S]*>/i.test(value);
+}
+
+function ensureHtmlBlock(value: string): string {
+  const trimmed = value.trim();
+  if (!trimmed || looksLikeHtml(trimmed)) return value;
+
+  return trimmed
+    .split(/\n{2,}/)
+    .map((paragraph) => {
+      const html = escapeHtmlText(paragraph.trim()).replace(/\n/g, "<br>");
+      return `<p>${html}</p>`;
+    })
+    .join("");
+}
+
+function prepareRichTextItemForExternalUse(item: unknown): unknown {
+  const record = asRecord(item);
+  if (!record) return item;
+
+  return {
+    ...record,
+    ...(typeof record.description === "string"
+      ? { description: ensureHtmlBlock(record.description) }
+      : {}),
+    ...(typeof record.content === "string"
+      ? { content: ensureHtmlBlock(record.content) }
+      : {}),
+    ...(typeof record.recipient === "string"
+      ? { recipient: ensureHtmlBlock(record.recipient) }
+      : {}),
+    ...(Array.isArray(record.roles)
+      ? {
+          roles: record.roles.map((role) =>
+            prepareRichTextItemForExternalUse(role),
+          ),
+        }
+      : {}),
+  };
+}
+
+function prepareSectionForExternalUse(
+  section: unknown,
+  publicBaseUrl: string | null,
+): unknown {
+  const withAbsoluteWebsites = absolutizeSectionWebsites(
+    section,
+    publicBaseUrl,
+  );
+  const record = asRecord(withAbsoluteWebsites);
+  if (!record) return withAbsoluteWebsites;
+
+  return {
+    ...record,
+    items: asArray(record.items).map((item) =>
+      prepareRichTextItemForExternalUse(item),
+    ),
+  };
+}
+
 function normalizeOptions(value: unknown) {
   const record = asRecord(value);
   return {
@@ -659,6 +729,7 @@ export function prepareReactiveResumeV5DocumentForExternalUse(
   const parsed = parseV5ResumeData(input) as RecordLike;
   const picture = asRecord(parsed.picture) ?? {};
   const basics = asRecord(parsed.basics) ?? {};
+  const summary = asRecord(parsed.summary) ?? {};
   const sections = asRecord(parsed.sections) ?? {};
 
   return {
@@ -671,24 +742,53 @@ export function prepareReactiveResumeV5DocumentForExternalUse(
       ...basics,
       website: absolutizeV5UrlNode(basics.website, publicBaseUrl),
     },
+    summary: {
+      ...summary,
+      content:
+        typeof summary.content === "string"
+          ? ensureHtmlBlock(summary.content)
+          : summary.content,
+    },
     sections: {
       ...sections,
-      profiles: absolutizeSectionWebsites(sections.profiles, publicBaseUrl),
-      experience: absolutizeSectionWebsites(sections.experience, publicBaseUrl),
-      education: absolutizeSectionWebsites(sections.education, publicBaseUrl),
-      projects: absolutizeSectionWebsites(sections.projects, publicBaseUrl),
-      awards: absolutizeSectionWebsites(sections.awards, publicBaseUrl),
-      certifications: absolutizeSectionWebsites(
+      profiles: prepareSectionForExternalUse(sections.profiles, publicBaseUrl),
+      experience: prepareSectionForExternalUse(
+        sections.experience,
+        publicBaseUrl,
+      ),
+      education: prepareSectionForExternalUse(
+        sections.education,
+        publicBaseUrl,
+      ),
+      projects: prepareSectionForExternalUse(sections.projects, publicBaseUrl),
+      awards: prepareSectionForExternalUse(sections.awards, publicBaseUrl),
+      certifications: prepareSectionForExternalUse(
         sections.certifications,
         publicBaseUrl,
       ),
-      publications: absolutizeSectionWebsites(
+      publications: prepareSectionForExternalUse(
         sections.publications,
         publicBaseUrl,
       ),
-      volunteer: absolutizeSectionWebsites(sections.volunteer, publicBaseUrl),
-      references: absolutizeSectionWebsites(sections.references, publicBaseUrl),
+      volunteer: prepareSectionForExternalUse(
+        sections.volunteer,
+        publicBaseUrl,
+      ),
+      references: prepareSectionForExternalUse(
+        sections.references,
+        publicBaseUrl,
+      ),
     },
+    customSections: asArray(parsed.customSections).map((section) => {
+      const record = asRecord(section);
+      if (!record) return section;
+      return {
+        ...record,
+        items: asArray(record.items).map((item) =>
+          prepareRichTextItemForExternalUse(item),
+        ),
+      };
+    }),
   };
 }
 


### PR DESCRIPTION
**Summary**
- Wrap plain-text RR prose fields in HTML paragraphs before sending payloads to Reactive Resume.
- Preserve existing HTML, escape raw text safely, and keep line breaks readable.
- Cover summary, section descriptions, role descriptions, custom section content, and cover-letter content.
- Add focused tests for wrapping, escaping, HTML preservation, and non-mutation of local documents.

**Testing**
- `biome ci` passed.
- Orchestrator typecheck passed.
- Focused unit tests for `rxresume/document` and `pdf-tailoring` passed.
- Full orchestrator test suite passed.