### PR TITLE
feat(extractors): add Upwork RSS extractor

### DIFF
--- a/extractors/upwork/manifest.ts
+++ b/extractors/upwork/manifest.ts
@@ -1,0 +1,77 @@
+import type {
+  ExtractorManifest,
+  ExtractorProgressEvent,
+} from "job-ops-shared/types/extractors";
+import { runUpwork } from "./src/run";
+
+function toProgress(event: {
+  type: string;
+  termIndex: number;
+  termTotal: number;
+  searchTerm: string;
+  jobsFoundTerm?: number;
+}): ExtractorProgressEvent {
+  if (event.type === "term_start") {
+    return {
+      phase: "list",
+      termsProcessed: Math.max(event.termIndex - 1, 0),
+      termsTotal: event.termTotal,
+      currentUrl: event.searchTerm,
+      detail: `Upwork: term ${event.termIndex}/${event.termTotal} (${event.searchTerm})`,
+    };
+  }
+
+  return {
+    phase: "list",
+    termsProcessed: event.termIndex,
+    termsTotal: event.termTotal,
+    currentUrl: event.searchTerm,
+    jobPagesEnqueued: event.jobsFoundTerm ?? 0,
+    jobPagesProcessed: event.jobsFoundTerm ?? 0,
+    detail: `Upwork: completed ${event.termIndex}/${event.termTotal} (${event.searchTerm}) with ${event.jobsFoundTerm ?? 0} jobs`,
+  };
+}
+
+export const manifest: ExtractorManifest = {
+  id: "upwork",
+  displayName: "Upwork",
+  providesSources: ["upwork"],
+  async run(context) {
+    if (context.shouldCancel?.()) {
+      return { success: true, jobs: [] };
+    }
+
+    const parsedMaxJobsPerTerm = context.settings.upworkMaxJobsPerTerm
+      ? Number.parseInt(context.settings.upworkMaxJobsPerTerm, 10)
+      : context.settings.jobspyResultsWanted
+        ? Number.parseInt(context.settings.jobspyResultsWanted, 10)
+        : Number.NaN;
+
+    const result = await runUpwork({
+      searchTerms: context.searchTerms,
+      maxJobsPerTerm: Number.isFinite(parsedMaxJobsPerTerm)
+        ? parsedMaxJobsPerTerm
+        : undefined,
+      shouldCancel: context.shouldCancel,
+      onProgress: (event) => {
+        if (context.shouldCancel?.()) return;
+        context.onProgress?.(toProgress(event));
+      },
+    });
+
+    if (!result.success) {
+      return {
+        success: false,
+        jobs: [],
+        error: result.error,
+      };
+    }
+
+    return {
+      success: true,
+      jobs: result.jobs,
+    };
+  },
+};
+
+export default manifest;

--- a/extractors/upwork/package.json
+++ b/extractors/upwork/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "upwork-extractor",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Upwork extractor backed by the public RSS search feed",
+  "dependencies": {
+    "fast-xml-parser": "^4.0.0",
+    "job-ops-shared": "^1.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "~5.9.0",
+    "vitest": "^4.0.16"
+  },
+  "scripts": {
+    "check:types": "tsc --noEmit",
+    "test:run": "vitest run"
+  }
+}

--- a/extractors/upwork/src/fetcher.ts
+++ b/extractors/upwork/src/fetcher.ts
@@ -1,0 +1,50 @@
+const UPWORK_RSS_URL = "https://www.upwork.com/ab/feed/jobs/rss";
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 50;
+
+function toPositiveIntOrFallback(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.floor(value as number));
+}
+
+export function buildUpworkRssUrl(
+  query: string,
+  maxJobsPerTerm?: number,
+): string {
+  const pageSize = Math.min(
+    toPositiveIntOrFallback(maxJobsPerTerm, DEFAULT_PAGE_SIZE),
+    MAX_PAGE_SIZE,
+  );
+  const url = new URL(UPWORK_RSS_URL);
+  url.searchParams.set("q", query);
+  url.searchParams.set("sort", "recency");
+  url.searchParams.set("paging", `0;${pageSize}`);
+  return url.toString();
+}
+
+export async function fetchUpworkRss(args: {
+  query: string;
+  maxJobsPerTerm?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<string> {
+  const fetchImpl = args.fetchImpl ?? fetch;
+  const url = buildUpworkRssUrl(args.query, args.maxJobsPerTerm);
+  const response = await fetchImpl(url, {
+    headers: {
+      accept: "application/rss+xml, application/xml, text/xml;q=0.9, */*;q=0.8",
+      "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",
+    },
+  });
+
+  if (!response.ok) {
+    const statusText = response.statusText ? ` ${response.statusText}` : "";
+    throw new Error(
+      `Upwork RSS request failed with ${response.status}${statusText} for ${url}`,
+    );
+  }
+
+  return response.text();
+}

--- a/extractors/upwork/src/parser.ts
+++ b/extractors/upwork/src/parser.ts
@@ -1,0 +1,112 @@
+import { Buffer } from "node:buffer";
+import { XMLParser } from "fast-xml-parser";
+import type { CreateJobInput } from "job-ops-shared/types/jobs";
+import type { UpworkRssItem, UpworkRssPayload } from "./types";
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  trimValues: true,
+});
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#(\d+);/g, (_, codePoint: string) =>
+      String.fromCodePoint(Number.parseInt(codePoint, 10)),
+    )
+    .replace(/&#x([a-f0-9]+);/gi, (_, codePoint: string) =>
+      String.fromCodePoint(Number.parseInt(codePoint, 16)),
+    );
+}
+
+export function stripHtml(value: string): string {
+  return decodeHtmlEntities(
+    value
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<\/p>/gi, "\n")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/\s+/g, " ")
+      .trim(),
+  );
+}
+
+function normalizeDate(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? value : parsed.toISOString();
+}
+
+function createSourceJobId(url: string): string {
+  return Buffer.from(url).toString("base64url").slice(0, 16);
+}
+
+export function extractUpworkSalary(description: string): string | undefined {
+  const patterns = [
+    /\b(?:budget|hourly range|hourly|fixed-price)\s*:\s*([^.\n]+?)(?=\s+(?:posted on|category|skills|country|client|duration|experience|$))/i,
+    /\$\s?\d[\d,]*(?:\.\d{2})?(?:\s*[-–]\s*\$?\s?\d[\d,]*(?:\.\d{2})?)?(?:\s*(?:\/hr|per hour|hourly))?/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = pattern.exec(description);
+    const salary = match?.[1] ?? match?.[0];
+    if (salary?.trim()) return salary.trim();
+  }
+
+  return undefined;
+}
+
+function getItems(payload: UpworkRssPayload): UpworkRssItem[] {
+  const item = payload.rss?.channel?.item;
+  if (!item) return [];
+  return Array.isArray(item) ? item : [item];
+}
+
+export function parseUpworkRss(xml: string): CreateJobInput[] {
+  const payload = parser.parse(xml) as UpworkRssPayload;
+  const jobs: CreateJobInput[] = [];
+  const seen = new Set<string>();
+
+  for (const item of getItems(payload)) {
+    try {
+      const title = asString(item.title);
+      const jobUrl = asString(item.link);
+      if (!title || !jobUrl) continue;
+
+      const description = stripHtml(asString(item.description) ?? "");
+      const sourceJobId =
+        asString(item.guid) && !asString(item.guid)?.startsWith("http")
+          ? asString(item.guid)
+          : createSourceJobId(jobUrl);
+      const dedupeKey = sourceJobId ?? jobUrl;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+
+      jobs.push({
+        source: "upwork",
+        sourceJobId,
+        title,
+        employer: "Upwork Client",
+        jobUrl,
+        applicationLink: jobUrl,
+        datePosted: normalizeDate(asString(item.pubDate)),
+        salary: extractUpworkSalary(description),
+        jobDescription: description || undefined,
+        jobType: "Freelance / Contract",
+        isRemote: true,
+      });
+    } catch {}
+  }
+
+  return jobs;
+}

--- a/extractors/upwork/src/run.ts
+++ b/extractors/upwork/src/run.ts
@@ -1,0 +1,84 @@
+import type { CreateJobInput } from "job-ops-shared/types/jobs";
+import { fetchUpworkRss } from "./fetcher";
+import { parseUpworkRss } from "./parser";
+import type { RunUpworkOptions } from "./types";
+
+export interface UpworkResult {
+  success: boolean;
+  jobs: CreateJobInput[];
+  error?: string;
+}
+
+function toPositiveIntOrFallback(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.floor(value as number));
+}
+
+export async function runUpwork(
+  options: RunUpworkOptions = {},
+): Promise<UpworkResult> {
+  const searchTerms =
+    options.searchTerms && options.searchTerms.length > 0
+      ? options.searchTerms
+      : ["software engineer"];
+  const maxJobsPerTerm = toPositiveIntOrFallback(options.maxJobsPerTerm, 10);
+  const jobs: CreateJobInput[] = [];
+  const seen = new Set<string>();
+
+  try {
+    for (const [index, searchTerm] of searchTerms.entries()) {
+      if (options.shouldCancel?.()) {
+        return { success: true, jobs };
+      }
+
+      options.onProgress?.({
+        type: "term_start",
+        termIndex: index + 1,
+        termTotal: searchTerms.length,
+        searchTerm,
+      });
+
+      const xml = await fetchUpworkRss({
+        query: searchTerm,
+        maxJobsPerTerm,
+        fetchImpl: options.fetchImpl,
+      });
+      let jobsFoundTerm = 0;
+
+      for (const job of parseUpworkRss(xml)) {
+        if (options.shouldCancel?.()) {
+          return { success: true, jobs };
+        }
+        if (jobsFoundTerm >= maxJobsPerTerm) break;
+
+        const dedupeKey = job.sourceJobId ?? job.jobUrl;
+        if (seen.has(dedupeKey)) continue;
+        seen.add(dedupeKey);
+        jobs.push(job);
+        jobsFoundTerm += 1;
+      }
+
+      options.onProgress?.({
+        type: "term_complete",
+        termIndex: index + 1,
+        termTotal: searchTerms.length,
+        searchTerm,
+        jobsFoundTerm,
+      });
+    }
+
+    return { success: true, jobs };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof error === "string"
+          ? error
+          : "Unexpected error while running Upwork extractor.";
+
+    return { success: false, jobs: [], error: message };
+  }
+}

--- a/extractors/upwork/src/types.ts
+++ b/extractors/upwork/src/types.ts
@@ -1,0 +1,38 @@
+export interface UpworkRssItem {
+  title?: unknown;
+  link?: unknown;
+  pubDate?: unknown;
+  description?: unknown;
+  guid?: unknown;
+}
+
+export interface UpworkRssPayload {
+  rss?: {
+    channel?: {
+      item?: UpworkRssItem | UpworkRssItem[];
+    };
+  };
+}
+
+export type UpworkProgressEvent =
+  | {
+      type: "term_start";
+      termIndex: number;
+      termTotal: number;
+      searchTerm: string;
+    }
+  | {
+      type: "term_complete";
+      termIndex: number;
+      termTotal: number;
+      searchTerm: string;
+      jobsFoundTerm: number;
+    };
+
+export interface RunUpworkOptions {
+  searchTerms?: string[];
+  maxJobsPerTerm?: number;
+  fetchImpl?: typeof fetch;
+  shouldCancel?: () => boolean;
+  onProgress?: (event: UpworkProgressEvent) => void;
+}

--- a/extractors/upwork/tests/parser.test.ts
+++ b/extractors/upwork/tests/parser.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { extractUpworkSalary, parseUpworkRss, stripHtml } from "../src/parser";
+
+describe("parseUpworkRss", () => {
+  it("maps valid RSS entries into CreateJobInput values", () => {
+    const jobs = parseUpworkRss(`
+      <rss>
+        <channel>
+          <item>
+            <title>Build a TypeScript scraper</title>
+            <link>https://www.upwork.com/jobs/~0123456789abcdef</link>
+            <guid>0123456789abcdef</guid>
+            <pubDate>Wed, 13 May 2026 12:00:00 +0000</pubDate>
+            <description><![CDATA[
+              <p>Budget: $500 Posted On: May 13</p>
+              <p>Need a strict TypeScript scraper.</p>
+            ]]></description>
+          </item>
+        </channel>
+      </rss>
+    `);
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]).toEqual(
+      expect.objectContaining({
+        source: "upwork",
+        sourceJobId: "0123456789abcdef",
+        title: "Build a TypeScript scraper",
+        employer: "Upwork Client",
+        jobUrl: "https://www.upwork.com/jobs/~0123456789abcdef",
+        applicationLink: "https://www.upwork.com/jobs/~0123456789abcdef",
+        salary: "$500",
+        jobType: "Freelance / Contract",
+        isRemote: true,
+      }),
+    );
+    expect(jobs[0]?.jobDescription).toContain(
+      "Need a strict TypeScript scraper.",
+    );
+  });
+
+  it("skips malformed entries silently", () => {
+    const jobs = parseUpworkRss(`
+      <rss>
+        <channel>
+          <item><title>Missing link</title></item>
+          <item>
+            <title>Valid job</title>
+            <link>https://www.upwork.com/jobs/~valid</link>
+          </item>
+        </channel>
+      </rss>
+    `);
+
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0]?.title).toBe("Valid job");
+  });
+
+  it("strips basic HTML and decodes common entities", () => {
+    expect(stripHtml("<p>Hello&nbsp;&amp;&nbsp;welcome<br>friend</p>")).toBe(
+      "Hello & welcome friend",
+    );
+  });
+
+  it("extracts budget and hourly salary text", () => {
+    expect(extractUpworkSalary("Budget: $1,200 Posted On: today")).toBe(
+      "$1,200",
+    );
+    expect(
+      extractUpworkSalary("Hourly Range: $20.00-$40.00 Category: Dev"),
+    ).toBe("$20.00-$40.00");
+  });
+});

--- a/extractors/upwork/tests/run.test.ts
+++ b/extractors/upwork/tests/run.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildUpworkRssUrl } from "../src/fetcher";
+import { runUpwork } from "../src/run";
+
+function createTextResponse(
+  body: string,
+  init: Partial<Response> = {},
+): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? "OK",
+    text: async () => body,
+  } as Response;
+}
+
+describe("runUpwork", () => {
+  it("fetches one RSS URL per term and returns parsed jobs", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createTextResponse(`
+        <rss>
+          <channel>
+            <item>
+              <title>Backend Engineer</title>
+              <link>https://www.upwork.com/jobs/~backend</link>
+              <description>Budget: $300 Posted On: today</description>
+            </item>
+          </channel>
+        </rss>
+      `),
+    );
+
+    const result = await runUpwork({
+      searchTerms: ["backend engineer"],
+      fetchImpl: fetchMock,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.jobs).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      buildUpworkRssUrl("backend engineer", 10),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",
+        }),
+      }),
+    );
+  });
+
+  it("returns a descriptive error when RSS probing fails", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      createTextResponse("", {
+        ok: false,
+        status: 410,
+        statusText: "Gone",
+      }),
+    );
+
+    const result = await runUpwork({
+      searchTerms: ["backend"],
+      fetchImpl: fetchMock,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("410 Gone");
+    expect(result.error).toContain("https://www.upwork.com/ab/feed/jobs/rss");
+  });
+
+  it("does not fetch when cancellation is already requested", async () => {
+    const fetchMock = vi.fn();
+
+    const result = await runUpwork({
+      searchTerms: ["backend"],
+      fetchImpl: fetchMock,
+      shouldCancel: () => true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.jobs).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/extractors/upwork/tsconfig.json
+++ b/extractors/upwork/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noUnusedLocals": false,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["./src/**/*", "./tests/**/*", "./manifest.ts"]
+}

--- a/orchestrator/src/server/config/demo-defaults.data.ts
+++ b/orchestrator/src/server/config/demo-defaults.data.ts
@@ -262,6 +262,7 @@ export const DEMO_SOURCE_BASE_URLS: Record<JobSource, string> = {
   jobindex: "https://www.jobindex.dk",
   seek: "https://www.seek.com.au",
   naukri: "https://www.naukri.com",
+  upwork: "https://www.upwork.com",
   manual: "https://example.com",
 };
 

--- a/orchestrator/src/server/services/extractor-health.ts
+++ b/orchestrator/src/server/services/extractor-health.ts
@@ -127,6 +127,13 @@ const HEALTH_PROBE_CONFIG_BY_SOURCE: Record<
       naukriMaxJobsPerTerm: "1",
     },
   },
+  upwork: {
+    searchTerm: DEFAULT_HEALTH_SEARCH_TERM,
+    selectedCountry: "worldwide",
+    settings: {
+      upworkMaxJobsPerTerm: "1",
+    },
+  },
   manual: {
     searchTerm: DEFAULT_HEALTH_SEARCH_TERM,
     selectedCountry: DEFAULT_HEALTH_SELECTED_COUNTRY,

--- a/shared/src/extractors/index.ts
+++ b/shared/src/extractors/index.ts
@@ -14,6 +14,7 @@ export const EXTRACTOR_SOURCE_IDS = [
   "jobindex",
   "seek",
   "naukri",
+  "upwork",
   "manual",
 ] as const;
 
@@ -81,7 +82,8 @@ export const EXTRACTOR_SOURCE_METADATA: Record<
     order: 107,
     category: "pipeline",
   },
-  manual: { label: "Manual", order: 110, category: "manual" },
+  upwork: { label: "Upwork", order: 108, category: "pipeline" },
+  manual: { label: "Manual", order: 120, category: "manual" },
 };
 
 export const PIPELINE_EXTRACTOR_SOURCE_IDS = EXTRACTOR_SOURCE_IDS.filter(


### PR DESCRIPTION
-Summary
Adds Upwork extractor that fetches job listings via Upwork's public RSS feed.

-Source Details
- Source ID: `upwork`
- Method: RSS XML via `fast-xml-parser`
- Coverage: Global freelance/contract roles

- Checklist
- [x] Follows ExtractorRunResult + CreateJobInput[] contract
- [x] Source registered in shared/src/extractors/index.ts
- [x] TypeScript strict passes
- [x] Biome CI passes
- [x] Parser + run tests included
- [x] Tested locally