### PR TITLE
Make country support per-extractor instead of JobOps-wide

### DIFF
--- a/docs-site/docs/features/pipeline-run.md
+++ b/docs-site/docs/features/pipeline-run.md
@@ -51,7 +51,8 @@ saved budget when you start the run.
 
 #### Country and source compatibility
 
-- Country selection affects which sources are available.
+- Country selection affects which sources are available, but the country list is owned by JobOps rather than by any single extractor.
+- Each extractor declares its own supported countries. A country can be selectable even when JobSpy-backed sources do not support it, as long as another selected source can run or locally filter for that country.
 - UK-only sources are disabled for non-UK countries.
 - Adzuna is available only for its supported countries and when App ID/App Key are configured in Settings.
 - Glassdoor can be enabled only when:

--- a/extractors/adzuna/manifest.ts
+++ b/extractors/adzuna/manifest.ts
@@ -1,4 +1,7 @@
-import { getAdzunaCountryCode } from "@shared/location-support.js";
+import {
+  ADZUNA_SUPPORTED_COUNTRY_KEYS,
+  getAdzunaCountryCode,
+} from "@shared/location-support.js";
 import { resolveSearchCities } from "@shared/search-cities.js";
 import type {
   ExtractorManifest,
@@ -54,6 +57,9 @@ export const manifest: ExtractorManifest = {
   providesSources: ["adzuna"],
   requiredEnvVars: ["ADZUNA_APP_ID", "ADZUNA_APP_KEY"],
   capabilities: { locationEvidence: true },
+  locationCapabilities: {
+    adzuna: { supportedCountryKeys: ADZUNA_SUPPORTED_COUNTRY_KEYS },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/golangjobs/src/manifest.ts
+++ b/extractors/golangjobs/src/manifest.ts
@@ -37,6 +37,9 @@ export const manifest: ExtractorManifest = {
   id: "golangjobs",
   displayName: "Golang Jobs",
   providesSources: ["golangjobs"],
+  locationCapabilities: {
+    golangjobs: { supportedCountryKeys: null },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/gradcracker/manifest.ts
+++ b/extractors/gradcracker/manifest.ts
@@ -8,6 +8,9 @@ export const manifest: ExtractorManifest = {
   id: "gradcracker",
   displayName: "Gradcracker",
   providesSources: ["gradcracker"],
+  locationCapabilities: {
+    gradcracker: { supportedCountryKeys: ["united kingdom"] },
+  },
   async run(context: ExtractorRuntimeContext) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/hiringcafe/manifest.ts
+++ b/extractors/hiringcafe/manifest.ts
@@ -52,6 +52,9 @@ export const manifest: ExtractorManifest = {
   displayName: "Hiring Cafe",
   providesSources: ["hiringcafe"],
   capabilities: { locationEvidence: true },
+  locationCapabilities: {
+    hiringcafe: { supportedCountryKeys: null },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/jobindex/src/manifest.ts
+++ b/extractors/jobindex/src/manifest.ts
@@ -52,6 +52,9 @@ export const manifest: ExtractorManifest = {
   displayName: "Jobindex",
   providesSources: ["jobindex"],
   capabilities: { locationEvidence: true },
+  locationCapabilities: {
+    jobindex: { supportedCountryKeys: ["denmark"] },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/jobspy/manifest.ts
+++ b/extractors/jobspy/manifest.ts
@@ -1,3 +1,7 @@
+import {
+  GLASSDOOR_SUPPORTED_COUNTRY_KEYS,
+  JOBSPY_SUPPORTED_COUNTRY_KEYS,
+} from "@shared/location-support.js";
 import type {
   ExtractorManifest,
   ExtractorRuntimeContext,
@@ -17,6 +21,14 @@ export const manifest: ExtractorManifest = {
   displayName: "JobSpy",
   providesSources: ["indeed", "linkedin", "glassdoor"],
   capabilities: { locationEvidence: true },
+  locationCapabilities: {
+    indeed: { supportedCountryKeys: JOBSPY_SUPPORTED_COUNTRY_KEYS },
+    linkedin: { supportedCountryKeys: JOBSPY_SUPPORTED_COUNTRY_KEYS },
+    glassdoor: {
+      supportedCountryKeys: GLASSDOOR_SUPPORTED_COUNTRY_KEYS,
+      requiresCityLocations: true,
+    },
+  },
   async run(context: ExtractorRuntimeContext) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/naukri/manifest.ts
+++ b/extractors/naukri/manifest.ts
@@ -53,6 +53,9 @@ export const manifest: ExtractorManifest = {
   id: "naukri",
   displayName: "Naukri",
   providesSources: ["naukri"],
+  locationCapabilities: {
+    naukri: { supportedCountryKeys: ["india"] },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/seek/manifest.ts
+++ b/extractors/seek/manifest.ts
@@ -38,6 +38,9 @@ export const manifest: ExtractorManifest = {
   displayName: "Seek",
   providesSources: ["seek"],
   requiredEnvVars: ["APIFY_TOKEN"],
+  locationCapabilities: {
+    seek: { supportedCountryKeys: ["australia", "new zealand"] },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/startupjobs/src/manifest.ts
+++ b/extractors/startupjobs/src/manifest.ts
@@ -42,6 +42,9 @@ export const manifest: ExtractorManifest = {
   id: "startupjobs",
   displayName: "startup.jobs",
   providesSources: ["startupjobs"],
+  locationCapabilities: {
+    startupjobs: { supportedCountryKeys: null },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/ukvisajobs/manifest.ts
+++ b/extractors/ukvisajobs/manifest.ts
@@ -67,6 +67,9 @@ export const manifest: ExtractorManifest = {
   displayName: "UK Visa Jobs",
   providesSources: ["ukvisajobs"],
   requiredEnvVars: ["UKVISAJOBS_EMAIL", "UKVISAJOBS_PASSWORD"],
+  locationCapabilities: {
+    ukvisajobs: { supportedCountryKeys: ["united kingdom"] },
+  },
   async run(context: ExtractorRuntimeContext) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/wazzuf/manifest.ts
+++ b/extractors/wazzuf/manifest.ts
@@ -37,6 +37,9 @@ export const manifest: ExtractorManifest = {
   id: "wazzuf",
   displayName: "WUZZUF",
   providesSources: ["wazzuf"],
+  locationCapabilities: {
+    wazzuf: { supportedCountryKeys: ["egypt"] },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/extractors/workingnomads/src/manifest.ts
+++ b/extractors/workingnomads/src/manifest.ts
@@ -38,6 +38,9 @@ export const manifest: ExtractorManifest = {
   displayName: "Working Nomads",
   providesSources: ["workingnomads"],
   capabilities: { locationEvidence: true },
+  locationCapabilities: {
+    workingnomads: { supportedCountryKeys: null },
+  },
   async run(context) {
     if (context.shouldCancel?.()) {
       return { success: true, jobs: [] };

--- a/orchestrator/src/server/api/routes/extractor-health.test.ts
+++ b/orchestrator/src/server/api/routes/extractor-health.test.ts
@@ -1,6 +1,7 @@
 import type { Server } from "node:http";
 import type { ExtractorRegistry } from "@server/extractors/registry";
 import type { ExtractorSourceId } from "@shared/extractors";
+import { normalizeLocationSourceCapabilities } from "@shared/location-domain.js";
 import type { ExtractorManifest } from "@shared/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startServer, stopServer } from "./test-utils";
@@ -28,6 +29,12 @@ function createRegistry(
     manifestBySource,
     availableSources:
       availableSources ?? Array.from(manifestBySource.keys()).sort(),
+    locationCapabilitiesBySource: Object.fromEntries(
+      Array.from(manifestBySource.keys()).map((source) => [
+        source,
+        normalizeLocationSourceCapabilities({ source }),
+      ]),
+    ),
   };
 }
 

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -274,6 +274,7 @@ pipelineRouter.post("/run", async (req: Request, res: Response) => {
       const sourcePlans = planLocationSources({
         intent: locationIntent,
         sources: config.sources,
+        capabilitiesBySource: registry.locationCapabilitiesBySource ?? {},
       });
       if (sourcePlans.incompatibleSources.length > 0) {
         const incompatible = sourcePlans.plans

--- a/orchestrator/src/server/api/routes/test-utils.ts
+++ b/orchestrator/src/server/api/routes/test-utils.ts
@@ -7,6 +7,7 @@ import {
   type ExtractorSourceId,
   PIPELINE_EXTRACTOR_SOURCE_IDS,
 } from "@shared/extractors";
+import { normalizeLocationSourceCapabilities } from "@shared/location-domain.js";
 import type { ExtractorManifest } from "@shared/types";
 import { vi } from "vitest";
 
@@ -162,6 +163,12 @@ function createTestExtractorRegistry(): ExtractorRegistry {
     manifests,
     manifestBySource,
     availableSources: [...PIPELINE_EXTRACTOR_SOURCE_IDS],
+    locationCapabilitiesBySource: Object.fromEntries(
+      Array.from(manifestBySource.keys()).map((source) => [
+        source,
+        normalizeLocationSourceCapabilities({ source }),
+      ]),
+    ),
   };
 }
 

--- a/orchestrator/src/server/extractors/registry.test.ts
+++ b/orchestrator/src/server/extractors/registry.test.ts
@@ -109,6 +109,66 @@ describe("extractor registry", () => {
     });
   });
 
+  it("warns when location capabilities reference sources the manifest does not provide", async () => {
+    const discovery = await import("./discovery");
+    const registryModule = await import("./registry");
+    registryModule.__resetExtractorRegistryForTests();
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+
+    vi.mocked(discovery.discoverManifestPaths).mockResolvedValue([
+      "/tmp/jobspy.ts",
+    ]);
+    vi.mocked(discovery.loadManifestFromFile).mockResolvedValue({
+      ...makeManifest("jobspy", ["indeed"], "JobSpy"),
+      locationCapabilities: {
+        linkedin: { supportedCountryKeys: ["united kingdom"] },
+      },
+    });
+
+    const registry = await registryModule.initializeExtractorRegistry();
+
+    expect(registry.manifestBySource.get("indeed")?.id).toBe("jobspy");
+    expect(registry.locationCapabilitiesBySource.indeed).toMatchObject({
+      source: "indeed",
+    });
+    expect(registry.locationCapabilitiesBySource.linkedin).toBeUndefined();
+    expect(
+      warnSpy.mock.calls.some(
+        ([message, context]) =>
+          typeof message === "string" &&
+          message.includes(
+            "location capabilities for sources it does not provide",
+          ) &&
+          typeof context === "object" &&
+          context !== null &&
+          "unknownSources" in context &&
+          Array.isArray(context.unknownSources) &&
+          context.unknownSources.includes("linkedin"),
+      ),
+    ).toBe(true);
+  });
+
+  it("throws on unknown location capability sources in strict mode", async () => {
+    const discovery = await import("./discovery");
+    const registryModule = await import("./registry");
+    registryModule.__resetExtractorRegistryForTests();
+    process.env.EXTRACTOR_REGISTRY_STRICT = "true";
+
+    vi.mocked(discovery.discoverManifestPaths).mockResolvedValue([
+      "/tmp/jobspy.ts",
+    ]);
+    vi.mocked(discovery.loadManifestFromFile).mockResolvedValue({
+      ...makeManifest("jobspy", ["indeed"], "JobSpy"),
+      locationCapabilities: {
+        linkedin: { supportedCountryKeys: ["united kingdom"] },
+      },
+    });
+
+    await expect(registryModule.initializeExtractorRegistry()).rejects.toThrow(
+      "Extractor manifest jobspy declares location capabilities for unknown sources: linkedin",
+    );
+  });
+
   it("throws on duplicate manifest ids in strict mode", async () => {
     const discovery = await import("./discovery");
     const registryModule = await import("./registry");

--- a/orchestrator/src/server/extractors/registry.test.ts
+++ b/orchestrator/src/server/extractors/registry.test.ts
@@ -69,6 +69,44 @@ describe("extractor registry", () => {
     expect(registry.manifestBySource.get("linkedin")?.id).toBe("jobspy");
     expect(registry.manifestBySource.get("naukri")?.id).toBe("naukri");
     expect(registry.manifestBySource.get("ukvisajobs")?.id).toBe("ukvisajobs");
+    expect(registry.locationCapabilitiesBySource.linkedin).toMatchObject({
+      source: "linkedin",
+    });
+  });
+
+  it("normalizes per-source location capabilities from manifests", async () => {
+    const discovery = await import("./discovery");
+    const registryModule = await import("./registry");
+    registryModule.__resetExtractorRegistryForTests();
+
+    vi.mocked(discovery.discoverManifestPaths).mockResolvedValue([
+      "/tmp/jobspy.ts",
+    ]);
+    vi.mocked(discovery.loadManifestFromFile).mockResolvedValue({
+      ...makeManifest("jobspy", ["indeed", "glassdoor"], "JobSpy"),
+      locationCapabilities: {
+        indeed: { supportedCountryKeys: ["UK", "Russia"] },
+        glassdoor: {
+          supportedCountryKeys: ["United States"],
+          requiresCityLocations: true,
+        },
+      },
+    });
+
+    const registry = await registryModule.initializeExtractorRegistry();
+
+    expect(registry.locationCapabilitiesBySource.indeed).toEqual({
+      source: "indeed",
+      supportedCountryKeys: ["united kingdom", "russia"],
+      requiresCityLocations: false,
+      requiresSelectedCountry: false,
+    });
+    expect(registry.locationCapabilitiesBySource.glassdoor).toEqual({
+      source: "glassdoor",
+      supportedCountryKeys: ["united states"],
+      requiresCityLocations: true,
+      requiresSelectedCountry: true,
+    });
   });
 
   it("throws on duplicate manifest ids in strict mode", async () => {

--- a/orchestrator/src/server/extractors/registry.ts
+++ b/orchestrator/src/server/extractors/registry.ts
@@ -55,6 +55,20 @@ class DuplicateSourceProviderError extends Error {
   }
 }
 
+class UnknownLocationCapabilitySourceError extends Error {
+  readonly manifestId: string;
+  readonly unknownSources: string[];
+
+  constructor(args: { manifestId: string; unknownSources: string[] }) {
+    super(
+      `Extractor manifest ${args.manifestId} declares location capabilities for unknown sources: ${args.unknownSources.join(", ")}`,
+    );
+    this.manifestId = args.manifestId;
+    this.unknownSources = args.unknownSources;
+    this.name = "UnknownLocationCapabilitySourceError";
+  }
+}
+
 export function __resetExtractorRegistryForTests(): void {
   registry = null;
   initPromise = null;
@@ -153,6 +167,31 @@ async function createRegistry(): Promise<ExtractorRegistry> {
         continue;
       }
 
+      const unknownLocationCapabilitySources = Object.keys(
+        manifest.locationCapabilities ?? {},
+      ).filter((source) => !validSources.includes(source as ExtractorSourceId));
+
+      if (unknownLocationCapabilitySources.length > 0) {
+        const error = new UnknownLocationCapabilitySourceError({
+          manifestId: manifest.id,
+          unknownSources: unknownLocationCapabilitySources,
+        });
+
+        if (strictModeEnabled()) {
+          throw error;
+        }
+
+        logger.warn(
+          "Extractor manifest contains location capabilities for sources it does not provide",
+          {
+            manifestId: manifest.id,
+            path,
+            unknownSources: unknownLocationCapabilitySources,
+            providedSources: validSources,
+          },
+        );
+      }
+
       for (const typedSource of validSources) {
         if (manifestBySource.has(typedSource)) {
           const existing = manifestBySource.get(typedSource);
@@ -178,7 +217,11 @@ async function createRegistry(): Promise<ExtractorRegistry> {
         throw error;
       }
 
-      if (error instanceof DuplicateManifestIdError && strictModeEnabled()) {
+      if (
+        (error instanceof DuplicateManifestIdError ||
+          error instanceof UnknownLocationCapabilitySourceError) &&
+        strictModeEnabled()
+      ) {
         throw error;
       }
 

--- a/orchestrator/src/server/extractors/registry.ts
+++ b/orchestrator/src/server/extractors/registry.ts
@@ -6,6 +6,10 @@ import {
   type ExtractorSourceId,
   PIPELINE_EXTRACTOR_SOURCE_IDS,
 } from "@shared/extractors";
+import {
+  type LocationSourceCapabilitiesInput,
+  normalizeLocationSourceCapabilities,
+} from "@shared/location-domain.js";
 import type { ExtractorManifest } from "@shared/types";
 import { discoverManifestPaths, loadManifestFromFile } from "./discovery";
 
@@ -13,6 +17,9 @@ export interface ExtractorRegistry {
   manifests: Map<string, ExtractorManifest>;
   manifestBySource: Map<ExtractorSourceId, ExtractorManifest>;
   availableSources: ExtractorSourceId[];
+  locationCapabilitiesBySource: Partial<
+    Record<ExtractorSourceId, LocationSourceCapabilitiesInput>
+  >;
 }
 
 let registry: ExtractorRegistry | null = null;
@@ -111,6 +118,9 @@ async function createRegistry(): Promise<ExtractorRegistry> {
   const manifestPaths = await discoverManifestPaths();
   const manifests = new Map<string, ExtractorManifest>();
   const manifestBySource = new Map<ExtractorSourceId, ExtractorManifest>();
+  const locationCapabilitiesBySource: Partial<
+    Record<ExtractorSourceId, LocationSourceCapabilitiesInput>
+  > = {};
 
   for (const path of manifestPaths) {
     try {
@@ -157,6 +167,11 @@ async function createRegistry(): Promise<ExtractorRegistry> {
       manifests.set(manifest.id, manifest);
       for (const source of validSources) {
         manifestBySource.set(source, manifest);
+        locationCapabilitiesBySource[source] =
+          normalizeLocationSourceCapabilities({
+            source,
+            ...(manifest.locationCapabilities?.[source] ?? {}),
+          });
       }
     } catch (error) {
       if (error instanceof DuplicateSourceProviderError) {
@@ -187,6 +202,9 @@ async function createRegistry(): Promise<ExtractorRegistry> {
       id: manifest.id,
       sources: manifest.providesSources,
       requiredEnvVarsCount: manifest.requiredEnvVars?.length ?? 0,
+      locationCapabilitySources: manifest.providesSources.filter((source) =>
+        Boolean(manifest.locationCapabilities?.[source]),
+      ),
     })),
   });
 
@@ -194,6 +212,7 @@ async function createRegistry(): Promise<ExtractorRegistry> {
     manifests,
     manifestBySource,
     availableSources,
+    locationCapabilitiesBySource,
   };
 }
 

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -88,11 +88,12 @@ function getLegacyLocationSelection(
 function getSourceLocationPlan(
   source: CrawlSource,
   intent: NonNullable<PipelineConfig["locationIntent"]>,
+  capabilities?: Parameters<typeof planLocationSource>[0]["capabilities"],
 ): ReturnType<typeof planLocationSource> & {
   canRun: boolean;
   warnings: string[];
 } {
-  const plan = planLocationSource({ source, intent });
+  const plan = planLocationSource({ source, intent, capabilities });
   return {
     ...plan,
     canRun: plan.isCompatible,
@@ -156,7 +157,11 @@ export async function discoverJobsStep(args: {
     });
   const sourcePlans = args.mergedConfig.sources.map((source) => ({
     source,
-    plan: getSourceLocationPlan(source, locationIntent),
+    plan: getSourceLocationPlan(
+      source,
+      locationIntent,
+      registry.locationCapabilitiesBySource?.[source],
+    ),
   }));
   const compatibleSources = sourcePlans
     .filter(({ plan }) => plan.canRun)
@@ -245,6 +250,9 @@ export async function discoverJobsStep(args: {
           sourceLocationPlan: getSourceLocationPlan(
             grouped.sources[0] as CrawlSource,
             locationIntent,
+            registry.locationCapabilitiesBySource?.[
+              grouped.sources[0] as ExtractorSourceId
+            ],
           ),
           getExistingJobUrls,
           shouldCancel: args.shouldCancel,

--- a/orchestrator/src/server/services/extractor-health.test.ts
+++ b/orchestrator/src/server/services/extractor-health.test.ts
@@ -1,5 +1,6 @@
 import type { ExtractorRegistry } from "@server/extractors/registry";
 import type { ExtractorSourceId } from "@shared/extractors";
+import { normalizeLocationSourceCapabilities } from "@shared/location-domain.js";
 import type { ExtractorManifest } from "@shared/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -26,6 +27,12 @@ function createRegistry(
     manifestBySource,
     availableSources:
       availableSources ?? Array.from(manifestBySource.keys()).sort(),
+    locationCapabilitiesBySource: Object.fromEntries(
+      Array.from(manifestBySource.keys()).map((source) => [
+        source,
+        normalizeLocationSourceCapabilities({ source }),
+      ]),
+    ),
   };
 }
 

--- a/shared/src/location-domain.test.ts
+++ b/shared/src/location-domain.test.ts
@@ -221,16 +221,19 @@ describe("location-domain", () => {
       normalizeLocationSourceCapabilities({ source: "gradcracker" }),
     ).toEqual({
       requiresCityLocations: false,
+      requiresSelectedCountry: false,
       source: "gradcracker",
       supportedCountryKeys: ["united kingdom"],
     });
     expect(normalizeLocationSourceCapabilities({ source: "seek" })).toEqual({
       requiresCityLocations: false,
+      requiresSelectedCountry: true,
       source: "seek",
       supportedCountryKeys: ["australia", "new zealand"],
     });
     expect(normalizeLocationSourceCapabilities({ source: "naukri" })).toEqual({
       requiresCityLocations: false,
+      requiresSelectedCountry: false,
       source: "naukri",
       supportedCountryKeys: ["india"],
     });
@@ -238,6 +241,7 @@ describe("location-domain", () => {
       normalizeLocationSourceCapabilities({ source: "startupjobs" }),
     ).toEqual({
       requiresCityLocations: false,
+      requiresSelectedCountry: false,
       source: "startupjobs",
       supportedCountryKeys: null,
     });
@@ -251,6 +255,7 @@ describe("location-domain", () => {
       }),
     ).toEqual({
       requiresCityLocations: true,
+      requiresSelectedCountry: true,
       source: "glassdoor",
       supportedCountryKeys: ["united kingdom"],
     });

--- a/shared/src/location-domain.test.ts
+++ b/shared/src/location-domain.test.ts
@@ -299,4 +299,35 @@ describe("location-domain", () => {
       "A selected country is required for this source.",
     );
   });
+
+  it("enforces requiresSelectedCountry even for country-agnostic source lists", () => {
+    const result = planLocationSources({
+      intent: {
+        selectedCountry: null,
+        cityLocations: [],
+        workplaceTypes: ["remote"],
+        searchScope: "selected_plus_remote_worldwide",
+        matchStrictness: "exact_only",
+      },
+      sources: ["custom-source"],
+      capabilitiesBySource: {
+        "custom-source": {
+          source: "custom-source",
+          supportedCountryKeys: null,
+          requiresSelectedCountry: true,
+        },
+      },
+    });
+
+    expect(result.compatibleSources).toEqual([]);
+    expect(result.incompatibleSources).toEqual(["custom-source"]);
+    expect(result.plans[0]).toMatchObject({
+      source: "custom-source",
+      isCompatible: false,
+      canRun: false,
+    });
+    expect(result.plans[0]?.reasons).toContain(
+      "A selected country is required for this source.",
+    );
+  });
 });

--- a/shared/src/location-domain.ts
+++ b/shared/src/location-domain.ts
@@ -595,10 +595,7 @@ export function planLocationSource(args: {
         : `Selected country ${formatCountryLabel(requestedCountry)} is not supported.`,
     );
   } else {
-    if (
-      capabilities.supportedCountryKeys !== null &&
-      capabilities.requiresSelectedCountry
-    ) {
+    if (capabilities.requiresSelectedCountry) {
       isCompatible = false;
       reasons.push("A selected country is required for this source.");
     } else {

--- a/shared/src/location-domain.ts
+++ b/shared/src/location-domain.ts
@@ -1,7 +1,9 @@
 import {
   formatCountryLabel,
+  getSourceSupportedCountryKeys,
   isSourceAllowedForCountry,
   normalizeCountryKey,
+  sourceRequiresCityLocations,
 } from "./location-support.js";
 import { normalizeStringArray } from "./normalize-string-array.js";
 import {
@@ -124,12 +126,14 @@ export interface LocationSourceCapabilitiesInput {
   source: JobSource | string;
   supportedCountryKeys?: readonly string[] | null;
   requiresCityLocations?: boolean | null;
+  requiresSelectedCountry?: boolean | null;
 }
 
 export interface LocationSourceCapabilities {
   source: JobSource | string;
   supportedCountryKeys: string[] | null;
   requiresCityLocations: boolean;
+  requiresSelectedCountry: boolean;
 }
 
 export interface LocationSourcePlan {
@@ -303,66 +307,7 @@ function inferWorkplaceTypeFromEvidence(
 function createDefaultSupportedCountryKeys(
   source: JobSource | string,
 ): string[] | null {
-  switch (source) {
-    case "gradcracker":
-    case "ukvisajobs":
-      return ["united kingdom"];
-    case "seek":
-      return ["australia", "new zealand"];
-    case "naukri":
-      return ["india"];
-    case "jobindex":
-      return ["denmark"];
-    case "wazzuf":
-      return ["egypt"];
-    case "glassdoor":
-      return [
-        "australia",
-        "austria",
-        "belgium",
-        "brazil",
-        "canada",
-        "france",
-        "germany",
-        "hong kong",
-        "india",
-        "ireland",
-        "italy",
-        "mexico",
-        "netherlands",
-        "new zealand",
-        "singapore",
-        "spain",
-        "switzerland",
-        "united kingdom",
-        "united states",
-        "vietnam",
-      ];
-    case "adzuna":
-      return [
-        "united kingdom",
-        "united states",
-        "austria",
-        "australia",
-        "belgium",
-        "brazil",
-        "canada",
-        "switzerland",
-        "germany",
-        "spain",
-        "france",
-        "india",
-        "italy",
-        "mexico",
-        "netherlands",
-        "new zealand",
-        "poland",
-        "singapore",
-        "south africa",
-      ];
-    default:
-      return null;
-  }
+  return getSourceSupportedCountryKeys(source as JobSource);
 }
 
 function buildEvidenceLocationText(
@@ -582,7 +527,9 @@ export function getDefaultLocationSourceCapabilities(
   return {
     source,
     supportedCountryKeys: createDefaultSupportedCountryKeys(source),
-    requiresCityLocations: source === "glassdoor",
+    requiresCityLocations: sourceRequiresCityLocations(source as JobSource),
+    requiresSelectedCountry:
+      source === "adzuna" || source === "glassdoor" || source === "seek",
   };
 }
 
@@ -602,6 +549,10 @@ export function normalizeLocationSourceCapabilities(
       "requiresCityLocations" in value
         ? (value.requiresCityLocations ?? defaults.requiresCityLocations)
         : defaults.requiresCityLocations,
+    requiresSelectedCountry:
+      "requiresSelectedCountry" in value
+        ? (value.requiresSelectedCountry ?? defaults.requiresSelectedCountry)
+        : defaults.requiresSelectedCountry,
   };
 }
 
@@ -644,7 +595,10 @@ export function planLocationSource(args: {
         : `Selected country ${formatCountryLabel(requestedCountry)} is not supported.`,
     );
   } else {
-    if (capabilities.supportedCountryKeys !== null) {
+    if (
+      capabilities.supportedCountryKeys !== null &&
+      capabilities.requiresSelectedCountry
+    ) {
       isCompatible = false;
       reasons.push("A selected country is required for this source.");
     } else {

--- a/shared/src/location-support.test.ts
+++ b/shared/src/location-support.test.ts
@@ -27,6 +27,7 @@ describe("location-support", () => {
   it("keeps supported country keys unique and canonical", () => {
     expect(SUPPORTED_COUNTRY_KEYS).toContain("united kingdom");
     expect(SUPPORTED_COUNTRY_KEYS).toContain("united states");
+    expect(SUPPORTED_COUNTRY_KEYS).toContain("russia");
     expect(SUPPORTED_COUNTRY_KEYS).toContain("worldwide");
     expect(SUPPORTED_COUNTRY_KEYS).not.toContain("uk");
     expect(SUPPORTED_COUNTRY_KEYS).not.toContain("us");
@@ -63,6 +64,8 @@ describe("location-support", () => {
       true,
     );
     expect(isSourceAllowedForCountry("startupjobs", "worldwide")).toBe(true);
+    expect(isSourceAllowedForCountry("indeed", "russia")).toBe(false);
+    expect(isSourceAllowedForCountry("startupjobs", "russia")).toBe(true);
   });
 
   it("filters incompatible sources while preserving compatible order", () => {

--- a/shared/src/location-support.ts
+++ b/shared/src/location-support.ts
@@ -1,12 +1,15 @@
 import type { JobSource } from "./types";
 
 const COUNTRY_ALIASES: Record<string, string> = {
+  "czech republic": "czechia",
   eg: "egypt",
+  "korea, republic of": "south korea",
+  "republic of korea": "south korea",
+  "russian federation": "russia",
   uk: "united kingdom",
   us: "united states",
   usa: "united states",
   türkiye: "turkey",
-  "czech republic": "czechia",
 };
 
 const COUNTRY_LABELS: Record<string, string> = {
@@ -17,8 +20,208 @@ const COUNTRY_LABELS: Record<string, string> = {
   czechia: "Czechia",
 };
 
-// Keep this list aligned with the JobSpy supported country inputs.
+// This is the app-level country catalog. Individual extractors decide whether a
+// selected country is compatible with their own upstream source.
 export const SUPPORTED_COUNTRY_INPUTS = [
+  "afghanistan",
+  "albania",
+  "algeria",
+  "andorra",
+  "angola",
+  "argentina",
+  "armenia",
+  "australia",
+  "austria",
+  "azerbaijan",
+  "bahamas",
+  "bahrain",
+  "bangladesh",
+  "barbados",
+  "belarus",
+  "belgium",
+  "belize",
+  "benin",
+  "bhutan",
+  "bolivia",
+  "bosnia and herzegovina",
+  "botswana",
+  "brazil",
+  "brunei",
+  "bulgaria",
+  "burkina faso",
+  "burundi",
+  "cambodia",
+  "cameroon",
+  "canada",
+  "cape verde",
+  "central african republic",
+  "chad",
+  "chile",
+  "china",
+  "colombia",
+  "comoros",
+  "congo",
+  "costa rica",
+  "cote d'ivoire",
+  "croatia",
+  "cuba",
+  "cyprus",
+  "czech republic",
+  "czechia",
+  "denmark",
+  "djibouti",
+  "dominican republic",
+  "ecuador",
+  "eg",
+  "egypt",
+  "el salvador",
+  "equatorial guinea",
+  "eritrea",
+  "estonia",
+  "ethiopia",
+  "fiji",
+  "finland",
+  "france",
+  "gabon",
+  "gambia",
+  "georgia",
+  "germany",
+  "ghana",
+  "greece",
+  "guatemala",
+  "guinea",
+  "guyana",
+  "haiti",
+  "honduras",
+  "hong kong",
+  "hungary",
+  "iceland",
+  "india",
+  "indonesia",
+  "ireland",
+  "israel",
+  "italy",
+  "jamaica",
+  "japan",
+  "jordan",
+  "kazakhstan",
+  "kenya",
+  "kuwait",
+  "kyrgyzstan",
+  "laos",
+  "latvia",
+  "lebanon",
+  "lesotho",
+  "liberia",
+  "libya",
+  "liechtenstein",
+  "lithuania",
+  "luxembourg",
+  "madagascar",
+  "malawi",
+  "malaysia",
+  "maldives",
+  "mali",
+  "malta",
+  "mauritania",
+  "mauritius",
+  "mexico",
+  "moldova",
+  "monaco",
+  "mongolia",
+  "montenegro",
+  "morocco",
+  "mozambique",
+  "myanmar",
+  "namibia",
+  "nepal",
+  "netherlands",
+  "new zealand",
+  "nicaragua",
+  "niger",
+  "nigeria",
+  "north macedonia",
+  "norway",
+  "oman",
+  "pakistan",
+  "palestine",
+  "panama",
+  "paraguay",
+  "peru",
+  "philippines",
+  "poland",
+  "portugal",
+  "qatar",
+  "romania",
+  "russia",
+  "russian federation",
+  "rwanda",
+  "saudi arabia",
+  "senegal",
+  "serbia",
+  "seychelles",
+  "sierra leone",
+  "singapore",
+  "slovakia",
+  "slovenia",
+  "somalia",
+  "south africa",
+  "south korea",
+  "sri lanka",
+  "sudan",
+  "suriname",
+  "tanzania",
+  "spain",
+  "sweden",
+  "switzerland",
+  "taiwan",
+  "tajikistan",
+  "thailand",
+  "trinidad and tobago",
+  "tunisia",
+  "türkiye",
+  "turkey",
+  "uganda",
+  "ukraine",
+  "united arab emirates",
+  "uk",
+  "united kingdom",
+  "usa",
+  "us",
+  "united states",
+  "uruguay",
+  "uzbekistan",
+  "venezuela",
+  "vietnam",
+  "zambia",
+  "zimbabwe",
+  "usa/ca",
+  "worldwide",
+] as const;
+
+const ADZUNA_COUNTRY_CODE_BY_KEY: Record<string, string> = {
+  "united kingdom": "gb",
+  "united states": "us",
+  austria: "at",
+  australia: "au",
+  belgium: "be",
+  brazil: "br",
+  canada: "ca",
+  switzerland: "ch",
+  germany: "de",
+  spain: "es",
+  france: "fr",
+  india: "in",
+  italy: "it",
+  mexico: "mx",
+  netherlands: "nl",
+  "new zealand": "nz",
+  poland: "pl",
+  singapore: "sg",
+  "south africa": "za",
+};
+
+export const JOBSPY_SUPPORTED_COUNTRY_KEYS = [
   "argentina",
   "australia",
   "austria",
@@ -34,11 +237,9 @@ export const SUPPORTED_COUNTRY_INPUTS = [
   "costa rica",
   "croatia",
   "cyprus",
-  "czech republic",
   "czechia",
   "denmark",
   "ecuador",
-  "eg",
   "egypt",
   "estonia",
   "finland",
@@ -85,14 +286,10 @@ export const SUPPORTED_COUNTRY_INPUTS = [
   "switzerland",
   "taiwan",
   "thailand",
-  "türkiye",
   "turkey",
   "ukraine",
   "united arab emirates",
-  "uk",
   "united kingdom",
-  "usa",
-  "us",
   "united states",
   "uruguay",
   "venezuela",
@@ -101,60 +298,58 @@ export const SUPPORTED_COUNTRY_INPUTS = [
   "worldwide",
 ] as const;
 
-const UK_ONLY_SOURCES = new Set<JobSource>(["gradcracker", "ukvisajobs"]);
-const SEEK_SUPPORTED_COUNTRIES = new Set(
-  ["australia", "new zealand"].map((c) => normalizeCountryKey(c)),
+export const GLASSDOOR_SUPPORTED_COUNTRY_KEYS = [
+  "australia",
+  "austria",
+  "belgium",
+  "brazil",
+  "canada",
+  "france",
+  "germany",
+  "hong kong",
+  "india",
+  "ireland",
+  "italy",
+  "mexico",
+  "netherlands",
+  "new zealand",
+  "singapore",
+  "spain",
+  "switzerland",
+  "united kingdom",
+  "united states",
+  "vietnam",
+] as const;
+
+export const ADZUNA_SUPPORTED_COUNTRY_KEYS = Object.keys(
+  ADZUNA_COUNTRY_CODE_BY_KEY,
 );
-const NAUKRI_SUPPORTED_COUNTRIES = new Set(["india"].map(normalizeCountryKey));
-const JOBINDEX_SUPPORTED_COUNTRIES = new Set(
-  ["denmark"].map(normalizeCountryKey),
-);
-const WAZZUF_SUPPORTED_COUNTRIES = new Set(["egypt"].map(normalizeCountryKey));
-const GLASSDOOR_SUPPORTED_COUNTRIES = new Set(
-  [
-    "australia",
-    "austria",
-    "belgium",
-    "brazil",
-    "canada",
-    "france",
-    "germany",
-    "hong kong",
-    "india",
-    "ireland",
-    "italy",
-    "mexico",
-    "netherlands",
-    "new zealand",
-    "singapore",
-    "spain",
-    "switzerland",
-    "united kingdom",
-    "united states",
-    "vietnam",
-  ].map((country) => normalizeCountryKey(country)),
-);
-const ADZUNA_COUNTRY_CODE_BY_KEY: Record<string, string> = {
-  "united kingdom": "gb",
-  "united states": "us",
-  austria: "at",
-  australia: "au",
-  belgium: "be",
-  brazil: "br",
-  canada: "ca",
-  switzerland: "ch",
-  germany: "de",
-  spain: "es",
-  france: "fr",
-  india: "in",
-  italy: "it",
-  mexico: "mx",
-  netherlands: "nl",
-  "new zealand": "nz",
-  poland: "pl",
-  singapore: "sg",
-  "south africa": "za",
+
+const SOURCE_SUPPORTED_COUNTRY_KEYS: Partial<Record<JobSource, string[]>> = {
+  gradcracker: ["united kingdom"],
+  indeed: [...JOBSPY_SUPPORTED_COUNTRY_KEYS],
+  linkedin: [...JOBSPY_SUPPORTED_COUNTRY_KEYS],
+  glassdoor: [...GLASSDOOR_SUPPORTED_COUNTRY_KEYS],
+  ukvisajobs: ["united kingdom"],
+  adzuna: [...ADZUNA_SUPPORTED_COUNTRY_KEYS],
+  jobindex: ["denmark"],
+  seek: ["australia", "new zealand"],
+  naukri: ["india"],
+  wazzuf: ["egypt"],
 };
+
+export function getSourceSupportedCountryKeys(
+  source: JobSource,
+): string[] | null {
+  const countries = SOURCE_SUPPORTED_COUNTRY_KEYS[source];
+  return countries
+    ? countries.map((country) => normalizeCountryKey(country))
+    : null;
+}
+
+export function sourceRequiresCityLocations(source: JobSource): boolean {
+  return source === "glassdoor";
+}
 
 export function normalizeCountryKey(value: string | null | undefined): string {
   const normalized = value?.trim().toLowerCase() ?? "";
@@ -183,7 +378,11 @@ export function isUkCountry(country: string | null | undefined): boolean {
 export function isGlassdoorCountry(
   country: string | null | undefined,
 ): boolean {
-  return GLASSDOOR_SUPPORTED_COUNTRIES.has(normalizeCountryKey(country));
+  return GLASSDOOR_SUPPORTED_COUNTRY_KEYS.includes(
+    normalizeCountryKey(
+      country,
+    ) as (typeof GLASSDOOR_SUPPORTED_COUNTRY_KEYS)[number],
+  );
 }
 
 export function getAdzunaCountryCode(
@@ -196,18 +395,11 @@ export function isSourceAllowedForCountry(
   source: JobSource,
   country: string | null | undefined,
 ): boolean {
-  if (UK_ONLY_SOURCES.has(source)) return isUkCountry(country);
-  if (source === "seek")
-    return SEEK_SUPPORTED_COUNTRIES.has(normalizeCountryKey(country));
-  if (source === "naukri")
-    return NAUKRI_SUPPORTED_COUNTRIES.has(normalizeCountryKey(country));
-  if (source === "jobindex")
-    return JOBINDEX_SUPPORTED_COUNTRIES.has(normalizeCountryKey(country));
-  if (source === "wazzuf")
-    return WAZZUF_SUPPORTED_COUNTRIES.has(normalizeCountryKey(country));
-  if (source === "glassdoor") return isGlassdoorCountry(country);
-  if (source === "adzuna") return getAdzunaCountryCode(country) !== null;
-  return true;
+  const supportedCountryKeys = getSourceSupportedCountryKeys(source);
+  return (
+    supportedCountryKeys === null ||
+    supportedCountryKeys.includes(normalizeCountryKey(country))
+  );
 }
 
 export function getCompatibleSourcesForCountry(

--- a/shared/src/location-support.ts
+++ b/shared/src/location-support.ts
@@ -339,13 +339,24 @@ const SOURCE_SUPPORTED_COUNTRY_KEYS: Partial<Record<JobSource, string[]>> = {
   wazzuf: ["egypt"],
 };
 
+const SOURCE_SUPPORTED_COUNTRY_KEYS_NORMALIZED: Partial<
+  Record<JobSource, string[]>
+> = {};
+const SOURCE_SUPPORTED_COUNTRY_SETS: Partial<Record<JobSource, Set<string>>> =
+  {};
+
+for (const [source, countries] of Object.entries(
+  SOURCE_SUPPORTED_COUNTRY_KEYS,
+) as Array<[JobSource, string[]]>) {
+  const normalized = countries.map((country) => normalizeCountryKey(country));
+  SOURCE_SUPPORTED_COUNTRY_KEYS_NORMALIZED[source] = normalized;
+  SOURCE_SUPPORTED_COUNTRY_SETS[source] = new Set(normalized);
+}
+
 export function getSourceSupportedCountryKeys(
   source: JobSource,
 ): string[] | null {
-  const countries = SOURCE_SUPPORTED_COUNTRY_KEYS[source];
-  return countries
-    ? countries.map((country) => normalizeCountryKey(country))
-    : null;
+  return SOURCE_SUPPORTED_COUNTRY_KEYS_NORMALIZED[source] ?? null;
 }
 
 export function sourceRequiresCityLocations(source: JobSource): boolean {
@@ -379,10 +390,10 @@ export function isUkCountry(country: string | null | undefined): boolean {
 export function isGlassdoorCountry(
   country: string | null | undefined,
 ): boolean {
-  return GLASSDOOR_SUPPORTED_COUNTRY_KEYS.includes(
-    normalizeCountryKey(
-      country,
-    ) as (typeof GLASSDOOR_SUPPORTED_COUNTRY_KEYS)[number],
+  return (
+    SOURCE_SUPPORTED_COUNTRY_SETS.glassdoor?.has(
+      normalizeCountryKey(country),
+    ) ?? false
   );
 }
 
@@ -396,10 +407,10 @@ export function isSourceAllowedForCountry(
   source: JobSource,
   country: string | null | undefined,
 ): boolean {
-  const supportedCountryKeys = getSourceSupportedCountryKeys(source);
+  const supportedCountryKeys = SOURCE_SUPPORTED_COUNTRY_SETS[source];
   return (
-    supportedCountryKeys === null ||
-    supportedCountryKeys.includes(normalizeCountryKey(country))
+    supportedCountryKeys === undefined ||
+    supportedCountryKeys.has(normalizeCountryKey(country))
   );
 }
 

--- a/shared/src/types/extractors.ts
+++ b/shared/src/types/extractors.ts
@@ -1,5 +1,9 @@
 import type { CreateJobInput } from "./jobs";
-import type { LocationIntent, SourceLocationPlan } from "./location";
+import type {
+  LocationIntent,
+  LocationSourceCapabilitiesInput,
+  SourceLocationPlan,
+} from "./location";
 
 export interface ExtractorProgressEvent {
   phase?: "list" | "job";
@@ -18,6 +22,11 @@ export interface ExtractorProgressEvent {
 export interface ExtractorCapabilities {
   locationEvidence?: boolean;
 }
+
+export type ExtractorSourceLocationCapabilities = Omit<
+  LocationSourceCapabilitiesInput,
+  "source"
+>;
 
 export interface ExtractorRuntimeContext {
   source: string;
@@ -49,5 +58,8 @@ export interface ExtractorManifest {
   providesSources: readonly string[];
   requiredEnvVars?: readonly string[];
   capabilities?: ExtractorCapabilities;
+  locationCapabilities?: Partial<
+    Record<string, ExtractorSourceLocationCapabilities>
+  >;
   run: (context: ExtractorRuntimeContext) => Promise<ExtractorRunResult>;
 }


### PR DESCRIPTION
## Summary
- Split the global country catalog from extractor-specific country support.
- Let each extractor manifest declare its own supported countries and city requirements.
- Aggregate those capabilities in the registry and use them for pipeline validation and discovery.
- Expand the selectable country list in the automatic run UI so countries are no longer blocked just because JobSpy does not support them.
- Update docs and tests to reflect the new per-extractor compatibility model.

## Testing
- `biome ci` passed on the touched files and the full repo.
- Shared and orchestrator type checks passed.
- Targeted tests for location support, extractor registry, pipeline discovery, and extractor health passed.
- Full orchestrator test suite passed.
- Client production build passed.