### PR TITLE
Add job document uploads and Ghostwriter context attachments

### DIFF
--- a/orchestrator/src/client/api/client.notes.test.ts
+++ b/orchestrator/src/client/api/client.notes.test.ts
@@ -10,6 +10,14 @@ function createJsonResponse(status: number, payload: unknown): Response {
   } as Response;
 }
 
+function createBlobResponse(status: number, blob: Blob): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    blob: async () => blob,
+  } as Response;
+}
+
 describe("job notes API client", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -230,6 +238,120 @@ describe("job notes API client", () => {
       expect.objectContaining({
         method: "DELETE",
       }),
+    );
+  });
+
+  it("fetches job documents with a cache-busting query param", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(200, {
+        ok: true,
+        data: [
+          {
+            id: "doc-1",
+            jobId: "job-1",
+            fileName: "cover-letter.txt",
+            mediaType: "text/plain",
+            byteSize: 42,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        meta: { requestId: "req-docs" },
+      }),
+    );
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+    await expect(api.getJobDocuments("job-1")).resolves.toEqual([
+      {
+        id: "doc-1",
+        jobId: "job-1",
+        fileName: "cover-letter.txt",
+        mediaType: "text/plain",
+        byteSize: 42,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/jobs/job-1/documents?t=1700000000000",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+  });
+
+  it("uploads a job document", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      createJsonResponse(201, {
+        ok: true,
+        data: {
+          id: "doc-1",
+          jobId: "job-1",
+          fileName: "cover-letter.txt",
+          mediaType: "text/plain",
+          byteSize: 42,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        meta: { requestId: "req-upload-doc" },
+      }),
+    );
+
+    await expect(
+      api.uploadJobDocument("job-1", {
+        fileName: "cover-letter.txt",
+        mediaType: "text/plain",
+        dataBase64: "SGVsbG8=",
+      }),
+    ).resolves.toMatchObject({
+      id: "doc-1",
+      fileName: "cover-letter.txt",
+    });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/jobs/job-1/documents",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          fileName: "cover-letter.txt",
+          mediaType: "text/plain",
+          dataBase64: "SGVsbG8=",
+        }),
+      }),
+    );
+  });
+
+  it("downloads and deletes a job document", async () => {
+    const blob = new Blob(["document"]);
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(createBlobResponse(200, blob))
+      .mockResolvedValueOnce(
+        createJsonResponse(200, {
+          ok: true,
+          data: null,
+          meta: { requestId: "req-delete-doc" },
+        }),
+      );
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+
+    await expect(api.getJobDocumentBlob("job-1", "doc-1")).resolves.toBe(blob);
+    await expect(
+      api.deleteJobDocument("job-1", "doc-1"),
+    ).resolves.toBeUndefined();
+
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      1,
+      "/api/jobs/job-1/documents/doc-1/content?v=loyw3v28",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+    expect(fetchSpy).toHaveBeenNthCalledWith(
+      2,
+      "/api/jobs/job-1/documents/doc-1",
+      expect.objectContaining({ method: "DELETE" }),
     );
   });
 });

--- a/orchestrator/src/client/api/core.ts
+++ b/orchestrator/src/client/api/core.ts
@@ -53,10 +53,16 @@ export type StreamSseInput =
       content: string;
       selectedNoteIds?: string[];
       selectedEmailIds?: string[];
+      selectedDocumentIds?: string[];
       attachments?: import("@shared/types").JobChatImageAttachment[];
       stream: true;
     }
-  | { selectedNoteIds?: string[]; selectedEmailIds?: string[]; stream: true };
+  | {
+      selectedNoteIds?: string[];
+      selectedEmailIds?: string[];
+      selectedDocumentIds?: string[];
+      stream: true;
+    };
 
 function describeAction(endpoint: string, method?: string): string {
   const verb = (method || "GET").toUpperCase();

--- a/orchestrator/src/client/api/ghostwriter.ts
+++ b/orchestrator/src/client/api/ghostwriter.ts
@@ -10,11 +10,13 @@ import { fetchApi, streamSseEvents, withQuery } from "./core";
 type GhostwriterContextSelectionInput = {
   selectedNoteIds?: string[];
   selectedEmailIds?: string[];
+  selectedDocumentIds?: string[];
 };
 
 type GhostwriterContextSelectionResult = {
   selectedNoteIds: string[];
   selectedEmailIds: string[];
+  selectedDocumentIds: string[];
 };
 
 type GhostwriterMessageContextInput = GhostwriterContextSelectionInput & {
@@ -147,6 +149,7 @@ export async function streamJobGhostwriterMessage(
       content: input.content,
       selectedNoteIds: input.selectedNoteIds,
       selectedEmailIds: input.selectedEmailIds,
+      selectedDocumentIds: input.selectedDocumentIds,
       attachments: input.attachments,
       stream: true,
     },
@@ -221,6 +224,7 @@ export async function streamRegenerateJobChatMessage(
     {
       selectedNoteIds: input.selectedNoteIds,
       selectedEmailIds: input.selectedEmailIds,
+      selectedDocumentIds: input.selectedDocumentIds,
       stream: true,
     },
     {
@@ -243,6 +247,7 @@ export async function streamRegenerateJobGhostwriterMessage(
     {
       selectedNoteIds: input.selectedNoteIds,
       selectedEmailIds: input.selectedEmailIds,
+      selectedDocumentIds: input.selectedDocumentIds,
       stream: true,
     },
     {
@@ -269,6 +274,7 @@ export async function editJobGhostwriterMessage(
       content: input.content,
       selectedNoteIds: input.selectedNoteIds,
       selectedEmailIds: input.selectedEmailIds,
+      selectedDocumentIds: input.selectedDocumentIds,
       attachments: input.attachments,
       stream: true,
     },

--- a/orchestrator/src/client/api/jobs.ts
+++ b/orchestrator/src/client/api/jobs.ts
@@ -5,6 +5,7 @@ import type {
   JobActionRequest,
   JobActionResponse,
   JobActionStreamEvent,
+  JobDocument,
   JobListItem,
   JobNote,
   JobOutcome,
@@ -98,6 +99,51 @@ export async function updateJob(
 
 export async function getJobNotes(id: string): Promise<JobNote[]> {
   return fetchApi<JobNote[]>(withQuery(`/jobs/${id}/notes`, { t: Date.now() }));
+}
+
+export async function getJobDocuments(id: string): Promise<JobDocument[]> {
+  return fetchApi<JobDocument[]>(
+    withQuery(`/jobs/${id}/documents`, { t: Date.now() }),
+  );
+}
+
+export async function uploadJobDocument(
+  id: string,
+  input: {
+    fileName: string;
+    mediaType?: string | null;
+    dataBase64: string;
+  },
+): Promise<JobDocument> {
+  return fetchApi<JobDocument>(`/jobs/${id}/documents`, {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function deleteJobDocument(
+  jobId: string,
+  documentId: string,
+): Promise<void> {
+  await fetchApi<void>(`/jobs/${jobId}/documents/${documentId}`, {
+    method: "DELETE",
+  });
+}
+
+export async function getJobDocumentBlob(
+  jobId: string,
+  documentId: string,
+): Promise<Blob> {
+  const cacheBuster = Date.now().toString(36);
+  return fetchBlobApi(
+    withQuery(
+      `/jobs/${encodeURIComponent(jobId)}/documents/${encodeURIComponent(documentId)}/content`,
+      { v: cacheBuster },
+    ),
+    {
+      cache: "no-store",
+    },
+  );
 }
 
 export async function getJobEmails(

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.test.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.test.tsx
@@ -1,4 +1,8 @@
-import type { JobNote, PostApplicationJobEmailItem } from "@shared/types";
+import type {
+  JobDocument,
+  JobNote,
+  PostApplicationJobEmailItem,
+} from "@shared/types";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { GhostwriterContextSelector } from "./GhostwriterContextSelector";
@@ -53,6 +57,17 @@ const makeEmail = (
   sourceUrl: "https://mail.google.com/mail/u/0/#all/thread-1",
 });
 
+const makeDocument = (overrides: Partial<JobDocument> = {}): JobDocument => ({
+  id: "doc-1",
+  jobId: "job-1",
+  fileName: "take-home.md",
+  mediaType: "text/markdown",
+  byteSize: 1024,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  ...overrides,
+});
+
 function renderSelector(
   overrides: Partial<
     React.ComponentProps<typeof GhostwriterContextSelector>
@@ -62,30 +77,37 @@ function renderSelector(
     <GhostwriterContextSelector
       notes={[makeNote({})]}
       emails={[makeEmail()]}
+      documents={[makeDocument()]}
       selectedNoteIds={[]}
       selectedEmailIds={[]}
+      selectedDocumentIds={[]}
       onNotesChange={vi.fn()}
       onEmailsChange={vi.fn()}
+      onDocumentsChange={vi.fn()}
       {...overrides}
     />,
   );
 }
 
 describe("GhostwriterContextSelector", () => {
-  it("renders notes and emails in one context picker", () => {
+  it("renders notes, documents, and emails in one context picker", () => {
     const onNotesChange = vi.fn();
     const onEmailsChange = vi.fn();
-    renderSelector({ onNotesChange, onEmailsChange });
+    const onDocumentsChange = vi.fn();
+    renderSelector({ onNotesChange, onEmailsChange, onDocumentsChange });
 
     fireEvent.click(screen.getByRole("button", { name: /context/i }));
 
     expect(screen.getByText("Notes")).toBeInTheDocument();
+    expect(screen.getByText("Documents")).toBeInTheDocument();
     expect(screen.getByText("Emails")).toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText(/Recruiter call/));
+    fireEvent.click(screen.getByLabelText(/take-home.md/));
     fireEvent.click(screen.getByLabelText(/Interview update/));
 
     expect(onNotesChange).toHaveBeenCalledWith(["note-1"]);
+    expect(onDocumentsChange).toHaveBeenCalledWith(["doc-1"]);
     expect(onEmailsChange).toHaveBeenCalledWith(["email-1"]);
   });
 
@@ -93,10 +115,11 @@ describe("GhostwriterContextSelector", () => {
     renderSelector({
       selectedNoteIds: ["note-1"],
       selectedEmailIds: ["email-1"],
+      selectedDocumentIds: ["doc-1"],
     });
 
     expect(
-      screen.getByRole("button", { name: /2 context/i }),
+      screen.getByRole("button", { name: /3 context/i }),
     ).toBeInTheDocument();
   });
 
@@ -142,5 +165,22 @@ describe("GhostwriterContextSelector", () => {
     expect(screen.getByLabelText(/Ninth email/)).toBeDisabled();
     expect(screen.getByText("8 note limit")).toBeInTheDocument();
     expect(screen.getByText("8 email limit")).toBeInTheDocument();
+  });
+
+  it("disables unsupported documents", () => {
+    renderSelector({
+      documents: [
+        makeDocument({
+          id: "doc-unsupported",
+          fileName: "archive.zip",
+          mediaType: "application/zip",
+        }),
+      ],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /context/i }));
+
+    expect(screen.getByLabelText(/archive.zip/)).toBeDisabled();
+    expect(screen.getByText("PDF or text-like files only")).toBeInTheDocument();
   });
 });

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.test.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.test.tsx
@@ -123,6 +123,39 @@ describe("GhostwriterContextSelector", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows estimated token counts for selected context", () => {
+    renderSelector({
+      notes: [
+        makeNote({
+          id: "note-1",
+          content: "A".repeat(400),
+        }),
+      ],
+      documents: [
+        makeDocument({
+          id: "doc-1",
+          byteSize: 800,
+        }),
+      ],
+      emails: [
+        makeEmail({
+          id: "email-1",
+          snippet: "A".repeat(200),
+        }),
+      ],
+      selectedNoteIds: ["note-1"],
+      selectedEmailIds: ["email-1"],
+      selectedDocumentIds: ["doc-1"],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /3 context/i }));
+
+    expect(screen.getByText("≈350 tokens")).toBeInTheDocument();
+    expect(screen.getByText("≈100 tokens")).toBeInTheDocument();
+    expect(screen.getByText("≈200 tokens")).toBeInTheDocument();
+    expect(screen.getByText("≈50 tokens")).toBeInTheDocument();
+  });
+
   it("shows independent limits and trimming feedback per group", () => {
     const selectedNoteIds = Array.from(
       { length: 8 },
@@ -182,5 +215,25 @@ describe("GhostwriterContextSelector", () => {
 
     expect(screen.getByLabelText(/archive.zip/)).toBeDisabled();
     expect(screen.getByText("PDF or text-like files only")).toBeInTheDocument();
+  });
+
+  it("allows DOCX documents", () => {
+    const onDocumentsChange = vi.fn();
+    renderSelector({
+      documents: [
+        makeDocument({
+          id: "doc-docx",
+          fileName: "interview-pack.docx",
+          mediaType:
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }),
+      ],
+      onDocumentsChange,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /context/i }));
+    fireEvent.click(screen.getByLabelText(/interview-pack.docx/));
+
+    expect(onDocumentsChange).toHaveBeenCalledWith(["doc-docx"]);
   });
 });

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.test.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.test.tsx
@@ -150,10 +150,30 @@ describe("GhostwriterContextSelector", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /3 context/i }));
 
-    expect(screen.getByText("≈350 tokens")).toBeInTheDocument();
+    expect(screen.getByText("≈150 tokens")).toBeInTheDocument();
     expect(screen.getByText("≈100 tokens")).toBeInTheDocument();
-    expect(screen.getByText("≈200 tokens")).toBeInTheDocument();
     expect(screen.getByText("≈50 tokens")).toBeInTheDocument();
+    expect(screen.queryByText("≈200 tokens")).not.toBeInTheDocument();
+  });
+
+  it("does not show document byte sizes as token estimates or trim badges", () => {
+    renderSelector({
+      documents: [
+        makeDocument({
+          id: "doc-1",
+          fileName: "large-brief.pdf",
+          mediaType: "application/pdf",
+          byteSize: 500_000,
+        }),
+      ],
+      selectedDocumentIds: ["doc-1"],
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /1 context/i }));
+
+    expect(screen.queryByText(/tokens/)).not.toBeInTheDocument();
+    expect(screen.queryByText("Trimmed for AI")).not.toBeInTheDocument();
+    expect(screen.getByText(/488.3 KB/)).toBeInTheDocument();
   });
 
   it("shows independent limits and trimming feedback per group", () => {

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.tsx
@@ -21,9 +21,8 @@ import type {
 import { ChevronDown, FileText, Info, Mail, Paperclip } from "lucide-react";
 import type React from "react";
 import {
+  canUseJobDocumentForTextContext,
   formatJobDocumentByteSize,
-  isJobDocumentPdf,
-  isJobDocumentTextLike,
 } from "@/client/lib/job-documents";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -69,6 +68,7 @@ type ContextGroupProps<TItem> = {
   maxSelected: number;
   maxItemChars: number;
   maxTotalChars: number;
+  showTokenEstimate?: boolean;
   disabled?: boolean;
   isLoading?: boolean;
   isSaving?: boolean;
@@ -146,7 +146,7 @@ function getEmailMeta(email: PostApplicationJobEmailItem): string {
 }
 
 function canUseDocumentForGhostwriter(document: JobDocument): boolean {
-  return isJobDocumentPdf(document) || isJobDocumentTextLike(document);
+  return canUseJobDocumentForTextContext(document);
 }
 
 function getDocumentMeta(document: JobDocument): string {
@@ -168,6 +168,7 @@ function ContextGroup<TItem>({
   maxSelected,
   maxItemChars,
   maxTotalChars,
+  showTokenEstimate = true,
   disabled,
   isLoading,
   isSaving,
@@ -179,16 +180,18 @@ function ContextGroup<TItem>({
   getUnavailableReason,
   onChange,
 }: ContextGroupProps<TItem>) {
-  const { selectedContentChars, estimatedTokens } =
-    estimateSelectedContextTokens({
-      items,
-      selectedIds,
-      maxItemChars,
-      maxTotalChars,
-      getId,
-      getContentLength,
-    });
-  const hasTotalOverflow = selectedContentChars > maxTotalChars;
+  const { selectedContentChars, estimatedTokens } = showTokenEstimate
+    ? estimateSelectedContextTokens({
+        items,
+        selectedIds,
+        maxItemChars,
+        maxTotalChars,
+        getId,
+        getContentLength,
+      })
+    : { selectedContentChars: 0, estimatedTokens: 0 };
+  const hasTotalOverflow =
+    showTokenEstimate && selectedContentChars > maxTotalChars;
   const isAtSelectionLimit = selectedIds.length >= maxSelected;
 
   const toggleItem = (itemId: string) => {
@@ -235,7 +238,8 @@ function ContextGroup<TItem>({
           items.map((item) => {
             const itemId = getId(item);
             const isSelected = selectedIds.includes(itemId);
-            const isTrimmed = getContentLength(item) > maxItemChars;
+            const isTrimmed =
+              showTokenEstimate && getContentLength(item) > maxItemChars;
             const unavailableReason = getUnavailableReason?.(item) ?? null;
             const isUnavailable =
               !isSelected && (isAtSelectionLimit || Boolean(unavailableReason));
@@ -337,15 +341,6 @@ export const GhostwriterContextSelector: React.FC<
       getContentLength: (note) => note.content.trim().length,
     }).estimatedTokens +
     estimateSelectedContextTokens({
-      items: documents,
-      selectedIds: selectedDocumentIds,
-      maxItemChars: GHOSTWRITER_DOCUMENT_CONTEXT_MAX_DOCUMENT_CHARS,
-      maxTotalChars: GHOSTWRITER_DOCUMENT_CONTEXT_MAX_TOTAL_CHARS,
-      getId: (document) => document.id,
-      getContentLength: (document) => document.byteSize,
-      filterItem: canUseDocumentForGhostwriter,
-    }).estimatedTokens +
-    estimateSelectedContextTokens({
       items: emails,
       selectedIds: selectedEmailIds,
       maxItemChars: GHOSTWRITER_EMAIL_CONTEXT_MAX_SNIPPET_CHARS,
@@ -435,13 +430,14 @@ export const GhostwriterContextSelector: React.FC<
             maxSelected={GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED}
             maxItemChars={GHOSTWRITER_DOCUMENT_CONTEXT_MAX_DOCUMENT_CHARS}
             maxTotalChars={GHOSTWRITER_DOCUMENT_CONTEXT_MAX_TOTAL_CHARS}
+            showTokenEstimate={false}
             disabled={disabled}
             isLoading={areDocumentsLoading}
             isSaving={isSaving}
             getId={(document) => document.id}
             getTitle={(document) => document.fileName}
             getMeta={getDocumentMeta}
-            getContentLength={(document) => document.byteSize}
+            getContentLength={() => 0}
             getCheckboxId={(document) =>
               `ghostwriter-document-context-${document.id}`
             }

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.tsx
@@ -35,6 +35,11 @@ import {
 } from "@/components/ui/popover";
 import { cn, formatDateTime } from "@/lib/utils";
 
+const APPROX_CHARS_PER_TOKEN = 4;
+const tokenCountFormatter = new Intl.NumberFormat("en", {
+  maximumFractionDigits: 1,
+});
+
 type GhostwriterContextSelectorProps = {
   notes: JobNote[];
   emails: PostApplicationJobEmailItem[];
@@ -76,6 +81,16 @@ type ContextGroupProps<TItem> = {
   onChange: (selectedIds: string[]) => void;
 };
 
+function estimateTokensFromChars(chars: number): number {
+  if (chars <= 0) return 0;
+  return Math.ceil(chars / APPROX_CHARS_PER_TOKEN);
+}
+
+function formatTokenEstimate(tokens: number): string {
+  if (tokens < 1000) return `${tokens}`;
+  return `${tokenCountFormatter.format(tokens / 1000)}k`;
+}
+
 function getSelectedItems<TItem>(
   items: TItem[],
   selectedIds: string[],
@@ -85,6 +100,35 @@ function getSelectedItems<TItem>(
   return selectedIds
     .map((itemId) => itemsById.get(itemId))
     .filter((item): item is TItem => Boolean(item));
+}
+
+function estimateSelectedContextTokens<TItem>(input: {
+  items: TItem[];
+  selectedIds: string[];
+  maxItemChars: number;
+  maxTotalChars: number;
+  getId: (item: TItem) => string;
+  getContentLength: (item: TItem) => number;
+  filterItem?: (item: TItem) => boolean;
+}): { selectedContentChars: number; estimatedTokens: number } {
+  const selectedContentChars = getSelectedItems(
+    input.items,
+    input.selectedIds,
+    input.getId,
+  )
+    .filter((item) => input.filterItem?.(item) ?? true)
+    .reduce(
+      (total, item) =>
+        total + Math.min(input.getContentLength(item), input.maxItemChars),
+      0,
+    );
+
+  return {
+    selectedContentChars,
+    estimatedTokens: estimateTokensFromChars(
+      Math.min(selectedContentChars, input.maxTotalChars),
+    ),
+  };
 }
 
 function getSenderLabel(email: PostApplicationJobEmailItem): string {
@@ -135,11 +179,15 @@ function ContextGroup<TItem>({
   getUnavailableReason,
   onChange,
 }: ContextGroupProps<TItem>) {
-  const selectedItems = getSelectedItems(items, selectedIds, getId);
-  const selectedContentChars = selectedItems.reduce(
-    (total, item) => total + Math.min(getContentLength(item), maxItemChars),
-    0,
-  );
+  const { selectedContentChars, estimatedTokens } =
+    estimateSelectedContextTokens({
+      items,
+      selectedIds,
+      maxItemChars,
+      maxTotalChars,
+      getId,
+      getContentLength,
+    });
   const hasTotalOverflow = selectedContentChars > maxTotalChars;
   const isAtSelectionLimit = selectedIds.length >= maxSelected;
 
@@ -160,11 +208,18 @@ function ContextGroup<TItem>({
           <Icon className="h-3.5 w-3.5" />
           <span>{title}</span>
         </div>
-        {selectedIds.length > 0 && (
-          <Badge variant="secondary" className="text-[10px]">
-            {selectedIds.length}/{maxSelected}
-          </Badge>
-        )}
+        <div className="flex shrink-0 items-center gap-1.5">
+          {estimatedTokens > 0 && (
+            <Badge variant="outline" className="text-[10px]">
+              ≈{formatTokenEstimate(estimatedTokens)} tokens
+            </Badge>
+          )}
+          {selectedIds.length > 0 && (
+            <Badge variant="secondary" className="text-[10px]">
+              {selectedIds.length}/{maxSelected}
+            </Badge>
+          )}
+        </div>
       </div>
 
       <div className="py-1">
@@ -272,6 +327,32 @@ export const GhostwriterContextSelector: React.FC<
     selectedNoteIds.length +
     selectedEmailIds.length +
     selectedDocumentIds.length;
+  const estimatedContextTokens =
+    estimateSelectedContextTokens({
+      items: notes,
+      selectedIds: selectedNoteIds,
+      maxItemChars: GHOSTWRITER_NOTE_CONTEXT_MAX_NOTE_CHARS,
+      maxTotalChars: GHOSTWRITER_NOTE_CONTEXT_MAX_TOTAL_CHARS,
+      getId: (note) => note.id,
+      getContentLength: (note) => note.content.trim().length,
+    }).estimatedTokens +
+    estimateSelectedContextTokens({
+      items: documents,
+      selectedIds: selectedDocumentIds,
+      maxItemChars: GHOSTWRITER_DOCUMENT_CONTEXT_MAX_DOCUMENT_CHARS,
+      maxTotalChars: GHOSTWRITER_DOCUMENT_CONTEXT_MAX_TOTAL_CHARS,
+      getId: (document) => document.id,
+      getContentLength: (document) => document.byteSize,
+      filterItem: canUseDocumentForGhostwriter,
+    }).estimatedTokens +
+    estimateSelectedContextTokens({
+      items: emails,
+      selectedIds: selectedEmailIds,
+      maxItemChars: GHOSTWRITER_EMAIL_CONTEXT_MAX_SNIPPET_CHARS,
+      maxTotalChars: GHOSTWRITER_EMAIL_CONTEXT_MAX_TOTAL_CHARS,
+      getId: (email) => email.message.id,
+      getContentLength: (email) => email.message.snippet.trim().length,
+    }).estimatedTokens;
   const triggerLabel =
     selectedCount > 0 ? `${selectedCount} context` : "Context";
 
@@ -297,11 +378,18 @@ export const GhostwriterContextSelector: React.FC<
         <div className="border-b px-3 py-2.5">
           <div className="flex items-center justify-between gap-3">
             <div className="text-sm font-medium">Ghostwriter context</div>
-            {selectedCount > 0 && (
-              <Badge variant="secondary" className="text-[10px]">
-                {selectedCount} selected
-              </Badge>
-            )}
+            <div className="flex shrink-0 items-center gap-1.5">
+              {estimatedContextTokens > 0 && (
+                <Badge variant="outline" className="text-[10px]">
+                  ≈{formatTokenEstimate(estimatedContextTokens)} tokens
+                </Badge>
+              )}
+              {selectedCount > 0 && (
+                <Badge variant="secondary" className="text-[10px]">
+                  {selectedCount} selected
+                </Badge>
+              )}
+            </div>
           </div>
         </div>
 

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterContextSelector.tsx
@@ -1,4 +1,9 @@
 import {
+  GHOSTWRITER_DOCUMENT_CONTEXT_MAX_DOCUMENT_CHARS,
+  GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED,
+  GHOSTWRITER_DOCUMENT_CONTEXT_MAX_TOTAL_CHARS,
+} from "@shared/ghostwriter-document-context.js";
+import {
   GHOSTWRITER_EMAIL_CONTEXT_MAX_SELECTED,
   GHOSTWRITER_EMAIL_CONTEXT_MAX_SNIPPET_CHARS,
   GHOSTWRITER_EMAIL_CONTEXT_MAX_TOTAL_CHARS,
@@ -8,9 +13,18 @@ import {
   GHOSTWRITER_NOTE_CONTEXT_MAX_SELECTED,
   GHOSTWRITER_NOTE_CONTEXT_MAX_TOTAL_CHARS,
 } from "@shared/ghostwriter-note-context.js";
-import type { JobNote, PostApplicationJobEmailItem } from "@shared/types";
+import type {
+  JobDocument,
+  JobNote,
+  PostApplicationJobEmailItem,
+} from "@shared/types";
 import { ChevronDown, FileText, Info, Mail, Paperclip } from "lucide-react";
 import type React from "react";
+import {
+  formatJobDocumentByteSize,
+  isJobDocumentPdf,
+  isJobDocumentTextLike,
+} from "@/client/lib/job-documents";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -24,14 +38,18 @@ import { cn, formatDateTime } from "@/lib/utils";
 type GhostwriterContextSelectorProps = {
   notes: JobNote[];
   emails: PostApplicationJobEmailItem[];
+  documents: JobDocument[];
   selectedNoteIds: string[];
   selectedEmailIds: string[];
+  selectedDocumentIds: string[];
   disabled?: boolean;
   areNotesLoading?: boolean;
   areEmailsLoading?: boolean;
+  areDocumentsLoading?: boolean;
   isSaving?: boolean;
   onNotesChange: (selectedNoteIds: string[]) => void;
   onEmailsChange: (selectedEmailIds: string[]) => void;
+  onDocumentsChange: (selectedDocumentIds: string[]) => void;
 };
 
 type ContextGroupProps<TItem> = {
@@ -54,6 +72,7 @@ type ContextGroupProps<TItem> = {
   getMeta: (item: TItem) => string;
   getContentLength: (item: TItem) => number;
   getCheckboxId: (item: TItem) => string;
+  getUnavailableReason?: (item: TItem) => string | null;
   onChange: (selectedIds: string[]) => void;
 };
 
@@ -82,6 +101,17 @@ function getEmailMeta(email: PostApplicationJobEmailItem): string {
   return `${getSenderLabel(email)}${receivedAt ? ` - ${receivedAt}` : ""}`;
 }
 
+function canUseDocumentForGhostwriter(document: JobDocument): boolean {
+  return isJobDocumentPdf(document) || isJobDocumentTextLike(document);
+}
+
+function getDocumentMeta(document: JobDocument): string {
+  return [
+    document.mediaType || "Unknown type",
+    formatJobDocumentByteSize(document.byteSize),
+  ].join(" - ");
+}
+
 function ContextGroup<TItem>({
   title,
   icon: Icon,
@@ -102,6 +132,7 @@ function ContextGroup<TItem>({
   getMeta,
   getContentLength,
   getCheckboxId,
+  getUnavailableReason,
   onChange,
 }: ContextGroupProps<TItem>) {
   const selectedItems = getSelectedItems(items, selectedIds, getId);
@@ -150,7 +181,9 @@ function ContextGroup<TItem>({
             const itemId = getId(item);
             const isSelected = selectedIds.includes(itemId);
             const isTrimmed = getContentLength(item) > maxItemChars;
-            const isUnavailable = !isSelected && isAtSelectionLimit;
+            const unavailableReason = getUnavailableReason?.(item) ?? null;
+            const isUnavailable =
+              !isSelected && (isAtSelectionLimit || Boolean(unavailableReason));
             const checkboxId = getCheckboxId(item);
 
             return (
@@ -188,7 +221,7 @@ function ContextGroup<TItem>({
                     )}
                   </span>
                   <span className="mt-0.5 block truncate text-xs text-muted-foreground">
-                    {getMeta(item)}
+                    {unavailableReason ?? getMeta(item)}
                   </span>
                 </label>
               </div>
@@ -222,16 +255,23 @@ export const GhostwriterContextSelector: React.FC<
 > = ({
   notes,
   emails,
+  documents,
   selectedNoteIds,
   selectedEmailIds,
+  selectedDocumentIds,
   disabled,
   areNotesLoading,
   areEmailsLoading,
+  areDocumentsLoading,
   isSaving,
   onNotesChange,
   onEmailsChange,
+  onDocumentsChange,
 }) => {
-  const selectedCount = selectedNoteIds.length + selectedEmailIds.length;
+  const selectedCount =
+    selectedNoteIds.length +
+    selectedEmailIds.length +
+    selectedDocumentIds.length;
   const triggerLabel =
     selectedCount > 0 ? `${selectedCount} context` : "Context";
 
@@ -293,6 +333,36 @@ export const GhostwriterContextSelector: React.FC<
             getContentLength={(note) => note.content.trim().length}
             getCheckboxId={(note) => `ghostwriter-note-context-${note.id}`}
             onChange={onNotesChange}
+          />
+
+          <ContextGroup
+            title="Documents"
+            icon={Paperclip}
+            items={documents}
+            selectedIds={selectedDocumentIds}
+            loadingLabel="Loading documents..."
+            emptyLabel="No uploaded documents yet."
+            limitLabel={`${GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED} document limit`}
+            overflowLabel="Selected documents exceed the AI context budget; later document text will be trimmed."
+            maxSelected={GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED}
+            maxItemChars={GHOSTWRITER_DOCUMENT_CONTEXT_MAX_DOCUMENT_CHARS}
+            maxTotalChars={GHOSTWRITER_DOCUMENT_CONTEXT_MAX_TOTAL_CHARS}
+            disabled={disabled}
+            isLoading={areDocumentsLoading}
+            isSaving={isSaving}
+            getId={(document) => document.id}
+            getTitle={(document) => document.fileName}
+            getMeta={getDocumentMeta}
+            getContentLength={(document) => document.byteSize}
+            getCheckboxId={(document) =>
+              `ghostwriter-document-context-${document.id}`
+            }
+            getUnavailableReason={(document) =>
+              canUseDocumentForGhostwriter(document)
+                ? null
+                : "PDF or text-like files only"
+            }
+            onChange={onDocumentsChange}
           />
 
           <ContextGroup

--- a/orchestrator/src/client/components/ghostwriter/GhostwriterPanel.tsx
+++ b/orchestrator/src/client/components/ghostwriter/GhostwriterPanel.tsx
@@ -5,6 +5,7 @@ import type {
   JobChatImageAttachment,
   JobChatMessage,
   JobChatStreamEvent,
+  JobDocument,
   JobNote,
   PostApplicationJobEmailItem,
 } from "@shared/types";
@@ -47,11 +48,14 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
   const [branches, setBranches] = useState<BranchInfo[]>([]);
   const [notes, setNotes] = useState<JobNote[]>([]);
   const [emails, setEmails] = useState<PostApplicationJobEmailItem[]>([]);
+  const [documents, setDocuments] = useState<JobDocument[]>([]);
   const [selectedNoteIds, setSelectedNoteIds] = useState<string[]>([]);
   const [selectedEmailIds, setSelectedEmailIds] = useState<string[]>([]);
+  const [selectedDocumentIds, setSelectedDocumentIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [areNotesLoading, setAreNotesLoading] = useState(true);
   const [areEmailsLoading, setAreEmailsLoading] = useState(true);
+  const [areDocumentsLoading, setAreDocumentsLoading] = useState(true);
   const [isSavingContext, setIsSavingContext] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingMessageId, setStreamingMessageId] = useState<string | null>(
@@ -86,6 +90,7 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
     setBranches(data.branches);
     setSelectedNoteIds(data.selectedNoteIds);
     setSelectedEmailIds(data.selectedEmailIds);
+    setSelectedDocumentIds(data.selectedDocumentIds);
   }, [job.id]);
 
   const loadNotes = useCallback(async () => {
@@ -112,16 +117,33 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
     }
   }, [job.id]);
 
+  const loadDocuments = useCallback(async () => {
+    setAreDocumentsLoading(true);
+    try {
+      const data = await api.getJobDocuments(job.id);
+      setDocuments(data);
+    } catch (error) {
+      showErrorToast(error, "Failed to load documents");
+    } finally {
+      setAreDocumentsLoading(false);
+    }
+  }, [job.id]);
+
   const load = useCallback(async () => {
     setIsLoading(true);
     try {
-      await Promise.all([loadMessages(), loadNotes(), loadEmails()]);
+      await Promise.all([
+        loadMessages(),
+        loadNotes(),
+        loadEmails(),
+        loadDocuments(),
+      ]);
     } catch (error) {
       showErrorToast(error, "Failed to load Ghostwriter");
     } finally {
       setIsLoading(false);
     }
-  }, [loadEmails, loadMessages, loadNotes]);
+  }, [loadDocuments, loadEmails, loadMessages, loadNotes]);
 
   useEffect(() => {
     void load();
@@ -138,6 +160,14 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
       current.filter((noteId) => noteIds.has(noteId)),
     );
   }, [areNotesLoading, notes]);
+
+  useEffect(() => {
+    if (areDocumentsLoading) return;
+    const documentIds = new Set(documents.map((document) => document.id));
+    setSelectedDocumentIds((current) =>
+      current.filter((documentId) => documentIds.has(documentId)),
+    );
+  }, [areDocumentsLoading, documents]);
 
   const onStreamEvent = useCallback(
     (event: JobChatStreamEvent) => {
@@ -255,6 +285,7 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
             content,
             selectedNoteIds,
             selectedEmailIds,
+            selectedDocumentIds,
             attachments,
             signal: controller.signal,
           },
@@ -280,6 +311,7 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
       messages,
       onStreamEvent,
       selectedEmailIds,
+      selectedDocumentIds,
       selectedNoteIds,
     ],
   );
@@ -321,7 +353,12 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
         await api.streamRegenerateJobGhostwriterMessage(
           job.id,
           assistantMessageId,
-          { selectedNoteIds, selectedEmailIds, signal: controller.signal },
+          {
+            selectedNoteIds,
+            selectedEmailIds,
+            selectedDocumentIds,
+            signal: controller.signal,
+          },
           { onEvent: onStreamEvent },
         );
         await loadMessages();
@@ -341,6 +378,7 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
       loadMessages,
       onStreamEvent,
       selectedEmailIds,
+      selectedDocumentIds,
       selectedNoteIds,
     ],
   );
@@ -394,6 +432,7 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
             content,
             selectedNoteIds,
             selectedEmailIds,
+            selectedDocumentIds,
             attachments,
             signal: controller.signal,
           },
@@ -416,6 +455,7 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
       loadMessages,
       onStreamEvent,
       selectedEmailIds,
+      selectedDocumentIds,
       selectedNoteIds,
     ],
   );
@@ -424,16 +464,21 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
     async (input: {
       selectedNoteIds?: string[];
       selectedEmailIds?: string[];
+      selectedDocumentIds?: string[];
       errorMessage: string;
     }) => {
       const previousSelectedNoteIds = selectedNoteIds;
       const previousSelectedEmailIds = selectedEmailIds;
+      const previousSelectedDocumentIds = selectedDocumentIds;
 
       if (input.selectedNoteIds !== undefined) {
         setSelectedNoteIds(input.selectedNoteIds);
       }
       if (input.selectedEmailIds !== undefined) {
         setSelectedEmailIds(input.selectedEmailIds);
+      }
+      if (input.selectedDocumentIds !== undefined) {
+        setSelectedDocumentIds(input.selectedDocumentIds);
       }
 
       setIsSavingContext(true);
@@ -442,18 +487,21 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
         const result = await api.updateJobGhostwriterContext(job.id, {
           selectedNoteIds: input.selectedNoteIds,
           selectedEmailIds: input.selectedEmailIds,
+          selectedDocumentIds: input.selectedDocumentIds,
         });
         setSelectedNoteIds(result.selectedNoteIds);
         setSelectedEmailIds(result.selectedEmailIds);
+        setSelectedDocumentIds(result.selectedDocumentIds);
       } catch (error) {
         setSelectedNoteIds(previousSelectedNoteIds);
         setSelectedEmailIds(previousSelectedEmailIds);
+        setSelectedDocumentIds(previousSelectedDocumentIds);
         showErrorToast(error, input.errorMessage);
       } finally {
         setIsSavingContext(false);
       }
     },
-    [job.id, selectedEmailIds, selectedNoteIds],
+    [job.id, selectedDocumentIds, selectedEmailIds, selectedNoteIds],
   );
 
   const updateSelectedNotes = useCallback(
@@ -470,6 +518,15 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
       updateSelectedContext({
         selectedEmailIds: nextSelectedEmailIds,
         errorMessage: "Failed to update Ghostwriter emails",
+      }),
+    [updateSelectedContext],
+  );
+
+  const updateSelectedDocuments = useCallback(
+    (nextSelectedDocumentIds: string[]) =>
+      updateSelectedContext({
+        selectedDocumentIds: nextSelectedDocumentIds,
+        errorMessage: "Failed to update Ghostwriter documents",
       }),
     [updateSelectedContext],
   );
@@ -570,17 +627,23 @@ export const GhostwriterPanel: React.FC<GhostwriterPanelProps> = ({
             <GhostwriterContextSelector
               notes={notes}
               emails={emails}
+              documents={documents}
               selectedNoteIds={selectedNoteIds}
               selectedEmailIds={selectedEmailIds}
+              selectedDocumentIds={selectedDocumentIds}
               disabled={isLoading || isStreaming}
               areNotesLoading={areNotesLoading}
               areEmailsLoading={areEmailsLoading}
+              areDocumentsLoading={areDocumentsLoading}
               isSaving={isSavingContext}
               onNotesChange={(nextSelectedNoteIds) =>
                 void updateSelectedNotes(nextSelectedNoteIds)
               }
               onEmailsChange={(nextSelectedEmailIds) =>
                 void updateSelectedEmails(nextSelectedEmailIds)
+              }
+              onDocumentsChange={(nextSelectedDocumentIds) =>
+                void updateSelectedDocuments(nextSelectedDocumentIds)
               }
             />
           }

--- a/orchestrator/src/client/lib/file-upload-payload.ts
+++ b/orchestrator/src/client/lib/file-upload-payload.ts
@@ -1,0 +1,25 @@
+import { fileToDataUrl } from "@client/components/design-resume/utils";
+
+export type FileUploadPayload = {
+  fileName: string;
+  mediaType: string | null;
+  dataBase64: string;
+};
+
+export async function fileToUploadPayload(
+  file: File,
+  errorMessage: string,
+): Promise<FileUploadPayload> {
+  const dataUrl = await fileToDataUrl(file);
+  const match = /^data:([^;]*);base64,(.+)$/s.exec(dataUrl.trim());
+
+  if (!match) {
+    throw new Error(errorMessage);
+  }
+
+  return {
+    fileName: file.name,
+    mediaType: file.type || match[1] || null,
+    dataBase64: match[2],
+  };
+}

--- a/orchestrator/src/client/lib/job-document-upload.ts
+++ b/orchestrator/src/client/lib/job-document-upload.ts
@@ -1,0 +1,21 @@
+import * as api from "@client/api";
+import { fileToDataUrl } from "@client/components/design-resume/utils";
+import type { JobDocument } from "@shared/types";
+
+export async function uploadJobDocumentFromFile(
+  jobId: string,
+  file: File,
+): Promise<JobDocument> {
+  const dataUrl = await fileToDataUrl(file);
+  const match = /^data:([^;]*);base64,(.+)$/s.exec(dataUrl.trim());
+
+  if (!match) {
+    throw new Error("Document could not be encoded for upload.");
+  }
+
+  return api.uploadJobDocument(jobId, {
+    fileName: file.name,
+    mediaType: file.type || match[1] || null,
+    dataBase64: match[2],
+  });
+}

--- a/orchestrator/src/client/lib/job-document-upload.ts
+++ b/orchestrator/src/client/lib/job-document-upload.ts
@@ -1,21 +1,19 @@
 import * as api from "@client/api";
-import { fileToDataUrl } from "@client/components/design-resume/utils";
 import type { JobDocument } from "@shared/types";
+import { fileToUploadPayload } from "./file-upload-payload";
 
 export async function uploadJobDocumentFromFile(
   jobId: string,
   file: File,
 ): Promise<JobDocument> {
-  const dataUrl = await fileToDataUrl(file);
-  const match = /^data:([^;]*);base64,(.+)$/s.exec(dataUrl.trim());
-
-  if (!match) {
-    throw new Error("Document could not be encoded for upload.");
-  }
+  const payload = await fileToUploadPayload(
+    file,
+    "Document could not be encoded for upload.",
+  );
 
   return api.uploadJobDocument(jobId, {
-    fileName: file.name,
-    mediaType: file.type || match[1] || null,
-    dataBase64: match[2],
+    fileName: payload.fileName,
+    mediaType: payload.mediaType,
+    dataBase64: payload.dataBase64,
   });
 }

--- a/orchestrator/src/client/lib/job-documents.test.ts
+++ b/orchestrator/src/client/lib/job-documents.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  canOpenJobDocumentInline,
+  canPreviewJobDocumentAsObject,
+  canPreviewJobDocumentAsText,
+  canUseJobDocumentForTextContext,
+} from "./job-documents";
+
+describe("job document helpers", () => {
+  it("allows DOCX as Ghostwriter context but not as raw browser text preview", () => {
+    const document = {
+      fileName: "interview-pack.docx",
+      mediaType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    };
+
+    expect(canUseJobDocumentForTextContext(document)).toBe(true);
+    expect(canPreviewJobDocumentAsText(document)).toBe(false);
+    expect(canOpenJobDocumentInline(document)).toBe(false);
+  });
+
+  it("does not inline SVG even though it is an image media type", () => {
+    const document = {
+      fileName: "diagram.svg",
+      mediaType: "image/svg+xml",
+    };
+
+    expect(canPreviewJobDocumentAsObject(document)).toBe(false);
+    expect(canOpenJobDocumentInline(document)).toBe(false);
+  });
+});

--- a/orchestrator/src/client/lib/job-documents.ts
+++ b/orchestrator/src/client/lib/job-documents.ts
@@ -1,0 +1,60 @@
+import type { JobDocument } from "@shared/types.js";
+
+const bytesFormatter = new Intl.NumberFormat("en", {
+  maximumFractionDigits: 1,
+});
+
+export type JobDocumentPreviewTarget = Pick<
+  JobDocument,
+  "fileName" | "mediaType"
+>;
+
+export function formatJobDocumentByteSize(byteSize: number): string {
+  if (byteSize < 1024) return `${byteSize} B`;
+  if (byteSize < 1024 * 1024) {
+    return `${bytesFormatter.format(byteSize / 1024)} KB`;
+  }
+  return `${bytesFormatter.format(byteSize / (1024 * 1024))} MB`;
+}
+
+export function getJobDocumentFileExtension(fileName: string): string {
+  const extension = fileName.toLowerCase().split(".").pop();
+  return extension && extension !== fileName.toLowerCase() ? extension : "";
+}
+
+export function isJobDocumentPdf(document: JobDocumentPreviewTarget): boolean {
+  return (
+    document.mediaType === "application/pdf" ||
+    getJobDocumentFileExtension(document.fileName) === "pdf"
+  );
+}
+
+export function isJobDocumentImage(
+  document: JobDocumentPreviewTarget,
+): boolean {
+  return Boolean(document.mediaType?.startsWith("image/"));
+}
+
+export function isJobDocumentTextLike(
+  document: JobDocumentPreviewTarget,
+): boolean {
+  const extension = getJobDocumentFileExtension(document.fileName);
+  return (
+    document.mediaType?.startsWith("text/") ||
+    document.mediaType === "application/json" ||
+    document.mediaType === "application/xml" ||
+    ["csv", "json", "md", "markdown", "txt", "xml", "log"].includes(extension)
+  );
+}
+
+export function canPreviewJobDocumentAsObject(
+  document: JobDocumentPreviewTarget,
+): boolean {
+  return isJobDocumentPdf(document) || isJobDocumentImage(document);
+}
+
+export function canPreviewJobDocumentAsText(
+  document: JobDocumentPreviewTarget,
+): boolean {
+  return isJobDocumentTextLike(document);
+}

--- a/orchestrator/src/client/lib/job-documents.ts
+++ b/orchestrator/src/client/lib/job-documents.ts
@@ -1,13 +1,23 @@
-import type { JobDocument } from "@shared/types.js";
+import {
+  getJobDocumentFileExtension,
+  isJobDocumentDocx,
+  isJobDocumentImage,
+  isJobDocumentPdf,
+  isJobDocumentTextLike,
+  type JobDocumentTypeTarget,
+} from "@shared/job-document-classification.js";
+
+export {
+  getJobDocumentFileExtension,
+  isJobDocumentDocx,
+  isJobDocumentImage,
+  isJobDocumentPdf,
+  isJobDocumentTextLike,
+};
 
 const bytesFormatter = new Intl.NumberFormat("en", {
   maximumFractionDigits: 1,
 });
-
-export type JobDocumentPreviewTarget = Pick<
-  JobDocument,
-  "fileName" | "mediaType"
->;
 
 export function formatJobDocumentByteSize(byteSize: number): string {
   if (byteSize < 1024) return `${byteSize} B`;
@@ -17,44 +27,14 @@ export function formatJobDocumentByteSize(byteSize: number): string {
   return `${bytesFormatter.format(byteSize / (1024 * 1024))} MB`;
 }
 
-export function getJobDocumentFileExtension(fileName: string): string {
-  const extension = fileName.toLowerCase().split(".").pop();
-  return extension && extension !== fileName.toLowerCase() ? extension : "";
-}
-
-export function isJobDocumentPdf(document: JobDocumentPreviewTarget): boolean {
-  return (
-    document.mediaType === "application/pdf" ||
-    getJobDocumentFileExtension(document.fileName) === "pdf"
-  );
-}
-
-export function isJobDocumentImage(
-  document: JobDocumentPreviewTarget,
-): boolean {
-  return Boolean(document.mediaType?.startsWith("image/"));
-}
-
-export function isJobDocumentTextLike(
-  document: JobDocumentPreviewTarget,
-): boolean {
-  const extension = getJobDocumentFileExtension(document.fileName);
-  return (
-    document.mediaType?.startsWith("text/") ||
-    document.mediaType === "application/json" ||
-    document.mediaType === "application/xml" ||
-    ["csv", "json", "md", "markdown", "txt", "xml", "log"].includes(extension)
-  );
-}
-
 export function canPreviewJobDocumentAsObject(
-  document: JobDocumentPreviewTarget,
+  document: JobDocumentTypeTarget,
 ): boolean {
   return isJobDocumentPdf(document) || isJobDocumentImage(document);
 }
 
 export function canPreviewJobDocumentAsText(
-  document: JobDocumentPreviewTarget,
+  document: JobDocumentTypeTarget,
 ): boolean {
   return isJobDocumentTextLike(document);
 }

--- a/orchestrator/src/client/lib/job-documents.ts
+++ b/orchestrator/src/client/lib/job-documents.ts
@@ -1,19 +1,28 @@
 import {
+  canOpenJobDocumentInline,
+  canPreviewJobDocumentAsRawText,
+  canUseJobDocumentForTextContext,
   getJobDocumentFileExtension,
   isJobDocumentDocx,
   isJobDocumentImage,
   isJobDocumentPdf,
+  isJobDocumentSafeInlineImage,
   isJobDocumentTextLike,
   type JobDocumentTypeTarget,
 } from "@shared/job-document-classification.js";
 
 export {
+  canOpenJobDocumentInline,
+  canPreviewJobDocumentAsRawText,
+  canUseJobDocumentForTextContext,
   getJobDocumentFileExtension,
   isJobDocumentDocx,
   isJobDocumentImage,
   isJobDocumentPdf,
+  isJobDocumentSafeInlineImage,
   isJobDocumentTextLike,
 };
+export type { JobDocumentTypeTarget };
 
 const bytesFormatter = new Intl.NumberFormat("en", {
   maximumFractionDigits: 1,
@@ -30,11 +39,11 @@ export function formatJobDocumentByteSize(byteSize: number): string {
 export function canPreviewJobDocumentAsObject(
   document: JobDocumentTypeTarget,
 ): boolean {
-  return isJobDocumentPdf(document) || isJobDocumentImage(document);
+  return isJobDocumentPdf(document) || isJobDocumentSafeInlineImage(document);
 }
 
 export function canPreviewJobDocumentAsText(
   document: JobDocumentTypeTarget,
 ): boolean {
-  return isJobDocumentTextLike(document);
+  return canPreviewJobDocumentAsRawText(document);
 }

--- a/orchestrator/src/client/lib/job-pdf-upload.ts
+++ b/orchestrator/src/client/lib/job-pdf-upload.ts
@@ -1,21 +1,19 @@
 import * as api from "@client/api";
-import { fileToDataUrl } from "@client/components/design-resume/utils";
 import type { Job } from "@shared/types";
+import { fileToUploadPayload } from "./file-upload-payload";
 
 export async function uploadJobPdfFromFile(
   jobId: string,
   file: File,
 ): Promise<Job> {
-  const dataUrl = await fileToDataUrl(file);
-  const match = /^data:([^;]+);base64,(.+)$/s.exec(dataUrl.trim());
-
-  if (!match) {
-    throw new Error("PDF file could not be encoded for upload.");
-  }
+  const payload = await fileToUploadPayload(
+    file,
+    "PDF file could not be encoded for upload.",
+  );
 
   return api.uploadJobPdf(jobId, {
-    fileName: file.name,
-    mediaType: file.type || match[1],
-    dataBase64: match[2],
+    fileName: payload.fileName,
+    mediaType: payload.mediaType ?? undefined,
+    dataBase64: payload.dataBase64,
   });
 }

--- a/orchestrator/src/client/lib/private-pdf.ts
+++ b/orchestrator/src/client/lib/private-pdf.ts
@@ -13,6 +13,12 @@ function openBlob(blob: Blob, filename?: string): void {
   window.setTimeout(() => URL.revokeObjectURL(url), 60_000);
 }
 
+async function createObjectUrlFromBlob(
+  loadBlob: () => Promise<Blob>,
+): Promise<string> {
+  return URL.createObjectURL(await loadBlob());
+}
+
 export async function openJobPdf(jobId: string): Promise<void> {
   openBlob(await api.getJobPdfBlob(jobId));
 }
@@ -25,7 +31,7 @@ export async function downloadJobPdf(
 }
 
 export async function createJobPdfObjectUrl(jobId: string): Promise<string> {
-  return URL.createObjectURL(await api.getJobPdfBlob(jobId));
+  return createObjectUrlFromBlob(() => api.getJobPdfBlob(jobId));
 }
 
 export async function openJobDocument(
@@ -47,14 +53,15 @@ export async function createJobDocumentObjectUrl(
   jobId: string,
   documentId: string,
 ): Promise<string> {
-  return URL.createObjectURL(await api.getJobDocumentBlob(jobId, documentId));
+  return createObjectUrlFromBlob(() =>
+    api.getJobDocumentBlob(jobId, documentId),
+  );
 }
 
 export async function createDesignResumePdfObjectUrl(
   pdfUrl?: string,
 ): Promise<string> {
-  const blob = await api.getDesignResumePdfBlob(pdfUrl);
-  return URL.createObjectURL(blob);
+  return createObjectUrlFromBlob(() => api.getDesignResumePdfBlob(pdfUrl));
 }
 
 export async function downloadDesignResumePdf(

--- a/orchestrator/src/client/lib/private-pdf.ts
+++ b/orchestrator/src/client/lib/private-pdf.ts
@@ -1,4 +1,8 @@
 import * as api from "@/client/api";
+import {
+  canOpenJobDocumentInline,
+  type JobDocumentTypeTarget,
+} from "@/client/lib/job-documents";
 
 function openBlob(blob: Blob, filename?: string): void {
   const url = URL.createObjectURL(blob);
@@ -36,9 +40,16 @@ export async function createJobPdfObjectUrl(jobId: string): Promise<string> {
 
 export async function openJobDocument(
   jobId: string,
-  documentId: string,
+  document: JobDocumentTypeTarget & { id: string },
 ): Promise<void> {
-  openBlob(await api.getJobDocumentBlob(jobId, documentId));
+  if (!canOpenJobDocumentInline(document)) {
+    openBlob(
+      await api.getJobDocumentBlob(jobId, document.id),
+      document.fileName,
+    );
+    return;
+  }
+  openBlob(await api.getJobDocumentBlob(jobId, document.id));
 }
 
 export async function downloadJobDocument(

--- a/orchestrator/src/client/lib/private-pdf.ts
+++ b/orchestrator/src/client/lib/private-pdf.ts
@@ -24,6 +24,32 @@ export async function downloadJobPdf(
   openBlob(await api.getJobPdfBlob(jobId), filename);
 }
 
+export async function createJobPdfObjectUrl(jobId: string): Promise<string> {
+  return URL.createObjectURL(await api.getJobPdfBlob(jobId));
+}
+
+export async function openJobDocument(
+  jobId: string,
+  documentId: string,
+): Promise<void> {
+  openBlob(await api.getJobDocumentBlob(jobId, documentId));
+}
+
+export async function downloadJobDocument(
+  jobId: string,
+  documentId: string,
+  filename: string,
+): Promise<void> {
+  openBlob(await api.getJobDocumentBlob(jobId, documentId), filename);
+}
+
+export async function createJobDocumentObjectUrl(
+  jobId: string,
+  documentId: string,
+): Promise<string> {
+  return URL.createObjectURL(await api.getJobDocumentBlob(jobId, documentId));
+}
+
 export async function createDesignResumePdfObjectUrl(
   pdfUrl?: string,
 ): Promise<string> {

--- a/orchestrator/src/client/lib/queryKeys.ts
+++ b/orchestrator/src/client/lib/queryKeys.ts
@@ -46,6 +46,8 @@ export const queryKeys = {
       [...queryKeys.jobs.all, "stage-events", id] as const,
     tasks: (id: string) => [...queryKeys.jobs.all, "tasks", id] as const,
     notes: (id: string) => [...queryKeys.jobs.all, "notes", id] as const,
+    documents: (id: string) =>
+      [...queryKeys.jobs.all, "documents", id] as const,
     emails: (id: string, limit: number) =>
       [...queryKeys.jobs.all, "emails", id, { limit }] as const,
   },

--- a/orchestrator/src/client/lib/useObjectUrl.ts
+++ b/orchestrator/src/client/lib/useObjectUrl.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+
+export function useObjectUrl(createObjectUrl: () => Promise<string> | null): {
+  objectUrl: string | null;
+  isLoading: boolean;
+  error: string | null;
+} {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let nextObjectUrl: string | null = null;
+    const promise = createObjectUrl();
+
+    setObjectUrl(null);
+    setError(null);
+
+    if (!promise) {
+      setIsLoading(false);
+      return undefined;
+    }
+
+    setIsLoading(true);
+    void promise
+      .then((url) => {
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        nextObjectUrl = url;
+        setObjectUrl(url);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Preview unavailable.");
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      if (nextObjectUrl) URL.revokeObjectURL(nextObjectUrl);
+    };
+  }, [createObjectUrl]);
+
+  return { objectUrl, isLoading, error };
+}

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -510,9 +510,7 @@ export const JobPage: React.FC = () => {
       job.title,
     )}-resume.pdf`;
     await downloadJobPdf(job.id, filename).catch((error) => {
-      toast.error(
-        error instanceof Error ? error.message : "Could not download PDF",
-      );
+      showErrorToast(error, "Could not download PDF");
     });
   };
 

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -11,7 +11,6 @@ import {
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import confetti from "canvas-confetti";
 import {
-  AlertTriangle,
   ArrowLeft,
   ClipboardList,
   DollarSign,
@@ -20,7 +19,6 @@ import {
   MessageSquareText,
   PlusCircle,
   Sparkles,
-  Upload,
 } from "lucide-react";
 import React from "react";
 import {
@@ -53,7 +51,7 @@ import {
   PDF_REGENERATING_MESSAGE,
   STALE_PDF_MESSAGE,
 } from "@/client/lib/pdf-freshness";
-import { openJobPdf } from "@/client/lib/private-pdf";
+import { downloadJobPdf, openJobPdf } from "@/client/lib/private-pdf";
 import { queryKeys } from "@/client/lib/queryKeys";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -62,6 +60,7 @@ import {
   formatDateTime,
   formatJobForWebhook,
   formatTimestamp,
+  safeFilenamePart,
   sourceLabel as sourceLabels,
 } from "@/lib/utils";
 import * as api from "../api";
@@ -72,8 +71,8 @@ import {
   type LogEventFormValues,
   LogEventModal,
 } from "../components/LogEventModal";
-import { TooltipWhenDisabled } from "../components/TooltipWhenDisabled";
 import { JobTimeline } from "./job/Timeline";
+import { JobDocumentsPanel } from "./job-page/JobDocumentsPanel";
 import { JobEmailsPanel } from "./job-page/JobEmailsPanel";
 import { JobNotesCard } from "./job-page/JobNotesCard";
 import {
@@ -505,6 +504,28 @@ export const JobPage: React.FC = () => {
     }
   };
 
+  const handleDownloadPdf = async () => {
+    if (!job || !job.pdfPath || pdfActionsDisabled) return;
+    const filename = `${safeFilenamePart(job.employer)}-${safeFilenamePart(
+      job.title,
+    )}-resume.pdf`;
+    await downloadJobPdf(job.id, filename).catch((error) => {
+      toast.error(
+        error instanceof Error ? error.message : "Could not download PDF",
+      );
+    });
+  };
+
+  const handleViewJobDescription = () => {
+    if (!job) return;
+    navigate(`${baseJobPath}/documents`, { state: jobPageNavigationState });
+    window.setTimeout(() => {
+      document
+        .getElementById("job-description-panel")
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 50);
+  };
+
   const currentStage = job
     ? (events.at(-1)?.toStage ??
       (job.status === "applied" || job.status === "in_progress"
@@ -778,76 +799,41 @@ export const JobPage: React.FC = () => {
             )}
 
             {activeMemoryView === "documents" && (
-              <section className="rounded-xl border border-border/50 bg-card/75">
-                <div className="border-b border-border/50 px-4 py-3">
-                  <div className="flex items-center gap-2 text-base font-semibold">
-                    <FileText className="h-4 w-4" />
-                    Documents
-                  </div>
-                </div>
-                <div className="space-y-4 p-4">
-                  <div className="rounded-lg border border-border/60 bg-background/25 p-4">
-                    <div className="flex flex-wrap items-center justify-between gap-3">
-                      <div>
-                        <div className="text-sm font-semibold">Resume PDF</div>
-                        <div className="mt-1 text-xs text-muted-foreground">
-                          Generated or uploaded application material for this
-                          job.
-                        </div>
-                      </div>
-                      {isStalePdf && (
-                        <div className="flex basis-full items-start gap-2 rounded-md border border-amber-200/70 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-400/25 dark:bg-amber-400/10 dark:text-amber-100">
-                          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                          <span>{STALE_PDF_MESSAGE}</span>
-                        </div>
-                      )}
-                      {job.pdfPath ? (
-                        <TooltipWhenDisabled
-                          reason={pdfRegeneratingReason}
-                          className="w-full sm:w-auto"
-                        >
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={pdfActionsDisabled}
-                            onClick={() => {
-                              if (pdfActionsDisabled) return;
-                              void openJobPdf(job.id).catch((error) => {
-                                toast.error(
-                                  error instanceof Error
-                                    ? error.message
-                                    : "Could not open PDF",
-                                );
-                              });
-                            }}
-                          >
-                            <FileText className="mr-1.5 h-3.5 w-3.5" />
-                            {pdfLabels.view}
-                          </Button>
-                        </TooltipWhenDisabled>
-                      ) : (
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => uploadPdfInputRef.current?.click()}
-                          disabled={isUploadingPdf}
-                        >
-                          <Upload className="mr-1.5 h-3.5 w-3.5" />
-                          Upload PDF
-                        </Button>
-                      )}
-                    </div>
-                  </div>
+              <div className="space-y-4">
+                <JobDocumentsPanel
+                  job={job}
+                  isStalePdf={isStalePdf}
+                  isUploadingPdf={isUploadingPdf}
+                  pdfActionsDisabled={pdfActionsDisabled}
+                  pdfRegeneratingReason={pdfRegeneratingReason}
+                  pdfViewLabel={pdfLabels.view}
+                  pdfDownloadLabel={pdfLabels.download}
+                  stalePdfMessage={STALE_PDF_MESSAGE}
+                  onUploadPdf={() => uploadPdfInputRef.current?.click()}
+                  onViewPdf={() => {
+                    if (pdfActionsDisabled) return;
+                    void openJobPdf(job.id).catch((error) => {
+                      toast.error(
+                        error instanceof Error
+                          ? error.message
+                          : "Could not open PDF",
+                      );
+                    });
+                  }}
+                  onDownloadPdf={() => void handleDownloadPdf()}
+                  onRegeneratePdf={() => void handleRegeneratePdf()}
+                />
 
-                  <JobBriefPane job={job} />
+                <JobBriefPane job={job} />
 
+                <div id="job-description-panel">
                   <JobDescriptionPanel
                     description={job.jobDescription}
                     jobUrl={job.jobUrl}
                     onSave={handleSaveJobDescription}
                   />
                 </div>
-              </section>
+              </div>
             )}
 
             {activeMemoryView === "timeline" && (
@@ -944,6 +930,7 @@ export const JobPage: React.FC = () => {
               pdfActionsDisabled={pdfActionsDisabled}
               pdfRegeneratingReason={pdfRegeneratingReason}
               pdfViewLabel={pdfLabels.view}
+              pdfDownloadLabel={pdfLabels.download}
               onStartTailoring={() => navigate(`/jobs/discovered/${job.id}`)}
               onMarkApplied={() => void handleMarkApplied()}
               onMoveToInProgress={() => void handleMoveToInProgress()}
@@ -959,10 +946,12 @@ export const JobPage: React.FC = () => {
                   );
                 });
               }}
+              onDownloadPdf={() => void handleDownloadPdf()}
               onUploadPdf={() => uploadPdfInputRef.current?.click()}
               onRegeneratePdf={() => void handleRegeneratePdf()}
               onSkip={() => void handleSkip()}
               onOpenEditDetails={openEditDetails}
+              onViewJobDescription={handleViewJobDescription}
               onCopyJobInfo={() => void handleCopyJobInfo()}
               onRescore={() => void handleRescore()}
               onCheckSponsor={() => void handleCheckSponsor()}

--- a/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
+++ b/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
@@ -14,12 +14,20 @@ import {
   Upload,
 } from "lucide-react";
 import type React from "react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDelete } from "@/client/components/ConfirmDelete";
 import { TooltipWhenDisabled } from "@/client/components/TooltipWhenDisabled";
 import { showErrorToast } from "@/client/lib/error-toast";
 import { uploadJobDocumentFromFile } from "@/client/lib/job-document-upload";
+import {
+  canPreviewJobDocumentAsObject,
+  canPreviewJobDocumentAsText,
+  formatJobDocumentByteSize,
+  isJobDocumentImage,
+  isJobDocumentPdf,
+  isJobDocumentTextLike,
+} from "@/client/lib/job-documents";
 import {
   createJobDocumentObjectUrl,
   createJobPdfObjectUrl,
@@ -27,6 +35,7 @@ import {
   openJobDocument,
 } from "@/client/lib/private-pdf";
 import { queryKeys } from "@/client/lib/queryKeys";
+import { useObjectUrl } from "@/client/lib/useObjectUrl";
 import {
   Accordion,
   AccordionContent,
@@ -52,55 +61,15 @@ type JobDocumentsPanelProps = {
   onRegeneratePdf: () => void;
 };
 
-const bytesFormatter = new Intl.NumberFormat("en", {
-  maximumFractionDigits: 1,
-});
-
-function formatByteSize(byteSize: number): string {
-  if (byteSize < 1024) return `${byteSize} B`;
-  if (byteSize < 1024 * 1024) {
-    return `${bytesFormatter.format(byteSize / 1024)} KB`;
-  }
-  return `${bytesFormatter.format(byteSize / (1024 * 1024))} MB`;
-}
-
-function getFileExtension(fileName: string): string {
-  const extension = fileName.toLowerCase().split(".").pop();
-  return extension && extension !== fileName.toLowerCase() ? extension : "";
-}
-
-function isPdf(document: Pick<JobDocument, "fileName" | "mediaType">): boolean {
-  return (
-    document.mediaType === "application/pdf" ||
-    getFileExtension(document.fileName) === "pdf"
-  );
-}
-
-function isImage(
-  document: Pick<JobDocument, "fileName" | "mediaType">,
-): boolean {
-  return Boolean(document.mediaType?.startsWith("image/"));
-}
-
-function isTextLike(document: Pick<JobDocument, "fileName" | "mediaType">) {
-  const extension = getFileExtension(document.fileName);
-  return (
-    document.mediaType?.startsWith("text/") ||
-    document.mediaType === "application/json" ||
-    document.mediaType === "application/xml" ||
-    ["csv", "json", "md", "markdown", "txt", "xml", "log"].includes(extension)
-  );
-}
-
 function DocumentIcon({
   document,
 }: {
   document: Pick<JobDocument, "fileName" | "mediaType">;
 }) {
-  if (isPdf(document) || isTextLike(document)) {
+  if (isJobDocumentPdf(document) || isJobDocumentTextLike(document)) {
     return <FileText className="h-3.5 w-3.5 text-sky-400/80" />;
   }
-  if (isImage(document)) {
+  if (isJobDocumentImage(document)) {
     return <ImageIcon className="h-3.5 w-3.5 text-emerald-400/80" />;
   }
   return <File className="h-3.5 w-3.5 text-muted-foreground" />;
@@ -109,34 +78,26 @@ function DocumentIcon({
 const DocumentPreview: React.FC<{
   document: JobDocument;
 }> = ({ document }) => {
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
   const [textPreview, setTextPreview] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const canPreviewAsObject = isPdf(document) || isImage(document);
-  const canPreviewAsText = isTextLike(document);
+  const [textError, setTextError] = useState<string | null>(null);
+  const canPreviewAsObject = canPreviewJobDocumentAsObject(document);
+  const canPreviewAsText = canPreviewJobDocumentAsText(document);
+  const loadObjectUrl = useCallback(
+    () =>
+      canPreviewAsObject
+        ? createJobDocumentObjectUrl(document.jobId, document.id)
+        : null,
+    [canPreviewAsObject, document.id, document.jobId],
+  );
+  const { objectUrl, error } = useObjectUrl(loadObjectUrl);
 
   useEffect(() => {
     let cancelled = false;
-    let nextObjectUrl: string | null = null;
 
-    setObjectUrl(null);
     setTextPreview(null);
-    setError(null);
+    setTextError(null);
 
-    if (canPreviewAsObject) {
-      void createJobDocumentObjectUrl(document.jobId, document.id)
-        .then((url) => {
-          if (cancelled) {
-            URL.revokeObjectURL(url);
-            return;
-          }
-          nextObjectUrl = url;
-          setObjectUrl(url);
-        })
-        .catch(() => {
-          if (!cancelled) setError("Preview unavailable.");
-        });
-    } else if (canPreviewAsText) {
+    if (canPreviewAsText) {
       void api
         .getJobDocumentBlob(document.jobId, document.id)
         .then((blob) => blob.text())
@@ -144,15 +105,14 @@ const DocumentPreview: React.FC<{
           if (!cancelled) setTextPreview(text.slice(0, 80_000));
         })
         .catch(() => {
-          if (!cancelled) setError("Preview unavailable.");
+          if (!cancelled) setTextError("Preview unavailable.");
         });
     }
 
     return () => {
       cancelled = true;
-      if (nextObjectUrl) URL.revokeObjectURL(nextObjectUrl);
     };
-  }, [canPreviewAsObject, canPreviewAsText, document.id, document.jobId]);
+  }, [canPreviewAsText, document.id, document.jobId]);
 
   if (!canPreviewAsObject && !canPreviewAsText) {
     return (
@@ -162,16 +122,16 @@ const DocumentPreview: React.FC<{
     );
   }
 
-  if (error) {
+  if (error || textError) {
     return (
       <div className="rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
-        {error}
+        {error || textError}
       </div>
     );
   }
 
   if (canPreviewAsObject && objectUrl) {
-    return isImage(document) ? (
+    return isJobDocumentImage(document) ? (
       <div className="max-h-[560px] overflow-auto rounded-md border border-border/50 bg-background/40 p-3">
         <img
           src={objectUrl}
@@ -205,31 +165,11 @@ const DocumentPreview: React.FC<{
 };
 
 const ResumePdfPreview: React.FC<{ jobId: string }> = ({ jobId }) => {
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-    let nextObjectUrl: string | null = null;
-
-    void createJobPdfObjectUrl(jobId)
-      .then((url) => {
-        if (cancelled) {
-          URL.revokeObjectURL(url);
-          return;
-        }
-        nextObjectUrl = url;
-        setObjectUrl(url);
-      })
-      .catch(() => {
-        if (!cancelled) setError("Preview unavailable.");
-      });
-
-    return () => {
-      cancelled = true;
-      if (nextObjectUrl) URL.revokeObjectURL(nextObjectUrl);
-    };
-  }, [jobId]);
+  const loadObjectUrl = useCallback(
+    () => createJobPdfObjectUrl(jobId),
+    [jobId],
+  );
+  const { objectUrl, error } = useObjectUrl(loadObjectUrl);
 
   if (error) {
     return (
@@ -466,7 +406,8 @@ export const JobDocumentsPanel: React.FC<JobDocumentsPanelProps> = ({
                       </div>
                       <p className="mt-0.5 text-xs text-muted-foreground/65">
                         {document.mediaType || "Unknown type"} ·{" "}
-                        {formatByteSize(document.byteSize)} · Uploaded{" "}
+                        {formatJobDocumentByteSize(document.byteSize)} ·
+                        Uploaded{" "}
                         {formatDateTime(document.createdAt) ??
                           document.createdAt}
                       </p>

--- a/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
+++ b/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
@@ -5,7 +5,7 @@ import {
   AlertTriangle,
   Download,
   ExternalLink,
-  File,
+  File as FileIcon,
   FileText,
   ImageIcon,
   Loader2,
@@ -72,7 +72,7 @@ function DocumentIcon({
   if (isJobDocumentSafeInlineImage(document)) {
     return <ImageIcon className="h-3.5 w-3.5 text-emerald-400/80" />;
   }
-  return <File className="h-3.5 w-3.5 text-muted-foreground" />;
+  return <FileIcon className="h-3.5 w-3.5 text-muted-foreground" />;
 }
 
 const DocumentPreview: React.FC<{
@@ -235,7 +235,7 @@ export const JobDocumentsPanel: React.FC<JobDocumentsPanelProps> = ({
     });
   };
 
-  const handleUploadDocument = async (file: File) => {
+  const handleUploadDocument = async (file: globalThis.File) => {
     try {
       setIsUploadingDocument(true);
       await uploadJobDocumentFromFile(job.id, file);

--- a/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
+++ b/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
@@ -1,0 +1,559 @@
+import * as api from "@client/api";
+import type { Job, JobDocument } from "@shared/types.js";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  Download,
+  ExternalLink,
+  File,
+  FileText,
+  ImageIcon,
+  Loader2,
+  RefreshCcw,
+  Trash2,
+  Upload,
+} from "lucide-react";
+import type React from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+import { ConfirmDelete } from "@/client/components/ConfirmDelete";
+import { TooltipWhenDisabled } from "@/client/components/TooltipWhenDisabled";
+import { showErrorToast } from "@/client/lib/error-toast";
+import { uploadJobDocumentFromFile } from "@/client/lib/job-document-upload";
+import {
+  createJobDocumentObjectUrl,
+  createJobPdfObjectUrl,
+  downloadJobDocument,
+  openJobDocument,
+} from "@/client/lib/private-pdf";
+import { queryKeys } from "@/client/lib/queryKeys";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatDateTime } from "@/lib/utils";
+
+type JobDocumentsPanelProps = {
+  job: Job;
+  isStalePdf: boolean;
+  isUploadingPdf: boolean;
+  pdfActionsDisabled: boolean;
+  pdfRegeneratingReason: string | null;
+  pdfViewLabel: string;
+  pdfDownloadLabel: string;
+  stalePdfMessage: string;
+  onUploadPdf: () => void;
+  onViewPdf: () => void;
+  onDownloadPdf: () => void;
+  onRegeneratePdf: () => void;
+};
+
+const bytesFormatter = new Intl.NumberFormat("en", {
+  maximumFractionDigits: 1,
+});
+
+function formatByteSize(byteSize: number): string {
+  if (byteSize < 1024) return `${byteSize} B`;
+  if (byteSize < 1024 * 1024) {
+    return `${bytesFormatter.format(byteSize / 1024)} KB`;
+  }
+  return `${bytesFormatter.format(byteSize / (1024 * 1024))} MB`;
+}
+
+function getFileExtension(fileName: string): string {
+  const extension = fileName.toLowerCase().split(".").pop();
+  return extension && extension !== fileName.toLowerCase() ? extension : "";
+}
+
+function isPdf(document: Pick<JobDocument, "fileName" | "mediaType">): boolean {
+  return (
+    document.mediaType === "application/pdf" ||
+    getFileExtension(document.fileName) === "pdf"
+  );
+}
+
+function isImage(
+  document: Pick<JobDocument, "fileName" | "mediaType">,
+): boolean {
+  return Boolean(document.mediaType?.startsWith("image/"));
+}
+
+function isTextLike(document: Pick<JobDocument, "fileName" | "mediaType">) {
+  const extension = getFileExtension(document.fileName);
+  return (
+    document.mediaType?.startsWith("text/") ||
+    document.mediaType === "application/json" ||
+    document.mediaType === "application/xml" ||
+    ["csv", "json", "md", "markdown", "txt", "xml", "log"].includes(extension)
+  );
+}
+
+function DocumentIcon({
+  document,
+}: {
+  document: Pick<JobDocument, "fileName" | "mediaType">;
+}) {
+  if (isPdf(document) || isTextLike(document)) {
+    return <FileText className="h-3.5 w-3.5 text-sky-400/80" />;
+  }
+  if (isImage(document)) {
+    return <ImageIcon className="h-3.5 w-3.5 text-emerald-400/80" />;
+  }
+  return <File className="h-3.5 w-3.5 text-muted-foreground" />;
+}
+
+const DocumentPreview: React.FC<{
+  document: JobDocument;
+}> = ({ document }) => {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [textPreview, setTextPreview] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const canPreviewAsObject = isPdf(document) || isImage(document);
+  const canPreviewAsText = isTextLike(document);
+
+  useEffect(() => {
+    let cancelled = false;
+    let nextObjectUrl: string | null = null;
+
+    setObjectUrl(null);
+    setTextPreview(null);
+    setError(null);
+
+    if (canPreviewAsObject) {
+      void createJobDocumentObjectUrl(document.jobId, document.id)
+        .then((url) => {
+          if (cancelled) {
+            URL.revokeObjectURL(url);
+            return;
+          }
+          nextObjectUrl = url;
+          setObjectUrl(url);
+        })
+        .catch(() => {
+          if (!cancelled) setError("Preview unavailable.");
+        });
+    } else if (canPreviewAsText) {
+      void api
+        .getJobDocumentBlob(document.jobId, document.id)
+        .then((blob) => blob.text())
+        .then((text) => {
+          if (!cancelled) setTextPreview(text.slice(0, 80_000));
+        })
+        .catch(() => {
+          if (!cancelled) setError("Preview unavailable.");
+        });
+    }
+
+    return () => {
+      cancelled = true;
+      if (nextObjectUrl) URL.revokeObjectURL(nextObjectUrl);
+    };
+  }, [canPreviewAsObject, canPreviewAsText, document.id, document.jobId]);
+
+  if (!canPreviewAsObject && !canPreviewAsText) {
+    return (
+      <div className="rounded-md border border-dashed border-border/60 bg-background/30 p-4 text-sm text-muted-foreground">
+        This file type cannot be previewed here.
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        {error}
+      </div>
+    );
+  }
+
+  if (canPreviewAsObject && objectUrl) {
+    return isImage(document) ? (
+      <div className="max-h-[560px] overflow-auto rounded-md border border-border/50 bg-background/40 p-3">
+        <img
+          src={objectUrl}
+          alt={document.fileName}
+          className="mx-auto max-h-[520px] max-w-full object-contain"
+        />
+      </div>
+    ) : (
+      <iframe
+        title={document.fileName}
+        src={objectUrl}
+        className="h-[560px] w-full rounded-md border border-border/50 bg-background"
+      />
+    );
+  }
+
+  if (canPreviewAsText && textPreview !== null) {
+    return (
+      <pre className="max-h-[520px] overflow-auto rounded-md border border-border/50 bg-background/60 p-4 text-xs leading-6 text-foreground/80">
+        {textPreview}
+      </pre>
+    );
+  }
+
+  return (
+    <div className="flex min-h-32 items-center justify-center rounded-md border border-border/50 bg-background/30 text-sm text-muted-foreground">
+      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+      Loading preview
+    </div>
+  );
+};
+
+const ResumePdfPreview: React.FC<{ jobId: string }> = ({ jobId }) => {
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    let nextObjectUrl: string | null = null;
+
+    void createJobPdfObjectUrl(jobId)
+      .then((url) => {
+        if (cancelled) {
+          URL.revokeObjectURL(url);
+          return;
+        }
+        nextObjectUrl = url;
+        setObjectUrl(url);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Preview unavailable.");
+      });
+
+    return () => {
+      cancelled = true;
+      if (nextObjectUrl) URL.revokeObjectURL(nextObjectUrl);
+    };
+  }, [jobId]);
+
+  if (error) {
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        {error}
+      </div>
+    );
+  }
+
+  if (!objectUrl) {
+    return (
+      <div className="flex min-h-32 items-center justify-center rounded-md border border-border/50 bg-background/30 text-sm text-muted-foreground">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Loading preview
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      title="Resume PDF"
+      src={objectUrl}
+      className="h-[560px] w-full rounded-md border border-border/50 bg-background"
+    />
+  );
+};
+
+export const JobDocumentsPanel: React.FC<JobDocumentsPanelProps> = ({
+  job,
+  isStalePdf,
+  isUploadingPdf,
+  pdfActionsDisabled,
+  pdfRegeneratingReason,
+  pdfViewLabel,
+  pdfDownloadLabel,
+  stalePdfMessage,
+  onUploadPdf,
+  onViewPdf,
+  onDownloadPdf,
+  onRegeneratePdf,
+}) => {
+  const queryClient = useQueryClient();
+  const uploadDocumentInputRef = useRef<HTMLInputElement | null>(null);
+  const [isUploadingDocument, setIsUploadingDocument] = useState(false);
+  const [documentToDelete, setDocumentToDelete] = useState<JobDocument | null>(
+    null,
+  );
+
+  const documentsQuery = useQuery({
+    queryKey: queryKeys.jobs.documents(job.id),
+    queryFn: () => api.getJobDocuments(job.id),
+  });
+
+  const defaultAccordionValues = useMemo(() => {
+    const values = ["job-description"];
+    if (job.pdfPath) values.unshift("resume-pdf");
+    return values;
+  }, [job.pdfPath]);
+
+  const refreshDocuments = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: queryKeys.jobs.documents(job.id),
+    });
+  };
+
+  const handleUploadDocument = async (file: File) => {
+    try {
+      setIsUploadingDocument(true);
+      await uploadJobDocumentFromFile(job.id, file);
+      await refreshDocuments();
+      toast.success("Document uploaded");
+    } catch (error) {
+      showErrorToast(error, "Failed to upload document");
+    } finally {
+      setIsUploadingDocument(false);
+      if (uploadDocumentInputRef.current) {
+        uploadDocumentInputRef.current.value = "";
+      }
+    }
+  };
+
+  const handleDeleteDocument = async () => {
+    if (!documentToDelete) return;
+    try {
+      await api.deleteJobDocument(job.id, documentToDelete.id);
+      await refreshDocuments();
+      toast.success("Document deleted");
+    } catch (error) {
+      showErrorToast(error, "Failed to delete document");
+    } finally {
+      setDocumentToDelete(null);
+    }
+  };
+
+  return (
+    <>
+      <section className="rounded-xl border border-border/50 bg-card/75">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/50 px-4 py-3">
+          <div className="flex items-center gap-2 text-base font-semibold">
+            <FileText className="h-4 w-4" />
+            Documents
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => uploadDocumentInputRef.current?.click()}
+              disabled={isUploadingDocument}
+            >
+              {isUploadingDocument ? (
+                <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Upload className="mr-1.5 h-3.5 w-3.5" />
+              )}
+              Upload document
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={onUploadPdf}
+              disabled={isUploadingPdf}
+            >
+              <Upload className="mr-1.5 h-3.5 w-3.5" />
+              {isUploadingPdf
+                ? "Uploading PDF"
+                : job.pdfPath
+                  ? "Replace PDF"
+                  : "Upload PDF"}
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-4 p-4">
+          <Accordion
+            type="multiple"
+            defaultValue={defaultAccordionValues}
+            className="space-y-3"
+          >
+            {job.pdfPath ? (
+              <AccordionItem
+                value="resume-pdf"
+                className="overflow-hidden rounded-lg border border-border/45 bg-muted/25"
+              >
+                <div className="relative">
+                  <AccordionTrigger className="flex items-center justify-between gap-2 border-b border-border/35 bg-muted/5 px-3 py-2.5 pr-4 text-left hover:bg-muted/40 hover:no-underline">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 text-sm font-semibold text-foreground/90">
+                        <FileText className="h-3.5 w-3.5 text-sky-400/80" />
+                        Resume PDF
+                        <Badge variant="secondary" className="text-[10px]">
+                          {job.pdfFreshness}
+                        </Badge>
+                      </div>
+                      <p className="mt-0.5 text-xs text-muted-foreground/65">
+                        Generated or uploaded application material for this job.
+                      </p>
+                    </div>
+                  </AccordionTrigger>
+                  <div className="flex flex-wrap justify-end gap-1 border-b border-border/35 bg-muted/5 px-3 pb-2 sm:absolute sm:right-8 sm:top-1/2 sm:border-b-0 sm:bg-transparent sm:p-0 sm:-translate-y-1/2">
+                    <TooltipWhenDisabled
+                      reason={pdfRegeneratingReason}
+                      className="w-auto"
+                    >
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={onViewPdf}
+                        disabled={pdfActionsDisabled}
+                      >
+                        <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                        {pdfViewLabel}
+                      </Button>
+                    </TooltipWhenDisabled>
+                    <TooltipWhenDisabled
+                      reason={pdfRegeneratingReason}
+                      className="w-auto"
+                    >
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={onDownloadPdf}
+                        disabled={pdfActionsDisabled}
+                      >
+                        <Download className="mr-1.5 h-3.5 w-3.5" />
+                        {pdfDownloadLabel}
+                      </Button>
+                    </TooltipWhenDisabled>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={onUploadPdf}
+                      disabled={isUploadingPdf}
+                    >
+                      <Upload className="mr-1.5 h-3.5 w-3.5" />
+                      Replace PDF
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={onRegeneratePdf}
+                      disabled={Boolean(pdfRegeneratingReason)}
+                    >
+                      <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
+                      Regenerate
+                    </Button>
+                  </div>
+                </div>
+                <AccordionContent className="p-0">
+                  <div className="space-y-3 bg-background/20 p-4">
+                    {isStalePdf ? (
+                      <div className="flex items-start gap-2 rounded-md border border-amber-200/70 bg-amber-50 px-3 py-2 text-xs text-amber-900 dark:border-amber-400/25 dark:bg-amber-400/10 dark:text-amber-100">
+                        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                        <span>{stalePdfMessage}</span>
+                      </div>
+                    ) : null}
+                    <ResumePdfPreview jobId={job.id} />
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            ) : null}
+
+            {documentsQuery.data?.map((document) => (
+              <AccordionItem
+                key={document.id}
+                value={document.id}
+                className="overflow-hidden rounded-lg border border-border/45 bg-muted/25"
+              >
+                <div className="relative">
+                  <AccordionTrigger className="flex items-center justify-between gap-2 border-b border-border/35 bg-muted/5 px-3 py-2.5 pr-4 text-left hover:bg-muted/40 hover:no-underline">
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-2 text-sm font-semibold text-foreground/90">
+                        <DocumentIcon document={document} />
+                        <span className="truncate">{document.fileName}</span>
+                      </div>
+                      <p className="mt-0.5 text-xs text-muted-foreground/65">
+                        {document.mediaType || "Unknown type"} ·{" "}
+                        {formatByteSize(document.byteSize)} · Uploaded{" "}
+                        {formatDateTime(document.createdAt) ??
+                          document.createdAt}
+                      </p>
+                    </div>
+                  </AccordionTrigger>
+                  <div className="flex flex-wrap justify-end gap-1 border-b border-border/35 bg-muted/5 px-3 pb-2 sm:absolute sm:right-8 sm:top-1/2 sm:border-b-0 sm:bg-transparent sm:p-0 sm:-translate-y-1/2">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() =>
+                        void openJobDocument(job.id, document.id).catch(
+                          (error) =>
+                            showErrorToast(error, "Could not open document"),
+                        )
+                      }
+                    >
+                      <ExternalLink className="mr-1.5 h-3.5 w-3.5" />
+                      Open
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() =>
+                        void downloadJobDocument(
+                          job.id,
+                          document.id,
+                          document.fileName,
+                        ).catch((error) =>
+                          showErrorToast(error, "Could not download document"),
+                        )
+                      }
+                    >
+                      <Download className="mr-1.5 h-3.5 w-3.5" />
+                      Download
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => setDocumentToDelete(document)}
+                    >
+                      <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+                      Delete
+                    </Button>
+                  </div>
+                </div>
+                <AccordionContent className="p-0">
+                  <div className="bg-background/20 p-4">
+                    <DocumentPreview document={document} />
+                  </div>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+
+          {documentsQuery.isLoading ? (
+            <div className="flex min-h-20 items-center justify-center rounded-lg border border-border/50 bg-background/25 text-sm text-muted-foreground">
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Loading documents
+            </div>
+          ) : null}
+
+          {!job.pdfPath && documentsQuery.data?.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-border/60 bg-background/25 p-6 text-sm text-muted-foreground">
+              No documents attached yet.
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <input
+        ref={uploadDocumentInputRef}
+        type="file"
+        className="hidden"
+        onChange={(event) => {
+          const file = event.currentTarget.files?.[0];
+          if (file) void handleUploadDocument(file);
+        }}
+      />
+
+      <ConfirmDelete
+        isOpen={Boolean(documentToDelete)}
+        onClose={() => setDocumentToDelete(null)}
+        onConfirm={handleDeleteDocument}
+        title="Delete document?"
+        description={`This removes ${documentToDelete?.fileName ?? "this document"} from this job.`}
+      />
+    </>
+  );
+};

--- a/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
+++ b/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
@@ -24,8 +24,8 @@ import {
   canPreviewJobDocumentAsObject,
   canPreviewJobDocumentAsText,
   formatJobDocumentByteSize,
-  isJobDocumentImage,
   isJobDocumentPdf,
+  isJobDocumentSafeInlineImage,
   isJobDocumentTextLike,
 } from "@/client/lib/job-documents";
 import {
@@ -69,7 +69,7 @@ function DocumentIcon({
   if (isJobDocumentPdf(document) || isJobDocumentTextLike(document)) {
     return <FileText className="h-3.5 w-3.5 text-sky-400/80" />;
   }
-  if (isJobDocumentImage(document)) {
+  if (isJobDocumentSafeInlineImage(document)) {
     return <ImageIcon className="h-3.5 w-3.5 text-emerald-400/80" />;
   }
   return <File className="h-3.5 w-3.5 text-muted-foreground" />;
@@ -131,7 +131,7 @@ const DocumentPreview: React.FC<{
   }
 
   if (canPreviewAsObject && objectUrl) {
-    return isJobDocumentImage(document) ? (
+    return isJobDocumentSafeInlineImage(document) ? (
       <div className="max-h-[560px] overflow-auto rounded-md border border-border/50 bg-background/40 p-3">
         <img
           src={objectUrl}
@@ -418,9 +418,8 @@ export const JobDocumentsPanel: React.FC<JobDocumentsPanelProps> = ({
                       size="sm"
                       variant="ghost"
                       onClick={() =>
-                        void openJobDocument(job.id, document.id).catch(
-                          (error) =>
-                            showErrorToast(error, "Could not open document"),
+                        void openJobDocument(job.id, document).catch((error) =>
+                          showErrorToast(error, "Could not open document"),
                         )
                       }
                     >

--- a/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
+++ b/orchestrator/src/client/pages/job-page/JobDocumentsPanel.tsx
@@ -224,8 +224,8 @@ export const JobDocumentsPanel: React.FC<JobDocumentsPanelProps> = ({
   });
 
   const defaultAccordionValues = useMemo(() => {
-    const values = ["job-description"];
-    if (job.pdfPath) values.unshift("resume-pdf");
+    const values: string[] = [];
+    if (job.pdfPath) values.push("resume-pdf");
     return values;
   }, [job.pdfPath]);
 

--- a/orchestrator/src/client/pages/job-page/JobPageRightSidebar.test.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageRightSidebar.test.tsx
@@ -1,0 +1,111 @@
+import { createJob } from "@shared/testing/factories.js";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { JobPageRightSidebar } from "./JobPageRightSidebar";
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+  }: {
+    children: ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" disabled={disabled} onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+}));
+
+const noop = vi.fn();
+
+function renderRightSidebar(overrides: Parameters<typeof createJob>[0] = {}) {
+  const job = createJob({
+    status: "ready",
+    pdfPath: "data/pdfs/resume_job-1.pdf",
+    pdfFreshness: "stale",
+    ...overrides,
+  });
+
+  return render(
+    <JobPageRightSidebar
+      job={job}
+      tasks={[]}
+      jobLink={job.jobUrl}
+      isDiscovered={job.status === "discovered"}
+      isReady={job.status === "ready"}
+      isApplied={job.status === "applied"}
+      isInProgress={job.status === "in_progress"}
+      canLogEvents={false}
+      isBusy={false}
+      isUploadingPdf={false}
+      pdfActionsDisabled={false}
+      pdfRegeneratingReason={null}
+      pdfViewLabel="View old PDF"
+      pdfDownloadLabel="Download old PDF"
+      onStartTailoring={noop}
+      onMarkApplied={noop}
+      onMoveToInProgress={noop}
+      onOpenLogEvent={noop}
+      onEditTailoring={noop}
+      onViewPdf={noop}
+      onDownloadPdf={noop}
+      onUploadPdf={noop}
+      onRegeneratePdf={noop}
+      onSkip={noop}
+      onOpenEditDetails={noop}
+      onViewJobDescription={noop}
+      onCopyJobInfo={noop}
+      onRescore={noop}
+      onCheckSponsor={noop}
+    />,
+  );
+}
+
+describe("JobPageRightSidebar actions", () => {
+  it("includes the orchestrator detail menu actions on the job page", () => {
+    renderRightSidebar();
+
+    expect(
+      screen.getByRole("button", { name: /edit details/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /view job description/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /copy job info/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /recalculate match/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: /replace pdf/i }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByRole("button", { name: /view old pdf/i }).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByRole("button", { name: /download old pdf/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses upload wording when the job has no resume PDF", () => {
+    renderRightSidebar({ pdfPath: null, pdfFreshness: "missing" });
+
+    expect(
+      screen.getAllByRole("button", { name: /upload pdf/i }).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByRole("button", { name: /download pdf/i })).toBeNull();
+  });
+});

--- a/orchestrator/src/client/pages/job-page/JobPageRightSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageRightSidebar.tsx
@@ -3,6 +3,7 @@ import {
   CalendarClock,
   CheckCircle2,
   Copy,
+  Download,
   Edit2,
   ExternalLink,
   FileText,
@@ -40,16 +41,19 @@ type JobPageRightSidebarProps = {
   pdfActionsDisabled: boolean;
   pdfRegeneratingReason: string | null;
   pdfViewLabel: string;
+  pdfDownloadLabel: string;
   onStartTailoring: () => void;
   onMarkApplied: () => void;
   onMoveToInProgress: () => void;
   onOpenLogEvent: () => void;
   onEditTailoring: () => void;
   onViewPdf: () => void;
+  onDownloadPdf: () => void;
   onUploadPdf: () => void;
   onRegeneratePdf: () => void;
   onSkip: () => void;
   onOpenEditDetails: () => void;
+  onViewJobDescription: () => void;
   onCopyJobInfo: () => void;
   onRescore: () => void;
   onCheckSponsor: () => void;
@@ -69,16 +73,19 @@ export const JobPageRightSidebar: React.FC<JobPageRightSidebarProps> = ({
   pdfActionsDisabled,
   pdfRegeneratingReason,
   pdfViewLabel,
+  pdfDownloadLabel,
   onStartTailoring,
   onMarkApplied,
   onMoveToInProgress,
   onOpenLogEvent,
   onEditTailoring,
   onViewPdf,
+  onDownloadPdf,
   onUploadPdf,
   onRegeneratePdf,
   onSkip,
   onOpenEditDetails,
+  onViewJobDescription,
   onCopyJobInfo,
   onRescore,
   onCheckSponsor,
@@ -243,6 +250,10 @@ export const JobPageRightSidebar: React.FC<JobPageRightSidebarProps> = ({
               <Edit2 className="mr-2 h-4 w-4" />
               Edit details
             </DropdownMenuItem>
+            <DropdownMenuItem onSelect={onViewJobDescription}>
+              <Edit2 className="mr-2 h-4 w-4" />
+              View job description
+            </DropdownMenuItem>
             <DropdownMenuItem onSelect={onCopyJobInfo}>
               <Copy className="mr-2 h-4 w-4" />
               Copy job info
@@ -254,6 +265,33 @@ export const JobPageRightSidebar: React.FC<JobPageRightSidebarProps> = ({
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={onUploadPdf} disabled={isUploadingPdf}>
+              <Upload className="mr-2 h-4 w-4" />
+              {isUploadingPdf
+                ? "Uploading PDF..."
+                : job.pdfPath
+                  ? "Replace PDF"
+                  : "Upload PDF"}
+            </DropdownMenuItem>
+            {job.pdfPath && (
+              <>
+                <DropdownMenuItem
+                  onSelect={onViewPdf}
+                  disabled={pdfActionsDisabled}
+                >
+                  <ExternalLink className="mr-2 h-4 w-4" />
+                  {pdfViewLabel}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onSelect={onDownloadPdf}
+                  disabled={pdfActionsDisabled}
+                >
+                  <Download className="mr-2 h-4 w-4" />
+                  {pdfDownloadLabel}
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+              </>
+            )}
             <DropdownMenuItem onSelect={onCheckSponsor}>
               Check sponsorship status
             </DropdownMenuItem>

--- a/orchestrator/src/server/api/routes/ghostwriter.test.ts
+++ b/orchestrator/src/server/api/routes/ghostwriter.test.ts
@@ -29,6 +29,7 @@ vi.mock("@server/services/ghostwriter", () => ({
       activeRootMessageId: null,
       selectedNoteIds: ["note-1"],
       selectedEmailIds: ["email-1"],
+      selectedDocumentIds: ["doc-1"],
     },
   ]),
   createThread: vi.fn(
@@ -42,6 +43,7 @@ vi.mock("@server/services/ghostwriter", () => ({
       activeRootMessageId: null,
       selectedNoteIds: [],
       selectedEmailIds: [],
+      selectedDocumentIds: [],
     }),
   ),
   updateContextForJob: vi.fn(
@@ -49,9 +51,11 @@ vi.mock("@server/services/ghostwriter", () => ({
       jobId: string;
       selectedNoteIds?: string[];
       selectedEmailIds?: string[];
+      selectedDocumentIds?: string[];
     }) => ({
       selectedNoteIds: input.selectedNoteIds ?? [],
       selectedEmailIds: input.selectedEmailIds ?? [],
+      selectedDocumentIds: input.selectedDocumentIds ?? [],
     }),
   ),
   listMessages: vi.fn(async () => ({
@@ -67,6 +71,7 @@ vi.mock("@server/services/ghostwriter", () => ({
     branches: [],
     selectedNoteIds: ["note-1"],
     selectedEmailIds: ["email-1"],
+    selectedDocumentIds: ["doc-1"],
   })),
   listMessagesForJob: vi.fn(async () => ({
     messages: [
@@ -81,6 +86,7 @@ vi.mock("@server/services/ghostwriter", () => ({
     branches: [],
     selectedNoteIds: ["note-1"],
     selectedEmailIds: ["email-1"],
+    selectedDocumentIds: ["doc-1"],
   })),
   sendMessage: vi.fn(async () => ({
     userMessage: {
@@ -237,6 +243,19 @@ describe.sequential("Ghostwriter API", () => {
     expect(res.status).toBe(200);
     expect(body.ok).toBe(true);
     expect(body.data.selectedEmailIds).toEqual(["email-1"]);
+  });
+
+  it("updates selected Ghostwriter documents", async () => {
+    const res = await fetch(`${baseUrl}/api/jobs/job-1/chat/context`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ selectedDocumentIds: ["doc-1"] }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.selectedDocumentIds).toEqual(["doc-1"]);
   });
 
   it("rejects empty Ghostwriter context updates", async () => {

--- a/orchestrator/src/server/api/routes/ghostwriter.ts
+++ b/orchestrator/src/server/api/routes/ghostwriter.ts
@@ -19,9 +19,11 @@ const listMessagesQuerySchema = z.object({
 
 const selectedNoteIdsSchema = z.array(z.string().trim().min(1)).default([]);
 const selectedEmailIdsSchema = z.array(z.string().trim().min(1)).default([]);
+const selectedDocumentIdsSchema = z.array(z.string().trim().min(1)).default([]);
 const selectedContextSchema = {
   selectedNoteIds: selectedNoteIdsSchema.optional(),
   selectedEmailIds: selectedEmailIdsSchema.optional(),
+  selectedDocumentIds: selectedDocumentIdsSchema.optional(),
 };
 
 const updateContextSchema = z
@@ -31,7 +33,8 @@ const updateContextSchema = z
   .refine(
     (input) =>
       input.selectedNoteIds !== undefined ||
-      input.selectedEmailIds !== undefined,
+      input.selectedEmailIds !== undefined ||
+      input.selectedDocumentIds !== undefined,
     {
       message: "At least one context selection must be provided.",
     },
@@ -115,6 +118,7 @@ ghostwriterRouter.get(
         branches: result.branches,
         selectedNoteIds: result.selectedNoteIds,
         selectedEmailIds: result.selectedEmailIds,
+        selectedDocumentIds: result.selectedDocumentIds,
       });
     });
   }),
@@ -137,6 +141,7 @@ ghostwriterRouter.patch(
         jobId,
         selectedNoteIds: parsed.data.selectedNoteIds,
         selectedEmailIds: parsed.data.selectedEmailIds,
+        selectedDocumentIds: parsed.data.selectedDocumentIds,
       });
       ok(res, result);
     });
@@ -170,6 +175,7 @@ ghostwriterRouter.post(
             attachments: parsed.data.attachments,
             selectedNoteIds: parsed.data.selectedNoteIds,
             selectedEmailIds: parsed.data.selectedEmailIds,
+            selectedDocumentIds: parsed.data.selectedDocumentIds,
             stream: {
               onReady: ({ runId, threadId, messageId, requestId }) =>
                 writeSseData(res, {
@@ -229,6 +235,7 @@ ghostwriterRouter.post(
         attachments: parsed.data.attachments,
         selectedNoteIds: parsed.data.selectedNoteIds,
         selectedEmailIds: parsed.data.selectedEmailIds,
+        selectedDocumentIds: parsed.data.selectedDocumentIds,
       });
 
       ok(res, {
@@ -290,6 +297,7 @@ ghostwriterRouter.post(
             assistantMessageId,
             selectedNoteIds: parsed.data.selectedNoteIds,
             selectedEmailIds: parsed.data.selectedEmailIds,
+            selectedDocumentIds: parsed.data.selectedDocumentIds,
             stream: {
               onReady: ({ runId, threadId, messageId, requestId }) =>
                 writeSseData(res, {
@@ -348,6 +356,7 @@ ghostwriterRouter.post(
         assistantMessageId,
         selectedNoteIds: parsed.data.selectedNoteIds,
         selectedEmailIds: parsed.data.selectedEmailIds,
+        selectedDocumentIds: parsed.data.selectedDocumentIds,
       });
 
       ok(res, result);
@@ -387,6 +396,7 @@ ghostwriterRouter.post(
             attachments: parsed.data.attachments,
             selectedNoteIds: parsed.data.selectedNoteIds,
             selectedEmailIds: parsed.data.selectedEmailIds,
+            selectedDocumentIds: parsed.data.selectedDocumentIds,
             stream: {
               onReady: ({ runId, threadId, messageId, requestId }) =>
                 writeSseData(res, {
@@ -447,6 +457,7 @@ ghostwriterRouter.post(
         attachments: parsed.data.attachments,
         selectedNoteIds: parsed.data.selectedNoteIds,
         selectedEmailIds: parsed.data.selectedEmailIds,
+        selectedDocumentIds: parsed.data.selectedDocumentIds,
       });
 
       ok(res, {
@@ -588,6 +599,7 @@ ghostwriterRouter.post(
             attachments: parsed.data.attachments,
             selectedNoteIds: parsed.data.selectedNoteIds,
             selectedEmailIds: parsed.data.selectedEmailIds,
+            selectedDocumentIds: parsed.data.selectedDocumentIds,
             stream: {
               onReady: ({ runId, messageId, requestId }) =>
                 writeSseData(res, {
@@ -648,6 +660,7 @@ ghostwriterRouter.post(
         attachments: parsed.data.attachments,
         selectedNoteIds: parsed.data.selectedNoteIds,
         selectedEmailIds: parsed.data.selectedEmailIds,
+        selectedDocumentIds: parsed.data.selectedDocumentIds,
       });
 
       ok(res, {
@@ -715,6 +728,7 @@ ghostwriterRouter.post(
             assistantMessageId,
             selectedNoteIds: parsed.data.selectedNoteIds,
             selectedEmailIds: parsed.data.selectedEmailIds,
+            selectedDocumentIds: parsed.data.selectedDocumentIds,
             stream: {
               onReady: ({ runId, messageId, requestId }) =>
                 writeSseData(res, {
@@ -774,6 +788,7 @@ ghostwriterRouter.post(
         assistantMessageId,
         selectedNoteIds: parsed.data.selectedNoteIds,
         selectedEmailIds: parsed.data.selectedEmailIds,
+        selectedDocumentIds: parsed.data.selectedDocumentIds,
       });
 
       ok(res, result);

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -753,7 +753,7 @@ describe.sequential("Jobs API routes", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
-        fileName: "payload.html",
+        fileName: "payload's (test)!*.html",
         mediaType: "text/html",
         dataBase64: Buffer.from("<script>alert(1)</script>").toString("base64"),
       }),
@@ -772,6 +772,43 @@ describe.sequential("Jobs API routes", () => {
     expect(contentRes.headers.get("content-disposition")).toContain(
       "attachment",
     );
+    expect(contentRes.headers.get("content-disposition")).toContain(
+      "filename*=UTF-8''payload%27s%20%28test%29%21%2A.html",
+    );
+  });
+
+  it("returns a JSON error when a stored job document file is missing", async () => {
+    const { createJob } = await import("@server/repositories/jobs");
+    const { createJobDocument } = await import(
+      "@server/repositories/job-documents"
+    );
+    const job = await createJob({
+      source: "manual",
+      title: "Missing Document File Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/missing-document-file",
+      jobDescription: "Missing document file description",
+    });
+    const document = await createJobDocument({
+      jobId: job.id,
+      fileName: "missing.html",
+      mediaType: "text/html",
+      byteSize: 100,
+      storagePath: "/definitely/missing/job-document.html",
+    });
+
+    const res = await fetch(
+      `${baseUrl}/api/jobs/${job.id}/documents/${document.id}/content`,
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(404);
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("NOT_FOUND");
+    expect(res.headers.get("content-disposition")).toBeNull();
+    expect(res.headers.get("cache-control")).toBeNull();
+    expect(res.headers.get("x-content-type-options")).toBeNull();
+    expect(res.headers.get("content-type")).toMatch(/^application\/json/);
   });
 
   it("rejects uploaded job documents with invalid base64", async () => {

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -674,6 +674,145 @@ describe.sequential("Jobs API routes", () => {
     expect(typeof body.meta.requestId).toBe("string");
   });
 
+  it("uploads, lists, serves, and deletes arbitrary job documents", async () => {
+    const { createJob } = await import("@server/repositories/jobs");
+    const job = await createJob({
+      source: "manual",
+      title: "Document Upload Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/document-upload",
+      jobDescription: "Document upload description",
+    });
+    const documentContent = Buffer.from("cover letter draft");
+
+    const uploadRes = await fetch(`${baseUrl}/api/jobs/${job.id}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fileName: "cover-letter.txt",
+        mediaType: "text/plain",
+        dataBase64: documentContent.toString("base64"),
+      }),
+    });
+    const uploadBody = await uploadRes.json();
+
+    expect(uploadRes.status).toBe(201);
+    expect(uploadBody.ok).toBe(true);
+    expect(uploadBody.data).toMatchObject({
+      jobId: job.id,
+      fileName: "cover-letter.txt",
+      mediaType: "text/plain",
+      byteSize: documentContent.byteLength,
+    });
+    expect(uploadBody.data).not.toHaveProperty("storagePath");
+    expect(typeof uploadBody.meta.requestId).toBe("string");
+
+    const listRes = await fetch(`${baseUrl}/api/jobs/${job.id}/documents`);
+    const listBody = await listRes.json();
+    expect(listRes.status).toBe(200);
+    expect(listBody.ok).toBe(true);
+    expect(listBody.data).toHaveLength(1);
+    expect(listBody.data[0].id).toBe(uploadBody.data.id);
+
+    const contentRes = await fetch(
+      `${baseUrl}/api/jobs/${job.id}/documents/${uploadBody.data.id}/content`,
+    );
+    const content = Buffer.from(await contentRes.arrayBuffer()).toString(
+      "utf8",
+    );
+    expect(contentRes.status).toBe(200);
+    expect(contentRes.headers.get("cache-control")).toBe("no-store");
+    expect(content).toBe("cover letter draft");
+
+    const deleteRes = await fetch(
+      `${baseUrl}/api/jobs/${job.id}/documents/${uploadBody.data.id}`,
+      { method: "DELETE" },
+    );
+    const deleteBody = await deleteRes.json();
+    expect(deleteRes.status).toBe(200);
+    expect(deleteBody.ok).toBe(true);
+
+    const emptyListRes = await fetch(`${baseUrl}/api/jobs/${job.id}/documents`);
+    const emptyListBody = await emptyListRes.json();
+    expect(emptyListBody.data).toEqual([]);
+  });
+
+  it("rejects uploaded job documents with invalid base64", async () => {
+    const { createJob } = await import("@server/repositories/jobs");
+    const job = await createJob({
+      source: "manual",
+      title: "Bad Document Upload Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/bad-document-upload",
+      jobDescription: "Bad document upload description",
+    });
+
+    const res = await fetch(`${baseUrl}/api/jobs/${job.id}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fileName: "notes.txt",
+        mediaType: "text/plain",
+        dataBase64: "not-valid-base64!!!",
+      }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("INVALID_REQUEST");
+    expect(body.error.message).toMatch(/valid base64/i);
+    expect(typeof body.meta.requestId).toBe("string");
+  });
+
+  it("keeps job documents scoped to their owning job", async () => {
+    const { createJob } = await import("@server/repositories/jobs");
+    const firstJob = await createJob({
+      source: "manual",
+      title: "First Document Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/first-document-role",
+      jobDescription: "First document description",
+    });
+    const secondJob = await createJob({
+      source: "manual",
+      title: "Second Document Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/second-document-role",
+      jobDescription: "Second document description",
+    });
+
+    const uploadRes = await fetch(
+      `${baseUrl}/api/jobs/${firstJob.id}/documents`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          fileName: "first.txt",
+          mediaType: "text/plain",
+          dataBase64: Buffer.from("first").toString("base64"),
+        }),
+      },
+    );
+    const uploadBody = await uploadRes.json();
+
+    const crossJobContentRes = await fetch(
+      `${baseUrl}/api/jobs/${secondJob.id}/documents/${uploadBody.data.id}/content`,
+    );
+    const crossJobDeleteRes = await fetch(
+      `${baseUrl}/api/jobs/${secondJob.id}/documents/${uploadBody.data.id}`,
+      { method: "DELETE" },
+    );
+    const secondListRes = await fetch(
+      `${baseUrl}/api/jobs/${secondJob.id}/documents`,
+    );
+    const secondListBody = await secondListRes.json();
+
+    expect(crossJobContentRes.status).toBe(404);
+    expect(crossJobDeleteRes.status).toBe(404);
+    expect(secondListBody.data).toEqual([]);
+  });
+
   it("serves legacy job PDFs when pdfPath is not set", async () => {
     const { createJob } = await import("@server/repositories/jobs");
     const { getLegacyJobPdfPath } = await import(

--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -722,6 +722,8 @@ describe.sequential("Jobs API routes", () => {
     );
     expect(contentRes.status).toBe(200);
     expect(contentRes.headers.get("cache-control")).toBe("no-store");
+    expect(contentRes.headers.get("content-disposition")).toBe("inline");
+    expect(contentRes.headers.get("content-type")).toMatch(/^text\/plain/);
     expect(content).toBe("cover letter draft");
 
     const deleteRes = await fetch(
@@ -735,6 +737,41 @@ describe.sequential("Jobs API routes", () => {
     const emptyListRes = await fetch(`${baseUrl}/api/jobs/${job.id}/documents`);
     const emptyListBody = await emptyListRes.json();
     expect(emptyListBody.data).toEqual([]);
+  });
+
+  it("serves unsafe uploaded document types as attachments", async () => {
+    const { createJob } = await import("@server/repositories/jobs");
+    const job = await createJob({
+      source: "manual",
+      title: "Unsafe Document Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/unsafe-document",
+      jobDescription: "Unsafe document description",
+    });
+
+    const uploadRes = await fetch(`${baseUrl}/api/jobs/${job.id}/documents`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fileName: "payload.html",
+        mediaType: "text/html",
+        dataBase64: Buffer.from("<script>alert(1)</script>").toString("base64"),
+      }),
+    });
+    const uploadBody = await uploadRes.json();
+
+    const contentRes = await fetch(
+      `${baseUrl}/api/jobs/${job.id}/documents/${uploadBody.data.id}/content`,
+    );
+
+    expect(contentRes.status).toBe(200);
+    expect(contentRes.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(contentRes.headers.get("content-type")).toMatch(
+      /^application\/octet-stream/,
+    );
+    expect(contentRes.headers.get("content-disposition")).toContain(
+      "attachment",
+    );
   });
 
   it("rejects uploaded job documents with invalid base64", async () => {

--- a/orchestrator/src/server/api/routes/jobs/documents.ts
+++ b/orchestrator/src/server/api/routes/jobs/documents.ts
@@ -33,13 +33,27 @@ export const jobsDocumentsRouter = Router();
 const tailoringGenerateFields = ["summary", "headline", "skills"] as const;
 type TailoringGenerateField = (typeof tailoringGenerateFields)[number];
 
+function encodeContentDispositionFileName(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*~]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
 function contentDispositionAttachment(fileName: string): string {
   const fallbackFileName =
     fileName
       .replace(/["\\\r\n]/g, "_")
       .replace(/[^\x20-\x7E]/g, "_")
       .trim() || "document";
-  return `attachment; filename="${fallbackFileName}"; filename*=UTF-8''${encodeURIComponent(fileName)}`;
+  return `attachment; filename="${fallbackFileName}"; filename*=UTF-8''${encodeContentDispositionFileName(fileName)}`;
+}
+
+function removeJobDocumentContentHeaders(res: Response): void {
+  res.removeHeader("Cache-Control");
+  res.removeHeader("Content-Disposition");
+  res.removeHeader("Content-Type");
+  res.removeHeader("X-Content-Type-Options");
 }
 
 function setJobDocumentContentHeaders(
@@ -296,6 +310,7 @@ jobsDocumentsRouter.get(
       setJobDocumentContentHeaders(res, document);
       res.sendFile(document.storagePath, (error) => {
         if (error && !res.headersSent) {
+          removeJobDocumentContentHeaders(res);
           fail(
             res,
             new AppError({

--- a/orchestrator/src/server/api/routes/jobs/documents.ts
+++ b/orchestrator/src/server/api/routes/jobs/documents.ts
@@ -5,11 +5,16 @@ import { logger } from "@infra/logger";
 import { isDemoMode } from "@server/config/demo";
 import { resolveRequestOrigin } from "@server/infra/request-origin";
 import { generateFinalPdf, summarizeJob } from "@server/pipeline/index";
+import * as jobDocumentsRepo from "@server/repositories/job-documents";
 import * as jobsRepo from "@server/repositories/jobs";
 import {
   simulateGeneratePdf,
   simulateSummarizeJob,
 } from "@server/services/demo-simulator";
+import {
+  removeStoredJobDocument,
+  storeJobDocument,
+} from "@server/services/job-document-storage";
 import { uploadJobPdf } from "@server/services/job-pdf-upload";
 import { type Request, type Response, Router } from "express";
 import {
@@ -18,6 +23,7 @@ import {
   queueTailoringAutoPdfRegenerationIfNeeded,
   requireJob,
   toJobsRouteError,
+  uploadJobDocumentSchema,
   uploadJobPdfSchema,
 } from "./shared";
 
@@ -146,6 +152,197 @@ jobsDocumentsRouter.post("/:id/pdf", async (req: Request, res: Response) => {
     fail(res, err);
   }
 });
+
+jobsDocumentsRouter.get(
+  "/:id/documents",
+  async (req: Request, res: Response) => {
+    try {
+      await requireJob(req.params.id);
+      ok(res, await jobDocumentsRepo.listJobDocuments(req.params.id));
+    } catch (error) {
+      const err = toJobsRouteError(error);
+      logger[err.status === 404 ? "warn" : "error"](
+        "Job documents list failed",
+        {
+          route: "GET /api/jobs/:id/documents",
+          jobId: req.params.id,
+          status: err.status,
+          code: err.code,
+          details: err.details,
+        },
+      );
+      fail(res, err);
+    }
+  },
+);
+
+jobsDocumentsRouter.post(
+  "/:id/documents",
+  async (req: Request, res: Response) => {
+    let storagePath: string | null = null;
+
+    try {
+      const input = uploadJobDocumentSchema.parse(req.body);
+      await requireJob(req.params.id);
+
+      const stored = await storeJobDocument({
+        jobId: req.params.id,
+        fileName: input.fileName,
+        mediaType: input.mediaType,
+        dataBase64: input.dataBase64,
+      });
+      storagePath = stored.storagePath;
+
+      const document = await jobDocumentsRepo.createJobDocument({
+        jobId: req.params.id,
+        fileName: stored.fileName,
+        mediaType: stored.mediaType,
+        byteSize: stored.byteSize,
+        storagePath: stored.storagePath,
+      });
+
+      logger.info("Job document uploaded", {
+        route: "POST /api/jobs/:id/documents",
+        jobId: req.params.id,
+        documentId: document.id,
+        fileName: document.fileName,
+        mediaType: document.mediaType,
+        byteSize: document.byteSize,
+      });
+
+      ok(res, document, 201);
+    } catch (error) {
+      const err = toJobsRouteError(error, {
+        invalidRequestFallbackMessage: "Invalid job document upload request",
+      });
+
+      if (storagePath) {
+        await removeStoredJobDocument(storagePath).catch((cleanupError) => {
+          logger.warn("Failed to clean up uploaded job document after error", {
+            route: "POST /api/jobs/:id/documents",
+            jobId: req.params.id,
+            cleanupError,
+          });
+        });
+      }
+
+      logger.error("Job document upload failed", {
+        route: "POST /api/jobs/:id/documents",
+        jobId: req.params.id,
+        status: err.status,
+        code: err.code,
+        details: err.details,
+      });
+
+      fail(res, err);
+    }
+  },
+);
+
+jobsDocumentsRouter.get(
+  "/:id/documents/:documentId/content",
+  async (req: Request, res: Response) => {
+    try {
+      await requireJob(req.params.id);
+      const document = await jobDocumentsRepo.getJobDocumentForJob(
+        req.params.id,
+        req.params.documentId,
+      );
+
+      if (!document) {
+        throw new AppError({
+          status: 404,
+          code: "NOT_FOUND",
+          message: "Document not found",
+        });
+      }
+
+      res.setHeader("Cache-Control", "no-store");
+      res.setHeader("X-Content-Type-Options", "nosniff");
+      if (document.mediaType) {
+        res.type(document.mediaType);
+      }
+      res.sendFile(document.storagePath, (error) => {
+        if (error && !res.headersSent) {
+          fail(
+            res,
+            new AppError({
+              status: 404,
+              code: "NOT_FOUND",
+              message: "Document not found",
+            }),
+          );
+        }
+      });
+    } catch (error) {
+      const err = toJobsRouteError(error);
+      logger[err.status === 404 ? "warn" : "error"](
+        "Job document fetch failed",
+        {
+          route: "GET /api/jobs/:id/documents/:documentId/content",
+          jobId: req.params.id,
+          documentId: req.params.documentId,
+          status: err.status,
+          code: err.code,
+          details: err.details,
+        },
+      );
+      fail(res, err);
+    }
+  },
+);
+
+jobsDocumentsRouter.delete(
+  "/:id/documents/:documentId",
+  async (req: Request, res: Response) => {
+    try {
+      await requireJob(req.params.id);
+      const document = await jobDocumentsRepo.deleteJobDocumentForJob(
+        req.params.id,
+        req.params.documentId,
+      );
+
+      if (!document) {
+        throw new AppError({
+          status: 404,
+          code: "NOT_FOUND",
+          message: "Document not found",
+        });
+      }
+
+      await removeStoredJobDocument(document.storagePath).catch((error) => {
+        logger.warn("Failed to delete job document file", {
+          route: "DELETE /api/jobs/:id/documents/:documentId",
+          jobId: req.params.id,
+          documentId: req.params.documentId,
+          error,
+        });
+      });
+
+      logger.info("Job document deleted", {
+        route: "DELETE /api/jobs/:id/documents/:documentId",
+        jobId: req.params.id,
+        documentId: req.params.documentId,
+      });
+
+      ok(res, null);
+    } catch (error) {
+      const err = toJobsRouteError(error);
+      logger[err.status === 404 ? "warn" : "error"](
+        "Job document delete failed",
+        {
+          route: "DELETE /api/jobs/:id/documents/:documentId",
+          jobId: req.params.id,
+          documentId: req.params.documentId,
+          status: err.status,
+          code: err.code,
+          details: err.details,
+        },
+      );
+      fail(res, err);
+    }
+  },
+);
 
 jobsDocumentsRouter.post(
   "/:id/summarize",

--- a/orchestrator/src/server/api/routes/jobs/documents.ts
+++ b/orchestrator/src/server/api/routes/jobs/documents.ts
@@ -16,6 +16,7 @@ import {
   storeJobDocument,
 } from "@server/services/job-document-storage";
 import { uploadJobPdf } from "@server/services/job-pdf-upload";
+import { getSafeInlineJobDocumentMediaType } from "@shared/job-document-classification.js";
 import { type Request, type Response, Router } from "express";
 import {
   appErrorFromPipelineFailure,
@@ -31,6 +32,41 @@ export const jobsDocumentsRouter = Router();
 
 const tailoringGenerateFields = ["summary", "headline", "skills"] as const;
 type TailoringGenerateField = (typeof tailoringGenerateFields)[number];
+
+function contentDispositionAttachment(fileName: string): string {
+  const fallbackFileName =
+    fileName
+      .replace(/["\\\r\n]/g, "_")
+      .replace(/[^\x20-\x7E]/g, "_")
+      .trim() || "document";
+  return `attachment; filename="${fallbackFileName}"; filename*=UTF-8''${encodeURIComponent(fileName)}`;
+}
+
+function setJobDocumentContentHeaders(
+  res: Response,
+  document: { fileName: string; mediaType: string | null },
+): void {
+  const safeInlineMediaType = getSafeInlineJobDocumentMediaType(document);
+
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+
+  if (!safeInlineMediaType) {
+    res.setHeader(
+      "Content-Disposition",
+      contentDispositionAttachment(document.fileName),
+    );
+    res.type("application/octet-stream");
+    return;
+  }
+
+  res.setHeader("Content-Disposition", "inline");
+  if (safeInlineMediaType === "text/plain") {
+    res.setHeader("Content-Type", "text/plain; charset=utf-8");
+    return;
+  }
+  res.type(safeInlineMediaType);
+}
 
 const parseTailoringGenerateFields = (
   raw: string | undefined,
@@ -257,11 +293,7 @@ jobsDocumentsRouter.get(
         });
       }
 
-      res.setHeader("Cache-Control", "no-store");
-      res.setHeader("X-Content-Type-Options", "nosniff");
-      if (document.mediaType) {
-        res.type(document.mediaType);
-      }
+      setJobDocumentContentHeaders(res, document);
       res.sendFile(document.storagePath, (error) => {
         if (error && !res.headersSent) {
           fail(

--- a/orchestrator/src/server/api/routes/jobs/shared.ts
+++ b/orchestrator/src/server/api/routes/jobs/shared.ts
@@ -234,6 +234,12 @@ export const uploadJobPdfSchema = z.object({
   dataBase64: z.string().trim().min(1),
 });
 
+export const uploadJobDocumentSchema = z.object({
+  fileName: z.string().trim().min(1).max(255),
+  mediaType: z.string().trim().max(200).nullable().optional(),
+  dataBase64: z.string().trim().min(1),
+});
+
 export const JOBS_BENCHMARK_ENABLED =
   process.env.BENCHMARK_JOBS_TIMING === "1" ||
   process.env.BENCHMARK_JOBS_TIMING === "true";

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -320,6 +320,7 @@ const migrations = [
     active_root_message_id TEXT,
     selected_note_ids TEXT NOT NULL DEFAULT '[]',
     selected_email_ids TEXT NOT NULL DEFAULT '[]',
+    selected_document_ids TEXT NOT NULL DEFAULT '[]',
     FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
     FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
   )`,
@@ -876,6 +877,7 @@ const migrations = [
   `ALTER TABLE job_chat_threads ADD COLUMN active_root_message_id TEXT`,
   `ALTER TABLE job_chat_threads ADD COLUMN selected_note_ids TEXT NOT NULL DEFAULT '[]'`,
   `ALTER TABLE job_chat_threads ADD COLUMN selected_email_ids TEXT NOT NULL DEFAULT '[]'`,
+  `ALTER TABLE job_chat_threads ADD COLUMN selected_document_ids TEXT NOT NULL DEFAULT '[]'`,
   `ALTER TABLE pipeline_runs ADD COLUMN config_snapshot TEXT`,
   `ALTER TABLE analytics_install_state ADD COLUMN raw_event_replay_version INTEGER NOT NULL DEFAULT 0`,
   `ALTER TABLE analytics_install_state ADD COLUMN raw_event_replay_completed_at TEXT`,

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -289,6 +289,26 @@ const migrations = [
   `CREATE INDEX IF NOT EXISTS idx_design_resume_assets_document_id
     ON design_resume_assets(document_id)`,
 
+  `CREATE TABLE IF NOT EXISTS job_documents (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT 'tenant_default',
+    job_id TEXT NOT NULL,
+    file_name TEXT NOT NULL,
+    media_type TEXT,
+    byte_size INTEGER NOT NULL,
+    storage_path TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+    FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE
+  )`,
+
+  `CREATE INDEX IF NOT EXISTS idx_job_documents_job_id
+    ON job_documents(job_id)`,
+
+  `CREATE INDEX IF NOT EXISTS idx_job_documents_tenant_job_id
+    ON job_documents(tenant_id, job_id)`,
+
   `CREATE TABLE IF NOT EXISTS job_chat_threads (
     id TEXT PRIMARY KEY,
     tenant_id TEXT NOT NULL DEFAULT 'tenant_default',
@@ -996,6 +1016,7 @@ function ensureTenantColumns(): void {
     "job_chat_runs",
     "design_resume_documents",
     "design_resume_assets",
+    "job_documents",
     "post_application_integrations",
     "post_application_sync_runs",
     "post_application_messages",

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -314,6 +314,7 @@ export const jobChatThreads = sqliteTable(
     activeRootMessageId: text("active_root_message_id"),
     selectedNoteIds: text("selected_note_ids").notNull().default("[]"),
     selectedEmailIds: text("selected_email_ids").notNull().default("[]"),
+    selectedDocumentIds: text("selected_document_ids").notNull().default("[]"),
   },
   (table) => ({
     jobUpdatedIndex: index("idx_job_chat_threads_job_updated").on(

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -530,6 +530,33 @@ export const designResumeAssets = sqliteTable(
   }),
 );
 
+export const jobDocuments = sqliteTable(
+  "job_documents",
+  {
+    id: text("id").primaryKey(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .default("tenant_default")
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    jobId: text("job_id")
+      .notNull()
+      .references(() => jobs.id, { onDelete: "cascade" }),
+    fileName: text("file_name").notNull(),
+    mediaType: text("media_type"),
+    byteSize: integer("byte_size").notNull(),
+    storagePath: text("storage_path").notNull(),
+    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => ({
+    jobIndex: index("idx_job_documents_job_id").on(table.jobId),
+    tenantJobIndex: index("idx_job_documents_tenant_job_id").on(
+      table.tenantId,
+      table.jobId,
+    ),
+  }),
+);
+
 export const postApplicationIntegrations = sqliteTable(
   "post_application_integrations",
   {
@@ -756,6 +783,8 @@ export type TaskRow = typeof tasks.$inferSelect;
 export type NewTaskRow = typeof tasks.$inferInsert;
 export type JobNoteRow = typeof jobNotes.$inferSelect;
 export type NewJobNoteRow = typeof jobNotes.$inferInsert;
+export type JobDocumentRow = typeof jobDocuments.$inferSelect;
+export type NewJobDocumentRow = typeof jobDocuments.$inferInsert;
 export type InterviewRow = typeof interviews.$inferSelect;
 export type NewInterviewRow = typeof interviews.$inferInsert;
 export type PipelineRunRow = typeof pipelineRuns.$inferSelect;

--- a/orchestrator/src/server/repositories/ghostwriter.ts
+++ b/orchestrator/src/server/repositories/ghostwriter.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { normalizeGhostwriterSelectedDocumentIds } from "@shared/ghostwriter-document-context.js";
 import { normalizeGhostwriterSelectedEmailIds } from "@shared/ghostwriter-email-context.js";
 import { normalizeGhostwriterSelectedNoteIds } from "@shared/ghostwriter-note-context.js";
 import type {
@@ -38,6 +39,13 @@ function parseSelectedNoteIds(value: string | null): string[] {
 
 function parseSelectedEmailIds(value: string | null): string[] {
   return parseSelectedContextIds(value, normalizeGhostwriterSelectedEmailIds);
+}
+
+function parseSelectedDocumentIds(value: string | null): string[] {
+  return parseSelectedContextIds(
+    value,
+    normalizeGhostwriterSelectedDocumentIds,
+  );
 }
 
 function parseImageAttachments(value: string | null): JobChatImageAttachment[] {
@@ -88,6 +96,7 @@ function mapThread(row: typeof jobChatThreads.$inferSelect): JobChatThread {
     activeRootMessageId: row.activeRootMessageId,
     selectedNoteIds: parseSelectedNoteIds(row.selectedNoteIds),
     selectedEmailIds: parseSelectedEmailIds(row.selectedEmailIds),
+    selectedDocumentIds: parseSelectedDocumentIds(row.selectedDocumentIds),
   };
 }
 
@@ -213,6 +222,7 @@ export async function createThread(input: {
     lastMessageAt: null,
     selectedNoteIds: "[]",
     selectedEmailIds: "[]",
+    selectedDocumentIds: "[]",
   });
 
   const thread = await getThreadById(id);
@@ -254,6 +264,7 @@ export async function updateThreadContext(input: {
   threadId: string;
   selectedNoteIds?: string[];
   selectedEmailIds?: string[];
+  selectedDocumentIds?: string[];
 }): Promise<JobChatThread | null> {
   const now = new Date().toISOString();
   const tenantId = getActiveTenantId();
@@ -272,6 +283,15 @@ export async function updateThreadContext(input: {
         ? {
             selectedEmailIds: JSON.stringify(
               normalizeGhostwriterSelectedEmailIds(input.selectedEmailIds),
+            ),
+          }
+        : {}),
+      ...(input.selectedDocumentIds !== undefined
+        ? {
+            selectedDocumentIds: JSON.stringify(
+              normalizeGhostwriterSelectedDocumentIds(
+                input.selectedDocumentIds,
+              ),
             ),
           }
         : {}),

--- a/orchestrator/src/server/repositories/job-documents.ts
+++ b/orchestrator/src/server/repositories/job-documents.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { JobDocument } from "@shared/types";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { db, schema } from "../db/index";
 import { getActiveTenantId } from "../tenancy/context";
 
@@ -92,6 +92,27 @@ export async function getJobDocumentForJob(
     );
 
   return row ? mapRowToJobDocument(row) : null;
+}
+
+export async function listJobDocumentsByIds(
+  jobId: string,
+  documentIds: readonly string[],
+): Promise<JobDocumentWithStorage[]> {
+  if (documentIds.length === 0) return [];
+
+  const tenantId = getActiveTenantId();
+  const rows = await db
+    .select()
+    .from(jobDocuments)
+    .where(
+      and(
+        eq(jobDocuments.tenantId, tenantId),
+        eq(jobDocuments.jobId, jobId),
+        inArray(jobDocuments.id, [...documentIds]),
+      ),
+    );
+
+  return rows.map(mapRowToJobDocument);
 }
 
 export async function deleteJobDocumentForJob(

--- a/orchestrator/src/server/repositories/job-documents.ts
+++ b/orchestrator/src/server/repositories/job-documents.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from "node:crypto";
+import type { JobDocument } from "@shared/types";
+import { and, desc, eq } from "drizzle-orm";
+import { db, schema } from "../db/index";
+import { getActiveTenantId } from "../tenancy/context";
+
+const { jobDocuments } = schema;
+
+type CreateJobDocumentInput = {
+  jobId: string;
+  fileName: string;
+  mediaType: string | null;
+  byteSize: number;
+  storagePath: string;
+};
+
+export type JobDocumentWithStorage = JobDocument & {
+  storagePath: string;
+};
+
+function mapRowToJobDocument(
+  row: typeof jobDocuments.$inferSelect,
+): JobDocumentWithStorage {
+  return {
+    id: row.id,
+    jobId: row.jobId,
+    fileName: row.fileName,
+    mediaType: row.mediaType ?? null,
+    byteSize: row.byteSize,
+    storagePath: row.storagePath,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export async function listJobDocuments(jobId: string): Promise<JobDocument[]> {
+  const tenantId = getActiveTenantId();
+  const rows = await db
+    .select()
+    .from(jobDocuments)
+    .where(
+      and(eq(jobDocuments.tenantId, tenantId), eq(jobDocuments.jobId, jobId)),
+    )
+    .orderBy(desc(jobDocuments.createdAt), desc(jobDocuments.id));
+
+  return rows
+    .map(mapRowToJobDocument)
+    .map(({ storagePath: _storagePath, ...document }) => document);
+}
+
+export async function createJobDocument(
+  input: CreateJobDocumentInput,
+): Promise<JobDocument> {
+  const tenantId = getActiveTenantId();
+  const now = new Date().toISOString();
+  const id = randomUUID();
+
+  await db.insert(jobDocuments).values({
+    id,
+    tenantId,
+    jobId: input.jobId,
+    fileName: input.fileName,
+    mediaType: input.mediaType,
+    byteSize: input.byteSize,
+    storagePath: input.storagePath,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  const document = await getJobDocumentForJob(input.jobId, id);
+  if (!document) {
+    throw new Error("Created job document could not be loaded.");
+  }
+  const { storagePath: _storagePath, ...publicDocument } = document;
+  return publicDocument;
+}
+
+export async function getJobDocumentForJob(
+  jobId: string,
+  documentId: string,
+): Promise<JobDocumentWithStorage | null> {
+  const tenantId = getActiveTenantId();
+  const [row] = await db
+    .select()
+    .from(jobDocuments)
+    .where(
+      and(
+        eq(jobDocuments.tenantId, tenantId),
+        eq(jobDocuments.jobId, jobId),
+        eq(jobDocuments.id, documentId),
+      ),
+    );
+
+  return row ? mapRowToJobDocument(row) : null;
+}
+
+export async function deleteJobDocumentForJob(
+  jobId: string,
+  documentId: string,
+): Promise<JobDocumentWithStorage | null> {
+  const document = await getJobDocumentForJob(jobId, documentId);
+  if (!document) return null;
+
+  const tenantId = getActiveTenantId();
+  await db
+    .delete(jobDocuments)
+    .where(
+      and(
+        eq(jobDocuments.tenantId, tenantId),
+        eq(jobDocuments.jobId, jobId),
+        eq(jobDocuments.id, documentId),
+      ),
+    );
+
+  return document;
+}

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -7,6 +7,10 @@ import {
 import { logger } from "@infra/logger";
 import { sanitizeUnknown } from "@infra/sanitize";
 import { getRequestId } from "@server/infra/request-context";
+import {
+  DocxTextExtractionError,
+  extractDocxText,
+} from "@server/services/document-text-extraction";
 import { GeminiCliClient } from "@server/services/llm/gemini-cli/client";
 import type { JsonSchemaDefinition } from "@server/services/llm/types";
 import { resolveLlmRuntimeSettings } from "@server/services/modelSelection";
@@ -15,9 +19,9 @@ import {
   getResumeSchemaValidationMessage,
   safeParseV5ResumeData,
 } from "@server/services/rxresume/schema";
+import { DOCX_MIME } from "@shared/job-document-classification.js";
 import type { DesignResumeDocument, DesignResumeJson } from "@shared/types";
 import { jsonrepair } from "jsonrepair";
-import JSZip from "jszip";
 import { buildHeaders, getResponseDetail, joinUrl } from "../llm/utils/http";
 import { parseErrorMessage, truncate } from "../llm/utils/string";
 import { replaceCurrentDesignResumeDocument } from "./index";
@@ -66,8 +70,6 @@ const MAX_IMPORT_FILE_BYTES = 10 * 1024 * 1024;
 const OPENAI_DEFAULT_TIMEOUT_MS = 60_000;
 const OPENROUTER_DEFAULT_TIMEOUT_MS = 90_000;
 const GEMINI_DEFAULT_TIMEOUT_MS = 90_000;
-const DOCX_MIME =
-  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
 const SUPPORTED_EXTENSION_TO_MEDIA_TYPE: Record<
   string,
@@ -526,49 +528,6 @@ ${JSON.stringify(template, null, 2)}
 `.trim();
 }
 
-function decodeXmlEntities(value: string): string {
-  return value.replace(
-    /&(?:#x([0-9a-fA-F]+)|#([0-9]+)|amp|lt|gt|quot|apos);/g,
-    (match, hex, dec) => {
-      if (hex) return String.fromCodePoint(Number.parseInt(hex, 16));
-      if (dec) return String.fromCodePoint(Number.parseInt(dec, 10));
-      switch (match) {
-        case "&amp;":
-          return "&";
-        case "&lt;":
-          return "<";
-        case "&gt;":
-          return ">";
-        case "&quot;":
-          return '"';
-        case "&apos;":
-          return "'";
-        default:
-          return match;
-      }
-    },
-  );
-}
-
-function normalizeDocxXmlText(xml: string): string {
-  return decodeXmlEntities(
-    xml
-      .replace(/<w:tab\b[^>]*\/>/g, "\t")
-      .replace(/<w:br\b[^>]*\/>/g, "\n")
-      .replace(/<w:cr\b[^>]*\/>/g, "\n")
-      .replace(/<\/w:p>/g, "\n")
-      .replace(/<\/w:tr>/g, "\n")
-      .replace(/<\/w:tc>/g, "\t")
-      .replace(/<w:t\b[^>]*>/g, "")
-      .replace(/<\/w:t>/g, "")
-      .replace(/<[^>]+>/g, ""),
-  )
-    .replace(/\r\n?/g, "\n")
-    .replace(/[ \t]+\n/g, "\n")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
 async function extractPdfText(decoded: Buffer): Promise<string> {
   try {
     const { default: pdfParse } = await import("pdf-parse");
@@ -586,21 +545,20 @@ async function extractPdfText(decoded: Buffer): Promise<string> {
   }
 }
 
-async function extractDocxText(decoded: Buffer): Promise<string> {
-  let zip: JSZip;
+async function extractResumeDocxText(decoded: Buffer): Promise<string> {
+  let text: string;
   try {
-    zip = await JSZip.loadAsync(decoded);
-  } catch {
+    text = await extractDocxText(decoded);
+  } catch (error) {
+    if (
+      error instanceof DocxTextExtractionError &&
+      error.code === "MISSING_DOCUMENT"
+    ) {
+      throw badRequest("Resume DOCX file is missing document content.");
+    }
     throw badRequest("Resume DOCX file could not be read.");
   }
 
-  const documentXml = zip.file("word/document.xml");
-  if (!documentXml) {
-    throw badRequest("Resume DOCX file is missing document content.");
-  }
-
-  const xml = await documentXml.async("string");
-  const text = normalizeDocxXmlText(xml);
   if (!text) {
     throw badRequest("Resume DOCX file did not contain readable text.");
   }
@@ -1253,7 +1211,7 @@ export async function importDesignResumeFromFile(
 
   try {
     let documentText: string | null =
-      mediaType === DOCX_MIME ? await extractDocxText(decoded) : null;
+      mediaType === DOCX_MIME ? await extractResumeDocxText(decoded) : null;
     if (isGeminiCli && mediaType === "application/pdf") {
       documentText = await extractPdfText(decoded);
     }

--- a/orchestrator/src/server/services/document-text-extraction.ts
+++ b/orchestrator/src/server/services/document-text-extraction.ts
@@ -1,0 +1,79 @@
+import JSZip from "jszip";
+
+export type DocxTextExtractionErrorCode = "INVALID_DOCX" | "MISSING_DOCUMENT";
+
+export class DocxTextExtractionError extends Error {
+  code: DocxTextExtractionErrorCode;
+
+  constructor(code: DocxTextExtractionErrorCode, message: string) {
+    super(message);
+    this.name = "DocxTextExtractionError";
+    this.code = code;
+  }
+}
+
+function decodeXmlEntities(value: string): string {
+  return value.replace(
+    /&(?:#x([0-9a-fA-F]+)|#([0-9]+)|amp|lt|gt|quot|apos);/g,
+    (match, hex, dec) => {
+      if (hex) return String.fromCodePoint(Number.parseInt(hex, 16));
+      if (dec) return String.fromCodePoint(Number.parseInt(dec, 10));
+      switch (match) {
+        case "&amp;":
+          return "&";
+        case "&lt;":
+          return "<";
+        case "&gt;":
+          return ">";
+        case "&quot;":
+          return '"';
+        case "&apos;":
+          return "'";
+        default:
+          return match;
+      }
+    },
+  );
+}
+
+export function normalizeDocxXmlText(xml: string): string {
+  return decodeXmlEntities(
+    xml
+      .replace(/<w:tab\b[^>]*\/>/g, "\t")
+      .replace(/<w:br\b[^>]*\/>/g, "\n")
+      .replace(/<w:cr\b[^>]*\/>/g, "\n")
+      .replace(/<\/w:p>/g, "\n")
+      .replace(/<\/w:tr>/g, "\n")
+      .replace(/<\/w:tc>/g, "\t")
+      .replace(/<w:t\b[^>]*>/g, "")
+      .replace(/<\/w:t>/g, "")
+      .replace(/<[^>]+>/g, ""),
+  )
+    .replace(/\r\n?/g, "\n")
+    .replace(/[ \t]+\n/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export async function extractDocxText(buffer: Buffer): Promise<string> {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(buffer);
+  } catch {
+    throw new DocxTextExtractionError(
+      "INVALID_DOCX",
+      "DOCX file could not be read.",
+    );
+  }
+
+  const documentXml = zip.file("word/document.xml");
+  if (!documentXml) {
+    throw new DocxTextExtractionError(
+      "MISSING_DOCUMENT",
+      "DOCX file is missing document content.",
+    );
+  }
+
+  const xml = await documentXml.async("string");
+  return normalizeDocxXmlText(xml);
+}

--- a/orchestrator/src/server/services/ghostwriter-context.test.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.test.ts
@@ -1,5 +1,6 @@
 import type { AppError } from "@infra/errors";
 import { createJob } from "@shared/testing/factories";
+import JSZip from "jszip";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildJobChatPromptContext } from "./ghostwriter-context";
 
@@ -434,6 +435,56 @@ describe("buildJobChatPromptContext", () => {
     );
     expect(context.selectedDocumentsSnapshot).not.toContain("skip.txt");
     expect(context.selectedDocumentsSnapshot).not.toContain("A".repeat(6001));
+  });
+
+  it("extracts DOCX documents for selected job document context", async () => {
+    const job = createJob({ id: "job-ctx-docx" });
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      `
+        <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+          <w:body>
+            <w:p><w:r><w:t>Interview pack</w:t></w:r></w:p>
+            <w:p><w:r><w:t>Discuss reliability &amp; incident response.</w:t></w:r></w:p>
+          </w:body>
+        </w:document>
+      `,
+    );
+
+    vi.mocked(getJobById).mockResolvedValue(job);
+    vi.mocked(getProfile).mockResolvedValue({});
+    vi.mocked(listJobDocumentsByIds).mockResolvedValue([
+      {
+        id: "doc-docx",
+        jobId: job.id,
+        fileName: "interview-pack.docx",
+        mediaType:
+          "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        byteSize: 2048,
+        storagePath: "/tmp/interview-pack.docx",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+    ]);
+    mocks.readFile.mockResolvedValue(
+      await zip.generateAsync({ type: "nodebuffer" }),
+    );
+
+    const context = await buildJobChatPromptContext(
+      job.id,
+      [],
+      [],
+      ["doc-docx"],
+    );
+
+    expect(context.selectedDocumentsSnapshot).toContain(
+      "Document 1: interview-pack.docx",
+    );
+    expect(context.selectedDocumentsSnapshot).toContain("Interview pack");
+    expect(context.selectedDocumentsSnapshot).toContain(
+      "Discuss reliability & incident response.",
+    );
   });
 
   it("throws not found for unknown job", async () => {

--- a/orchestrator/src/server/services/ghostwriter-context.test.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.test.ts
@@ -5,14 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildJobChatPromptContext } from "./ghostwriter-context";
 
 const mocks = vi.hoisted(() => ({
-  readFile: vi.fn(),
+  open: vi.fn(),
 }));
 
 vi.mock("node:fs/promises", () => ({
   default: {
-    readFile: mocks.readFile,
+    open: mocks.open,
   },
-  readFile: mocks.readFile,
+  open: mocks.open,
 }));
 
 vi.mock("../repositories/jobs", () => ({
@@ -52,12 +52,36 @@ import { listJobPostApplicationEmailsByIds } from "./post-application/job-emails
 import { getProfile } from "./profile";
 import { getWritingStyle } from "./writing-style";
 
+function mockDocumentFile(buffer: Buffer) {
+  const read = vi.fn(
+    async (
+      target: Buffer,
+      offset: number,
+      length: number,
+      position: number,
+    ) => {
+      const start = position ?? 0;
+      const bytesRead = buffer.copy(
+        target,
+        offset,
+        start,
+        Math.min(buffer.byteLength, start + length),
+      );
+      return { bytesRead, buffer: target };
+    },
+  );
+  const close = vi.fn(async () => undefined);
+
+  mocks.open.mockResolvedValue({ read, close });
+  return { read, close };
+}
+
 describe("buildJobChatPromptContext", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(listJobNotesByIds).mockResolvedValue([]);
     vi.mocked(listJobDocumentsByIds).mockResolvedValue([]);
-    mocks.readFile.mockResolvedValue(Buffer.from(""));
+    mockDocumentFile(Buffer.from(""));
     vi.mocked(listJobPostApplicationEmailsByIds).mockResolvedValue([]);
     vi.mocked(getSetting).mockResolvedValue(null);
     vi.mocked(getWritingStyle).mockResolvedValue({
@@ -418,12 +442,12 @@ describe("buildJobChatPromptContext", () => {
         updatedAt: "2026-01-02T00:00:00.000Z",
       },
     ]);
-    mocks.readFile.mockResolvedValue(Buffer.from("A".repeat(7000)));
+    mockDocumentFile(Buffer.from("A".repeat(7000)));
 
     const context = await buildJobChatPromptContext(job.id, [], [], ["doc-1"]);
 
     expect(listJobDocumentsByIds).toHaveBeenCalledWith(job.id, ["doc-1"]);
-    expect(mocks.readFile).toHaveBeenCalledWith("/tmp/take-home.md");
+    expect(mocks.open).toHaveBeenCalledWith("/tmp/take-home.md", "r");
     expect(context.selectedDocumentsSnapshot).toContain(
       "Selected Job Documents:",
     );
@@ -467,9 +491,7 @@ describe("buildJobChatPromptContext", () => {
         updatedAt: "2026-01-02T00:00:00.000Z",
       },
     ]);
-    mocks.readFile.mockResolvedValue(
-      await zip.generateAsync({ type: "nodebuffer" }),
-    );
+    mockDocumentFile(await zip.generateAsync({ type: "nodebuffer" }));
 
     const context = await buildJobChatPromptContext(
       job.id,
@@ -485,6 +507,36 @@ describe("buildJobChatPromptContext", () => {
     expect(context.selectedDocumentsSnapshot).toContain(
       "Discuss reliability & incident response.",
     );
+  });
+
+  it("reads only the configured document prefix for Ghostwriter context", async () => {
+    const job = createJob({ id: "job-ctx-document-prefix" });
+    vi.mocked(getJobById).mockResolvedValue(job);
+    vi.mocked(getProfile).mockResolvedValue({});
+    vi.mocked(listJobDocumentsByIds).mockResolvedValue([
+      {
+        id: "doc-large",
+        jobId: job.id,
+        fileName: "large.txt",
+        mediaType: "text/plain",
+        byteSize: 10 * 1024 * 1024,
+        storagePath: "/tmp/large.txt",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+    ]);
+    const { read, close } = mockDocumentFile(Buffer.from("A".repeat(7000)));
+
+    await buildJobChatPromptContext(job.id, [], [], ["doc-large"]);
+
+    expect(mocks.open).toHaveBeenCalledWith("/tmp/large.txt", "r");
+    expect(read).toHaveBeenCalledWith(
+      expect.any(Buffer),
+      0,
+      2 * 1024 * 1024,
+      0,
+    );
+    expect(close).toHaveBeenCalled();
   });
 
   it("throws not found for unknown job", async () => {

--- a/orchestrator/src/server/services/ghostwriter-context.test.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.test.ts
@@ -3,9 +3,24 @@ import { createJob } from "@shared/testing/factories";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { buildJobChatPromptContext } from "./ghostwriter-context";
 
+const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readFile: mocks.readFile,
+  },
+  readFile: mocks.readFile,
+}));
+
 vi.mock("../repositories/jobs", () => ({
   getJobById: vi.fn(),
   listJobNotesByIds: vi.fn(),
+}));
+
+vi.mock("../repositories/job-documents", () => ({
+  listJobDocumentsByIds: vi.fn(),
 }));
 
 vi.mock("./post-application/job-emails", () => ({
@@ -29,6 +44,7 @@ vi.mock("./writing-style", async (importOriginal) => {
   };
 });
 
+import { listJobDocumentsByIds } from "../repositories/job-documents";
 import { getJobById, listJobNotesByIds } from "../repositories/jobs";
 import { getSetting } from "../repositories/settings";
 import { listJobPostApplicationEmailsByIds } from "./post-application/job-emails";
@@ -39,6 +55,8 @@ describe("buildJobChatPromptContext", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(listJobNotesByIds).mockResolvedValue([]);
+    vi.mocked(listJobDocumentsByIds).mockResolvedValue([]);
+    mocks.readFile.mockResolvedValue(Buffer.from(""));
     vi.mocked(listJobPostApplicationEmailsByIds).mockResolvedValue([]);
     vi.mocked(getSetting).mockResolvedValue(null);
     vi.mocked(getWritingStyle).mockResolvedValue({
@@ -371,6 +389,51 @@ describe("buildJobChatPromptContext", () => {
     expect(context.selectedEmailsSnapshot).not.toContain("mail.google.com");
     expect(context.selectedEmailsSnapshot).not.toContain("Not selected");
     expect(context.selectedEmailsSnapshot).not.toContain("A".repeat(1301));
+  });
+
+  it("builds selected job documents context with shared truncation limits", async () => {
+    const job = createJob({ id: "job-ctx-documents" });
+    vi.mocked(getJobById).mockResolvedValue(job);
+    vi.mocked(getProfile).mockResolvedValue({});
+    vi.mocked(listJobDocumentsByIds).mockResolvedValue([
+      {
+        id: "doc-2",
+        jobId: job.id,
+        fileName: "skip.txt",
+        mediaType: "text/plain",
+        byteSize: 7,
+        storagePath: "/tmp/skip.txt",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "doc-1",
+        jobId: job.id,
+        fileName: "take-home.md",
+        mediaType: "text/markdown",
+        byteSize: 7000,
+        storagePath: "/tmp/take-home.md",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+    ]);
+    mocks.readFile.mockResolvedValue(Buffer.from("A".repeat(7000)));
+
+    const context = await buildJobChatPromptContext(job.id, [], [], ["doc-1"]);
+
+    expect(listJobDocumentsByIds).toHaveBeenCalledWith(job.id, ["doc-1"]);
+    expect(mocks.readFile).toHaveBeenCalledWith("/tmp/take-home.md");
+    expect(context.selectedDocumentsSnapshot).toContain(
+      "Selected Job Documents:",
+    );
+    expect(context.selectedDocumentsSnapshot).toContain(
+      "Document 1: take-home.md",
+    );
+    expect(context.selectedDocumentsSnapshot).toContain(
+      "Context note: document text trimmed for AI context limits.",
+    );
+    expect(context.selectedDocumentsSnapshot).not.toContain("skip.txt");
+    expect(context.selectedDocumentsSnapshot).not.toContain("A".repeat(6001));
   });
 
   it("throws not found for unknown job", async () => {

--- a/orchestrator/src/server/services/ghostwriter-context.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { open } from "node:fs/promises";
 import { badRequest, notFound } from "@infra/errors";
 import { logger } from "@infra/logger";
 import { sanitizeUnknown } from "@infra/sanitize";
@@ -241,19 +241,29 @@ async function buildSelectedEmailsSnapshot(
   ]);
 }
 
+async function readFilePrefix(path: string, maxBytes: number): Promise<Buffer> {
+  const file = await open(path, "r");
+  try {
+    const buffer = Buffer.alloc(maxBytes);
+    const { bytesRead } = await file.read(buffer, 0, maxBytes, 0);
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    await file.close();
+  }
+}
+
 async function extractDocumentText(
   document: jobDocumentsRepo.JobDocumentWithStorage,
 ): Promise<string> {
-  const buffer = await readFile(document.storagePath);
-  const limitedBuffer =
-    buffer.byteLength > MAX_DOCUMENT_READ_BYTES
-      ? buffer.subarray(0, MAX_DOCUMENT_READ_BYTES)
-      : buffer;
+  const buffer = await readFilePrefix(
+    document.storagePath,
+    MAX_DOCUMENT_READ_BYTES,
+  );
 
   if (isJobDocumentPdf(document)) {
     try {
       const { default: pdfParse } = await import("pdf-parse");
-      const result = await pdfParse(limitedBuffer);
+      const result = await pdfParse(buffer);
       return (result.text ?? "").trim();
     } catch (error) {
       logger.warn("Failed to extract Ghostwriter document PDF text", {
@@ -267,7 +277,7 @@ async function extractDocumentText(
 
   if (isJobDocumentDocx(document)) {
     try {
-      return await extractDocxText(limitedBuffer);
+      return await extractDocxText(buffer);
     } catch (error) {
       logger.warn("Failed to extract Ghostwriter document DOCX text", {
         jobId: document.jobId,
@@ -279,7 +289,7 @@ async function extractDocumentText(
   }
 
   if (isJobDocumentTextLike(document)) {
-    return limitedBuffer.toString("utf8").trim();
+    return buffer.toString("utf8").trim();
   }
 
   return "";

--- a/orchestrator/src/server/services/ghostwriter-context.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.ts
@@ -14,11 +14,18 @@ import {
   buildGhostwriterNoteContextItems,
   normalizeGhostwriterSelectedNoteIds,
 } from "@shared/ghostwriter-note-context.js";
+import {
+  canUseJobDocumentForTextContext,
+  isJobDocumentDocx,
+  isJobDocumentPdf,
+  isJobDocumentTextLike,
+} from "@shared/job-document-classification.js";
 import { settingsRegistry } from "@shared/settings-registry";
 import type { Job, JobDocument, ResumeProfile } from "@shared/types";
 import * as jobDocumentsRepo from "../repositories/job-documents";
 import * as jobsRepo from "../repositories/jobs";
 import * as settingsRepo from "../repositories/settings";
+import { extractDocxText } from "./document-text-extraction";
 import {
   getWritingLanguageLabel,
   resolveWritingOutputLanguage,
@@ -52,24 +59,6 @@ const MAX_PROJECTS = 6;
 const MAX_EXPERIENCE = 5;
 const MAX_ITEM_TEXT = 320;
 const MAX_DOCUMENT_READ_BYTES = 2 * 1024 * 1024;
-const TEXT_DOCUMENT_EXTENSIONS = new Set([
-  "txt",
-  "md",
-  "markdown",
-  "csv",
-  "tsv",
-  "json",
-  "log",
-]);
-const TEXT_DOCUMENT_MEDIA_TYPES = new Set([
-  "application/json",
-  "application/x-ndjson",
-  "application/xml",
-  "text/csv",
-  "text/markdown",
-  "text/plain",
-  "text/tab-separated-values",
-]);
 
 const STOP_SLOP_GHOSTWRITER_PROMPT = `
 Stop Slop revision rules for Ghostwriter prose:
@@ -97,33 +86,10 @@ function compactJoin(parts: Array<string | null | undefined>): string {
   return parts.filter(Boolean).join("\n");
 }
 
-function getDocumentExtension(fileName: string): string {
-  const extension = fileName.split(".").pop()?.trim().toLowerCase() ?? "";
-  return extension === fileName.toLowerCase() ? "" : extension;
-}
-
-function isPdfDocument(document: Pick<JobDocument, "fileName" | "mediaType">) {
-  return (
-    document.mediaType?.toLowerCase() === "application/pdf" ||
-    getDocumentExtension(document.fileName) === "pdf"
-  );
-}
-
-function isTextLikeDocument(
-  document: Pick<JobDocument, "fileName" | "mediaType">,
-) {
-  const mediaType = document.mediaType?.toLowerCase() ?? "";
-  return (
-    mediaType.startsWith("text/") ||
-    TEXT_DOCUMENT_MEDIA_TYPES.has(mediaType) ||
-    TEXT_DOCUMENT_EXTENSIONS.has(getDocumentExtension(document.fileName))
-  );
-}
-
 export function canUseJobDocumentForGhostwriterContext(
   document: Pick<JobDocument, "fileName" | "mediaType">,
 ): boolean {
-  return isPdfDocument(document) || isTextLikeDocument(document);
+  return canUseJobDocumentForTextContext(document);
 }
 
 function buildJobSnapshot(job: Job): string {
@@ -284,7 +250,7 @@ async function extractDocumentText(
       ? buffer.subarray(0, MAX_DOCUMENT_READ_BYTES)
       : buffer;
 
-  if (isPdfDocument(document)) {
+  if (isJobDocumentPdf(document)) {
     try {
       const { default: pdfParse } = await import("pdf-parse");
       const result = await pdfParse(limitedBuffer);
@@ -299,7 +265,20 @@ async function extractDocumentText(
     }
   }
 
-  if (isTextLikeDocument(document)) {
+  if (isJobDocumentDocx(document)) {
+    try {
+      return await extractDocxText(limitedBuffer);
+    } catch (error) {
+      logger.warn("Failed to extract Ghostwriter document DOCX text", {
+        jobId: document.jobId,
+        documentId: document.id,
+        error: sanitizeUnknown(error),
+      });
+      return "";
+    }
+  }
+
+  if (isJobDocumentTextLike(document)) {
     return limitedBuffer.toString("utf8").trim();
   }
 

--- a/orchestrator/src/server/services/ghostwriter-context.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.ts
@@ -1,6 +1,11 @@
+import { readFile } from "node:fs/promises";
 import { badRequest, notFound } from "@infra/errors";
 import { logger } from "@infra/logger";
 import { sanitizeUnknown } from "@infra/sanitize";
+import {
+  buildGhostwriterDocumentContextItems,
+  normalizeGhostwriterSelectedDocumentIds,
+} from "@shared/ghostwriter-document-context.js";
 import {
   buildGhostwriterEmailContextItems,
   normalizeGhostwriterSelectedEmailIds,
@@ -10,7 +15,8 @@ import {
   normalizeGhostwriterSelectedNoteIds,
 } from "@shared/ghostwriter-note-context.js";
 import { settingsRegistry } from "@shared/settings-registry";
-import type { Job, ResumeProfile } from "@shared/types";
+import type { Job, JobDocument, ResumeProfile } from "@shared/types";
+import * as jobDocumentsRepo from "../repositories/job-documents";
 import * as jobsRepo from "../repositories/jobs";
 import * as settingsRepo from "../repositories/settings";
 import {
@@ -36,6 +42,7 @@ export type JobChatPromptContext = {
   profileSnapshot: string;
   selectedNotesSnapshot: string;
   selectedEmailsSnapshot: string;
+  selectedDocumentsSnapshot: string;
 };
 
 const MAX_JOB_DESCRIPTION = 4000;
@@ -44,6 +51,25 @@ const MAX_SKILLS = 18;
 const MAX_PROJECTS = 6;
 const MAX_EXPERIENCE = 5;
 const MAX_ITEM_TEXT = 320;
+const MAX_DOCUMENT_READ_BYTES = 2 * 1024 * 1024;
+const TEXT_DOCUMENT_EXTENSIONS = new Set([
+  "txt",
+  "md",
+  "markdown",
+  "csv",
+  "tsv",
+  "json",
+  "log",
+]);
+const TEXT_DOCUMENT_MEDIA_TYPES = new Set([
+  "application/json",
+  "application/x-ndjson",
+  "application/xml",
+  "text/csv",
+  "text/markdown",
+  "text/plain",
+  "text/tab-separated-values",
+]);
 
 const STOP_SLOP_GHOSTWRITER_PROMPT = `
 Stop Slop revision rules for Ghostwriter prose:
@@ -69,6 +95,35 @@ function truncate(value: string | null | undefined, max: number): string {
 
 function compactJoin(parts: Array<string | null | undefined>): string {
   return parts.filter(Boolean).join("\n");
+}
+
+function getDocumentExtension(fileName: string): string {
+  const extension = fileName.split(".").pop()?.trim().toLowerCase() ?? "";
+  return extension === fileName.toLowerCase() ? "" : extension;
+}
+
+function isPdfDocument(document: Pick<JobDocument, "fileName" | "mediaType">) {
+  return (
+    document.mediaType?.toLowerCase() === "application/pdf" ||
+    getDocumentExtension(document.fileName) === "pdf"
+  );
+}
+
+function isTextLikeDocument(
+  document: Pick<JobDocument, "fileName" | "mediaType">,
+) {
+  const mediaType = document.mediaType?.toLowerCase() ?? "";
+  return (
+    mediaType.startsWith("text/") ||
+    TEXT_DOCUMENT_MEDIA_TYPES.has(mediaType) ||
+    TEXT_DOCUMENT_EXTENSIONS.has(getDocumentExtension(document.fileName))
+  );
+}
+
+export function canUseJobDocumentForGhostwriterContext(
+  document: Pick<JobDocument, "fileName" | "mediaType">,
+): boolean {
+  return isPdfDocument(document) || isTextLikeDocument(document);
 }
 
 function buildJobSnapshot(job: Job): string {
@@ -220,6 +275,78 @@ async function buildSelectedEmailsSnapshot(
   ]);
 }
 
+async function extractDocumentText(
+  document: jobDocumentsRepo.JobDocumentWithStorage,
+): Promise<string> {
+  const buffer = await readFile(document.storagePath);
+  const limitedBuffer =
+    buffer.byteLength > MAX_DOCUMENT_READ_BYTES
+      ? buffer.subarray(0, MAX_DOCUMENT_READ_BYTES)
+      : buffer;
+
+  if (isPdfDocument(document)) {
+    try {
+      const { default: pdfParse } = await import("pdf-parse");
+      const result = await pdfParse(limitedBuffer);
+      return (result.text ?? "").trim();
+    } catch (error) {
+      logger.warn("Failed to extract Ghostwriter document PDF text", {
+        jobId: document.jobId,
+        documentId: document.id,
+        error: sanitizeUnknown(error),
+      });
+      return "";
+    }
+  }
+
+  if (isTextLikeDocument(document)) {
+    return limitedBuffer.toString("utf8").trim();
+  }
+
+  return "";
+}
+
+async function buildSelectedDocumentsSnapshot(
+  jobId: string,
+  selectedDocumentIds: readonly string[],
+): Promise<string> {
+  const selectedDocuments = await listSelectedContextItems({
+    selectedIds: selectedDocumentIds,
+    normalize: normalizeGhostwriterSelectedDocumentIds,
+    listItems: (normalizedDocumentIds) =>
+      jobDocumentsRepo.listJobDocumentsByIds(jobId, normalizedDocumentIds),
+    getId: (document) => document.id,
+  });
+
+  if (selectedDocuments.length === 0) return "";
+
+  const documentsWithContent = await Promise.all(
+    selectedDocuments
+      .filter(canUseJobDocumentForGhostwriterContext)
+      .map(async (document) => ({
+        ...document,
+        content: await extractDocumentText(document),
+      })),
+  );
+  const context = buildGhostwriterDocumentContextItems(documentsWithContent);
+  if (context.items.length === 0) return "";
+
+  return compactJoin([
+    "Selected Job Documents:",
+    ...context.items.map((document, index) =>
+      compactJoin([
+        `Document ${index + 1}: ${document.fileName}`,
+        document.mediaType ? `Type: ${document.mediaType}` : null,
+        `Uploaded: ${document.createdAt}`,
+        document.wasTrimmed
+          ? "Context note: document text trimmed for AI context limits."
+          : null,
+        document.content ? `Content:\n${document.content}` : "Content: [empty]",
+      ]),
+    ),
+  ]);
+}
+
 async function buildSystemPrompt(
   style: WritingStyle,
   profile: ResumeProfile,
@@ -261,6 +388,7 @@ export async function buildJobChatPromptContext(
   jobId: string,
   selectedNoteIds: readonly string[] = [],
   selectedEmailIds: readonly string[] = [],
+  selectedDocumentIds: readonly string[] = [],
 ): Promise<JobChatPromptContext> {
   const job = await jobsRepo.getJobById(jobId);
   if (!job) {
@@ -285,11 +413,13 @@ export async function buildJobChatPromptContext(
     stopSlopEnabled,
     selectedNotesSnapshot,
     selectedEmailsSnapshot,
+    selectedDocumentsSnapshot,
   ] = await Promise.all([
     buildSystemPrompt(style, profile),
     isStopSlopEnabled(),
     buildSelectedNotesSnapshot(jobId, selectedNoteIds),
     buildSelectedEmailsSnapshot(jobId, selectedEmailIds),
+    buildSelectedDocumentsSnapshot(jobId, selectedDocumentIds),
   ]);
   const systemPrompt = stopSlopEnabled
     ? `${baseSystemPrompt}\n\n${STOP_SLOP_GHOSTWRITER_PROMPT}`
@@ -309,10 +439,13 @@ export async function buildJobChatPromptContext(
       profileChars: profileSnapshot.length,
       selectedNotesChars: selectedNotesSnapshot.length,
       selectedEmailsChars: selectedEmailsSnapshot.length,
+      selectedDocumentsChars: selectedDocumentsSnapshot.length,
       selectedNoteCount:
         normalizeGhostwriterSelectedNoteIds(selectedNoteIds).length,
       selectedEmailCount:
         normalizeGhostwriterSelectedEmailIds(selectedEmailIds).length,
+      selectedDocumentCount:
+        normalizeGhostwriterSelectedDocumentIds(selectedDocumentIds).length,
     }),
   });
 
@@ -324,5 +457,6 @@ export async function buildJobChatPromptContext(
     profileSnapshot,
     selectedNotesSnapshot,
     selectedEmailsSnapshot,
+    selectedDocumentsSnapshot,
   };
 }

--- a/orchestrator/src/server/services/ghostwriter.test.ts
+++ b/orchestrator/src/server/services/ghostwriter.test.ts
@@ -29,6 +29,9 @@ const mocks = vi.hoisted(() => ({
   jobsRepo: {
     listJobNotesByIds: vi.fn(),
   },
+  jobDocumentsRepo: {
+    listJobDocumentsByIds: vi.fn(),
+  },
   jobEmails: {
     listJobPostApplicationEmailsByIds: vi.fn(),
   },
@@ -53,6 +56,7 @@ vi.mock("@infra/request-context", () => ({
 
 vi.mock("./ghostwriter-context", () => ({
   buildJobChatPromptContext: mocks.buildJobChatPromptContext,
+  canUseJobDocumentForGhostwriterContext: vi.fn(() => true),
 }));
 
 vi.mock("../repositories/settings", () => ({
@@ -83,6 +87,10 @@ vi.mock("../repositories/ghostwriter", () => ({
 
 vi.mock("../repositories/jobs", () => ({
   listJobNotesByIds: mocks.jobsRepo.listJobNotesByIds,
+}));
+
+vi.mock("../repositories/job-documents", () => ({
+  listJobDocumentsByIds: mocks.jobDocumentsRepo.listJobDocumentsByIds,
 }));
 
 vi.mock("./post-application/job-emails", () => ({
@@ -118,6 +126,7 @@ const thread = {
   activeRootMessageId: "user-1",
   selectedNoteIds: [],
   selectedEmailIds: [],
+  selectedDocumentIds: [],
 };
 
 const baseUserMessage: JobChatMessage = {
@@ -181,9 +190,11 @@ describe("ghostwriter service", () => {
       profileSnapshot: "profile snapshot",
       selectedNotesSnapshot: "",
       selectedEmailsSnapshot: "",
+      selectedDocumentsSnapshot: "",
     });
 
     mocks.jobsRepo.listJobNotesByIds.mockResolvedValue([]);
+    mocks.jobDocumentsRepo.listJobDocumentsByIds.mockResolvedValue([]);
     mocks.jobEmails.listJobPostApplicationEmailsByIds.mockResolvedValue([]);
     mocks.repo.getOrCreateThreadForJob.mockResolvedValue(thread);
     mocks.repo.getThreadForJob.mockResolvedValue(thread);
@@ -354,6 +365,7 @@ describe("ghostwriter service", () => {
       profileSnapshot: "profile snapshot",
       selectedNotesSnapshot: "Selected Job Notes:\nNote 1: Recruiter call",
       selectedEmailsSnapshot: "",
+      selectedDocumentsSnapshot: "",
     });
     mocks.repo.createMessage
       .mockResolvedValueOnce(baseUserMessage)
@@ -375,10 +387,12 @@ describe("ghostwriter service", () => {
       threadId: "thread-1",
       selectedNoteIds: ["note-1"],
       selectedEmailIds: undefined,
+      selectedDocumentIds: undefined,
     });
     expect(mocks.buildJobChatPromptContext).toHaveBeenCalledWith(
       "job-1",
       ["note-1"],
+      [],
       [],
     );
     expect(mocks.llmCallJson.mock.calls[0][0].messages).toContainEqual({
@@ -459,6 +473,7 @@ describe("ghostwriter service", () => {
       profileSnapshot: "profile snapshot",
       selectedNotesSnapshot: "",
       selectedEmailsSnapshot: "Selected Job Emails:\nEmail 1: Interview update",
+      selectedDocumentsSnapshot: "",
     });
     mocks.repo.createMessage
       .mockResolvedValueOnce(baseUserMessage)
@@ -480,15 +495,101 @@ describe("ghostwriter service", () => {
       threadId: "thread-1",
       selectedNoteIds: undefined,
       selectedEmailIds: ["email-1"],
+      selectedDocumentIds: undefined,
     });
     expect(mocks.buildJobChatPromptContext).toHaveBeenCalledWith(
       "job-1",
       [],
       ["email-1"],
+      [],
     );
     expect(mocks.llmCallJson.mock.calls[0][0].messages).toContainEqual({
       role: "system",
       content: "Selected Job Emails:\nEmail 1: Interview update",
+    });
+  });
+
+  it("saves selected documents before building prompt context", async () => {
+    const assistantPartial: JobChatMessage = {
+      ...baseAssistantMessage,
+      id: "assistant-with-documents",
+      content: "",
+      status: "partial",
+    };
+    const assistantComplete: JobChatMessage = {
+      ...assistantPartial,
+      content: "Document-aware reply.",
+      status: "complete",
+    };
+    const threadWithDocuments = {
+      ...thread,
+      selectedDocumentIds: ["doc-1"],
+    };
+
+    mocks.jobDocumentsRepo.listJobDocumentsByIds.mockResolvedValue([
+      {
+        id: "doc-1",
+        jobId: "job-1",
+        fileName: "take-home.md",
+        mediaType: "text/markdown",
+        byteSize: 120,
+        storagePath: "/tmp/take-home.md",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    mocks.repo.updateThreadContext.mockResolvedValue(threadWithDocuments);
+    mocks.repo.getThreadForJob
+      .mockResolvedValueOnce(thread)
+      .mockResolvedValueOnce(threadWithDocuments);
+    mocks.buildJobChatPromptContext.mockResolvedValue({
+      job: { id: "job-1" },
+      style: {
+        tone: "professional",
+        formality: "medium",
+        constraints: "",
+        doNotUse: "",
+      },
+      systemPrompt: "system prompt",
+      jobSnapshot: '{"job":"snapshot"}',
+      profileSnapshot: "profile snapshot",
+      selectedNotesSnapshot: "",
+      selectedEmailsSnapshot: "",
+      selectedDocumentsSnapshot:
+        "Selected Job Documents:\nDocument 1: take-home.md",
+    });
+    mocks.repo.createMessage
+      .mockResolvedValueOnce(baseUserMessage)
+      .mockResolvedValueOnce(assistantPartial);
+    mocks.repo.updateMessage.mockResolvedValue(assistantComplete);
+    mocks.repo.getMessageById.mockResolvedValue(assistantComplete);
+
+    await sendMessageForJob({
+      jobId: "job-1",
+      content: "Use the document",
+      selectedDocumentIds: ["doc-1"],
+    });
+
+    expect(mocks.jobDocumentsRepo.listJobDocumentsByIds).toHaveBeenCalledWith(
+      "job-1",
+      ["doc-1"],
+    );
+    expect(mocks.repo.updateThreadContext).toHaveBeenCalledWith({
+      jobId: "job-1",
+      threadId: "thread-1",
+      selectedNoteIds: undefined,
+      selectedEmailIds: undefined,
+      selectedDocumentIds: ["doc-1"],
+    });
+    expect(mocks.buildJobChatPromptContext).toHaveBeenCalledWith(
+      "job-1",
+      [],
+      [],
+      ["doc-1"],
+    );
+    expect(mocks.llmCallJson.mock.calls[0][0].messages).toContainEqual({
+      role: "system",
+      content: "Selected Job Documents:\nDocument 1: take-home.md",
     });
   });
 
@@ -710,6 +811,22 @@ describe("ghostwriter service", () => {
         selectedEmailIds: Array.from(
           { length: 9 },
           (_, index) => `email-${index}`,
+        ),
+      }),
+    ).rejects.toMatchObject({
+      code: "INVALID_REQUEST",
+      status: 400,
+    });
+  });
+
+  it("rejects too many selected documents", async () => {
+    await expect(
+      sendMessageForJob({
+        jobId: "job-1",
+        content: "Use these",
+        selectedDocumentIds: Array.from(
+          { length: 6 },
+          (_, index) => `doc-${index}`,
         ),
       }),
     ).rejects.toMatchObject({

--- a/orchestrator/src/server/services/ghostwriter.ts
+++ b/orchestrator/src/server/services/ghostwriter.ts
@@ -8,6 +8,10 @@ import {
 import { logger } from "@infra/logger";
 import { getRequestId } from "@infra/request-context";
 import {
+  GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED,
+  normalizeGhostwriterSelectedDocumentIds,
+} from "@shared/ghostwriter-document-context.js";
+import {
   GHOSTWRITER_EMAIL_CONTEXT_MAX_SELECTED,
   normalizeGhostwriterSelectedEmailIds,
 } from "@shared/ghostwriter-email-context.js";
@@ -22,8 +26,12 @@ import type {
   JobChatRun,
 } from "@shared/types";
 import * as jobChatRepo from "../repositories/ghostwriter";
+import * as jobDocumentsRepo from "../repositories/job-documents";
 import * as jobsRepo from "../repositories/jobs";
-import { buildJobChatPromptContext } from "./ghostwriter-context";
+import {
+  buildJobChatPromptContext,
+  canUseJobDocumentForGhostwriterContext,
+} from "./ghostwriter-context";
 import { LlmService } from "./llm/service";
 import type { JsonSchemaDefinition } from "./llm/types";
 import { resolveLlmRuntimeSettings as resolveRuntimeLlmSettings } from "./modelSelection";
@@ -421,25 +429,83 @@ async function validateSelectedEmailIdsForJob(
   });
 }
 
+async function validateSelectedDocumentIdsForJob(
+  jobId: string,
+  selectedDocumentIds: readonly string[],
+): Promise<string[]> {
+  const normalizedIds =
+    normalizeGhostwriterSelectedDocumentIds(selectedDocumentIds);
+
+  if (normalizedIds.length > GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED) {
+    throw badRequest(
+      `Select up to ${GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED} documents for Ghostwriter context`,
+      {
+        maxSelectedDocuments: GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED,
+        selectedCount: normalizedIds.length,
+      },
+    );
+  }
+
+  if (normalizedIds.length === 0) return [];
+
+  const documents = await jobDocumentsRepo.listJobDocumentsByIds(
+    jobId,
+    normalizedIds,
+  );
+  const documentsById = new Map(
+    documents.map((document) => [document.id, document]),
+  );
+  const invalidDocumentIds = normalizedIds.filter(
+    (documentId) => !documentsById.has(documentId),
+  );
+  if (invalidDocumentIds.length > 0) {
+    throw badRequest("Selected documents must belong to this job", {
+      invalidDocumentIds,
+    });
+  }
+
+  const unsupportedDocumentIds = normalizedIds.filter((documentId) => {
+    const document = documentsById.get(documentId);
+    return document ? !canUseJobDocumentForGhostwriterContext(document) : false;
+  });
+  if (unsupportedDocumentIds.length > 0) {
+    throw badRequest(
+      "Selected documents must be PDFs or text-like files for Ghostwriter context",
+      { unsupportedDocumentIds },
+    );
+  }
+
+  return normalizedIds;
+}
+
 async function updateThreadContext(input: {
   jobId: string;
   threadId: string;
   selectedNoteIds?: readonly string[];
   selectedEmailIds?: readonly string[];
+  selectedDocumentIds?: readonly string[];
 }) {
-  const [selectedNoteIds, selectedEmailIds] = await Promise.all([
-    input.selectedNoteIds === undefined
-      ? Promise.resolve(undefined)
-      : validateSelectedNoteIdsForJob(input.jobId, input.selectedNoteIds),
-    input.selectedEmailIds === undefined
-      ? Promise.resolve(undefined)
-      : validateSelectedEmailIdsForJob(input.jobId, input.selectedEmailIds),
-  ]);
+  const [selectedNoteIds, selectedEmailIds, selectedDocumentIds] =
+    await Promise.all([
+      input.selectedNoteIds === undefined
+        ? Promise.resolve(undefined)
+        : validateSelectedNoteIdsForJob(input.jobId, input.selectedNoteIds),
+      input.selectedEmailIds === undefined
+        ? Promise.resolve(undefined)
+        : validateSelectedEmailIdsForJob(input.jobId, input.selectedEmailIds),
+      input.selectedDocumentIds === undefined
+        ? Promise.resolve(undefined)
+        : validateSelectedDocumentIdsForJob(
+            input.jobId,
+            input.selectedDocumentIds,
+          ),
+    ]);
   const thread = await jobChatRepo.updateThreadContext({
     jobId: input.jobId,
     threadId: input.threadId,
     selectedNoteIds,
     selectedEmailIds,
+    selectedDocumentIds,
   });
 
   if (!thread) {
@@ -465,6 +531,7 @@ export async function updateContextForJob(input: {
   jobId: string;
   selectedNoteIds?: readonly string[];
   selectedEmailIds?: readonly string[];
+  selectedDocumentIds?: readonly string[];
 }) {
   const thread = await ensureJobThread(input.jobId);
   const updatedThread = await updateThreadContext({
@@ -472,11 +539,13 @@ export async function updateContextForJob(input: {
     threadId: thread.id,
     selectedNoteIds: input.selectedNoteIds,
     selectedEmailIds: input.selectedEmailIds,
+    selectedDocumentIds: input.selectedDocumentIds,
   });
 
   return {
     selectedNoteIds: updatedThread.selectedNoteIds,
     selectedEmailIds: updatedThread.selectedEmailIds,
+    selectedDocumentIds: updatedThread.selectedDocumentIds,
   };
 }
 
@@ -524,6 +593,7 @@ export async function listMessagesForJob(input: {
   branches: BranchInfo[];
   selectedNoteIds: string[];
   selectedEmailIds: string[];
+  selectedDocumentIds: string[];
 }> {
   const thread = await ensureJobThread(input.jobId);
   const messages = await jobChatRepo.getActivePathFromRoot(thread.id);
@@ -533,6 +603,7 @@ export async function listMessagesForJob(input: {
     branches,
     selectedNoteIds: thread.selectedNoteIds,
     selectedEmailIds: thread.selectedEmailIds,
+    selectedDocumentIds: thread.selectedDocumentIds,
   };
 }
 
@@ -557,6 +628,7 @@ async function runAssistantReply(
       options.jobId,
       thread.selectedNoteIds,
       thread.selectedEmailIds,
+      thread.selectedDocumentIds,
     ),
     options.llmConfig ?? resolveLlmRuntimeSettings(),
     buildConversationMessages(options.threadId, options.parentMessageId),
@@ -648,6 +720,14 @@ async function runAssistantReply(
               {
                 role: "system" as const,
                 content: context.selectedEmailsSnapshot,
+              },
+            ]
+          : []),
+        ...(context.selectedDocumentsSnapshot
+          ? [
+              {
+                role: "system" as const,
+                content: context.selectedDocumentsSnapshot,
               },
             ]
           : []),
@@ -786,6 +866,7 @@ export async function sendMessage(input: {
   attachments?: readonly JobChatImageAttachment[];
   selectedNoteIds?: readonly string[];
   selectedEmailIds?: readonly string[];
+  selectedDocumentIds?: readonly string[];
   stream?: GenerateReplyOptions["stream"];
 }) {
   const content = input.content.trim();
@@ -799,13 +880,15 @@ export async function sendMessage(input: {
   }
   if (
     input.selectedNoteIds !== undefined ||
-    input.selectedEmailIds !== undefined
+    input.selectedEmailIds !== undefined ||
+    input.selectedDocumentIds !== undefined
   ) {
     await updateThreadContext({
       jobId: input.jobId,
       threadId: input.threadId,
       selectedNoteIds: input.selectedNoteIds,
       selectedEmailIds: input.selectedEmailIds,
+      selectedDocumentIds: input.selectedDocumentIds,
     });
   }
   const llmConfig = await resolveAndValidateImageInput(input.attachments);
@@ -862,6 +945,7 @@ export async function sendMessageForJob(input: {
   attachments?: readonly JobChatImageAttachment[];
   selectedNoteIds?: readonly string[];
   selectedEmailIds?: readonly string[];
+  selectedDocumentIds?: readonly string[];
   stream?: GenerateReplyOptions["stream"];
 }) {
   const thread = await ensureJobThread(input.jobId);
@@ -872,6 +956,7 @@ export async function sendMessageForJob(input: {
     attachments: input.attachments,
     selectedNoteIds: input.selectedNoteIds,
     selectedEmailIds: input.selectedEmailIds,
+    selectedDocumentIds: input.selectedDocumentIds,
     stream: input.stream,
   });
 }
@@ -882,6 +967,7 @@ export async function regenerateMessage(input: {
   assistantMessageId: string;
   selectedNoteIds?: readonly string[];
   selectedEmailIds?: readonly string[];
+  selectedDocumentIds?: readonly string[];
   stream?: GenerateReplyOptions["stream"];
 }) {
   const thread = await jobChatRepo.getThreadForJob(input.jobId, input.threadId);
@@ -890,13 +976,15 @@ export async function regenerateMessage(input: {
   }
   if (
     input.selectedNoteIds !== undefined ||
-    input.selectedEmailIds !== undefined
+    input.selectedEmailIds !== undefined ||
+    input.selectedDocumentIds !== undefined
   ) {
     await updateThreadContext({
       jobId: input.jobId,
       threadId: input.threadId,
       selectedNoteIds: input.selectedNoteIds,
       selectedEmailIds: input.selectedEmailIds,
+      selectedDocumentIds: input.selectedDocumentIds,
     });
   }
 
@@ -970,6 +1058,7 @@ export async function regenerateMessageForJob(input: {
   assistantMessageId: string;
   selectedNoteIds?: readonly string[];
   selectedEmailIds?: readonly string[];
+  selectedDocumentIds?: readonly string[];
   stream?: GenerateReplyOptions["stream"];
 }) {
   const thread = await ensureJobThread(input.jobId);
@@ -979,6 +1068,7 @@ export async function regenerateMessageForJob(input: {
     assistantMessageId: input.assistantMessageId,
     selectedNoteIds: input.selectedNoteIds,
     selectedEmailIds: input.selectedEmailIds,
+    selectedDocumentIds: input.selectedDocumentIds,
     stream: input.stream,
   });
 }
@@ -991,6 +1081,7 @@ export async function editMessage(input: {
   attachments?: readonly JobChatImageAttachment[];
   selectedNoteIds?: readonly string[];
   selectedEmailIds?: readonly string[];
+  selectedDocumentIds?: readonly string[];
   stream?: GenerateReplyOptions["stream"];
 }) {
   const content = input.content.trim();
@@ -1004,13 +1095,15 @@ export async function editMessage(input: {
   }
   if (
     input.selectedNoteIds !== undefined ||
-    input.selectedEmailIds !== undefined
+    input.selectedEmailIds !== undefined ||
+    input.selectedDocumentIds !== undefined
   ) {
     await updateThreadContext({
       jobId: input.jobId,
       threadId: input.threadId,
       selectedNoteIds: input.selectedNoteIds,
       selectedEmailIds: input.selectedEmailIds,
+      selectedDocumentIds: input.selectedDocumentIds,
     });
   }
   const llmConfig = await resolveAndValidateImageInput(input.attachments);
@@ -1078,6 +1171,7 @@ export async function editMessageForJob(input: {
   attachments?: readonly JobChatImageAttachment[];
   selectedNoteIds?: readonly string[];
   selectedEmailIds?: readonly string[];
+  selectedDocumentIds?: readonly string[];
   stream?: GenerateReplyOptions["stream"];
 }) {
   const thread = await ensureJobThread(input.jobId);
@@ -1089,6 +1183,7 @@ export async function editMessageForJob(input: {
     attachments: input.attachments,
     selectedNoteIds: input.selectedNoteIds,
     selectedEmailIds: input.selectedEmailIds,
+    selectedDocumentIds: input.selectedDocumentIds,
     stream: input.stream,
   });
 }

--- a/orchestrator/src/server/services/job-document-storage.ts
+++ b/orchestrator/src/server/services/job-document-storage.ts
@@ -1,0 +1,120 @@
+import { randomUUID } from "node:crypto";
+import { mkdir, rename, rm, writeFile } from "node:fs/promises";
+import { extname, join } from "node:path";
+import { badRequest } from "@infra/errors";
+import { getDataDir } from "@server/config/dataDir";
+import { getActiveTenantId } from "@server/tenancy/context";
+
+const MAX_JOB_DOCUMENT_BYTES = 10 * 1024 * 1024;
+
+export type StoredJobDocumentInput = {
+  jobId: string;
+  fileName: string;
+  mediaType?: string | null;
+  dataBase64: string;
+};
+
+function getTenantJobDocumentsDir(
+  jobId: string,
+  tenantId = getActiveTenantId(),
+): string {
+  return join(getDataDir(), "job-documents", tenantId, jobId);
+}
+
+export function normalizeJobDocumentFileName(fileName: string): string {
+  const trimmed = fileName.trim();
+  if (!trimmed) {
+    throw badRequest("Document upload requires a file name.");
+  }
+  if (trimmed.length > 255) {
+    throw badRequest("Document file names must be 255 characters or shorter.");
+  }
+  return trimmed;
+}
+
+export function normalizeJobDocumentMediaType(
+  mediaType?: string | null,
+): string | null {
+  const normalized = mediaType?.trim().toLowerCase() ?? "";
+  if (!normalized) return null;
+  if (normalized.length > 200) {
+    throw badRequest("Document media type must be 200 characters or shorter.");
+  }
+  return normalized;
+}
+
+export function decodeJobDocumentBase64(dataBase64: string): Buffer {
+  const trimmed = dataBase64.trim();
+  if (!trimmed) {
+    throw badRequest("Document upload requires file data.");
+  }
+
+  const normalized = trimmed.replace(/\s+/g, "");
+  if (
+    normalized.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
+  ) {
+    throw badRequest("Document file data must be valid base64.");
+  }
+
+  const paddingLength = normalized.endsWith("==")
+    ? 2
+    : normalized.endsWith("=")
+      ? 1
+      : 0;
+  const estimatedByteLength = (normalized.length / 4) * 3 - paddingLength;
+  if (estimatedByteLength > MAX_JOB_DOCUMENT_BYTES) {
+    throw badRequest("Documents must be 10 MB or smaller.");
+  }
+
+  const decoded = Buffer.from(normalized, "base64");
+  if (decoded.toString("base64") !== normalized) {
+    throw badRequest("Document file data must be valid base64.");
+  }
+  if (decoded.byteLength === 0) {
+    throw badRequest("Document file data must not be empty.");
+  }
+  if (decoded.byteLength > MAX_JOB_DOCUMENT_BYTES) {
+    throw badRequest("Documents must be 10 MB or smaller.");
+  }
+
+  return decoded;
+}
+
+export async function storeJobDocument(input: StoredJobDocumentInput): Promise<{
+  fileName: string;
+  mediaType: string | null;
+  byteSize: number;
+  storagePath: string;
+}> {
+  const fileName = normalizeJobDocumentFileName(input.fileName);
+  const mediaType = normalizeJobDocumentMediaType(input.mediaType);
+  const decoded = decodeJobDocumentBase64(input.dataBase64);
+  const documentsDir = getTenantJobDocumentsDir(input.jobId);
+  const extension = extname(fileName).slice(0, 32);
+  const storagePath = join(documentsDir, `${randomUUID()}${extension}`);
+  const tempPath = join(documentsDir, `${randomUUID()}.tmp`);
+
+  await mkdir(documentsDir, { recursive: true });
+
+  try {
+    await writeFile(tempPath, decoded);
+    await rename(tempPath, storagePath);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
+
+  return {
+    fileName,
+    mediaType,
+    byteSize: decoded.byteLength,
+    storagePath,
+  };
+}
+
+export async function removeStoredJobDocument(
+  storagePath: string,
+): Promise<void> {
+  await rm(storagePath, { force: true });
+}

--- a/orchestrator/src/server/services/job-document-storage.ts
+++ b/orchestrator/src/server/services/job-document-storage.ts
@@ -4,6 +4,7 @@ import { extname, join } from "node:path";
 import { badRequest } from "@infra/errors";
 import { getDataDir } from "@server/config/dataDir";
 import { getActiveTenantId } from "@server/tenancy/context";
+import { decodeBase64Upload } from "./upload-base64";
 
 const MAX_JOB_DOCUMENT_BYTES = 10 * 1024 * 1024;
 
@@ -43,44 +44,6 @@ export function normalizeJobDocumentMediaType(
   return normalized;
 }
 
-export function decodeJobDocumentBase64(dataBase64: string): Buffer {
-  const trimmed = dataBase64.trim();
-  if (!trimmed) {
-    throw badRequest("Document upload requires file data.");
-  }
-
-  const normalized = trimmed.replace(/\s+/g, "");
-  if (
-    normalized.length % 4 !== 0 ||
-    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
-  ) {
-    throw badRequest("Document file data must be valid base64.");
-  }
-
-  const paddingLength = normalized.endsWith("==")
-    ? 2
-    : normalized.endsWith("=")
-      ? 1
-      : 0;
-  const estimatedByteLength = (normalized.length / 4) * 3 - paddingLength;
-  if (estimatedByteLength > MAX_JOB_DOCUMENT_BYTES) {
-    throw badRequest("Documents must be 10 MB or smaller.");
-  }
-
-  const decoded = Buffer.from(normalized, "base64");
-  if (decoded.toString("base64") !== normalized) {
-    throw badRequest("Document file data must be valid base64.");
-  }
-  if (decoded.byteLength === 0) {
-    throw badRequest("Document file data must not be empty.");
-  }
-  if (decoded.byteLength > MAX_JOB_DOCUMENT_BYTES) {
-    throw badRequest("Documents must be 10 MB or smaller.");
-  }
-
-  return decoded;
-}
-
 export async function storeJobDocument(input: StoredJobDocumentInput): Promise<{
   fileName: string;
   mediaType: string | null;
@@ -89,7 +52,13 @@ export async function storeJobDocument(input: StoredJobDocumentInput): Promise<{
 }> {
   const fileName = normalizeJobDocumentFileName(input.fileName);
   const mediaType = normalizeJobDocumentMediaType(input.mediaType);
-  const decoded = decodeJobDocumentBase64(input.dataBase64);
+  const decoded = decodeBase64Upload({
+    dataBase64: input.dataBase64,
+    maxBytes: MAX_JOB_DOCUMENT_BYTES,
+    emptyMessage: "Document upload requires file data.",
+    invalidMessage: "Document file data must be valid base64.",
+    tooLargeMessage: "Documents must be 10 MB or smaller.",
+  });
   const documentsDir = getTenantJobDocumentsDir(input.jobId);
   const extension = extname(fileName).slice(0, 32);
   const storagePath = join(documentsDir, `${randomUUID()}${extension}`);

--- a/orchestrator/src/server/services/job-pdf-upload.ts
+++ b/orchestrator/src/server/services/job-pdf-upload.ts
@@ -3,6 +3,7 @@ import { mkdir, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { badRequest } from "@infra/errors";
 import { getTenantJobPdfPath, getTenantPdfDir } from "./pdf-storage";
+import { decodeBase64Upload } from "./upload-base64";
 
 type UploadJobPdfInput = {
   jobId: string;
@@ -46,56 +47,6 @@ function normalizePdfMediaType(input: {
   throw badRequest("Only PDF resumes are supported.");
 }
 
-function normalizeBase64Payload(dataBase64: string): string {
-  const trimmed = dataBase64.trim();
-  if (!trimmed) {
-    throw badRequest("Resume upload requires file data.");
-  }
-
-  const normalized = trimmed.replace(/\s+/g, "");
-  if (!normalized) {
-    throw badRequest("Resume upload requires file data.");
-  }
-
-  if (
-    normalized.length % 4 !== 0 ||
-    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
-  ) {
-    throw badRequest("Resume file data must be valid base64.");
-  }
-
-  const paddingLength = normalized.endsWith("==")
-    ? 2
-    : normalized.endsWith("=")
-      ? 1
-      : 0;
-  const estimatedByteLength = (normalized.length / 4) * 3 - paddingLength;
-  if (estimatedByteLength > MAX_UPLOAD_PDF_BYTES) {
-    throw badRequest("Resume PDFs must be 10 MB or smaller.");
-  }
-
-  return normalized;
-}
-
-function decodeBase64Payload(dataBase64: string): Buffer {
-  const normalized = normalizeBase64Payload(dataBase64);
-  const decoded = Buffer.from(normalized, "base64");
-
-  if (decoded.toString("base64") !== normalized) {
-    throw badRequest("Resume file data must be valid base64.");
-  }
-
-  if (decoded.byteLength === 0) {
-    throw badRequest("Resume file data must not be empty.");
-  }
-
-  if (decoded.byteLength > MAX_UPLOAD_PDF_BYTES) {
-    throw badRequest("Resume PDFs must be 10 MB or smaller.");
-  }
-
-  return decoded;
-}
-
 function assertPdfSignature(decoded: Buffer): void {
   if (decoded.byteLength < 5 || decoded.subarray(0, 5).toString() !== "%PDF-") {
     throw badRequest("Uploaded file must be a valid PDF.");
@@ -112,7 +63,13 @@ export async function uploadJobPdf(input: UploadJobPdfInput): Promise<{
     mediaType: input.mediaType,
   });
 
-  const decoded = decodeBase64Payload(input.dataBase64);
+  const decoded = decodeBase64Upload({
+    dataBase64: input.dataBase64,
+    maxBytes: MAX_UPLOAD_PDF_BYTES,
+    emptyMessage: "Resume upload requires file data.",
+    invalidMessage: "Resume file data must be valid base64.",
+    tooLargeMessage: "Resume PDFs must be 10 MB or smaller.",
+  });
   assertPdfSignature(decoded);
 
   const pdfDir = getTenantPdfDir();

--- a/orchestrator/src/server/services/upload-base64.ts
+++ b/orchestrator/src/server/services/upload-base64.ts
@@ -1,0 +1,59 @@
+import { badRequest } from "@infra/errors";
+
+type DecodeBase64UploadOptions = {
+  dataBase64: string;
+  maxBytes: number;
+  emptyMessage: string;
+  invalidMessage: string;
+  tooLargeMessage: string;
+};
+
+export function decodeBase64Upload({
+  dataBase64,
+  maxBytes,
+  emptyMessage,
+  invalidMessage,
+  tooLargeMessage,
+}: DecodeBase64UploadOptions): Buffer {
+  const trimmed = dataBase64.trim();
+  if (!trimmed) {
+    throw badRequest(emptyMessage);
+  }
+
+  const normalized = trimmed.replace(/\s+/g, "");
+  if (!normalized) {
+    throw badRequest(emptyMessage);
+  }
+
+  if (
+    normalized.length % 4 !== 0 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(normalized)
+  ) {
+    throw badRequest(invalidMessage);
+  }
+
+  const paddingLength = normalized.endsWith("==")
+    ? 2
+    : normalized.endsWith("=")
+      ? 1
+      : 0;
+  const estimatedByteLength = (normalized.length / 4) * 3 - paddingLength;
+  if (estimatedByteLength > maxBytes) {
+    throw badRequest(tooLargeMessage);
+  }
+
+  const decoded = Buffer.from(normalized, "base64");
+  if (decoded.toString("base64") !== normalized) {
+    throw badRequest(invalidMessage);
+  }
+
+  if (decoded.byteLength === 0) {
+    throw badRequest(emptyMessage);
+  }
+
+  if (decoded.byteLength > maxBytes) {
+    throw badRequest(tooLargeMessage);
+  }
+
+  return decoded;
+}

--- a/shared/src/ghostwriter-document-context.ts
+++ b/shared/src/ghostwriter-document-context.ts
@@ -1,0 +1,56 @@
+import {
+  buildGhostwriterContextBudgetItems,
+  normalizeGhostwriterSelectedContextIds,
+} from "./ghostwriter-context-utils";
+import type { JobDocument } from "./types";
+
+export const GHOSTWRITER_DOCUMENT_CONTEXT_MAX_SELECTED = 5;
+export const GHOSTWRITER_DOCUMENT_CONTEXT_MAX_DOCUMENT_CHARS = 6000;
+export const GHOSTWRITER_DOCUMENT_CONTEXT_MAX_TOTAL_CHARS = 12000;
+
+export type GhostwriterDocumentContextSource = JobDocument & {
+  content: string;
+};
+
+export type GhostwriterDocumentContextItem = {
+  id: string;
+  fileName: string;
+  mediaType: string | null;
+  byteSize: number;
+  createdAt: string;
+  content: string;
+  wasTrimmed: boolean;
+};
+
+export type GhostwriterDocumentContextBuildResult = {
+  items: GhostwriterDocumentContextItem[];
+  totalContentChars: number;
+  wasTotalTrimmed: boolean;
+};
+
+export function normalizeGhostwriterSelectedDocumentIds(
+  selectedDocumentIds: readonly string[],
+): string[] {
+  return normalizeGhostwriterSelectedContextIds(selectedDocumentIds);
+}
+
+export function buildGhostwriterDocumentContextItems(
+  documents: readonly GhostwriterDocumentContextSource[],
+): GhostwriterDocumentContextBuildResult {
+  const result = buildGhostwriterContextBudgetItems(documents, {
+    maxItemChars: GHOSTWRITER_DOCUMENT_CONTEXT_MAX_DOCUMENT_CHARS,
+    maxTotalChars: GHOSTWRITER_DOCUMENT_CONTEXT_MAX_TOTAL_CHARS,
+    getContent: (document) => document.content,
+    mapItem: ({ item, content, wasTrimmed }) => ({
+      id: item.id,
+      fileName: item.fileName,
+      mediaType: item.mediaType,
+      byteSize: item.byteSize,
+      createdAt: item.createdAt,
+      content,
+      wasTrimmed,
+    }),
+  });
+
+  return result;
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from "./ghostwriter-context-utils";
 export * from "./ghostwriter-document-context";
 export * from "./ghostwriter-email-context";
 export * from "./ghostwriter-note-context";
+export * from "./job-document-classification";
 export * from "./location-support";
 export * from "./types";
 export * from "./utils/type-conversion";

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./extractors";
 export * from "./ghostwriter-context-utils";
+export * from "./ghostwriter-document-context";
 export * from "./ghostwriter-email-context";
 export * from "./ghostwriter-note-context";
 export * from "./location-support";

--- a/shared/src/job-document-classification.ts
+++ b/shared/src/job-document-classification.ts
@@ -1,0 +1,69 @@
+import type { JobDocument } from "./types";
+
+export const DOCX_MIME =
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+const TEXT_DOCUMENT_EXTENSIONS = new Set([
+  "csv",
+  "docx",
+  "json",
+  "log",
+  "markdown",
+  "md",
+  "tsv",
+  "txt",
+  "xml",
+]);
+
+const TEXT_DOCUMENT_MEDIA_TYPES = new Set([
+  "application/json",
+  "application/x-ndjson",
+  "application/xml",
+  DOCX_MIME,
+  "text/csv",
+  "text/markdown",
+  "text/plain",
+  "text/tab-separated-values",
+]);
+
+export type JobDocumentTypeTarget = Pick<JobDocument, "fileName" | "mediaType">;
+
+export function getJobDocumentFileExtension(fileName: string): string {
+  const extension = fileName.toLowerCase().split(".").pop();
+  return extension && extension !== fileName.toLowerCase() ? extension : "";
+}
+
+export function isJobDocumentPdf(document: JobDocumentTypeTarget): boolean {
+  return (
+    document.mediaType?.toLowerCase() === "application/pdf" ||
+    getJobDocumentFileExtension(document.fileName) === "pdf"
+  );
+}
+
+export function isJobDocumentDocx(document: JobDocumentTypeTarget): boolean {
+  return (
+    document.mediaType?.toLowerCase() === DOCX_MIME ||
+    getJobDocumentFileExtension(document.fileName) === "docx"
+  );
+}
+
+export function isJobDocumentImage(document: JobDocumentTypeTarget): boolean {
+  return Boolean(document.mediaType?.toLowerCase().startsWith("image/"));
+}
+
+export function isJobDocumentTextLike(
+  document: JobDocumentTypeTarget,
+): boolean {
+  const mediaType = document.mediaType?.toLowerCase() ?? "";
+  return (
+    mediaType.startsWith("text/") ||
+    TEXT_DOCUMENT_MEDIA_TYPES.has(mediaType) ||
+    TEXT_DOCUMENT_EXTENSIONS.has(getJobDocumentFileExtension(document.fileName))
+  );
+}
+
+export function canUseJobDocumentForTextContext(
+  document: JobDocumentTypeTarget,
+): boolean {
+  return isJobDocumentPdf(document) || isJobDocumentTextLike(document);
+}

--- a/shared/src/job-document-classification.ts
+++ b/shared/src/job-document-classification.ts
@@ -26,6 +26,31 @@ const TEXT_DOCUMENT_MEDIA_TYPES = new Set([
   "text/tab-separated-values",
 ]);
 
+const RAW_TEXT_PREVIEW_EXTENSIONS = new Set(
+  [...TEXT_DOCUMENT_EXTENSIONS].filter((extension) => extension !== "docx"),
+);
+
+const RAW_TEXT_PREVIEW_MEDIA_TYPES = new Set(
+  [...TEXT_DOCUMENT_MEDIA_TYPES].filter((mediaType) => mediaType !== DOCX_MIME),
+);
+
+const SAFE_INLINE_IMAGE_MEDIA_TYPES = new Set([
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]);
+
+const SAFE_INLINE_IMAGE_EXTENSIONS_TO_MEDIA_TYPE = new Map([
+  ["avif", "image/avif"],
+  ["gif", "image/gif"],
+  ["jpeg", "image/jpeg"],
+  ["jpg", "image/jpeg"],
+  ["png", "image/png"],
+  ["webp", "image/webp"],
+]);
+
 export type JobDocumentTypeTarget = Pick<JobDocument, "fileName" | "mediaType">;
 
 export function getJobDocumentFileExtension(fileName: string): string {
@@ -51,6 +76,24 @@ export function isJobDocumentImage(document: JobDocumentTypeTarget): boolean {
   return Boolean(document.mediaType?.toLowerCase().startsWith("image/"));
 }
 
+export function getSafeInlineJobDocumentImageMediaType(
+  document: JobDocumentTypeTarget,
+): string | null {
+  const mediaType = document.mediaType?.toLowerCase() ?? "";
+  if (SAFE_INLINE_IMAGE_MEDIA_TYPES.has(mediaType)) return mediaType;
+  return (
+    SAFE_INLINE_IMAGE_EXTENSIONS_TO_MEDIA_TYPE.get(
+      getJobDocumentFileExtension(document.fileName),
+    ) ?? null
+  );
+}
+
+export function isJobDocumentSafeInlineImage(
+  document: JobDocumentTypeTarget,
+): boolean {
+  return Boolean(getSafeInlineJobDocumentImageMediaType(document));
+}
+
 export function isJobDocumentTextLike(
   document: JobDocumentTypeTarget,
 ): boolean {
@@ -66,4 +109,32 @@ export function canUseJobDocumentForTextContext(
   document: JobDocumentTypeTarget,
 ): boolean {
   return isJobDocumentPdf(document) || isJobDocumentTextLike(document);
+}
+
+export function canPreviewJobDocumentAsRawText(
+  document: JobDocumentTypeTarget,
+): boolean {
+  const mediaType = document.mediaType?.toLowerCase() ?? "";
+  return (
+    RAW_TEXT_PREVIEW_MEDIA_TYPES.has(mediaType) ||
+    RAW_TEXT_PREVIEW_EXTENSIONS.has(
+      getJobDocumentFileExtension(document.fileName),
+    )
+  );
+}
+
+export function getSafeInlineJobDocumentMediaType(
+  document: JobDocumentTypeTarget,
+): string | null {
+  if (isJobDocumentPdf(document)) return "application/pdf";
+  const imageMediaType = getSafeInlineJobDocumentImageMediaType(document);
+  if (imageMediaType) return imageMediaType;
+  if (canPreviewJobDocumentAsRawText(document)) return "text/plain";
+  return null;
+}
+
+export function canOpenJobDocumentInline(
+  document: JobDocumentTypeTarget,
+): boolean {
+  return Boolean(getSafeInlineJobDocumentMediaType(document));
 }

--- a/shared/src/types/chat.ts
+++ b/shared/src/types/chat.ts
@@ -32,6 +32,7 @@ export interface JobChatThread {
   activeRootMessageId: string | null;
   selectedNoteIds: string[];
   selectedEmailIds: string[];
+  selectedDocumentIds: string[];
 }
 
 export interface JobChatMessage {

--- a/shared/src/types/jobs.ts
+++ b/shared/src/types/jobs.ts
@@ -131,6 +131,16 @@ export interface JobNote {
   updatedAt: string;
 }
 
+export interface JobDocument {
+  id: string;
+  jobId: string;
+  fileName: string;
+  mediaType: string | null;
+  byteSize: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export type JobSource = ExtractorSourceId;
 
 export type JobPdfSource = "generated" | "uploaded";


### PR DESCRIPTION
## Summary
- Add tenant-scoped job document storage, upload/list/download/delete routes, and job-page UI for arbitrary attachments
- Render job documents in accordions with inline preview for PDFs, images, and text-like files, plus download and delete actions
- Keep resume PDF handling separate while exposing it in the job Documents section
- Expand the job page More Actions menu to match orchestrator job detail options, including PDF view/download and job description navigation
- Deduplicate shared document classification, DOCX text extraction, and selected-context token estimation logic

## Testing
- Added and updated server, client, and integration tests for document uploads, previews, deletions, Ghostwriter context selection, and job-page action parity
- Ran linting, type checks, client build, and the full orchestrator test suite successfully