### PR TITLE
Fix first-user setup password validation messaging

### DIFF
--- a/orchestrator/src/client/lib/error-format.test.ts
+++ b/orchestrator/src/client/lib/error-format.test.ts
@@ -144,6 +144,22 @@ describe("error-format", () => {
     expect(formatUserFacingError(error)).toBe("Please enter a valid job URL.");
   });
 
+  it("maps flattened password length errors to a friendly message", () => {
+    const error = {
+      message: "Invalid request body",
+      details: {
+        formErrors: [],
+        fieldErrors: {
+          password: ["String must contain at least 8 character(s)"],
+        },
+      },
+    };
+
+    expect(formatUserFacingError(error)).toBe(
+      "Password must be at least 8 characters.",
+    );
+  });
+
   it("falls back to generic message for unparseable JSON errors", () => {
     expect(formatUserFacingError(new Error("[not-valid-json]"))).toBe(
       "Something went wrong. Please try again.",

--- a/orchestrator/src/client/lib/error-format.ts
+++ b/orchestrator/src/client/lib/error-format.ts
@@ -2,6 +2,7 @@ type ZodLikeIssue = {
   code?: string;
   format?: string;
   minimum?: number;
+  maximum?: number;
   expected?: string;
   received?: string;
   type?: string;
@@ -57,6 +58,25 @@ function toSentenceCase(input: string): string {
   return input.charAt(0).toUpperCase() + input.slice(1);
 }
 
+function extractNumericConstraint(
+  message: string | undefined,
+  kind: "minimum" | "maximum",
+): number | null {
+  if (!message) return null;
+  const patterns =
+    kind === "minimum"
+      ? [/at least\s+(\d+)/i, />=\s*(\d+)/, /minimum(?:\s+of)?\s+(\d+)/i]
+      : [/at most\s+(\d+)/i, /<=\s*(\d+)/, /maximum(?:\s+of)?\s+(\d+)/i];
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(message);
+    const value = match?.[1] ? Number.parseInt(match[1], 10) : Number.NaN;
+    if (Number.isFinite(value)) return value;
+  }
+
+  return null;
+}
+
 function toFriendlyIssueMessage(issue: ZodLikeIssue): string | null {
   const path = toIssuePath(issue.path);
   const label = toFriendlyFieldLabel(path);
@@ -82,6 +102,25 @@ function toFriendlyIssueMessage(issue: ZodLikeIssue): string | null {
     return label
       ? `Please enter a valid ${label}.`
       : "Please enter a valid URL.";
+  }
+
+  if (path === "password") {
+    const minimum =
+      issue.minimum ?? extractNumericConstraint(issue.message, "minimum");
+    if (issue.code === "too_small" || minimum !== null) {
+      if (minimum === null || minimum <= 1) {
+        return "Please enter a password before continuing.";
+      }
+      return `Password must be at least ${minimum} characters.`;
+    }
+
+    const maximum =
+      issue.maximum ?? extractNumericConstraint(issue.message, "maximum");
+    if (issue.code === "too_big" || maximum !== null) {
+      return maximum === null
+        ? "Password is too long."
+        : `Password must be ${maximum} characters or fewer.`;
+    }
   }
 
   if (

--- a/orchestrator/src/server/api/routes/auth.test.ts
+++ b/orchestrator/src/server/api/routes/auth.test.ts
@@ -145,6 +145,12 @@ describe.sequential("Auth routes", () => {
       });
 
       expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.message).toBe(
+        "Password must be at least 8 characters.",
+      );
+      expect(body.error.details.fieldErrors.password).toBe("[REDACTED]");
     });
   });
 

--- a/orchestrator/src/server/api/routes/auth.ts
+++ b/orchestrator/src/server/api/routes/auth.ts
@@ -18,6 +18,31 @@ const setupSchema = loginSchema.extend({
   displayName: z.string().trim().min(1).max(120).optional(),
 });
 
+function toSetupValidationMessage(error: z.ZodError): string {
+  const issue = error.issues[0];
+  const path = issue?.path.join(".");
+
+  if (path === "password") {
+    if (issue?.code === "too_small") {
+      return `Password must be at least ${issue.minimum} characters.`;
+    }
+    if (issue?.code === "too_big") {
+      return `Password must be ${issue.maximum} characters or fewer.`;
+    }
+    return "Enter a valid password.";
+  }
+
+  if (path === "username") {
+    return "Enter a username.";
+  }
+
+  if (path === "displayName") {
+    return "Enter a name or leave the field blank.";
+  }
+
+  return "Invalid request body";
+}
+
 export const authRouter = Router();
 
 authRouter.post(
@@ -107,7 +132,13 @@ authRouter.post(
 
     const parsed = setupSchema.safeParse(req.body);
     if (!parsed.success) {
-      fail(res, badRequest("Invalid request body", parsed.error.flatten()));
+      fail(
+        res,
+        badRequest(
+          toSetupValidationMessage(parsed.error),
+          parsed.error.flatten(),
+        ),
+      );
       return;
     }
 


### PR DESCRIPTION
## Summary
- Return a password-specific validation message during first-user setup when Zod rejects the password.
- Keep the API error details sanitized while surfacing a friendlier top-level message.
- Extend client error formatting so flattened password validation issues render as a clear user-facing message.
- Add coverage for the setup route and the shared error formatter.

## Testing
- Added unit coverage for the auth setup validation response.
- Added formatter coverage for flattened password length errors.
- Verified formatting, type checks, client build, and the orchestrator test suite passed.