### PR TITLE
Harden JobSpy against partial LinkedIn source failures

### DIFF
--- a/extractors/jobspy/manifest.ts
+++ b/extractors/jobspy/manifest.ts
@@ -50,6 +50,15 @@ export const manifest: ExtractorManifest = {
           return;
         }
 
+        if (event.type === "source_error") {
+          context.onProgress?.({
+            phase: "list",
+            currentUrl: event.searchTerm,
+            detail: `JobSpy: ${event.source} failed for ${event.searchTerm}`,
+          });
+          return;
+        }
+
         context.onProgress?.({
           phase: "list",
           termsProcessed: event.termIndex,
@@ -71,6 +80,7 @@ export const manifest: ExtractorManifest = {
     return {
       success: true,
       jobs: result.jobs,
+      sourceErrors: result.sourceErrors,
     };
   },
 };

--- a/extractors/jobspy/scrape_jobs.py
+++ b/extractors/jobspy/scrape_jobs.py
@@ -1,6 +1,7 @@
 import csv
 import json
 import os
+import sys
 from pathlib import Path
 
 import pandas as pd
@@ -113,6 +114,59 @@ def _scrape_for_sites(
     return scrape_jobs(**kwargs)
 
 
+def _format_source_error(error: Exception) -> str:
+    message = str(error).strip() or error.__class__.__name__
+    message = " ".join(message.split())
+    if len(message) > 500:
+        message = f"{message[:497]}..."
+    return f"{error.__class__.__name__}: {message}"
+
+
+def _append_site_frame(
+    *,
+    frames: list[pd.DataFrame],
+    source_errors: list[str],
+    site: str,
+    search_term: str,
+    location: str | None,
+    results_wanted: int,
+    hours_old: int,
+    country_indeed: str,
+    linkedin_fetch_description: bool,
+    is_remote: bool,
+) -> None:
+    try:
+        frames.append(
+            _scrape_for_sites(
+                sites=[site],
+                search_term=search_term,
+                location=location,
+                results_wanted=results_wanted,
+                hours_old=hours_old,
+                country_indeed=country_indeed,
+                linkedin_fetch_description=linkedin_fetch_description,
+                is_remote=is_remote,
+            )
+        )
+    except Exception as error:
+        formatted_error = _format_source_error(error)
+        source_errors.append(f"{site}: {formatted_error}")
+        _emit_progress(
+            "source_error",
+            {
+                "source": site,
+                "searchTerm": search_term,
+                "error": formatted_error,
+            },
+        )
+        print(
+            f"jobspy: Source {site} failed; continuing with remaining sources. "
+            f"{formatted_error}",
+            file=sys.stderr,
+            flush=True,
+        )
+
+
 def main() -> int:
     sites = _parse_sites(_env_str("JOBSPY_SITES", "indeed,linkedin"))
     search_term = _env_str("JOBSPY_SEARCH_TERM", "web developer")
@@ -146,6 +200,7 @@ def main() -> int:
         },
     )
     frames: list[pd.DataFrame] = []
+    source_errors: list[str] = []
     # JobSpy's site-level geo filters are inconsistent:
     # - LinkedIn only respects `location`.
     # - Indeed/Glassdoor respect `country_indeed`, and `location` is optional
@@ -153,31 +208,31 @@ def main() -> int:
     # Run them separately so "country with no city" does not become a global
     # LinkedIn search, and so we do not inject synthetic locations into Indeed.
     if "linkedin" in sites:
-        frames.append(
-            _scrape_for_sites(
-                sites=["linkedin"],
-                search_term=search_term,
-                location=linkedin_location,
-                results_wanted=results_wanted,
-                hours_old=hours_old,
-                country_indeed="",
-                linkedin_fetch_description=linkedin_fetch_description,
-                is_remote=is_remote,
-            )
+        _append_site_frame(
+            frames=frames,
+            source_errors=source_errors,
+            site="linkedin",
+            search_term=search_term,
+            location=linkedin_location,
+            results_wanted=results_wanted,
+            hours_old=hours_old,
+            country_indeed="",
+            linkedin_fetch_description=linkedin_fetch_description,
+            is_remote=is_remote,
         )
 
     if "indeed" in sites:
-        frames.append(
-            _scrape_for_sites(
-                sites=["indeed"],
-                search_term=search_term,
-                location=indeed_location,
-                results_wanted=results_wanted,
-                hours_old=hours_old,
-                country_indeed=country_indeed,
-                linkedin_fetch_description=linkedin_fetch_description,
-                is_remote=is_remote,
-            )
+        _append_site_frame(
+            frames=frames,
+            source_errors=source_errors,
+            site="indeed",
+            search_term=search_term,
+            location=indeed_location,
+            results_wanted=results_wanted,
+            hours_old=hours_old,
+            country_indeed=country_indeed,
+            linkedin_fetch_description=linkedin_fetch_description,
+            is_remote=is_remote,
         )
 
     if "glassdoor" in sites:
@@ -195,18 +250,26 @@ def main() -> int:
                 print(
                     "jobspy: Glassdoor location matched country; keeping original location"
                 )
-        frames.append(
-            _scrape_for_sites(
-                sites=["glassdoor"],
-                search_term=search_term,
-                location=effective_glassdoor_location,
-                results_wanted=results_wanted,
-                hours_old=hours_old,
-                country_indeed=country_indeed,
-                linkedin_fetch_description=linkedin_fetch_description,
-                is_remote=is_remote,
-            )
+        _append_site_frame(
+            frames=frames,
+            source_errors=source_errors,
+            site="glassdoor",
+            search_term=search_term,
+            location=effective_glassdoor_location,
+            results_wanted=results_wanted,
+            hours_old=hours_old,
+            country_indeed=country_indeed,
+            linkedin_fetch_description=linkedin_fetch_description,
+            is_remote=is_remote,
         )
+
+    if source_errors and not frames:
+        print(
+            f"jobspy: All requested sources failed: {'; '.join(source_errors)}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
 
     jobs = pd.concat(frames, ignore_index=True) if frames else pd.DataFrame()
 

--- a/extractors/jobspy/src/run.ts
+++ b/extractors/jobspy/src/run.ts
@@ -34,6 +34,12 @@ export type JobSpyProgressEvent =
       termTotal: number;
       searchTerm: string;
       jobsFoundTerm: number;
+    }
+  | {
+      type: "source_error";
+      source: string;
+      searchTerm: string;
+      error: string;
     };
 
 export function parseJobSpyProgressLine(
@@ -53,7 +59,20 @@ export function parseJobSpyProgressLine(
   const termTotal = toNumberOrNull(parsed.termTotal);
   const searchTerm = toStringOrNull(parsed.searchTerm) ?? "";
 
-  if (!eventName || termIndex === null || termTotal === null) return null;
+  if (!eventName) return null;
+  if (eventName === "source_error") {
+    const source = toStringOrNull(parsed.source);
+    const error = toStringOrNull(parsed.error);
+    if (!source || !error) return null;
+    return {
+      type: "source_error",
+      source,
+      searchTerm,
+      error,
+    };
+  }
+
+  if (termIndex === null || termTotal === null) return null;
   if (eventName === "term_start") {
     return { type: "term_start", termIndex, termTotal, searchTerm };
   }
@@ -155,6 +174,7 @@ export interface JobSpyResult {
   success: boolean;
   jobs: CreateJobInput[];
   error?: string;
+  sourceErrors?: string[];
 }
 
 function normalizeOptionalString(
@@ -236,6 +256,7 @@ export async function runJobSpy(
 
   try {
     const jobs: CreateJobInput[] = [];
+    const sourceErrors: string[] = [];
     const seenJobUrls = new Set<string>();
     const totalRuns = searchTerms.length * runLocations.length;
     let runIndex = 0;
@@ -320,6 +341,11 @@ export async function runJobSpy(
           const handleLine = (line: string, stream: NodeJS.WriteStream) => {
             const event = parseJobSpyProgressLine(line);
             if (event) {
+              if (event.type === "source_error") {
+                sourceErrors.push(
+                  `${event.source}: ${event.error} (term: ${event.searchTerm})`,
+                );
+              }
               options.onProgress?.(event);
               return;
             }
@@ -364,7 +390,7 @@ export async function runJobSpy(
       }
     }
 
-    return { success: true, jobs };
+    return { success: true, jobs, sourceErrors };
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
     return { success: false, jobs: [], error: message };

--- a/extractors/jobspy/tests/run.test.ts
+++ b/extractors/jobspy/tests/run.test.ts
@@ -35,6 +35,19 @@ describe("parseJobSpyProgressLine", () => {
     });
   });
 
+  it("parses source_error progress lines", () => {
+    const event = parseJobSpyProgressLine(
+      'JOBOPS_PROGRESS {"event":"source_error","source":"linkedin","searchTerm":"forecasting","error":"ValueError: Invalid country string: eswatini"}',
+    );
+
+    expect(event).toEqual({
+      type: "source_error",
+      source: "linkedin",
+      searchTerm: "forecasting",
+      error: "ValueError: Invalid country string: eswatini",
+    });
+  });
+
   it("returns null for malformed payloads", () => {
     expect(parseJobSpyProgressLine("JOBOPS_PROGRESS {bad json")).toBeNull();
     expect(parseJobSpyProgressLine("JOBOPS_PROGRESS {}")).toBeNull();

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -138,6 +138,51 @@ describe("discoverJobsStep", () => {
     );
   });
 
+  it("keeps non-fatal source errors when an extractor succeeds with no jobs", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+
+    const jobspyManifest = {
+      id: "jobspy",
+      displayName: "JobSpy",
+      providesSources: ["indeed", "linkedin", "glassdoor"],
+      run: vi.fn().mockResolvedValue({
+        success: true,
+        jobs: [],
+        sourceErrors: [
+          "linkedin: ValueError: Invalid country string: eswatini (term: forecasting)",
+        ],
+      }),
+    };
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["forecasting"]),
+      jobspyCountryIndeed: "netherlands",
+    } as any);
+
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map([["jobspy", jobspyManifest as any]]),
+      manifestBySource: new Map([
+        ["indeed", jobspyManifest as any],
+        ["linkedin", jobspyManifest as any],
+        ["glassdoor", jobspyManifest as any],
+      ]),
+      availableSources: ["indeed", "linkedin", "glassdoor"],
+    } as any);
+
+    const result = await discoverJobsStep({
+      mergedConfig: {
+        ...baseConfig,
+        sources: ["indeed", "linkedin"],
+      },
+    });
+
+    expect(result.discoveredJobs).toEqual([]);
+    expect(result.sourceErrors).toEqual([
+      "linkedin: ValueError: Invalid country string: eswatini (term: forecasting)",
+    ]);
+  });
+
   it("throws when all requested sources are incompatible for country", async () => {
     const settingsRepo = await import("@server/repositories/settings");
     const registryModule = await import("@server/extractors/registry");

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -28,6 +28,7 @@ type DiscoveryTaskResult = {
   discoveredJobs: CreateJobInput[];
   sourceErrors: string[];
   challenge?: PendingChallenge;
+  fatal?: boolean;
 };
 
 type DiscoverySourceTask = {
@@ -277,6 +278,7 @@ export async function discoverJobsStep(args: {
             sourceErrors: [
               `${manifest.displayName || manifest.id}: ${result.error ?? "unknown error"} (sources: ${grouped.sources.join(",")})`,
             ],
+            fatal: true,
             challenge: result.challengeRequired
               ? {
                   extractorId: manifest.id,
@@ -290,7 +292,7 @@ export async function discoverJobsStep(args: {
 
         return {
           discoveredJobs: result.jobs,
-          sourceErrors: [],
+          sourceErrors: result.sourceErrors ?? [],
         };
       },
     });
@@ -338,6 +340,7 @@ export async function discoverJobsStep(args: {
           sourceErrors: [
             `${sourceTask.source}: ${error instanceof Error ? error.message : "unknown error"}`,
           ],
+          fatal: true,
         };
       }
     },
@@ -432,9 +435,13 @@ export async function discoverJobsStep(args: {
   // Don't throw "all sources failed" when challenges are pending — the
   // orchestrator will pause, let the user solve them, then re-run those
   // extractors.  Jobs from non-challenged extractors (if any) are kept.
+  const fatalSourceFailures = sourceResults.filter(
+    (sourceResult) => sourceResult.fatal,
+  ).length;
   if (
     filteredDiscoveredJobs.length === 0 &&
-    sourceErrors.length > 0 &&
+    sourceResults.length > 0 &&
+    fatalSourceFailures === sourceResults.length &&
     pendingChallenges.length === 0
   ) {
     throw new Error(`All sources failed: ${sourceErrors.join("; ")}`);

--- a/shared/src/types/extractors.ts
+++ b/shared/src/types/extractors.ts
@@ -36,6 +36,7 @@ export interface ExtractorRunResult {
   success: boolean;
   jobs: CreateJobInput[];
   error?: string;
+  sourceErrors?: string[];
   /** When set, the extractor failed because a Cloudflare challenge couldn't be
    *  solved headless. The value is the URL that needs a human to solve it in a
    *  headed browser. The pipeline should pause and prompt the user. */


### PR DESCRIPTION
## Summary
- Catch per-site JobSpy failures in the Python wrapper so one bad LinkedIn card no longer aborts the whole scrape.
- Emit structured `source_error` progress events and carry partial source warnings through the JobSpy manifest and pipeline.
- Add regression coverage for the Eswatini-style failure case and for keeping partial JobSpy results.

## Testing
- `biome ci` passed.
- Type checks passed for shared, orchestrator, gradcracker-extractor, and ukvisajobs-extractor.
- `orchestrator` client build passed.
- Added and ran focused tests for JobSpy progress parsing and discovery-step handling.
- Full orchestrator test suite passed.