### PR TITLE
Use Gemini JSON Schema structured outputs for Gmail sync

### DIFF
--- a/orchestrator/src/server/services/llm/providers/gemini.ts
+++ b/orchestrator/src/server/services/llm/providers/gemini.ts
@@ -21,8 +21,14 @@ export const geminiStrategy = createProviderStrategy({
 
     if (mode === "json_schema") {
       body.generationConfig = {
-        responseMimeType: "application/json",
-        responseSchema: toGeminiResponseSchema(jsonSchema.schema),
+        // Gemini JSON Schema structured outputs support nullable type arrays here.
+        // https://ai.google.dev/gemini-api/docs/structured-output#json_schemas
+        responseFormat: {
+          text: {
+            mimeType: "application/json",
+            schema: toGeminiJsonSchema(jsonSchema.schema),
+          },
+        },
       };
     } else if (mode === "json_object") {
       body.generationConfig = {
@@ -62,9 +68,9 @@ export const geminiStrategy = createProviderStrategy({
   },
 });
 
-function toGeminiResponseSchema(schema: unknown): unknown {
+function toGeminiJsonSchema(schema: unknown): unknown {
   if (Array.isArray(schema)) {
-    return schema.map((item) => toGeminiResponseSchema(item));
+    return schema.map((item) => toGeminiJsonSchema(item));
   }
   if (!schema || typeof schema !== "object") {
     return schema;
@@ -72,10 +78,17 @@ function toGeminiResponseSchema(schema: unknown): unknown {
 
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(schema)) {
-    // Gemini's responseSchema rejects JSON Schema's additionalProperties.
-    // Fix as part of #202.
-    if (key === "additionalProperties") continue;
-    out[key] = toGeminiResponseSchema(value);
+    out[key] = toGeminiJsonSchema(value);
+  }
+
+  const properties = out.properties;
+  if (
+    properties &&
+    typeof properties === "object" &&
+    !Array.isArray(properties) &&
+    !Object.hasOwn(out, "propertyOrdering")
+  ) {
+    out.propertyOrdering = Object.keys(properties);
   }
   return out;
 }

--- a/orchestrator/src/server/services/llm/providers/providers.test.ts
+++ b/orchestrator/src/server/services/llm/providers/providers.test.ts
@@ -193,7 +193,7 @@ describe("provider adapters", () => {
     ).toBe("gemini");
   });
 
-  it("strips unsupported additionalProperties keys from Gemini responseSchema", () => {
+  it("sends Gemini structured outputs through the JSON Schema responseFormat", () => {
     const request = geminiStrategy.buildRequest({
       mode: "json_schema",
       baseUrl: "https://generativelanguage.googleapis.com",
@@ -205,6 +205,11 @@ describe("provider adapters", () => {
         schema: {
           type: "object",
           properties: {
+            bestMatchIndex: {
+              type: ["integer", "null"],
+              description:
+                "Best matching active-job index from provided list, or null.",
+            },
             skills: {
               type: "array",
               items: {
@@ -218,7 +223,7 @@ describe("provider adapters", () => {
               },
             },
           },
-          required: ["skills"],
+          required: ["bestMatchIndex", "skills"],
           additionalProperties: false,
         },
       },
@@ -226,15 +231,27 @@ describe("provider adapters", () => {
 
     const generationConfig = (request.body as Record<string, unknown>)
       .generationConfig as Record<string, unknown>;
-    const responseSchema = generationConfig.responseSchema as Record<
+    const responseFormat = generationConfig.responseFormat as Record<
       string,
       unknown
     >;
+    const textFormat = responseFormat.text as Record<string, unknown>;
+    const responseSchema = textFormat.schema as Record<string, unknown>;
     const skills = (responseSchema.properties as Record<string, unknown>)
       .skills as Record<string, unknown>;
+    const bestMatchIndex = (
+      responseSchema.properties as Record<string, unknown>
+    ).bestMatchIndex as Record<string, unknown>;
     const itemSchema = skills.items as Record<string, unknown>;
 
-    expect(responseSchema.additionalProperties).toBeUndefined();
-    expect(itemSchema.additionalProperties).toBeUndefined();
+    expect(textFormat.mimeType).toBe("application/json");
+    expect(bestMatchIndex.type).toEqual(["integer", "null"]);
+    expect(responseSchema.additionalProperties).toBe(false);
+    expect(responseSchema.propertyOrdering).toEqual([
+      "bestMatchIndex",
+      "skills",
+    ]);
+    expect(itemSchema.additionalProperties).toBe(false);
+    expect(itemSchema.propertyOrdering).toEqual(["name", "keywords"]);
   });
 });


### PR DESCRIPTION
## Summary
- Switch Gemini structured-output requests to the current `responseFormat.text.schema` shape.
- Preserve nullable JSON Schema fields so the Gmail smart router can emit `null` where expected.
- Add `propertyOrdering` for Gemini object schemas and keep the provider test aligned with the updated request format.

## Testing
- Updated provider coverage to assert the Gemini request body uses `responseFormat.text.schema` and preserves nullable fields.
- Verified the provider test passes with the new schema shape.