### PR TITLE
Share LLM model selection between onboarding and settings

### DIFF
--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -18,7 +18,7 @@ const sidebars: SidebarsConfig = {
         "workflows/find-jobs-and-apply-workflow",
         "workflows/post-application-workflow",
         "workflows/add-an-extractor",
-        "workflows/add-a-visa-sponsor-provider",
+        // "workflows/add-a-visa-sponsor-provider",
       ],
     },
     {

--- a/orchestrator/src/client/components/LlmModelConfiguration.tsx
+++ b/orchestrator/src/client/components/LlmModelConfiguration.tsx
@@ -1,0 +1,544 @@
+import * as api from "@client/api";
+import { CodexAuthPanel } from "@client/components/CodexAuthPanel";
+import { GeminiCliSetupHint } from "@client/components/GeminiCliSetupHint";
+import { SettingsInput } from "@client/pages/settings/components/SettingsInput";
+import {
+  formatSecretHint,
+  getLlmProviderConfig,
+  LLM_PROVIDER_LABELS,
+  LLM_PROVIDERS,
+  type LlmProviderId,
+  supportsLlmModelSuggestions,
+} from "@client/pages/settings/utils";
+import { getDefaultModelForProvider } from "@shared/settings-registry";
+import type React from "react";
+import { useDeferredValue, useEffect, useState } from "react";
+import { SearchableDropdown } from "@/components/ui/searchable-dropdown";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+
+type TextFieldBinding = {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+};
+
+type LlmModelConfigurationProps = {
+  mode: "compact" | "settings";
+  disabled: boolean;
+  selectedProvider: LlmProviderId;
+  savedProvider?: string | null;
+  savedBaseUrl?: string | null;
+  apiKeyHint?: string | null;
+  effectiveModel?: string | null;
+  defaultModel?: string | null;
+  provider: TextFieldBinding;
+  baseUrl: TextFieldBinding;
+  apiKey: TextFieldBinding;
+  model: TextFieldBinding;
+  modelScorer?: TextFieldBinding;
+  modelTailoring?: TextFieldBinding;
+  modelProjectSelection?: TextFieldBinding;
+  validationSlot?: React.ReactNode;
+};
+
+export function LlmModelConfiguration({
+  mode,
+  disabled,
+  selectedProvider,
+  savedProvider,
+  savedBaseUrl,
+  apiKeyHint,
+  effectiveModel,
+  defaultModel,
+  provider,
+  baseUrl,
+  apiKey,
+  model,
+  modelScorer,
+  modelTailoring,
+  modelProjectSelection,
+  validationSlot,
+}: LlmModelConfigurationProps) {
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
+  const [isLoadingModels, setIsLoadingModels] = useState(false);
+  const [modelsError, setModelsError] = useState<string | null>(null);
+  const providerConfig = getLlmProviderConfig(selectedProvider);
+  const { showApiKey, showBaseUrl } = providerConfig;
+  const isCodexProvider = providerConfig.normalizedProvider === "codex";
+  const isGeminiCliProvider =
+    providerConfig.normalizedProvider === "gemini_cli";
+  const deferredProvider = useDeferredValue(selectedProvider);
+  const deferredBaseUrl = useDeferredValue(baseUrl.value);
+  const deferredApiKey = useDeferredValue(apiKey.value);
+  const supportsModelSuggestions =
+    supportsLlmModelSuggestions(selectedProvider);
+  const hasAvailableApiKey = showApiKey
+    ? Boolean(deferredApiKey.trim() || apiKeyHint)
+    : true;
+  const providerDefaultModel = getDefaultModelForProvider(
+    selectedProvider,
+    selectedProvider === savedProvider
+      ? (defaultModel ?? undefined)
+      : undefined,
+  );
+
+  useEffect(() => {
+    if (showBaseUrl) return;
+    if (baseUrl.value) {
+      baseUrl.onChange("");
+    }
+  }, [baseUrl, showBaseUrl]);
+
+  useEffect(() => {
+    if (!supportsModelSuggestions) {
+      setAvailableModels([]);
+      setModelsError(null);
+      setIsLoadingModels(false);
+      return;
+    }
+
+    if (!hasAvailableApiKey) {
+      setAvailableModels([]);
+      setModelsError(null);
+      setIsLoadingModels(false);
+      return;
+    }
+
+    let cancelled = false;
+    setIsLoadingModels(true);
+    setModelsError(null);
+
+    void api
+      .getLlmModels({
+        provider: deferredProvider,
+        baseUrl: showBaseUrl ? deferredBaseUrl.trim() || undefined : undefined,
+        apiKey: showApiKey ? deferredApiKey.trim() || undefined : undefined,
+      })
+      .then((models) => {
+        if (cancelled) return;
+        setAvailableModels(models);
+        setModelsError(null);
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setAvailableModels([]);
+        setModelsError(
+          error instanceof Error ? error.message : "Failed to load models.",
+        );
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setIsLoadingModels(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    deferredApiKey,
+    deferredBaseUrl,
+    deferredProvider,
+    hasAvailableApiKey,
+    showApiKey,
+    showBaseUrl,
+    supportsModelSuggestions,
+  ]);
+
+  const handleProviderChange = (value: string) => {
+    provider.onChange(value);
+    model.onChange("");
+    modelScorer?.onChange("");
+    modelTailoring?.onChange("");
+    modelProjectSelection?.onChange("");
+  };
+
+  const formattedKeyHint = formatSecretHint(apiKeyHint ?? null);
+  const hasSavedKey = Boolean(apiKeyHint);
+  const keyText = showApiKey ? formattedKeyHint : "Not required";
+  const resolvedBaseUrl = baseUrl.value.trim() || savedBaseUrl || "-";
+  const selectedDefaultModel = model.value.trim();
+  const previewDefaultModel =
+    selectedDefaultModel || effectiveModel || providerDefaultModel || "-";
+  const selectedScoringModel = modelScorer?.value.trim() ?? "";
+  const selectedTailoringModel = modelTailoring?.value.trim() ?? "";
+  const selectedProjectSelectionModel =
+    modelProjectSelection?.value.trim() ?? "";
+  const scoringModel = selectedScoringModel || previewDefaultModel;
+  const tailoringModel = selectedTailoringModel || previewDefaultModel;
+  const projectSelectionModel =
+    selectedProjectSelectionModel || previewDefaultModel;
+  const modelHelper = supportsModelSuggestions
+    ? !hasAvailableApiKey
+      ? `Add or save a ${providerConfig.label} API key to load available models.`
+      : isLoadingModels
+        ? "Loading available models..."
+        : modelsError
+          ? modelsError
+          : availableModels.length > 0
+            ? "Choose from the available text-generation models."
+            : "No text-generation models were returned."
+    : `Type the exact model name manually, or leave blank to use the ${providerConfig.label} default model.`;
+  const defaultModelOptions = buildModelOptions({
+    models: availableModels,
+    emptyLabel: `Use ${providerConfig.label} default`,
+    emptyValue: "",
+    fallbackValue: model.value.trim(),
+  });
+  const scoringModelOptions = buildModelOptions({
+    models: availableModels,
+    emptyLabel: "Inherit default model",
+    emptyValue: "",
+    fallbackValue: modelScorer?.value.trim(),
+  });
+  const tailoringModelOptions = buildModelOptions({
+    models: availableModels,
+    emptyLabel: "Inherit default model",
+    emptyValue: "",
+    fallbackValue: modelTailoring?.value.trim(),
+  });
+  const projectSelectionModelOptions = buildModelOptions({
+    models: availableModels,
+    emptyLabel: "Inherit default model",
+    emptyValue: "",
+    fallbackValue: modelProjectSelection?.value.trim(),
+  });
+  const providerGridClass =
+    mode === "compact"
+      ? "grid gap-5 lg:grid-cols-2"
+      : "grid gap-4 md:grid-cols-2";
+  const providerHintClass =
+    mode === "compact"
+      ? "text-sm text-muted-foreground"
+      : "text-xs text-muted-foreground";
+
+  return (
+    <div className="space-y-4">
+      <div className={mode === "compact" ? "space-y-6" : "space-y-4"}>
+        <div className="space-y-4">
+          {mode === "settings" ? (
+            <div className="text-sm font-medium">LLM Provider</div>
+          ) : null}
+          <div className={providerGridClass}>
+            <div className="space-y-2">
+              <label htmlFor="llmProvider" className="text-sm font-medium">
+                Provider
+              </label>
+              <Select
+                value={selectedProvider}
+                onValueChange={handleProviderChange}
+                disabled={disabled}
+              >
+                <SelectTrigger
+                  id="llmProvider"
+                  className={mode === "compact" ? "h-10" : undefined}
+                >
+                  <SelectValue placeholder="Select provider" />
+                </SelectTrigger>
+                <SelectContent>
+                  {LLM_PROVIDERS.map((llmProvider) => (
+                    <SelectItem key={llmProvider} value={llmProvider}>
+                      {LLM_PROVIDER_LABELS[llmProvider]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {provider.error ? (
+                <p className="text-xs text-destructive">{provider.error}</p>
+              ) : null}
+              {mode === "settings" ? (
+                <p className="text-xs text-muted-foreground">
+                  Used for scoring, tailoring, and extraction.
+                </p>
+              ) : null}
+              <p className={providerHintClass}>{providerConfig.providerHint}</p>
+              {isCodexProvider ? <CodexAuthPanel isBusy={disabled} /> : null}
+              {isGeminiCliProvider ? <GeminiCliSetupHint /> : null}
+            </div>
+            {showBaseUrl ? (
+              <SettingsInput
+                label={mode === "compact" ? "Base URL" : "LLM base URL"}
+                inputProps={{
+                  name: "llmBaseUrl",
+                  value: baseUrl.value,
+                  onChange: (event) => baseUrl.onChange(event.target.value),
+                }}
+                placeholder={providerConfig.baseUrlPlaceholder}
+                disabled={disabled}
+                error={baseUrl.error}
+                helper={providerConfig.baseUrlHelper}
+                current={mode === "settings" ? resolvedBaseUrl : undefined}
+              />
+            ) : null}
+            {showApiKey ? (
+              <SettingsInput
+                label={mode === "compact" ? "API key" : "LLM API key"}
+                inputProps={{
+                  name: "llmApiKey",
+                  value: apiKey.value,
+                  onChange: (event) => apiKey.onChange(event.target.value),
+                }}
+                type="password"
+                placeholder={
+                  mode === "compact" ? "Paste a new key" : "Enter new key"
+                }
+                disabled={disabled}
+                error={apiKey.error}
+                helper={renderKeyHelper(
+                  providerConfig.keyHelperText,
+                  providerConfig.keyHelperHref,
+                  hasSavedKey,
+                )}
+                current={mode === "settings" ? formattedKeyHint : undefined}
+              />
+            ) : mode === "compact" ? (
+              <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 px-4 py-4 text-sm text-muted-foreground">
+                No API key is required for this provider.
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {mode === "compact" ? validationSlot : null}
+      </div>
+
+      <Separator />
+
+      <ModelField
+        id="model"
+        label="Default model"
+        value={model.value}
+        onChange={model.onChange}
+        error={model.error}
+        supportsModelSuggestions={supportsModelSuggestions}
+        options={defaultModelOptions}
+        placeholder={providerDefaultModel || "Select a model"}
+        helper={modelHelper}
+        current={previewDefaultModel}
+        disabled={disabled || isLoadingModels}
+      />
+
+      {mode === "settings" ? (
+        <>
+          <Separator />
+
+          <div className="space-y-4">
+            <div className="text-sm font-medium">Task-Specific Overrides</div>
+
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              <ModelField
+                id="modelScorer"
+                label="Scoring Model"
+                value={modelScorer?.value ?? ""}
+                onChange={(value) => modelScorer?.onChange(value)}
+                error={modelScorer?.error}
+                supportsModelSuggestions={supportsModelSuggestions}
+                options={scoringModelOptions}
+                placeholder={previewDefaultModel || "Inherit default model"}
+                current={scoringModel}
+                disabled={disabled || isLoadingModels}
+              />
+              <ModelField
+                id="modelTailoring"
+                label="Tailoring Model"
+                value={modelTailoring?.value ?? ""}
+                onChange={(value) => modelTailoring?.onChange(value)}
+                error={modelTailoring?.error}
+                supportsModelSuggestions={supportsModelSuggestions}
+                options={tailoringModelOptions}
+                placeholder={previewDefaultModel || "Inherit default model"}
+                current={tailoringModel}
+                disabled={disabled || isLoadingModels}
+              />
+              <ModelField
+                id="modelProjectSelection"
+                label="Project Selection Model"
+                value={modelProjectSelection?.value ?? ""}
+                onChange={(value) => modelProjectSelection?.onChange(value)}
+                error={modelProjectSelection?.error}
+                supportsModelSuggestions={supportsModelSuggestions}
+                options={projectSelectionModelOptions}
+                placeholder={previewDefaultModel || "Inherit default model"}
+                current={projectSelectionModel}
+                disabled={disabled || isLoadingModels}
+              />
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="space-y-3 text-sm">
+            <div className="text-xs text-muted-foreground">Resolved config</div>
+            <div className="grid gap-x-4 gap-y-2 text-xs sm:grid-cols-[160px_1fr]">
+              <div className="text-muted-foreground">Provider</div>
+              <div className="font-mono">{selectedProvider || "-"}</div>
+
+              <div className="text-muted-foreground">Base URL</div>
+              <div className="font-mono">{resolvedBaseUrl}</div>
+
+              <div className="text-muted-foreground">API key</div>
+              <div className="font-mono">{keyText}</div>
+
+              <div className="text-muted-foreground">Default model</div>
+              <div className="font-mono">{previewDefaultModel}</div>
+
+              <div className="text-muted-foreground">Scoring model</div>
+              <div className="font-mono">
+                {selectedScoringModel ? scoringModel : "inherits"}
+              </div>
+
+              <div className="text-muted-foreground">Tailoring model</div>
+              <div className="font-mono">
+                {selectedTailoringModel ? tailoringModel : "inherits"}
+              </div>
+
+              <div className="text-muted-foreground">Project selection</div>
+              <div className="font-mono">
+                {selectedProjectSelectionModel
+                  ? projectSelectionModel
+                  : "inherits"}
+              </div>
+            </div>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function ModelField({
+  id,
+  label,
+  value,
+  onChange,
+  error,
+  supportsModelSuggestions,
+  options,
+  placeholder,
+  helper,
+  current,
+  disabled,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+  supportsModelSuggestions: boolean;
+  options: Array<{ value: string; label: string; searchText: string }>;
+  placeholder: string;
+  helper?: React.ReactNode;
+  current: string;
+  disabled: boolean;
+}) {
+  if (supportsModelSuggestions) {
+    return (
+      <div className="space-y-2">
+        <label htmlFor={id} className="text-sm font-medium">
+          {label}
+        </label>
+        <SearchableDropdown
+          inputId={id}
+          value={value}
+          options={options}
+          onValueChange={onChange}
+          placeholder={placeholder}
+          searchPlaceholder="Search models..."
+          emptyText="No models found."
+          ariaLabel={label}
+          disabled={disabled}
+          triggerClassName="h-9 w-full justify-between rounded-md border border-input bg-transparent px-3 text-sm font-normal shadow-sm"
+          contentClassName="w-[var(--radix-popover-trigger-width)] border-border bg-popover p-0"
+          listClassName="max-h-64"
+        />
+        {error ? <p className="text-xs text-destructive">{error}</p> : null}
+        {helper ? (
+          <div className="text-xs text-muted-foreground">{helper}</div>
+        ) : null}
+        <div className="text-xs text-muted-foreground">
+          Current: <span className="font-mono">{current}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <SettingsInput
+      label={label}
+      inputProps={{
+        name: id,
+        value,
+        onChange: (event) => onChange(event.target.value),
+      }}
+      placeholder={placeholder}
+      disabled={disabled}
+      error={error}
+      helper={helper}
+      current={current}
+    />
+  );
+}
+
+function renderKeyHelper(
+  helperText: string,
+  helperHref: string | null,
+  keepSavedKey: boolean,
+) {
+  return (
+    <>
+      {helperHref ? (
+        <a
+          href={helperHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
+        >
+          {helperText}
+        </a>
+      ) : (
+        helperText
+      )}
+      {keepSavedKey ? ". Leave blank to keep the saved key." : null}
+    </>
+  );
+}
+
+function buildModelOptions(input: {
+  models: string[];
+  emptyLabel: string;
+  emptyValue: string;
+  fallbackValue?: string;
+}) {
+  const options = [
+    {
+      value: input.emptyValue,
+      label: input.emptyLabel,
+      searchText: input.emptyLabel,
+    },
+    ...input.models.map((model) => ({
+      value: model,
+      label: model,
+      searchText: model,
+    })),
+  ];
+
+  const fallbackValue = input.fallbackValue?.trim();
+  if (
+    fallbackValue &&
+    !options.some((option) => option.value === fallbackValue)
+  ) {
+    options.unshift({
+      value: fallbackValue,
+      label: fallbackValue,
+      searchText: `${fallbackValue} custom`,
+    });
+  }
+
+  return options;
+}

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@client/api", () => ({
   getCodexAuthStatus: vi.fn(),
   startCodexAuth: vi.fn(),
   disconnectCodexAuth: vi.fn(),
+  getLlmModels: vi.fn(),
   validateLlm: vi.fn(),
   validateRxresume: vi.fn(),
   validateResumeConfig: vi.fn(),
@@ -67,6 +68,10 @@ const baseSettings = {
   llmProvider: { value: "openrouter", default: "openrouter", override: null },
   llmBaseUrl: { value: "", default: "", override: null },
   llmApiKeyHint: "sk-t",
+  model: { value: "gpt-4o", default: "gpt-4o", override: null },
+  modelScorer: { value: "gpt-4o", override: null },
+  modelTailoring: { value: "gpt-4o", override: null },
+  modelProjectSelection: { value: "gpt-4o", override: null },
   pdfRenderer: { value: "rxresume", default: "rxresume", override: null },
   onboardingBasicAuthDecision: null,
   rxresumeUrl: "https://resume.example.com",
@@ -158,6 +163,7 @@ describe("OnboardingPage", () => {
       terms: ["Platform Engineer", "Backend Engineer"],
       source: "ai",
     });
+    vi.mocked(api.getLlmModels).mockResolvedValue([]);
     vi.mocked(api.getCodexAuthStatus).mockResolvedValue({
       authenticated: false,
       username: null,
@@ -208,9 +214,87 @@ describe("OnboardingPage", () => {
       screen.getByText("Choose the LLM connection Job Ops should use."),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("API key")).toBeInTheDocument();
+    expect(screen.getByLabelText("Default model")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Task-Specific Overrides"),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText(/leave blank to keep the saved key/i),
     ).toBeInTheDocument();
+  });
+
+  it("saves the selected default model from onboarding", async () => {
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateRxresume).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateResumeConfig).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.updateSettings).mockResolvedValue(baseSettings as any);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Choose the LLM connection Job Ops should use."),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.change(screen.getByLabelText("Default model"), {
+      target: { value: "google/gemini-3-flash-preview" },
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /revalidate connection/i }),
+    );
+
+    await waitFor(() => {
+      expect(api.updateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: "google/gemini-3-flash-preview",
+          modelScorer: null,
+          modelTailoring: null,
+          modelProjectSelection: null,
+        }),
+      );
+    });
+  });
+
+  it("uses a saved API key hint when loading onboarding model suggestions", async () => {
+    currentSettings = {
+      ...baseSettings,
+      llmProvider: { value: "openai", default: "openai", override: null },
+      llmApiKeyHint: "sk-t",
+      model: { value: "gpt-4o", default: "gpt-4o", override: null },
+    };
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateRxresume).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateResumeConfig).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.getLlmModels).mockResolvedValue(["gpt-4.1"]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(api.getLlmModels).toHaveBeenCalledWith({
+        provider: "openai",
+        baseUrl: undefined,
+        apiKey: undefined,
+      });
+    });
   });
 
   it("shows Codex sign-in controls in onboarding when provider is codex", async () => {
@@ -822,6 +906,11 @@ describe("OnboardingPage", () => {
     await waitFor(() => {
       expect(api.updateSettings).toHaveBeenCalled();
     });
+    expect(api.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: null,
+      }),
+    );
 
     expect(
       screen.getByText("Choose the LLM connection Job Ops should use."),

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -108,8 +108,9 @@ export const OnboardingPage: React.FC = () => {
                     basicAuthChoice={flow.basicAuthChoice}
                     basicAuthPassword={flow.watch("basicAuthPassword")}
                     basicAuthUser={flow.watch("basicAuthUser")}
-                    control={flow.control}
                     currentStep={flow.currentStep}
+                    defaultModel={flow.settings?.model?.default}
+                    effectiveModel={flow.settings?.model?.value}
                     hasSavedSearchTermsInSession={
                       flow.hasSavedSearchTermsInSession
                     }
@@ -118,8 +119,11 @@ export const OnboardingPage: React.FC = () => {
                     isImportingResume={flow.isImportingResume}
                     isResumeReady={flow.baseResumeValidation.valid}
                     isRxResumeSelfHosted={flow.isRxResumeSelfHosted}
+                    llmApiKey={flow.watch("llmApiKey")}
+                    llmBaseUrl={flow.watch("llmBaseUrl")}
                     llmKeyHint={flow.llmKeyHint}
                     llmValidation={flow.llmValidation}
+                    model={flow.watch("model")}
                     resumeSetupMode={flow.resumeSetupMode}
                     rxresumeApiKey={flow.watch("rxresumeApiKey")}
                     rxresumeApiKeyHint={flow.settings?.rxresumeApiKeyHint}
@@ -129,7 +133,23 @@ export const OnboardingPage: React.FC = () => {
                     searchTerms={flow.watch("searchTerms")}
                     searchTermsSource={flow.searchTermsSource}
                     searchTermsStale={flow.searchTermsStale}
+                    savedBaseUrl={flow.settings?.llmBaseUrl?.value}
+                    savedProvider={flow.settings?.llmProvider?.value}
                     selectedProvider={flow.selectedProvider}
+                    onLlmApiKeyChange={(value) =>
+                      flow.setValue("llmApiKey", value, { shouldDirty: true })
+                    }
+                    onLlmBaseUrlChange={(value) =>
+                      flow.setValue("llmBaseUrl", value, { shouldDirty: true })
+                    }
+                    onLlmModelChange={(value) =>
+                      flow.setValue("model", value, { shouldDirty: true })
+                    }
+                    onLlmProviderChange={(value) =>
+                      flow.setValue("llmProvider", value, {
+                        shouldDirty: true,
+                      })
+                    }
                     onBasicAuthChoiceChange={flow.setBasicAuthChoice}
                     onBasicAuthPasswordChange={(value) =>
                       flow.setValue("basicAuthPassword", value)

--- a/orchestrator/src/client/pages/onboarding/components/LlmConnectionStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/LlmConnectionStep.tsx
@@ -1,153 +1,79 @@
-import { CodexAuthPanel } from "@client/components/CodexAuthPanel";
-import { GeminiCliSetupHint } from "@client/components/GeminiCliSetupHint";
-import { SettingsInput } from "@client/pages/settings/components/SettingsInput";
+import { LlmModelConfiguration } from "@client/components/LlmModelConfiguration";
 import {
   getLlmProviderConfig,
-  LLM_PROVIDER_LABELS,
-  LLM_PROVIDERS,
   type LlmProviderId,
 } from "@client/pages/settings/utils";
 import type React from "react";
-import { type Control, Controller } from "react-hook-form";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import type { OnboardingFormData, ValidationState } from "../types";
+import type { ValidationState } from "../types";
 import { InlineValidation } from "./InlineValidation";
 
-function renderKeyHelper(
-  helperText: string,
-  helperHref: string | null,
-  keepSavedKey: boolean,
-) {
-  return (
-    <>
-      {helperHref ? (
-        <a
-          href={helperHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
-        >
-          {helperText}
-        </a>
-      ) : (
-        helperText
-      )}
-      {keepSavedKey ? ". Leave blank to keep the saved key." : null}
-    </>
-  );
-}
-
 export const LlmConnectionStep: React.FC<{
-  control: Control<OnboardingFormData>;
+  apiKey: string;
+  baseUrl: string;
+  defaultModel: string | null | undefined;
+  effectiveModel: string | null | undefined;
   isBusy: boolean;
   llmKeyHint: string | null;
+  model: string;
+  savedBaseUrl: string | null | undefined;
+  savedProvider: string | null | undefined;
   selectedProvider: LlmProviderId;
   validation: ValidationState;
-}> = ({ control, isBusy, llmKeyHint, selectedProvider, validation }) => {
+  onApiKeyChange: (value: string) => void;
+  onBaseUrlChange: (value: string) => void;
+  onModelChange: (value: string) => void;
+  onProviderChange: (value: string) => void;
+}> = ({
+  apiKey,
+  baseUrl,
+  defaultModel,
+  effectiveModel,
+  isBusy,
+  llmKeyHint,
+  model,
+  savedBaseUrl,
+  savedProvider,
+  selectedProvider,
+  validation,
+  onApiKeyChange,
+  onBaseUrlChange,
+  onModelChange,
+  onProviderChange,
+}) => {
   const providerConfig = getLlmProviderConfig(selectedProvider);
-  const { showApiKey, showBaseUrl } = providerConfig;
-  const isCodexProvider = providerConfig.normalizedProvider === "codex";
-  const isGeminiCliProvider =
-    providerConfig.normalizedProvider === "gemini_cli";
 
   return (
-    <div className="space-y-6">
-      <div className="grid gap-5 lg:grid-cols-2">
-        <div className="space-y-2">
-          <label htmlFor="llmProvider" className="text-sm font-medium">
-            Provider
-          </label>
-          <Controller
-            name="llmProvider"
-            control={control}
-            render={({ field }) => (
-              <Select
-                value={selectedProvider}
-                onValueChange={(value) => field.onChange(value)}
-                disabled={isBusy}
-              >
-                <SelectTrigger id="llmProvider" className="h-10">
-                  <SelectValue placeholder="Select provider" />
-                </SelectTrigger>
-                <SelectContent>
-                  {LLM_PROVIDERS.map((provider) => (
-                    <SelectItem key={provider} value={provider}>
-                      {LLM_PROVIDER_LABELS[provider]}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          />
-          <p className="text-sm text-muted-foreground">
-            {providerConfig.providerHint}
-          </p>
-          {isCodexProvider ? <CodexAuthPanel isBusy={isBusy} /> : null}
-          {isGeminiCliProvider ? <GeminiCliSetupHint /> : null}
-        </div>
-
-        {showBaseUrl ? (
-          <Controller
-            name="llmBaseUrl"
-            control={control}
-            render={({ field }) => (
-              <SettingsInput
-                label="Base URL"
-                inputProps={{
-                  name: "llmBaseUrl",
-                  value: field.value,
-                  onChange: field.onChange,
-                }}
-                placeholder={providerConfig.baseUrlPlaceholder}
-                helper={providerConfig.baseUrlHelper}
-                disabled={isBusy}
-              />
-            )}
-          />
-        ) : null}
-      </div>
-
-      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
-        {showApiKey ? (
-          <Controller
-            name="llmApiKey"
-            control={control}
-            render={({ field }) => (
-              <SettingsInput
-                label="API key"
-                inputProps={{
-                  name: "llmApiKey",
-                  value: field.value,
-                  onChange: field.onChange,
-                }}
-                type="password"
-                placeholder="Paste a new key"
-                helper={renderKeyHelper(
-                  providerConfig.keyHelperText,
-                  providerConfig.keyHelperHref,
-                  Boolean(llmKeyHint),
-                )}
-                disabled={isBusy}
-              />
-            )}
-          />
-        ) : (
-          <div className="rounded-lg border border-dashed border-border/60 bg-muted/20 px-4 py-4 text-sm text-muted-foreground">
-            No API key is required for this provider.
-          </div>
-        )}
-      </div>
-
-      <InlineValidation
-        state={validation}
-        successMessage={`${providerConfig.label} connection verified.`}
-      />
-    </div>
+    <LlmModelConfiguration
+      mode="compact"
+      disabled={isBusy}
+      selectedProvider={selectedProvider}
+      savedProvider={savedProvider}
+      savedBaseUrl={savedBaseUrl}
+      apiKeyHint={llmKeyHint}
+      effectiveModel={effectiveModel}
+      defaultModel={defaultModel}
+      provider={{
+        value: selectedProvider,
+        onChange: onProviderChange,
+      }}
+      baseUrl={{
+        value: baseUrl,
+        onChange: onBaseUrlChange,
+      }}
+      apiKey={{
+        value: apiKey,
+        onChange: onApiKeyChange,
+      }}
+      model={{
+        value: model,
+        onChange: onModelChange,
+      }}
+      validationSlot={
+        <InlineValidation
+          state={validation}
+          successMessage={`${providerConfig.label} connection verified.`}
+        />
+      }
+    />
   );
 };

--- a/orchestrator/src/client/pages/onboarding/components/OnboardingStepContent.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/OnboardingStepContent.tsx
@@ -1,10 +1,8 @@
 import type { LlmProviderId } from "@client/pages/settings/utils";
 import type { SearchTermsSuggestionResponse } from "@shared/types.js";
 import type React from "react";
-import type { Control } from "react-hook-form";
 import type {
   BasicAuthChoice,
-  OnboardingFormData,
   ResumeSetupMode,
   StepId,
   ValidationState,
@@ -20,15 +18,19 @@ export const OnboardingStepContent: React.FC<{
   basicAuthChoice: BasicAuthChoice;
   basicAuthPassword: string;
   basicAuthUser: string;
-  control: Control<OnboardingFormData>;
   currentStep: StepId;
+  defaultModel: string | null | undefined;
+  effectiveModel: string | null | undefined;
   isBusy: boolean;
   isImportingResume: boolean;
   isGeneratingSearchTerms: boolean;
   isResumeReady: boolean;
   isRxResumeSelfHosted: boolean;
   hasSavedSearchTermsInSession: boolean;
+  llmApiKey: string;
+  llmBaseUrl: string;
   llmKeyHint: string | null;
+  model: string;
   llmValidation: ValidationState;
   resumeSetupMode: ResumeSetupMode;
   rxresumeApiKey: string;
@@ -39,7 +41,13 @@ export const OnboardingStepContent: React.FC<{
   searchTerms: string[];
   searchTermsSource: SearchTermsSuggestionResponse["source"] | null;
   searchTermsStale: boolean;
+  savedBaseUrl: string | null | undefined;
+  savedProvider: string | null | undefined;
   selectedProvider: LlmProviderId;
+  onLlmApiKeyChange: (value: string) => void;
+  onLlmBaseUrlChange: (value: string) => void;
+  onLlmModelChange: (value: string) => void;
+  onLlmProviderChange: (value: string) => void;
   onBasicAuthChoiceChange: (choice: BasicAuthChoice) => void;
   onBasicAuthPasswordChange: (value: string) => void;
   onBasicAuthUserChange: (value: string) => void;
@@ -56,11 +64,21 @@ export const OnboardingStepContent: React.FC<{
   if (props.currentStep === "llm") {
     return (
       <LlmConnectionStep
-        control={props.control}
+        apiKey={props.llmApiKey}
+        baseUrl={props.llmBaseUrl}
+        defaultModel={props.defaultModel}
+        effectiveModel={props.effectiveModel}
         isBusy={props.isBusy}
         llmKeyHint={props.llmKeyHint}
+        model={props.model}
+        savedBaseUrl={props.savedBaseUrl}
+        savedProvider={props.savedProvider}
         selectedProvider={props.selectedProvider}
         validation={props.llmValidation}
+        onApiKeyChange={props.onLlmApiKeyChange}
+        onBaseUrlChange={props.onLlmBaseUrlChange}
+        onModelChange={props.onLlmModelChange}
+        onProviderChange={props.onLlmProviderChange}
       />
     );
   }

--- a/orchestrator/src/client/pages/onboarding/types.ts
+++ b/orchestrator/src/client/pages/onboarding/types.ts
@@ -9,6 +9,7 @@ export type OnboardingFormData = {
   llmProvider: string;
   llmBaseUrl: string;
   llmApiKey: string;
+  model: string;
   pdfRenderer: PdfRenderer;
   rxresumeUrl: string;
   rxresumeApiKey: string;

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -86,6 +86,7 @@ export function useOnboardingFlow() {
         llmProvider: "",
         llmBaseUrl: "",
         llmApiKey: "",
+        model: "",
         pdfRenderer: "latex",
         rxresumeUrl: "",
         rxresumeApiKey: "",
@@ -119,6 +120,7 @@ export function useOnboardingFlow() {
       llmProvider: settings.llmProvider?.value || "",
       llmBaseUrl: settings.llmBaseUrl?.value || "",
       llmApiKey: "",
+      model: settings.model?.override ?? "",
       pdfRenderer: selectedId ? "rxresume" : "latex",
       rxresumeUrl: settings.rxresumeUrl ?? "",
       rxresumeApiKey: "",
@@ -392,6 +394,7 @@ export function useOnboardingFlow() {
     const values = getValues();
     const apiKeyValue = values.llmApiKey.trim();
     const baseUrlValue = values.llmBaseUrl.trim();
+    const modelValue = values.model.trim();
 
     if (requiresLlmKey && !apiKeyValue && !hasLlmKey) {
       toast.info("Add your LLM API key to continue");
@@ -408,7 +411,7 @@ export function useOnboardingFlow() {
     const update: Partial<UpdateSettingsInput> = {
       llmProvider: normalizedProvider,
       llmBaseUrl: showBaseUrl ? baseUrlValue || null : null,
-      model: null,
+      model: modelValue || null,
       modelScorer: null,
       modelTailoring: null,
       modelProjectSelection: null,
@@ -425,10 +428,11 @@ export function useOnboardingFlow() {
       setValue("llmApiKey", "");
       const defaultModel = getDefaultModelForProvider(normalizedProvider);
       toast.success("LLM provider connected", {
-        description:
-          normalizedProvider === "openai" ||
-          normalizedProvider === "gemini" ||
-          normalizedProvider === "gemini_cli"
+        description: modelValue
+          ? `Default model: ${modelValue}.`
+          : normalizedProvider === "openai" ||
+              normalizedProvider === "gemini" ||
+              normalizedProvider === "gemini_cli"
             ? `Default for ${providerConfig.label}: ${defaultModel}.`
             : "You can fine-tune models later in Settings.",
       });

--- a/orchestrator/src/client/pages/settings/components/ModelSettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/ModelSettingsSection.tsx
@@ -1,30 +1,13 @@
-import * as api from "@client/api";
-import { CodexAuthPanel } from "@client/components/CodexAuthPanel";
-import { GeminiCliSetupHint } from "@client/components/GeminiCliSetupHint";
-import { SettingsInput } from "@client/pages/settings/components/SettingsInput";
+import { LlmModelConfiguration } from "@client/components/LlmModelConfiguration";
 import { SettingsSectionFrame } from "@client/pages/settings/components/SettingsSectionFrame";
 import type { ModelValues } from "@client/pages/settings/types";
 import {
-  formatSecretHint,
-  getLlmProviderConfig,
-  LLM_PROVIDER_LABELS,
-  LLM_PROVIDERS,
-  supportsLlmModelSuggestions,
+  type LlmProviderId,
+  normalizeLlmProvider,
 } from "@client/pages/settings/utils";
-import { getDefaultModelForProvider } from "@shared/settings-registry";
 import type { UpdateSettingsInput } from "@shared/settings-schema.js";
 import type React from "react";
-import { useDeferredValue, useEffect, useRef, useState } from "react";
-import { Controller, useFormContext } from "react-hook-form";
-import { SearchableDropdown } from "@/components/ui/searchable-dropdown";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
+import { useFormContext } from "react-hook-form";
 
 type ModelSettingsSectionProps = {
   values: ModelValues;
@@ -33,563 +16,88 @@ type ModelSettingsSectionProps = {
   layoutMode?: "accordion" | "panel";
 };
 
-function renderKeyHelper(
-  helperText: string,
-  helperHref: string | null,
-  keepSavedKey: boolean,
-) {
-  return (
-    <>
-      {helperHref ? (
-        <a
-          href={helperHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline decoration-border underline-offset-4 transition-colors hover:text-foreground"
-        >
-          {helperText}
-        </a>
-      ) : (
-        helperText
-      )}
-      {keepSavedKey ? ". Leave blank to keep the saved key." : null}
-    </>
-  );
-}
-
 export const ModelSettingsSection: React.FC<ModelSettingsSectionProps> = ({
   values,
   isLoading,
   isSaving,
   layoutMode,
 }) => {
-  const [availableModels, setAvailableModels] = useState<string[]>([]);
-  const [isLoadingModels, setIsLoadingModels] = useState(false);
-  const [modelsError, setModelsError] = useState<string | null>(null);
   const {
-    effective,
-    default: defaultModel,
-    llmProvider,
-    llmBaseUrl,
-    llmApiKeyHint,
-  } = values;
-  const {
-    register,
-    control,
     watch,
     setValue,
-    formState: { errors, dirtyFields },
+    formState: { errors },
   } = useFormContext<UpdateSettingsInput>();
-
-  const selectedProvider = watch("llmProvider") || llmProvider || "openrouter";
-  const previousProviderRef = useRef(selectedProvider);
-  const providerConfig = getLlmProviderConfig(selectedProvider);
-  const { showApiKey, showBaseUrl } = providerConfig;
-  const isCodexProvider = providerConfig.normalizedProvider === "codex";
-  const isGeminiCliProvider =
-    providerConfig.normalizedProvider === "gemini_cli";
-
-  const llmBaseUrlValue = watch("llmBaseUrl");
-  const llmApiKeyValue = watch("llmApiKey") ?? "";
-  const modelValue = watch("model") ?? "";
-  const modelScorerValue = watch("modelScorer") ?? "";
-  const modelTailoringValue = watch("modelTailoring") ?? "";
-  const modelProjectSelectionValue = watch("modelProjectSelection") ?? "";
-  const providerDefaultModel = getDefaultModelForProvider(
-    selectedProvider,
-    selectedProvider === llmProvider ? defaultModel : undefined,
+  const selectedProvider = normalizeLlmProvider(
+    watch("llmProvider") || values.llmProvider || "openrouter",
   );
-  const deferredProvider = useDeferredValue(selectedProvider);
-  const deferredBaseUrl = useDeferredValue(llmBaseUrlValue ?? "");
-  const deferredApiKey = useDeferredValue(llmApiKeyValue);
-  const supportsModelSuggestions =
-    supportsLlmModelSuggestions(selectedProvider);
-  const hasAvailableApiKey = showApiKey
-    ? Boolean(deferredApiKey.trim() || llmApiKeyHint)
-    : true;
+  const disabled = isLoading || isSaving;
 
-  useEffect(() => {
-    if (showBaseUrl) return;
-    if (llmBaseUrlValue) {
-      setValue("llmBaseUrl", "", { shouldDirty: true });
-    }
-  }, [setValue, showBaseUrl, llmBaseUrlValue]);
-
-  useEffect(() => {
-    if (previousProviderRef.current === selectedProvider) {
-      return;
-    }
-
-    previousProviderRef.current = selectedProvider;
-    if (!dirtyFields.llmProvider) {
-      return;
-    }
-
-    setValue("model", "", { shouldDirty: true });
-    setValue("modelScorer", "", { shouldDirty: true });
-    setValue("modelTailoring", "", { shouldDirty: true });
-    setValue("modelProjectSelection", "", { shouldDirty: true });
-  }, [dirtyFields.llmProvider, selectedProvider, setValue]);
-
-  useEffect(() => {
-    if (!supportsModelSuggestions) {
-      setAvailableModels([]);
-      setModelsError(null);
-      setIsLoadingModels(false);
-      return;
-    }
-
-    if (!hasAvailableApiKey) {
-      setAvailableModels([]);
-      setModelsError(null);
-      setIsLoadingModels(false);
-      return;
-    }
-
-    let cancelled = false;
-    setIsLoadingModels(true);
-    setModelsError(null);
-
-    void api
-      .getLlmModels({
-        provider: deferredProvider,
-        baseUrl: showBaseUrl ? deferredBaseUrl.trim() || undefined : undefined,
-        apiKey: showApiKey ? deferredApiKey.trim() || undefined : undefined,
-      })
-      .then((models) => {
-        if (cancelled) return;
-        setAvailableModels(models);
-        setModelsError(null);
-      })
-      .catch((error) => {
-        if (cancelled) return;
-        setAvailableModels([]);
-        setModelsError(
-          error instanceof Error ? error.message : "Failed to load models.",
-        );
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setIsLoadingModels(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    deferredApiKey,
-    deferredBaseUrl,
-    deferredProvider,
-    hasAvailableApiKey,
-    showApiKey,
-    showBaseUrl,
-    supportsModelSuggestions,
-  ]);
-
-  const keyHint = formatSecretHint(llmApiKeyHint);
-  const keyText = showApiKey ? keyHint || "Not set" : "Not required";
-  const resolvedBaseUrl = llmBaseUrlValue?.trim() || llmBaseUrl || "-";
-  const selectedDefaultModel = modelValue.trim();
-  const previewDefaultModel =
-    selectedDefaultModel || effective || providerDefaultModel || "-";
-  const selectedScoringModel = modelScorerValue.trim();
-  const selectedTailoringModel = modelTailoringValue.trim();
-  const selectedProjectSelectionModel = modelProjectSelectionValue.trim();
-  const scoringModel = selectedScoringModel || previewDefaultModel;
-  const tailoringModel = selectedTailoringModel || previewDefaultModel;
-  const projectSelectionModel =
-    selectedProjectSelectionModel || previewDefaultModel;
-  const modelHelper = supportsModelSuggestions
-    ? !hasAvailableApiKey
-      ? `Add or save a ${providerConfig.label} API key to load available models.`
-      : isLoadingModels
-        ? "Loading available models..."
-        : modelsError
-          ? modelsError
-          : availableModels.length > 0
-            ? "Choose from the available text-generation models."
-            : "No text-generation models were returned."
-    : `Type the exact model name manually, or leave blank to use the ${providerConfig.label} default model.`;
-  const defaultModelOptions = buildModelOptions({
-    models: availableModels,
-    emptyLabel: `Use ${providerConfig.label} default`,
-    emptyValue: "",
-    fallbackValue: modelValue.trim(),
-  });
-  const scoringModelOptions = buildModelOptions({
-    models: availableModels,
-    emptyLabel: "Inherit default model",
-    emptyValue: "",
-    fallbackValue: modelScorerValue.trim(),
-  });
-  const tailoringModelOptions = buildModelOptions({
-    models: availableModels,
-    emptyLabel: "Inherit default model",
-    emptyValue: "",
-    fallbackValue: modelTailoringValue.trim(),
-  });
-  const projectSelectionModelOptions = buildModelOptions({
-    models: availableModels,
-    emptyLabel: "Inherit default model",
-    emptyValue: "",
-    fallbackValue: modelProjectSelectionValue.trim(),
-  });
+  const setStringField = (
+    field: keyof Pick<
+      UpdateSettingsInput,
+      | "llmBaseUrl"
+      | "llmApiKey"
+      | "model"
+      | "modelScorer"
+      | "modelTailoring"
+      | "modelProjectSelection"
+    >,
+    value: string,
+  ) => {
+    setValue(field, value, { shouldDirty: true, shouldValidate: true });
+  };
 
   return (
     <SettingsSectionFrame mode={layoutMode} title="Model" value="model">
-      <div className="space-y-4">
-        <div className="space-y-4">
-          <div className="text-sm font-medium">LLM Provider</div>
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <label htmlFor="llmProvider" className="text-sm font-medium">
-                Provider
-              </label>
-              <Controller
-                name="llmProvider"
-                control={control}
-                render={({ field }) => (
-                  <Select
-                    value={field.value ?? ""}
-                    onValueChange={(value) => field.onChange(value)}
-                    disabled={isLoading || isSaving}
-                  >
-                    <SelectTrigger id="llmProvider">
-                      <SelectValue placeholder="Select provider" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {LLM_PROVIDERS.map((provider) => (
-                        <SelectItem key={provider} value={provider}>
-                          {LLM_PROVIDER_LABELS[provider]}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-              {errors.llmProvider?.message && (
-                <p className="text-xs text-destructive">
-                  {errors.llmProvider.message as string}
-                </p>
-              )}
-              <p className="text-xs text-muted-foreground">
-                Used for scoring, tailoring, and extraction.
-              </p>
-              <p className="text-xs text-muted-foreground">
-                {providerConfig.providerHint}
-              </p>
-              {isCodexProvider ? (
-                <CodexAuthPanel isBusy={isLoading || isSaving} />
-              ) : null}
-              {isGeminiCliProvider ? <GeminiCliSetupHint /> : null}
-            </div>
-            {showBaseUrl && (
-              <SettingsInput
-                label="LLM base URL"
-                inputProps={register("llmBaseUrl")}
-                placeholder={providerConfig.baseUrlPlaceholder}
-                disabled={isLoading || isSaving}
-                error={errors.llmBaseUrl?.message as string | undefined}
-                helper={providerConfig.baseUrlHelper}
-                current={resolvedBaseUrl}
-              />
-            )}
-            {showApiKey && (
-              <SettingsInput
-                label="LLM API key"
-                inputProps={register("llmApiKey")}
-                type="password"
-                placeholder="Enter new key"
-                disabled={isLoading || isSaving}
-                error={errors.llmApiKey?.message as string | undefined}
-                helper={renderKeyHelper(
-                  providerConfig.keyHelperText,
-                  providerConfig.keyHelperHref,
-                  Boolean(keyHint),
-                )}
-                current={keyHint}
-              />
-            )}
-          </div>
-        </div>
-
-        <Separator />
-
-        {supportsModelSuggestions ? (
-          <div className="space-y-2">
-            <label htmlFor="model" className="text-sm font-medium">
-              Default model
-            </label>
-            <Controller
-              name="model"
-              control={control}
-              render={({ field }) => (
-                <SearchableDropdown
-                  inputId="model"
-                  value={field.value ?? ""}
-                  options={defaultModelOptions}
-                  onValueChange={field.onChange}
-                  placeholder={providerDefaultModel || "Select a model"}
-                  searchPlaceholder="Search models..."
-                  emptyText="No models found."
-                  ariaLabel="Default model"
-                  disabled={isLoading || isSaving || isLoadingModels}
-                  triggerClassName="h-9 w-full justify-between rounded-md border border-input bg-transparent px-3 text-sm font-normal shadow-sm"
-                  contentClassName="w-[var(--radix-popover-trigger-width)] border-border bg-popover p-0"
-                  listClassName="max-h-64"
-                />
-              )}
-            />
-            {errors.model?.message && (
-              <p className="text-xs text-destructive">
-                {errors.model.message as string}
-              </p>
-            )}
-            <div className="text-xs text-muted-foreground">{modelHelper}</div>
-            <div className="text-xs text-muted-foreground">
-              Current: <span className="font-mono">{previewDefaultModel}</span>
-            </div>
-          </div>
-        ) : (
-          <SettingsInput
-            label="Default model"
-            inputProps={register("model")}
-            placeholder={providerDefaultModel}
-            disabled={isLoading || isSaving}
-            error={errors.model?.message as string | undefined}
-            helper={modelHelper}
-            current={previewDefaultModel}
-          />
-        )}
-
-        <Separator />
-
-        <div className="space-y-4">
-          <div className="text-sm font-medium">Task-Specific Overrides</div>
-
-          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-            {supportsModelSuggestions ? (
-              <>
-                <div className="space-y-2">
-                  <label htmlFor="modelScorer" className="text-sm font-medium">
-                    Scoring Model
-                  </label>
-                  <Controller
-                    name="modelScorer"
-                    control={control}
-                    render={({ field }) => (
-                      <SearchableDropdown
-                        inputId="modelScorer"
-                        value={field.value ?? ""}
-                        options={scoringModelOptions}
-                        onValueChange={field.onChange}
-                        placeholder={
-                          previewDefaultModel || "Inherit default model"
-                        }
-                        searchPlaceholder="Search models..."
-                        emptyText="No models found."
-                        ariaLabel="Scoring Model"
-                        disabled={isLoading || isSaving || isLoadingModels}
-                        triggerClassName="h-9 w-full justify-between rounded-md border border-input bg-transparent px-3 text-sm font-normal shadow-sm"
-                        contentClassName="w-[var(--radix-popover-trigger-width)] border-border bg-popover p-0"
-                        listClassName="max-h-64"
-                      />
-                    )}
-                  />
-                  {errors.modelScorer?.message && (
-                    <p className="text-xs text-destructive">
-                      {errors.modelScorer.message as string}
-                    </p>
-                  )}
-                  <div className="text-xs text-muted-foreground">
-                    Current: <span className="font-mono">{scoringModel}</span>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <label
-                    htmlFor="modelTailoring"
-                    className="text-sm font-medium"
-                  >
-                    Tailoring Model
-                  </label>
-                  <Controller
-                    name="modelTailoring"
-                    control={control}
-                    render={({ field }) => (
-                      <SearchableDropdown
-                        inputId="modelTailoring"
-                        value={field.value ?? ""}
-                        options={tailoringModelOptions}
-                        onValueChange={field.onChange}
-                        placeholder={
-                          previewDefaultModel || "Inherit default model"
-                        }
-                        searchPlaceholder="Search models..."
-                        emptyText="No models found."
-                        ariaLabel="Tailoring Model"
-                        disabled={isLoading || isSaving || isLoadingModels}
-                        triggerClassName="h-9 w-full justify-between rounded-md border border-input bg-transparent px-3 text-sm font-normal shadow-sm"
-                        contentClassName="w-[var(--radix-popover-trigger-width)] border-border bg-popover p-0"
-                        listClassName="max-h-64"
-                      />
-                    )}
-                  />
-                  {errors.modelTailoring?.message && (
-                    <p className="text-xs text-destructive">
-                      {errors.modelTailoring.message as string}
-                    </p>
-                  )}
-                  <div className="text-xs text-muted-foreground">
-                    Current: <span className="font-mono">{tailoringModel}</span>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <label
-                    htmlFor="modelProjectSelection"
-                    className="text-sm font-medium"
-                  >
-                    Project Selection Model
-                  </label>
-                  <Controller
-                    name="modelProjectSelection"
-                    control={control}
-                    render={({ field }) => (
-                      <SearchableDropdown
-                        inputId="modelProjectSelection"
-                        value={field.value ?? ""}
-                        options={projectSelectionModelOptions}
-                        onValueChange={field.onChange}
-                        placeholder={
-                          previewDefaultModel || "Inherit default model"
-                        }
-                        searchPlaceholder="Search models..."
-                        emptyText="No models found."
-                        ariaLabel="Project Selection Model"
-                        disabled={isLoading || isSaving || isLoadingModels}
-                        triggerClassName="h-9 w-full justify-between rounded-md border border-input bg-transparent px-3 text-sm font-normal shadow-sm"
-                        contentClassName="w-[var(--radix-popover-trigger-width)] border-border bg-popover p-0"
-                        listClassName="max-h-64"
-                      />
-                    )}
-                  />
-                  {errors.modelProjectSelection?.message && (
-                    <p className="text-xs text-destructive">
-                      {errors.modelProjectSelection.message as string}
-                    </p>
-                  )}
-                  <div className="text-xs text-muted-foreground">
-                    Current:{" "}
-                    <span className="font-mono">{projectSelectionModel}</span>
-                  </div>
-                </div>
-              </>
-            ) : (
-              <>
-                <SettingsInput
-                  label="Scoring Model"
-                  inputProps={register("modelScorer")}
-                  placeholder={previewDefaultModel || "inherit"}
-                  disabled={isLoading || isSaving}
-                  error={errors.modelScorer?.message as string | undefined}
-                  current={scoringModel}
-                />
-
-                <SettingsInput
-                  label="Tailoring Model"
-                  inputProps={register("modelTailoring")}
-                  placeholder={previewDefaultModel || "inherit"}
-                  disabled={isLoading || isSaving}
-                  error={errors.modelTailoring?.message as string | undefined}
-                  current={tailoringModel}
-                />
-
-                <SettingsInput
-                  label="Project Selection Model"
-                  inputProps={register("modelProjectSelection")}
-                  placeholder={previewDefaultModel || "inherit"}
-                  disabled={isLoading || isSaving}
-                  error={
-                    errors.modelProjectSelection?.message as string | undefined
-                  }
-                  current={projectSelectionModel}
-                />
-              </>
-            )}
-          </div>
-        </div>
-
-        <Separator />
-
-        <div className="space-y-3 text-sm">
-          <div className="text-xs text-muted-foreground">Resolved config</div>
-          <div className="grid gap-x-4 gap-y-2 text-xs sm:grid-cols-[160px_1fr]">
-            <div className="text-muted-foreground">Provider</div>
-            <div className="font-mono">{selectedProvider || "-"}</div>
-
-            <div className="text-muted-foreground">Base URL</div>
-            <div className="font-mono">{resolvedBaseUrl}</div>
-
-            <div className="text-muted-foreground">API key</div>
-            <div className="font-mono">{keyText}</div>
-
-            <div className="text-muted-foreground">Default model</div>
-            <div className="font-mono">{previewDefaultModel}</div>
-
-            <div className="text-muted-foreground">Scoring model</div>
-            <div className="font-mono">
-              {selectedScoringModel ? scoringModel : "inherits"}
-            </div>
-
-            <div className="text-muted-foreground">Tailoring model</div>
-            <div className="font-mono">
-              {selectedTailoringModel ? tailoringModel : "inherits"}
-            </div>
-
-            <div className="text-muted-foreground">Project selection</div>
-            <div className="font-mono">
-              {selectedProjectSelectionModel
-                ? projectSelectionModel
-                : "inherits"}
-            </div>
-          </div>
-        </div>
-      </div>
+      <LlmModelConfiguration
+        mode="settings"
+        disabled={disabled}
+        selectedProvider={selectedProvider}
+        savedProvider={values.llmProvider}
+        savedBaseUrl={values.llmBaseUrl}
+        apiKeyHint={values.llmApiKeyHint}
+        effectiveModel={values.effective}
+        defaultModel={values.default}
+        provider={{
+          value: selectedProvider,
+          onChange: (value) =>
+            setValue("llmProvider", value as LlmProviderId, {
+              shouldDirty: true,
+              shouldValidate: true,
+            }),
+          error: errors.llmProvider?.message as string | undefined,
+        }}
+        baseUrl={{
+          value: watch("llmBaseUrl") ?? "",
+          onChange: (value) => setStringField("llmBaseUrl", value),
+          error: errors.llmBaseUrl?.message as string | undefined,
+        }}
+        apiKey={{
+          value: watch("llmApiKey") ?? "",
+          onChange: (value) => setStringField("llmApiKey", value),
+          error: errors.llmApiKey?.message as string | undefined,
+        }}
+        model={{
+          value: watch("model") ?? "",
+          onChange: (value) => setStringField("model", value),
+          error: errors.model?.message as string | undefined,
+        }}
+        modelScorer={{
+          value: watch("modelScorer") ?? "",
+          onChange: (value) => setStringField("modelScorer", value),
+          error: errors.modelScorer?.message as string | undefined,
+        }}
+        modelTailoring={{
+          value: watch("modelTailoring") ?? "",
+          onChange: (value) => setStringField("modelTailoring", value),
+          error: errors.modelTailoring?.message as string | undefined,
+        }}
+        modelProjectSelection={{
+          value: watch("modelProjectSelection") ?? "",
+          onChange: (value) => setStringField("modelProjectSelection", value),
+          error: errors.modelProjectSelection?.message as string | undefined,
+        }}
+      />
     </SettingsSectionFrame>
   );
 };
-
-function buildModelOptions(input: {
-  models: string[];
-  emptyLabel: string;
-  emptyValue: string;
-  fallbackValue?: string;
-}) {
-  const options = [
-    {
-      value: input.emptyValue,
-      label: input.emptyLabel,
-      searchText: input.emptyLabel,
-    },
-    ...input.models.map((model) => ({
-      value: model,
-      label: model,
-      searchText: model,
-    })),
-  ];
-
-  const fallbackValue = input.fallbackValue?.trim();
-  if (
-    fallbackValue &&
-    !options.some((option) => option.value === fallbackValue)
-  ) {
-    options.unshift({
-      value: fallbackValue,
-      label: fallbackValue,
-      searchText: `${fallbackValue} custom`,
-    });
-  }
-
-  return options;
-}


### PR DESCRIPTION
## Summary
- Extracted the LLM configuration UI into a shared component used by both Settings and Onboarding.
- Kept Settings on the full model editor path while giving Onboarding a compact provider, credentials, and default-model flow.
- Added onboarding support for saving the selected default model and covered the shared behavior with focused tests.

## Testing
- `biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`