### PR TITLE
Add app-wide fatal error boundary and fix reset-password input crash

### DIFF
--- a/orchestrator/src/client/components/AppErrorBoundary.test.tsx
+++ b/orchestrator/src/client/components/AppErrorBoundary.test.tsx
@@ -1,0 +1,190 @@
+import { act, fireEvent, render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AppErrorBoundary,
+  buildFatalIssueUrl,
+  createFatalErrorSnapshot,
+  FatalErrorScreen,
+  sanitizeCrashText,
+} from "./AppErrorBoundary";
+
+function renderBoundary(children: React.ReactNode, initialPath = "/settings") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AppErrorBoundary>{children}</AppErrorBoundary>
+    </MemoryRouter>,
+  );
+}
+
+const ExplodingChild = () => {
+  throw new Error("password=super-secret render failed");
+};
+
+describe("AppErrorBoundary", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (globalThis as { __APP_VERSION__?: string }).__APP_VERSION__ = "1.2.3";
+  });
+
+  it("shows a fatal fallback when a child render crashes", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const preventDefault = (event: ErrorEvent) => event.preventDefault();
+    window.addEventListener("error", preventDefault);
+
+    try {
+      renderBoundary(<ExplodingChild />, "/settings#environment");
+    } finally {
+      window.removeEventListener("error", preventDefault);
+    }
+
+    expect(
+      await screen.findByRole("heading", { name: "Something went wrong" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reload app/i })).toBeVisible();
+    expect(screen.getByRole("link", { name: /go home/i })).toHaveAttribute(
+      "href",
+      "/overview",
+    );
+
+    const issueLink = screen.getByRole("link", {
+      name: /open github issue/i,
+    });
+    expect(issueLink).toHaveAttribute(
+      "href",
+      expect.stringContaining(
+        "https://github.com/DaKheera47/job-ops/issues/new",
+      ),
+    );
+    expect(decodeURIComponent(issueLink.getAttribute("href") ?? "")).toContain(
+      "password=[redacted]",
+    );
+    expect(
+      decodeURIComponent(issueLink.getAttribute("href") ?? ""),
+    ).not.toContain("super-secret");
+
+    const details = screen.getByText("Technical details").closest("details");
+    expect(details).not.toBeNull();
+    expect(details).not.toHaveAttribute("open");
+
+    fireEvent.click(screen.getByText("Technical details"));
+    expect(
+      within(details as HTMLElement).getByText(/Version: v1\.2\.3/),
+    ).toBeInTheDocument();
+  });
+
+  it("calls the reload handler from the fatal screen button", () => {
+    const onReload = vi.fn();
+    const snapshot = createFatalErrorSnapshot(new Error("boom"), "runtime", {
+      route: "/settings",
+    });
+
+    render(<FatalErrorScreen snapshot={snapshot} onReload={onReload} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /reload app/i }));
+    expect(onReload).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the same fallback for uncaught runtime errors", async () => {
+    renderBoundary(<div>Healthy app</div>, "/jobs/ready");
+
+    act(() => {
+      window.dispatchEvent(
+        new ErrorEvent("error", {
+          error: new Error("authorization: Bearer abc.def.ghi runtime failed"),
+          message: "authorization: Bearer abc.def.ghi runtime failed",
+        }),
+      );
+    });
+
+    expect(
+      await screen.findByRole("heading", { name: "Something went wrong" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Healthy app")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Technical details"));
+    expect(screen.getByText(/authorization: \[redacted\]/)).toBeInTheDocument();
+    expect(screen.queryByText(/abc\.def\.ghi/)).not.toBeInTheDocument();
+  });
+
+  it("shows the fatal fallback for unhandled promise rejections", async () => {
+    renderBoundary(<div>Healthy app</div>, "/overview");
+    const event = new Event("unhandledrejection", {
+      cancelable: true,
+    }) as PromiseRejectionEvent;
+    Object.defineProperty(event, "reason", {
+      value: new Error("token=abc123 rejected"),
+    });
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(
+      await screen.findByRole("heading", { name: "Something went wrong" }),
+    ).toBeInTheDocument();
+    expect(event.defaultPrevented).toBe(true);
+
+    fireEvent.click(screen.getByText("Technical details"));
+    expect(screen.getByText(/token=\[redacted\]/)).toBeInTheDocument();
+    expect(screen.queryByText(/abc123/)).not.toBeInTheDocument();
+  });
+
+  it("normalizes non-Error promise rejections safely", async () => {
+    renderBoundary(<div>Healthy app</div>, "/overview");
+    const event = new Event("unhandledrejection", {
+      cancelable: true,
+    }) as PromiseRejectionEvent;
+    Object.defineProperty(event, "reason", {
+      value: { message: "password=plain-object-secret failed" },
+    });
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(
+      await screen.findByRole("heading", { name: "Something went wrong" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Technical details"));
+    expect(screen.getByText(/password=\[redacted\]/)).toBeInTheDocument();
+    expect(screen.queryByText(/plain-object-secret/)).not.toBeInTheDocument();
+  });
+
+  it("builds a sanitized GitHub issue link", () => {
+    const snapshot = createFatalErrorSnapshot(
+      new Error("apiKey='top-secret' exploded"),
+      "runtime",
+      {
+        componentStack:
+          "at Widget (password: hunter2 token=eyJaaaaaaaaaaa.bbbbbbbbbbbb.cccccccccccc)",
+        route: "/settings?tab=security",
+      },
+    );
+
+    const url = buildFatalIssueUrl(snapshot);
+    const issue = new URL(url);
+    const decodedTitle = issue.searchParams.get("title") ?? "";
+    const decodedBody = issue.searchParams.get("body") ?? "";
+    const decoded = `${decodedTitle}\n${decodedBody}`;
+
+    expect(url).toContain("https://github.com/DaKheera47/job-ops/issues/new");
+    expect(decoded).toContain("apiKey='[redacted]");
+    expect(decoded).toContain("password: [redacted]");
+    expect(decoded).toContain("token=[redacted]");
+    expect(decoded).not.toContain("top-secret");
+    expect(decoded).not.toContain("hunter2");
+  });
+
+  it("redacts long opaque values", () => {
+    const longSecret = "a".repeat(100);
+
+    expect(sanitizeCrashText(`secret=${longSecret}`)).toContain(
+      "secret=[redacted]",
+    );
+    expect(sanitizeCrashText(`value ${longSecret}`)).toContain(
+      "[redacted-long-value]",
+    );
+  });
+});

--- a/orchestrator/src/client/components/AppErrorBoundary.tsx
+++ b/orchestrator/src/client/components/AppErrorBoundary.tsx
@@ -1,0 +1,317 @@
+import { AlertTriangle, ExternalLink, Home, RotateCcw } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { GITHUB_REPO, getCurrentAppVersion } from "../lib/version";
+
+type FatalErrorSource = "react" | "runtime" | "unhandledrejection";
+
+export type FatalErrorSnapshot = {
+  id: string;
+  source: FatalErrorSource;
+  name: string;
+  message: string;
+  stack: string | null;
+  componentStack: string | null;
+  route: string;
+  appVersion: string;
+  userAgent: string;
+  timestamp: string;
+};
+
+const REDACTED = "[redacted]";
+const REDACTED_LONG_VALUE = "[redacted-long-value]";
+const MAX_TEXT_LENGTH = 6_000;
+const AUTHORIZATION_PATTERN =
+  /\b(authorization\s*[:=]\s*)(?:Bearer|Basic)?\s*[^\s,;{}]+/gi;
+const SENSITIVE_ASSIGNMENT_PATTERN =
+  /\b(cookie|password|passwd|secret|token|api[_-]?key|x-api-key|credential|set-cookie|proxy-authorization)(\s*[:=]\s*)(["']?)([^"'\s,;{}&]+)/gi;
+const BEARER_TOKEN_PATTERN = /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi;
+const JWT_PATTERN =
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
+const LONG_VALUE_PATTERN = /\b[A-Za-z0-9+/=_-]{80,}\b/g;
+
+function truncateText(value: string): string {
+  if (value.length <= MAX_TEXT_LENGTH) return value;
+  return `${value.slice(0, MAX_TEXT_LENGTH)}\n...[truncated]`;
+}
+
+export function sanitizeCrashText(input: unknown): string {
+  const text =
+    typeof input === "string"
+      ? input
+      : input === undefined || input === null
+        ? ""
+        : String(input);
+
+  return truncateText(text)
+    .replace(AUTHORIZATION_PATTERN, `$1${REDACTED}`)
+    .replace(SENSITIVE_ASSIGNMENT_PATTERN, `$1$2$3${REDACTED}`)
+    .replace(BEARER_TOKEN_PATTERN, `Bearer ${REDACTED}`)
+    .replace(JWT_PATTERN, REDACTED)
+    .replace(LONG_VALUE_PATTERN, REDACTED_LONG_VALUE);
+}
+
+function stringifyUnknownError(input: unknown): string {
+  if (typeof input === "string") return input;
+  if (input instanceof Error) return input.message;
+  if (input === null) return "null";
+  if (input === undefined) return "undefined";
+
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return String(input);
+  }
+}
+
+function toErrorParts(error: unknown): {
+  name: string;
+  message: string;
+  stack: string | null;
+} {
+  if (error instanceof Error) {
+    return {
+      name: sanitizeCrashText(error.name || "Error"),
+      message: sanitizeCrashText(error.message || "Unknown error"),
+      stack: error.stack ? sanitizeCrashText(error.stack) : null,
+    };
+  }
+
+  return {
+    name: "Error",
+    message: sanitizeCrashText(stringifyUnknownError(error)),
+    stack: null,
+  };
+}
+
+function currentRoute(): string {
+  if (typeof window === "undefined") return "unknown";
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}
+
+function userAgent(): string {
+  if (typeof navigator === "undefined") return "unknown";
+  return sanitizeCrashText(navigator.userAgent || "unknown");
+}
+
+export function createFatalErrorSnapshot(
+  error: unknown,
+  source: FatalErrorSource,
+  options: { componentStack?: string | null; route?: string } = {},
+): FatalErrorSnapshot {
+  const parts = toErrorParts(error);
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    source,
+    name: parts.name,
+    message: parts.message || "Unknown error",
+    stack: parts.stack,
+    componentStack: options.componentStack
+      ? sanitizeCrashText(options.componentStack)
+      : null,
+    route: sanitizeCrashText(options.route ?? currentRoute()),
+    appVersion: getCurrentAppVersion(),
+    userAgent: userAgent(),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function issueBody(snapshot: FatalErrorSnapshot): string {
+  const stack = snapshot.stack ?? "Not available";
+  const componentStack = snapshot.componentStack ?? "Not available";
+
+  return sanitizeCrashText(`## Client crash report
+
+- App version: ${snapshot.appVersion}
+- Route: ${snapshot.route}
+- Source: ${snapshot.source}
+- Time: ${snapshot.timestamp}
+- Browser: ${snapshot.userAgent}
+
+## Error
+
+${snapshot.name}: ${snapshot.message}
+
+## Stack
+
+\`\`\`
+${stack}
+\`\`\`
+
+## Component stack
+
+\`\`\`
+${componentStack}
+\`\`\`
+
+## Notes
+
+Please add what you were doing before the app showed this screen.
+`);
+}
+
+export function buildFatalIssueUrl(snapshot: FatalErrorSnapshot): string {
+  const title = sanitizeCrashText(`Client crash: ${snapshot.message}`).slice(
+    0,
+    180,
+  );
+  const params = new URLSearchParams({
+    title,
+    body: issueBody(snapshot),
+  });
+  return `https://github.com/${GITHUB_REPO}/issues/new?${params.toString()}`;
+}
+
+function formatDetails(snapshot: FatalErrorSnapshot): string {
+  return `Version: ${snapshot.appVersion}
+Route: ${snapshot.route}
+Source: ${snapshot.source}
+Time: ${snapshot.timestamp}
+Browser: ${snapshot.userAgent}
+
+${snapshot.name}: ${snapshot.message}
+
+Stack:
+${snapshot.stack ?? "Not available"}
+
+Component stack:
+${snapshot.componentStack ?? "Not available"}`;
+}
+
+export function FatalErrorScreen({
+  onReload = () => window.location.reload(),
+  snapshot,
+}: {
+  onReload?: () => void;
+  snapshot: FatalErrorSnapshot;
+}) {
+  const issueUrl = buildFatalIssueUrl(snapshot);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-10 text-foreground">
+      <section className="w-full max-w-2xl space-y-6 rounded-lg border border-border bg-card p-6 shadow-sm sm:p-8">
+        <div className="flex items-start gap-4">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-destructive/30 bg-destructive/10 text-destructive">
+            <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 space-y-2">
+            <h1 className="text-2xl font-semibold tracking-normal">
+              Something went wrong
+            </h1>
+            <p className="max-w-prose text-sm leading-6 text-muted-foreground">
+              JobOps hit an unexpected client error. Your data should still be
+              safe; reload the app or open a GitHub issue with the diagnostics
+              below.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" onClick={onReload}>
+            <RotateCcw className="h-4 w-4" aria-hidden="true" />
+            Reload app
+          </Button>
+          <Button asChild variant="outline">
+            <a href="/overview">
+              <Home className="h-4 w-4" aria-hidden="true" />
+              Go home
+            </a>
+          </Button>
+          <Button asChild variant="outline">
+            <a href={issueUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+              Open GitHub issue
+            </a>
+          </Button>
+        </div>
+
+        <details className="rounded-md border border-border bg-muted/30 p-4">
+          <summary className="cursor-pointer text-sm font-medium">
+            Technical details
+          </summary>
+          <pre className="mt-3 max-h-80 overflow-auto whitespace-pre-wrap break-words text-xs leading-5 text-muted-foreground">
+            {formatDetails(snapshot)}
+          </pre>
+        </details>
+      </section>
+    </main>
+  );
+}
+
+class ReactCrashBoundary extends React.Component<
+  { children: React.ReactNode; route: string },
+  { snapshot: FatalErrorSnapshot | null }
+> {
+  state: { snapshot: FatalErrorSnapshot | null } = { snapshot: null };
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    this.setState({
+      snapshot: createFatalErrorSnapshot(error, "react", {
+        componentStack: info.componentStack,
+        route: this.props.route,
+      }),
+    });
+  }
+
+  componentDidUpdate(previousProps: { route: string }) {
+    if (this.state.snapshot && previousProps.route !== this.props.route) {
+      this.setState({ snapshot: null });
+    }
+  }
+
+  render() {
+    if (this.state.snapshot) {
+      return <FatalErrorScreen snapshot={this.state.snapshot} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+export function AppErrorBoundary({ children }: { children: React.ReactNode }) {
+  const location = useLocation();
+  const route = `${location.pathname}${location.search}${location.hash}`;
+  const [globalSnapshot, setGlobalSnapshot] =
+    useState<FatalErrorSnapshot | null>(null);
+
+  useEffect(() => {
+    setGlobalSnapshot((current) => (current?.route === route ? current : null));
+  }, [route]);
+
+  useEffect(() => {
+    const handleError = (event: ErrorEvent) => {
+      event.preventDefault();
+      setGlobalSnapshot(
+        createFatalErrorSnapshot(event.error ?? event.message, "runtime", {
+          route,
+        }),
+      );
+    };
+    const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      event.preventDefault();
+      setGlobalSnapshot(
+        createFatalErrorSnapshot(event.reason, "unhandledrejection", {
+          route,
+        }),
+      );
+    };
+
+    window.addEventListener("error", handleError);
+    window.addEventListener("unhandledrejection", handleUnhandledRejection);
+
+    return () => {
+      window.removeEventListener("error", handleError);
+      window.removeEventListener(
+        "unhandledrejection",
+        handleUnhandledRejection,
+      );
+    };
+  }, [route]);
+
+  if (globalSnapshot) {
+    return <FatalErrorScreen snapshot={globalSnapshot} />;
+  }
+
+  return <ReactCrashBoundary route={route}>{children}</ReactCrashBoundary>;
+}

--- a/orchestrator/src/client/lib/version.ts
+++ b/orchestrator/src/client/lib/version.ts
@@ -1,6 +1,6 @@
 declare const __APP_VERSION__: string;
 
-const GITHUB_REPO = "DaKheera47/job-ops";
+export const GITHUB_REPO = "DaKheera47/job-ops";
 const STORAGE_KEY = "jobops_version_check";
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
@@ -33,16 +33,20 @@ export function parseVersion(rawVersion: string): string {
   return normalized || "unknown";
 }
 
+export function getCurrentAppVersion(): string {
+  const currentRaw =
+    typeof __APP_VERSION__ !== "undefined"
+      ? (__APP_VERSION__ as string)
+      : "unknown";
+  return parseVersion(currentRaw);
+}
+
 /**
  * Check for updates against GitHub releases API.
  * Results are cached for 24 hours to avoid rate limits.
  */
 export async function checkForUpdate(): Promise<VersionCheckResult> {
-  const currentRaw =
-    typeof __APP_VERSION__ !== "undefined"
-      ? (__APP_VERSION__ as string)
-      : "unknown";
-  const currentVersion = parseVersion(currentRaw);
+  const currentVersion = getCurrentAppVersion();
 
   // Check cached result
   const cached = canUseStorage() ? localStorage.getItem(STORAGE_KEY) : null;

--- a/orchestrator/src/client/main.tsx
+++ b/orchestrator/src/client/main.tsx
@@ -2,6 +2,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
+import { AppErrorBoundary } from "@/client/components/AppErrorBoundary";
 import { queryClient } from "@/client/lib/queryClient";
 import { App } from "./App";
 import "../index.css";
@@ -13,7 +14,9 @@ ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <App />
+        <AppErrorBoundary>
+          <App />
+        </AppErrorBoundary>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/orchestrator/src/client/pages/settings/components/EnvironmentSettingsSection.test.tsx
+++ b/orchestrator/src/client/pages/settings/components/EnvironmentSettingsSection.test.tsx
@@ -1,9 +1,19 @@
+import * as api from "@client/api";
 import type { UpdateSettingsInput } from "@shared/settings-schema.js";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { FormProvider, useForm } from "react-hook-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Accordion } from "@/components/ui/accordion";
 import { EnvironmentSettingsSection } from "./EnvironmentSettingsSection";
+
+vi.mock("@client/api", () => ({
+  createWorkspaceUser: vi.fn(),
+  getCurrentAuthUser: vi.fn(),
+  listWorkspaceUsers: vi.fn(),
+  resetWorkspaceUserPassword: vi.fn(),
+  setWorkspaceUserDisabled: vi.fn(),
+}));
 
 const EnvironmentSettingsHarness = () => {
   const queryClient = new QueryClient({
@@ -55,6 +65,33 @@ const EnvironmentSettingsHarness = () => {
 };
 
 describe("EnvironmentSettingsSection", () => {
+  beforeEach(() => {
+    vi.mocked(api.getCurrentAuthUser).mockResolvedValue({
+      id: "admin-user",
+      username: "admin",
+      displayName: "Admin User",
+      isSystemAdmin: true,
+      isDisabled: false,
+      workspaceId: "tenant-admin",
+      workspaceName: "Admin Workspace",
+      createdAt: "2026-05-13T00:00:00.000Z",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    });
+    vi.mocked(api.listWorkspaceUsers).mockResolvedValue([
+      {
+        id: "workspace-user",
+        username: "member",
+        displayName: "Member User",
+        isSystemAdmin: false,
+        isDisabled: false,
+        workspaceId: "tenant-member",
+        workspaceName: "Member Workspace",
+        createdAt: "2026-05-13T00:00:00.000Z",
+        updatedAt: "2026-05-13T00:00:00.000Z",
+      },
+    ]);
+  });
+
   it("renders values grouped logically and masks private secrets with hints", () => {
     render(<EnvironmentSettingsHarness />);
 
@@ -72,5 +109,18 @@ describe("EnvironmentSettingsSection", () => {
     expect(screen.getByText("Service Accounts")).toBeInTheDocument();
     expect(screen.getByText("Security")).toBeInTheDocument();
     expect(screen.queryByText("RxResume")).not.toBeInTheDocument();
+  });
+
+  it("updates a workspace user's reset password without crashing", async () => {
+    render(<EnvironmentSettingsHarness />);
+
+    const resetPasswordInput =
+      await screen.findByPlaceholderText("New password");
+
+    fireEvent.change(resetPasswordInput, {
+      target: { value: "new-password" },
+    });
+
+    expect(resetPasswordInput).toHaveValue("new-password");
   });
 });

--- a/orchestrator/src/client/pages/settings/components/EnvironmentSettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/EnvironmentSettingsSection.tsx
@@ -175,12 +175,13 @@ function AccountManagementSection() {
               <div className="flex gap-2">
                 <Input
                   value={resetPassword}
-                  onChange={(event) =>
+                  onChange={(event) => {
+                    const value = event.currentTarget.value;
                     setResetPasswordByUserId((current) => ({
                       ...current,
-                      [user.id]: event.currentTarget.value,
-                    }))
-                  }
+                      [user.id]: value,
+                    }));
+                  }}
                   placeholder="New password"
                   type="password"
                   autoComplete="new-password"


### PR DESCRIPTION
## Summary
- Added a top-level fatal error boundary with a reusable fallback screen, global runtime/unhandled-rejection capture, sanitized diagnostics, and a prefilled GitHub issue link.
- Wrapped the client app at the root so unexpected React/runtime crashes show recovery UI instead of a blank page.
- Fixed the Settings workspace user reset-password field so typing no longer crashes the app by reading the input value synchronously.
- Added regression coverage for the fatal boundary and the reset-password input path.

## Testing
- Focused unit tests added for render crashes, reload handling, runtime errors, promise rejections, redaction, and the Settings reset-password input.
- Validation passed: Biome, type checks, client build, and the relevant test suites.
- Full test suite completed successfully after isolating one unrelated transient server test rerun.