### PR TITLE
Send full CV content into job scoring prompts

### DIFF
--- a/orchestrator/src/server/services/scorer.test.ts
+++ b/orchestrator/src/server/services/scorer.test.ts
@@ -310,6 +310,216 @@ describe("salary penalty", () => {
     vi.clearAllMocks();
   });
 
+  function getScoringPrompt(): string {
+    const call = callJsonMock.mock.calls.at(-1)?.[0];
+    return call?.messages?.[0]?.content ?? "";
+  }
+
+  function getPromptProfile(): Record<string, any> {
+    const prompt = getScoringPrompt();
+    const match = prompt.match(
+      /CANDIDATE PROFILE:\n(?<profile>[\s\S]*?)\n\nJOB LISTING:/,
+    );
+    expect(match?.groups?.profile).toBeDefined();
+    return JSON.parse(match?.groups?.profile ?? "{}");
+  }
+
+  describe("profile prompt sanitization", () => {
+    it("includes top-level education and the full top-level CV content", async () => {
+      const { scoreJobSuitability } = await import("./scorer");
+      getEffectiveSettingsMock.mockResolvedValue({
+        penalizeMissingSalary: { value: false, default: false, override: null },
+        missingSalaryPenalty: { value: 10, default: 10, override: null },
+        scoringInstructions: { value: "", default: "", override: null },
+        rxresumeBaseResumeId: "base-resume-123",
+      } as any);
+
+      await scoreJobSuitability(
+        createJob({
+          id: "test-job-profile-top-level",
+          title: "Software Engineer Intern",
+        }),
+        {
+          basics: {
+            label: "Software Engineer",
+            summary: "Builds React and TypeScript applications.",
+            location: "Sheffield",
+            email: "private@example.com",
+            phone: "+44 7000 000000",
+            website: { url: "https://private.example.com" },
+          },
+          education: [
+            {
+              id: "education-private-id",
+              school: "University of Lancashire",
+              degree: "BSc Software Engineering",
+              location: "Preston",
+              period: "2022 - 2025",
+              description: "Computer Science and Software Engineering.",
+              website: { url: "https://university.example.com" },
+            },
+          ],
+          experience: Array.from({ length: 6 }, (_, index) => ({
+            company: `Company ${index + 1}`,
+            position: "Software Engineer",
+            summary: `Experience summary ${index + 1}`,
+            roles:
+              index === 0
+                ? [
+                    {
+                      id: "role-private-id",
+                      position: "Frontend Developer",
+                      period: "2024",
+                      description: "Built React features.",
+                    },
+                  ]
+                : [],
+          })),
+        },
+      );
+
+      const promptProfile = getPromptProfile();
+      expect(promptProfile.basics).toEqual({
+        label: "Software Engineer",
+        summary: "Builds React and TypeScript applications.",
+        location: "Sheffield",
+      });
+      expect(promptProfile.education).toEqual([
+        {
+          school: "University of Lancashire",
+          degree: "BSc Software Engineering",
+          location: "Preston",
+          period: "2022 - 2025",
+          description: "Computer Science and Software Engineering.",
+        },
+      ]);
+      expect(promptProfile.experience).toHaveLength(6);
+      expect(promptProfile.experience[5]).toEqual({
+        company: "Company 6",
+        position: "Software Engineer",
+        summary: "Experience summary 6",
+      });
+      expect(promptProfile.experience[0].roles).toEqual([
+        {
+          position: "Frontend Developer",
+          period: "2024",
+          description: "Built React features.",
+        },
+      ]);
+      expect(getScoringPrompt()).not.toContain("private@example.com");
+      expect(getScoringPrompt()).not.toContain("+44 7000 000000");
+      expect(getScoringPrompt()).not.toContain("education-private-id");
+      expect(getScoringPrompt()).not.toContain("role-private-id");
+      expect(getScoringPrompt()).not.toContain(
+        "https://university.example.com",
+      );
+    });
+
+    it("includes education from nested resume sections", async () => {
+      const { scoreJobSuitability } = await import("./scorer");
+      getEffectiveSettingsMock.mockResolvedValue({
+        penalizeMissingSalary: { value: false, default: false, override: null },
+        missingSalaryPenalty: { value: 10, default: 10, override: null },
+        scoringInstructions: { value: "", default: "", override: null },
+        rxresumeBaseResumeId: "base-resume-123",
+      } as any);
+
+      await scoreJobSuitability(
+        createJob({ id: "test-job-profile-sections" }),
+        {
+          sections: {
+            education: {
+              title: "Education",
+              hidden: false,
+              items: [
+                {
+                  school: "University of Sheffield",
+                  degree: "BSc Computer Science",
+                  area: "Software Engineering",
+                  location: "Sheffield",
+                },
+              ],
+            },
+          },
+          metadata: {
+            layout: "private-renderer-layout",
+          },
+        },
+      );
+
+      const promptProfile = getPromptProfile();
+      expect(promptProfile.education).toEqual([
+        {
+          school: "University of Sheffield",
+          degree: "BSc Computer Science",
+          area: "Software Engineering",
+          location: "Sheffield",
+        },
+      ]);
+      expect(getScoringPrompt()).not.toContain("private-renderer-layout");
+    });
+
+    it("excludes hidden and invisible CV items from prompt content", async () => {
+      const { scoreJobSuitability } = await import("./scorer");
+      getEffectiveSettingsMock.mockResolvedValue({
+        penalizeMissingSalary: { value: false, default: false, override: null },
+        missingSalaryPenalty: { value: 10, default: 10, override: null },
+        scoringInstructions: { value: "", default: "", override: null },
+        rxresumeBaseResumeId: "base-resume-123",
+      } as any);
+
+      await scoreJobSuitability(
+        createJob({ id: "test-job-profile-hidden-items" }),
+        {
+          sections: {
+            skills: {
+              items: [
+                { name: "Frontend", keywords: ["React"], visible: true },
+                {
+                  name: "Hidden Skill",
+                  keywords: ["PrivateSkill"],
+                  hidden: true,
+                },
+                {
+                  name: "Invisible Skill",
+                  keywords: ["InvisibleSkill"],
+                  visible: false,
+                },
+              ],
+            },
+            education: {
+              items: [
+                { school: "Visible University", degree: "BSc Computing" },
+                {
+                  school: "Hidden University",
+                  degree: "Private Degree",
+                  hidden: true,
+                },
+                {
+                  school: "Invisible University",
+                  degree: "Invisible Degree",
+                  visible: false,
+                },
+              ],
+            },
+          },
+        },
+      );
+
+      const promptProfile = getPromptProfile();
+      expect(promptProfile.skills).toEqual([
+        { name: "Frontend", keywords: ["React"] },
+      ]);
+      expect(promptProfile.education).toEqual([
+        { school: "Visible University", degree: "BSc Computing" },
+      ]);
+      expect(getScoringPrompt()).not.toContain("PrivateSkill");
+      expect(getScoringPrompt()).not.toContain("InvisibleSkill");
+      expect(getScoringPrompt()).not.toContain("Hidden University");
+      expect(getScoringPrompt()).not.toContain("Invisible University");
+    });
+  });
+
   describe("isSalaryMissing detection", () => {
     it("should detect null salary as missing", async () => {
       const { scoreJobSuitability } = await import("./scorer");

--- a/orchestrator/src/server/services/scorer.ts
+++ b/orchestrator/src/server/services/scorer.ts
@@ -21,6 +21,8 @@ type ScoringPreferences = {
   promptTemplate: string;
 };
 
+type ProfileRecord = Record<string, unknown>;
+
 /** JSON schema for suitability scoring response */
 const SCORING_SCHEMA: JsonSchemaDefinition = {
   name: "job_suitability_score",
@@ -276,33 +278,167 @@ function buildScoringPrompt(
 function sanitizeProfileForPrompt(
   profile: Record<string, unknown>,
 ): Record<string, unknown> {
-  const p = profile as {
-    basics?: Record<string, unknown>;
-    sections?: {
-      skills?: unknown;
-      experience?: { items?: unknown[] };
-      projects?: { items?: unknown[] };
-      education?: { items?: unknown[] };
-    };
-  };
-
-  const experienceItems = Array.isArray(p.sections?.experience?.items)
-    ? p.sections?.experience?.items.slice(0, 5)
-    : [];
-  const projectItems = Array.isArray(p.sections?.projects?.items)
-    ? p.sections?.projects?.items.slice(0, 6)
-    : [];
-
   return {
-    basics: {
-      label: p.basics?.label,
-      summary: p.basics?.summary,
-    },
-    skills: p.sections?.skills ?? null,
-    experience: experienceItems,
-    projects: projectItems,
-    education: p.sections?.education?.items ?? [],
+    basics: sanitizeBasics(profile.basics),
+    skills: sanitizeItems(profile, "skills", [
+      "name",
+      "description",
+      "level",
+      "proficiency",
+      "keywords",
+    ]),
+    experience: sanitizeItems(profile, "experience", [
+      "company",
+      "position",
+      "location",
+      "date",
+      "period",
+      "summary",
+      "description",
+    ]),
+    projects: sanitizeItems(profile, "projects", [
+      "name",
+      "description",
+      "date",
+      "period",
+      "summary",
+      "keywords",
+    ]),
+    education: sanitizeItems(profile, "education", [
+      "school",
+      "institution",
+      "degree",
+      "area",
+      "grade",
+      "location",
+      "date",
+      "period",
+      "summary",
+      "description",
+    ]),
+    languages: sanitizeItems(profile, "languages", [
+      "language",
+      "fluency",
+      "level",
+    ]),
+    awards: sanitizeItems(profile, "awards", [
+      "title",
+      "awarder",
+      "date",
+      "summary",
+      "description",
+    ]),
+    certifications: sanitizeItems(profile, "certifications", [
+      "title",
+      "issuer",
+      "date",
+      "summary",
+      "description",
+    ]),
+    publications: sanitizeItems(profile, "publications", [
+      "title",
+      "publisher",
+      "date",
+      "summary",
+      "description",
+    ]),
+    volunteer: sanitizeItems(profile, "volunteer", [
+      "organization",
+      "position",
+      "location",
+      "date",
+      "period",
+      "summary",
+      "description",
+    ]),
+    interests: sanitizeItems(profile, "interests", [
+      "name",
+      "summary",
+      "description",
+      "keywords",
+    ]),
   };
+}
+
+function sanitizeBasics(value: unknown): ProfileRecord {
+  if (!isRecord(value)) return {};
+  return pickDefined(value, ["label", "headline", "summary", "location"]);
+}
+
+function sanitizeItems(
+  profile: ProfileRecord,
+  sectionKey: string,
+  allowedKeys: string[],
+): ProfileRecord[] {
+  return collectSectionItems(profile, sectionKey)
+    .filter(isVisibleCvItem)
+    .map((item) => sanitizeCvItem(item, allowedKeys))
+    .filter((item) => Object.keys(item).length > 0);
+}
+
+function collectSectionItems(
+  profile: ProfileRecord,
+  sectionKey: string,
+): ProfileRecord[] {
+  const sections = isRecord(profile.sections) ? profile.sections : {};
+  const section = sections[sectionKey];
+
+  if (isRecord(section)) {
+    if (!isVisibleCvItem(section)) return [];
+    if (Array.isArray(section.items)) {
+      return section.items.filter(isRecord);
+    }
+  }
+
+  const topLevelSection = profile[sectionKey];
+  if (Array.isArray(topLevelSection)) return topLevelSection.filter(isRecord);
+  if (isRecord(topLevelSection)) {
+    if (!isVisibleCvItem(topLevelSection)) return [];
+    if (Array.isArray(topLevelSection.items)) {
+      return topLevelSection.items.filter(isRecord);
+    }
+  }
+
+  return [];
+}
+
+function sanitizeCvItem(
+  item: ProfileRecord,
+  allowedKeys: string[],
+): ProfileRecord {
+  const sanitized = pickDefined(item, allowedKeys);
+  if (Array.isArray(item.roles)) {
+    const roles = item.roles
+      .filter(isRecord)
+      .filter(isVisibleCvItem)
+      .map((role) =>
+        pickDefined(role, ["position", "period", "summary", "description"]),
+      )
+      .filter((role) => Object.keys(role).length > 0);
+    if (roles.length > 0) sanitized.roles = roles;
+  }
+  return sanitized;
+}
+
+function pickDefined(source: ProfileRecord, keys: string[]): ProfileRecord {
+  const result: ProfileRecord = {};
+  for (const key of keys) {
+    const value = source[key];
+    if (value !== undefined && value !== null && value !== "") {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function isVisibleCvItem(item: ProfileRecord): boolean {
+  if (item.hidden === true) return false;
+  if (item.visible === false) return false;
+  return true;
+}
+
+function isRecord(value: unknown): value is ProfileRecord {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 async function mockScore(


### PR DESCRIPTION
## Summary
- Expanded scoring prompt sanitization to include the full visible CV profile instead of the old token-trimmed subset.
- Fixed education handling for both top-level `education` arrays and nested `sections.education.items`.
- Preserved useful context like location while filtering out private/internal fields, hidden items, and renderer metadata.

## Testing
- Added scorer coverage for top-level and nested education, full experience inclusion, hidden/invisible item filtering, and private metadata exclusion.
- Passed focused scorer tests, Biome formatting/lint checks, shared/orchestrator/Extractor type checks, client build, and the full orchestrator test suite.