### PR TITLE
Add shared PDF text extraction and resume import fallback

### DIFF
--- a/orchestrator/src/server/services/design-resume/import-file.test.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.test.ts
@@ -1,4 +1,3 @@
-import { AppError } from "@infra/errors";
 import type { DesignResumeDocument, DesignResumeJson } from "@shared/types";
 import JSZip from "jszip";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -20,8 +19,23 @@ const requestContext = vi.hoisted(() => ({
 vi.mock("@server/services/modelSelection", () => modelSelection);
 vi.mock("./index", () => designResumeService);
 vi.mock("@server/infra/request-context", () => requestContext);
+vi.mock("pdf-parse", () => ({
+  default: vi.fn(),
+}));
 
+import pdfParse from "pdf-parse";
 import { importDesignResumeFromFile } from "./import-file";
+
+function makePdfParseResult(text: string) {
+  return {
+    numpages: 1,
+    numrender: 1,
+    info: {},
+    metadata: null,
+    version: "default" as const,
+    text,
+  };
+}
 
 function makeResumeDocument(
   resumeJson: DesignResumeJson = buildDefaultReactiveResumeDocument() as DesignResumeJson,
@@ -72,6 +86,9 @@ describe("importDesignResumeFromFile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal("fetch", vi.fn());
+    vi.mocked(pdfParse).mockResolvedValue(
+      makePdfParseResult("Taylor Quinn\nSenior Engineer"),
+    );
     modelSelection.resolveLlmRuntimeSettings.mockResolvedValue({
       provider: "openai",
       model: "gpt-4.1",
@@ -546,12 +563,213 @@ describe("importDesignResumeFromFile", () => {
     expect(String(body)).not.toContain(spacedBase64.trim());
   });
 
-  it("returns a capability error when the configured provider does not support direct file import", async () => {
+  it("imports PDFs through extracted text for Ollama", async () => {
     modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
       provider: "ollama",
       model: "llama3",
       baseUrl: "http://localhost:11434",
-      apiKey: "unused",
+      apiKey: null,
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: `{"basics":{"name":"Taylor Quinn"}}`,
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await importDesignResumeFromFile({
+      fileName: "resume.pdf",
+      mediaType: "application/pdf",
+      dataBase64: Buffer.from("pdf-data").toString("base64"),
+    });
+
+    expect(pdfParse).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const body =
+      fetchCall?.[1] && "body" in fetchCall[1] ? fetchCall[1].body : "";
+    expect(String(body)).toContain(
+      "The resume file was uploaded as PDF and converted locally to plain text before extraction.",
+    );
+    expect(String(body)).toContain("Taylor Quinn");
+  });
+
+  it("imports PDFs through extracted text for OpenAI-compatible endpoints", async () => {
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
+      provider: "openai_compatible",
+      model: "mistral:7b",
+      baseUrl: "http://localhost:11434/v1/chat/completions",
+      apiKey: null,
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: `{"basics":{"name":"Taylor Quinn"}}`,
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await importDesignResumeFromFile({
+      fileName: "resume.pdf",
+      mediaType: "application/pdf",
+      dataBase64: Buffer.from("pdf-data").toString("base64"),
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining("Taylor Quinn"),
+      }),
+    );
+  });
+
+  it("imports DOCX through extracted text for OpenAI-compatible endpoints", async () => {
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
+      provider: "openai_compatible",
+      model: "gemma3:4b",
+      baseUrl: "http://localhost:11434",
+      apiKey: null,
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          choices: [
+            {
+              message: {
+                content: `{"basics":{"name":"Taylor Quinn"}}`,
+              },
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+    const docxBase64 = await makeDocxBase64("Taylor Quinn\nSenior Engineer");
+
+    await importDesignResumeFromFile({
+      fileName: "resume.docx",
+      mediaType:
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      dataBase64: docxBase64,
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://localhost:11434/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining(
+          "The resume file was uploaded as DOCX and converted locally to plain text before extraction.",
+        ),
+      }),
+    );
+  });
+
+  it("falls back to extracted PDF text when native file input is unsupported", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            error: {
+              message: "This model does not support input_file attachments.",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            output_text: `{"basics":{"name":"Taylor Quinn"}}`,
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      );
+
+    await importDesignResumeFromFile({
+      fileName: "resume.pdf",
+      mediaType: "application/pdf",
+      dataBase64: Buffer.from("pdf-data").toString("base64"),
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    const secondCall = vi.mocked(fetch).mock.calls[1];
+    const secondBody =
+      secondCall?.[1] && "body" in secondCall[1] ? secondCall[1].body : "";
+    expect(String(secondBody)).not.toContain('"type":"input_file"');
+    expect(String(secondBody)).toContain(
+      "The resume file was uploaded as PDF and converted locally to plain text before extraction.",
+    );
+    expect(String(secondBody)).toContain("Taylor Quinn");
+  });
+
+  it("returns a clear error for PDFs without readable text during text fallback", async () => {
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
+      provider: "ollama",
+      model: "llama3",
+      baseUrl: "http://localhost:11434",
+      apiKey: null,
+    });
+    vi.mocked(pdfParse).mockResolvedValueOnce(makePdfParseResult("   "));
+
+    await expect(
+      importDesignResumeFromFile({
+        fileName: "resume.pdf",
+        mediaType: "application/pdf",
+        dataBase64: Buffer.from("pdf-data").toString("base64"),
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message: "Resume PDF did not contain readable text.",
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(
+      designResumeService.replaceCurrentDesignResumeDocument,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("returns a capability error when the configured provider is unsupported", async () => {
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
+      provider: "codex",
+      model: "gpt-5",
+      baseUrl: null,
+      apiKey: null,
     });
 
     await expect(
@@ -564,44 +782,6 @@ describe("importDesignResumeFromFile", () => {
       status: 503,
       message: expect.stringContaining("Resume file import is not available"),
     });
-  });
-
-  it("surfaces a model capability error instead of falling back to local extraction", async () => {
-    vi.mocked(fetch).mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          error: {
-            message: "This model does not support input_file attachments.",
-          },
-        }),
-        {
-          status: 400,
-          headers: { "Content-Type": "application/json" },
-        },
-      ),
-    );
-
-    let thrown: unknown;
-    try {
-      await importDesignResumeFromFile({
-        fileName: "resume.pdf",
-        mediaType: "application/pdf",
-        dataBase64: Buffer.from("pdf-data").toString("base64"),
-      });
-    } catch (error) {
-      thrown = error;
-    }
-
-    expect(thrown).toBeInstanceOf(AppError);
-    expect(thrown).toMatchObject({
-      status: 503,
-      message: expect.stringContaining(
-        "could not accept this attached PDF file directly",
-      ),
-    });
-    expect(
-      designResumeService.replaceCurrentDesignResumeDocument,
-    ).not.toHaveBeenCalled();
   });
 
   it("does not misclassify unrelated upstream errors as file capability failures", async () => {

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -10,6 +10,8 @@ import { getRequestId } from "@server/infra/request-context";
 import {
   DocxTextExtractionError,
   extractDocxText,
+  extractPdfText,
+  PdfTextExtractionError,
 } from "@server/services/document-text-extraction";
 import { GeminiCliClient } from "@server/services/llm/gemini-cli/client";
 import type { JsonSchemaDefinition } from "@server/services/llm/types";
@@ -34,7 +36,10 @@ type SupportedRuntimeProvider =
   | "openai"
   | "openrouter"
   | "gemini"
-  | "gemini_cli";
+  | "gemini_cli"
+  | "openai_compatible"
+  | "ollama"
+  | "lmstudio";
 
 const DESIGN_RESUME_IMPORT_CLI_JSON_SCHEMA: JsonSchemaDefinition = {
   name: "design_resume_import",
@@ -70,6 +75,9 @@ const MAX_IMPORT_FILE_BYTES = 10 * 1024 * 1024;
 const OPENAI_DEFAULT_TIMEOUT_MS = 60_000;
 const OPENROUTER_DEFAULT_TIMEOUT_MS = 90_000;
 const GEMINI_DEFAULT_TIMEOUT_MS = 90_000;
+const LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS = 120_000;
+const CHAT_COMPLETIONS_SUFFIX = "/v1/chat/completions";
+const API_VERSION_SUFFIX = "/v1";
 
 const SUPPORTED_EXTENSION_TO_MEDIA_TYPE: Record<
   string,
@@ -123,6 +131,9 @@ function normalizeRuntimeProvider(
   }
   if (normalized === "gemini") return "gemini";
   if (normalized === "gemini_cli") return "gemini_cli";
+  if (normalized === "openai_compatible") return "openai_compatible";
+  if (normalized === "ollama") return "ollama";
+  if (normalized === "lmstudio") return "lmstudio";
   return null;
 }
 
@@ -219,6 +230,28 @@ function buildDataUrl(
   dataBase64: string,
 ): string {
   return `data:${mediaType};base64,${dataBase64}`;
+}
+
+function normalizeBaseUrlOrEndpoint(baseUrlOrEndpoint: string): string {
+  return baseUrlOrEndpoint.trim().replace(/\/+$/, "");
+}
+
+function appendVersionedPath(baseUrl: string, path: string): string {
+  if (baseUrl.endsWith(API_VERSION_SUFFIX)) {
+    return joinUrl(baseUrl.slice(0, -API_VERSION_SUFFIX.length), path);
+  }
+  return joinUrl(baseUrl, path);
+}
+
+function resolveChatCompletionsUrl(baseUrlOrEndpoint: string): string {
+  const normalized = normalizeBaseUrlOrEndpoint(baseUrlOrEndpoint);
+  if (
+    normalized.endsWith(CHAT_COMPLETIONS_SUFFIX) ||
+    normalized.endsWith("/chat/completions")
+  ) {
+    return normalized;
+  }
+  return appendVersionedPath(normalized, CHAT_COMPLETIONS_SUFFIX);
 }
 
 function buildUserPrompt(): string {
@@ -528,23 +561,6 @@ ${JSON.stringify(template, null, 2)}
 `.trim();
 }
 
-async function extractPdfText(decoded: Buffer): Promise<string> {
-  try {
-    const { default: pdfParse } = await import("pdf-parse");
-    const data = (await pdfParse(decoded)) as { text?: string };
-    const text = typeof data?.text === "string" ? data.text.trim() : "";
-    if (!text) {
-      throw badRequest("Resume PDF did not contain readable text.");
-    }
-    return text;
-  } catch (error) {
-    if (error instanceof AppError && error.status === 400) {
-      throw error;
-    }
-    throw badRequest("Resume PDF file could not be read or is encrypted.");
-  }
-}
-
 async function extractResumeDocxText(decoded: Buffer): Promise<string> {
   let text: string;
   try {
@@ -566,16 +582,18 @@ async function extractResumeDocxText(decoded: Buffer): Promise<string> {
   return text;
 }
 
-function buildDocxPrompt(documentText: string, fileName: string): string {
-  return `
-The resume file was uploaded as DOCX and converted locally to plain text before extraction.
-File name: ${fileName}
-
-Extracted resume text:
-${documentText}
-
-${buildUserPrompt()}
-`.trim();
+async function extractResumePdfText(decoded: Buffer): Promise<string> {
+  try {
+    return await extractPdfText(decoded);
+  } catch (error) {
+    if (error instanceof PdfTextExtractionError) {
+      if (error.code === "EMPTY_TEXT") {
+        throw badRequest("Resume PDF did not contain readable text.");
+      }
+      throw badRequest("Resume PDF file could not be read or is encrypted.");
+    }
+    throw badRequest("Resume PDF file could not be read or is encrypted.");
+  }
 }
 
 function buildTextExtractPrompt(
@@ -596,6 +614,18 @@ ${documentText}
 
 ${buildUserPrompt()}
 `.trim();
+}
+
+function buildDocumentTextPrompt(
+  documentText: string,
+  fileName: string,
+  mediaType: SupportedImportMediaType,
+): string {
+  return buildTextExtractPrompt(
+    documentText,
+    fileName,
+    mediaType === "application/pdf" ? "PDF" : "DOCX",
+  );
 }
 
 function normalizeGeminiModelName(value: string): string {
@@ -772,7 +802,7 @@ function sanitizeNormalizedResume(input: unknown): DesignResumeJson {
 }
 
 function buildCapabilityErrorMessage(provider: string): string {
-  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, Gemini, or Gemini (CLI) to import resumes. DOCX files are converted to text locally before extraction. PDFs with Gemini (CLI) are converted to plain text locally before extraction.`;
+  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, Gemini, Gemini (CLI), OpenAI-compatible, Ollama, or LM Studio to import resumes. PDF and DOCX files can be converted to plain text locally before extraction when native file upload is unavailable.`;
 }
 
 function isFileCapabilityError(message: string): boolean {
@@ -823,6 +853,58 @@ function shouldRetryOpenRouterPdfWithAlternateEngine(input: {
   ].some((pattern) => normalized.includes(pattern));
 }
 
+function isTextOnlyImportProvider(provider: SupportedRuntimeProvider): boolean {
+  return (
+    provider === "openai_compatible" ||
+    provider === "ollama" ||
+    provider === "lmstudio"
+  );
+}
+
+function providerRequiresApiKey(provider: SupportedRuntimeProvider): boolean {
+  return (
+    provider === "openai" || provider === "openrouter" || provider === "gemini"
+  );
+}
+
+async function extractInitialDocumentText(input: {
+  provider: SupportedRuntimeProvider;
+  mediaType: SupportedImportMediaType;
+  decoded: Buffer;
+}): Promise<string | null> {
+  if (input.mediaType === DOCX_MIME) {
+    return extractResumeDocxText(input.decoded);
+  }
+  if (
+    input.mediaType === "application/pdf" &&
+    (input.provider === "gemini_cli" ||
+      isTextOnlyImportProvider(input.provider))
+  ) {
+    return extractResumePdfText(input.decoded);
+  }
+  return null;
+}
+
+function shouldFallbackToExtractedPdfText(input: {
+  provider: SupportedRuntimeProvider;
+  mediaType: SupportedImportMediaType;
+  documentText: string | null;
+  error: unknown;
+}): boolean {
+  if (
+    input.mediaType !== "application/pdf" ||
+    input.documentText ||
+    input.provider === "gemini_cli" ||
+    isTextOnlyImportProvider(input.provider)
+  ) {
+    return false;
+  }
+
+  const message =
+    input.error instanceof Error ? input.error.message : String(input.error);
+  return isFileCapabilityError(message);
+}
+
 async function extractWithOpenAi(args: {
   apiKey: string;
   baseUrl: string | null;
@@ -861,7 +943,11 @@ async function extractWithOpenAi(args: {
             ? [
                 {
                   type: "input_text",
-                  text: buildDocxPrompt(args.documentText, args.fileName),
+                  text: buildDocumentTextPrompt(
+                    args.documentText,
+                    args.fileName,
+                    args.mediaType,
+                  ),
                 },
               ]
             : [
@@ -943,7 +1029,11 @@ async function extractWithOpenRouter(args: {
           {
             role: "user",
             content: args.documentText
-              ? buildDocxPrompt(args.documentText, args.fileName)
+              ? buildDocumentTextPrompt(
+                  args.documentText,
+                  args.fileName,
+                  args.mediaType,
+                )
               : [
                   {
                     type: "text",
@@ -1046,7 +1136,11 @@ async function extractWithGemini(args: {
           parts: args.documentText
             ? [
                 {
-                  text: buildDocxPrompt(args.documentText, args.fileName),
+                  text: buildDocumentTextPrompt(
+                    args.documentText,
+                    args.fileName,
+                    args.mediaType,
+                  ),
                 },
               ]
             : [
@@ -1086,6 +1180,77 @@ async function extractWithGemini(args: {
   const text = extractGeminiText(payload);
   if (!text) {
     throw upstreamError("Gemini returned an empty response for resume import.");
+  }
+  return text;
+}
+
+function getDefaultChatCompletionsBaseUrl(
+  provider: "openai_compatible" | "ollama" | "lmstudio",
+): string {
+  if (provider === "ollama") return "http://localhost:11434";
+  if (provider === "lmstudio") return "http://localhost:1234";
+  return "https://api.openai.com";
+}
+
+async function extractWithTextChatCompletions(args: {
+  provider: "openai_compatible" | "ollama" | "lmstudio";
+  apiKey: string | null;
+  baseUrl: string | null;
+  model: string;
+  mediaType: SupportedImportMediaType;
+  fileName: string;
+  documentText: string;
+  requestId: string | undefined;
+}): Promise<string> {
+  const url = resolveChatCompletionsUrl(
+    args.baseUrl || getDefaultChatCompletionsBaseUrl(args.provider),
+  );
+  const response = await fetch(url, {
+    method: "POST",
+    headers: buildHeaders({
+      apiKey: args.apiKey,
+      provider: args.provider,
+    }),
+    body: JSON.stringify({
+      model: args.model,
+      stream: false,
+      messages: [
+        {
+          role: "system",
+          content: SYSTEM_PROMPT,
+        },
+        {
+          role: "user",
+          content: buildDocumentTextPrompt(
+            args.documentText,
+            args.fileName,
+            args.mediaType,
+          ),
+        },
+      ],
+    }),
+    signal: AbortSignal.timeout(LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS),
+  });
+
+  if (!response.ok) {
+    const detail = parseErrorMessage(await getResponseDetail(response));
+    throw new AppError({
+      status: response.status >= 500 ? 502 : 503,
+      message: detail || `${args.provider} returned ${response.status}.`,
+      details: {
+        provider: args.provider,
+        model: args.model,
+        requestId: args.requestId ?? null,
+      },
+    });
+  }
+
+  const payload = await response.json();
+  const text = extractChatCompletionText(payload);
+  if (!text) {
+    throw upstreamError(
+      `${args.provider} returned an empty response for resume import.`,
+    );
   }
   return text;
 }
@@ -1170,6 +1335,28 @@ async function extractResumeFromProvider(args: {
   if (args.provider === "openrouter") {
     return extractWithOpenRouter(args);
   }
+  if (
+    args.provider === "openai_compatible" ||
+    args.provider === "ollama" ||
+    args.provider === "lmstudio"
+  ) {
+    const text = args.documentText?.trim();
+    if (!text) {
+      throw badRequest(
+        `${args.provider} resume import requires plain-text resume content (DOCX or extracted PDF text).`,
+      );
+    }
+    return extractWithTextChatCompletions({
+      provider: args.provider,
+      apiKey: args.apiKey || null,
+      baseUrl: args.baseUrl,
+      model: args.model,
+      mediaType: args.mediaType,
+      fileName: args.fileName,
+      documentText: text,
+      requestId: args.requestId,
+    });
+  }
   return extractWithGemini(args);
 }
 
@@ -1202,30 +1389,67 @@ export async function importDesignResumeFromFile(
     );
   }
 
-  const isGeminiCli = provider === "gemini_cli";
-  if (!isGeminiCli && !runtime.apiKey) {
+  if (providerRequiresApiKey(provider) && !runtime.apiKey) {
     throw serviceUnavailable(
       "Connect your AI provider in Settings before importing a resume file.",
     );
   }
 
   try {
-    let documentText: string | null =
-      mediaType === DOCX_MIME ? await extractResumeDocxText(decoded) : null;
-    if (isGeminiCli && mediaType === "application/pdf") {
-      documentText = await extractPdfText(decoded);
-    }
-    const rawText = await extractResumeFromProvider({
+    let documentText = await extractInitialDocumentText({
       provider,
-      apiKey: runtime.apiKey ?? "",
-      baseUrl: runtime.baseUrl,
-      model: runtime.model,
       mediaType,
-      fileName,
-      dataBase64: normalizedBase64,
-      documentText,
-      requestId,
+      decoded,
     });
+    let rawText: string;
+    try {
+      rawText = await extractResumeFromProvider({
+        provider,
+        apiKey: runtime.apiKey ?? "",
+        baseUrl: runtime.baseUrl,
+        model: runtime.model,
+        mediaType,
+        fileName,
+        dataBase64: normalizedBase64,
+        documentText,
+        requestId,
+      });
+    } catch (error) {
+      if (
+        !shouldFallbackToExtractedPdfText({
+          provider,
+          mediaType,
+          documentText,
+          error,
+        })
+      ) {
+        throw error;
+      }
+
+      logger.info(
+        "Retrying design resume file import with extracted PDF text",
+        {
+          requestId: requestId ?? null,
+          provider,
+          model: runtime.model,
+          fileName,
+          mediaType,
+        },
+      );
+
+      documentText = await extractResumePdfText(decoded);
+      rawText = await extractResumeFromProvider({
+        provider,
+        apiKey: runtime.apiKey ?? "",
+        baseUrl: runtime.baseUrl,
+        model: runtime.model,
+        mediaType,
+        fileName,
+        dataBase64: normalizedBase64,
+        documentText,
+        requestId,
+      });
+    }
     const parsed = parseImportedResumeJson(rawText);
     const normalized = sanitizeNormalizedResume(parsed);
     const saved = await replaceCurrentDesignResumeDocument({

--- a/orchestrator/src/server/services/document-text-extraction.test.ts
+++ b/orchestrator/src/server/services/document-text-extraction.test.ts
@@ -1,0 +1,118 @@
+import JSZip from "jszip";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("pdf-parse", () => ({
+  default: vi.fn(),
+}));
+
+import pdfParse from "pdf-parse";
+import {
+  DocxTextExtractionError,
+  extractDocxText,
+  extractPdfText,
+} from "./document-text-extraction";
+
+function makePdfParseResult(text: string) {
+  return {
+    numpages: 1,
+    numrender: 1,
+    info: {},
+    metadata: null,
+    version: "default" as const,
+    text,
+  };
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}
+
+async function makeDocxBuffer(text: string): Promise<Buffer> {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:r>
+        <w:t>${escapeXml(text)}</w:t>
+      </w:r>
+    </w:p>
+  </w:body>
+</w:document>`,
+  );
+  return zip.generateAsync({ type: "nodebuffer" });
+}
+
+describe("document text extraction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("extracts readable PDF text", async () => {
+    vi.mocked(pdfParse).mockResolvedValueOnce(
+      makePdfParseResult("  Taylor Quinn\nSenior Engineer  "),
+    );
+
+    await expect(extractPdfText(Buffer.from("%PDF-1.4"))).resolves.toBe(
+      "Taylor Quinn\nSenior Engineer",
+    );
+  });
+
+  it("rejects PDFs with no readable text", async () => {
+    vi.mocked(pdfParse).mockResolvedValueOnce(makePdfParseResult("   "));
+
+    await expect(extractPdfText(Buffer.from("%PDF-1.4"))).rejects.toMatchObject(
+      {
+        name: "PdfTextExtractionError",
+        code: "EMPTY_TEXT",
+      },
+    );
+  });
+
+  it("rejects unreadable or encrypted PDFs", async () => {
+    vi.mocked(pdfParse).mockRejectedValueOnce(new Error("invalid pdf"));
+
+    await expect(
+      extractPdfText(Buffer.from("not a pdf")),
+    ).rejects.toMatchObject({
+      name: "PdfTextExtractionError",
+      code: "INVALID_PDF",
+    });
+  });
+
+  it("extracts readable DOCX text", async () => {
+    const buffer = await makeDocxBuffer("Taylor & Quinn\nSenior Engineer");
+
+    await expect(extractDocxText(buffer)).resolves.toBe(
+      "Taylor & Quinn\nSenior Engineer",
+    );
+  });
+
+  it("rejects invalid DOCX files", async () => {
+    await expect(
+      extractDocxText(Buffer.from("not a docx")),
+    ).rejects.toBeInstanceOf(DocxTextExtractionError);
+    await expect(
+      extractDocxText(Buffer.from("not a docx")),
+    ).rejects.toMatchObject({
+      code: "INVALID_DOCX",
+    });
+  });
+
+  it("rejects DOCX files missing document XML", async () => {
+    const zip = new JSZip();
+    zip.file("word/styles.xml", "<xml />");
+    const buffer = await zip.generateAsync({ type: "nodebuffer" });
+
+    await expect(extractDocxText(buffer)).rejects.toMatchObject({
+      code: "MISSING_DOCUMENT",
+    });
+  });
+});

--- a/orchestrator/src/server/services/document-text-extraction.ts
+++ b/orchestrator/src/server/services/document-text-extraction.ts
@@ -1,6 +1,7 @@
 import JSZip from "jszip";
 
 export type DocxTextExtractionErrorCode = "INVALID_DOCX" | "MISSING_DOCUMENT";
+export type PdfTextExtractionErrorCode = "INVALID_PDF" | "EMPTY_TEXT";
 
 export class DocxTextExtractionError extends Error {
   code: DocxTextExtractionErrorCode;
@@ -8,6 +9,16 @@ export class DocxTextExtractionError extends Error {
   constructor(code: DocxTextExtractionErrorCode, message: string) {
     super(message);
     this.name = "DocxTextExtractionError";
+    this.code = code;
+  }
+}
+
+export class PdfTextExtractionError extends Error {
+  code: PdfTextExtractionErrorCode;
+
+  constructor(code: PdfTextExtractionErrorCode, message: string) {
+    super(message);
+    this.name = "PdfTextExtractionError";
     this.code = code;
   }
 }
@@ -76,4 +87,27 @@ export async function extractDocxText(buffer: Buffer): Promise<string> {
 
   const xml = await documentXml.async("string");
   return normalizeDocxXmlText(xml);
+}
+
+export async function extractPdfText(buffer: Buffer): Promise<string> {
+  try {
+    const { default: pdfParse } = await import("pdf-parse");
+    const data = (await pdfParse(buffer)) as { text?: string };
+    const text = typeof data?.text === "string" ? data.text.trim() : "";
+    if (!text) {
+      throw new PdfTextExtractionError(
+        "EMPTY_TEXT",
+        "PDF file did not contain readable text.",
+      );
+    }
+    return text;
+  } catch (error) {
+    if (error instanceof PdfTextExtractionError) {
+      throw error;
+    }
+    throw new PdfTextExtractionError(
+      "INVALID_PDF",
+      "PDF file could not be read or is encrypted.",
+    );
+  }
 }

--- a/orchestrator/src/server/services/ghostwriter-context.test.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.test.ts
@@ -15,6 +15,10 @@ vi.mock("node:fs/promises", () => ({
   open: mocks.open,
 }));
 
+vi.mock("pdf-parse", () => ({
+  default: vi.fn(),
+}));
+
 vi.mock("../repositories/jobs", () => ({
   getJobById: vi.fn(),
   listJobNotesByIds: vi.fn(),
@@ -45,12 +49,24 @@ vi.mock("./writing-style", async (importOriginal) => {
   };
 });
 
+import pdfParse from "pdf-parse";
 import { listJobDocumentsByIds } from "../repositories/job-documents";
 import { getJobById, listJobNotesByIds } from "../repositories/jobs";
 import { getSetting } from "../repositories/settings";
 import { listJobPostApplicationEmailsByIds } from "./post-application/job-emails";
 import { getProfile } from "./profile";
 import { getWritingStyle } from "./writing-style";
+
+function makePdfParseResult(text: string) {
+  return {
+    numpages: 1,
+    numrender: 1,
+    info: {},
+    metadata: null,
+    version: "default" as const,
+    text,
+  };
+}
 
 function mockDocumentFile(buffer: Buffer) {
   const read = vi.fn(
@@ -82,6 +98,9 @@ describe("buildJobChatPromptContext", () => {
     vi.mocked(listJobNotesByIds).mockResolvedValue([]);
     vi.mocked(listJobDocumentsByIds).mockResolvedValue([]);
     mockDocumentFile(Buffer.from(""));
+    vi.mocked(pdfParse).mockResolvedValue(
+      makePdfParseResult("PDF context text"),
+    );
     vi.mocked(listJobPostApplicationEmailsByIds).mockResolvedValue([]);
     vi.mocked(getSetting).mockResolvedValue(null);
     vi.mocked(getWritingStyle).mockResolvedValue({
@@ -507,6 +526,42 @@ describe("buildJobChatPromptContext", () => {
     expect(context.selectedDocumentsSnapshot).toContain(
       "Discuss reliability & incident response.",
     );
+  });
+
+  it("extracts PDF documents for selected job document context", async () => {
+    const job = createJob({ id: "job-ctx-pdf" });
+    vi.mocked(getJobById).mockResolvedValue(job);
+    vi.mocked(getProfile).mockResolvedValue({});
+    vi.mocked(pdfParse).mockResolvedValueOnce(
+      makePdfParseResult("Interview pack\nDiscuss reliability."),
+    );
+    vi.mocked(listJobDocumentsByIds).mockResolvedValue([
+      {
+        id: "doc-pdf",
+        jobId: job.id,
+        fileName: "interview-pack.pdf",
+        mediaType: "application/pdf",
+        byteSize: 2048,
+        storagePath: "/tmp/interview-pack.pdf",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+    ]);
+    mockDocumentFile(Buffer.from("%PDF-1.4"));
+
+    const context = await buildJobChatPromptContext(
+      job.id,
+      [],
+      [],
+      ["doc-pdf"],
+    );
+
+    expect(pdfParse).toHaveBeenCalledOnce();
+    expect(context.selectedDocumentsSnapshot).toContain(
+      "Document 1: interview-pack.pdf",
+    );
+    expect(context.selectedDocumentsSnapshot).toContain("Interview pack");
+    expect(context.selectedDocumentsSnapshot).toContain("Discuss reliability.");
   });
 
   it("reads only the configured document prefix for Ghostwriter context", async () => {

--- a/orchestrator/src/server/services/ghostwriter-context.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.ts
@@ -25,7 +25,7 @@ import type { Job, JobDocument, ResumeProfile } from "@shared/types";
 import * as jobDocumentsRepo from "../repositories/job-documents";
 import * as jobsRepo from "../repositories/jobs";
 import * as settingsRepo from "../repositories/settings";
-import { extractDocxText } from "./document-text-extraction";
+import { extractDocxText, extractPdfText } from "./document-text-extraction";
 import {
   getWritingLanguageLabel,
   resolveWritingOutputLanguage,
@@ -262,9 +262,7 @@ async function extractDocumentText(
 
   if (isJobDocumentPdf(document)) {
     try {
-      const { default: pdfParse } = await import("pdf-parse");
-      const result = await pdfParse(buffer);
-      return (result.text ?? "").trim();
+      return await extractPdfText(buffer);
     } catch (error) {
       logger.warn("Failed to extract Ghostwriter document PDF text", {
         jobId: document.jobId,


### PR DESCRIPTION
## Summary
- Add shared server helpers for PDF and DOCX text extraction, including typed errors for unreadable or empty documents.
- Update resume import to support local text-only providers and retry native file imports with extracted PDF text when attachment handling fails.
- Reuse the shared PDF/DOCX helpers in Ghostwriter document context instead of duplicating parsing logic.
- Add coverage for helper behavior, local-provider resume import, fallback handling, and Ghostwriter PDF document extraction.

## Testing
- Added unit tests for readable, empty, invalid, and missing-content PDF/DOCX extraction cases.
- Added resume import tests for Ollama and OpenAI-compatible text fallback, plus native file capability retry behavior.
- Added Ghostwriter context tests to verify PDF/DOCX document text extraction uses the shared helper path.
- Targeted tests passed, type checking passed, and client build passed.