### PR TITLE
Add OpenPanel analytics for Resume Studio and auth identity

### DIFF
--- a/orchestrator/index.html
+++ b/orchestrator/index.html
@@ -9,6 +9,17 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <script defer src="https://umami.dakheera47.com/script.js" data-website-id="0dc42ed1-87c3-4ac0-9409-5a9b9588fe66"></script>
+    <script>
+      window.op=window.op||function(){var n=[];return new Proxy(function(){arguments.length&&n.push([].slice.call(arguments))},{get:function(t,r){return"q"===r?n:function(){n.push([r].concat([].slice.call(arguments)))}} ,has:function(t,r){return"q"===r}}) }();
+      window.op('init', {
+        apiUrl: 'https://openpanel.dakheera47.com/api',
+        clientId: '6a953241-309b-4e5a-be1b-412c5d7b6544',
+        trackScreenViews: true,
+        trackOutgoingLinks: true,
+        trackAttributes: true,
+      });
+    </script>
+    <script src="https://openpanel.dev/op1.js" defer async></script>
   </head>
   <body>
     <div id="root"></div>

--- a/orchestrator/src/client/App.tsx
+++ b/orchestrator/src/client/App.tsx
@@ -16,6 +16,7 @@ import { CSSTransition, SwitchTransition } from "react-transition-group";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import { OnboardingGate } from "./components/OnboardingGate";
+import { useAnalyticsIdentity } from "./hooks/useAnalyticsIdentity";
 import { useDemoInfo } from "./hooks/useDemoInfo";
 import { setAuthNavigator } from "./lib/auth-navigation";
 import { DesignResumePage } from "./pages/DesignResumePage";
@@ -52,6 +53,7 @@ const REDIRECTS: Array<{ from: string; to: string }> = [
 const DEMO_WAITLIST_BANNER_DISMISSED_KEY = "jobops.demoWaitlistBannerDismissed";
 
 export const App: React.FC = () => {
+  useAnalyticsIdentity();
   const location = useLocation();
   const navigate = useNavigate();
   const nodeRef = useRef<HTMLDivElement>(null);

--- a/orchestrator/src/client/api/auth.ts
+++ b/orchestrator/src/client/api/auth.ts
@@ -43,6 +43,11 @@ export type AuthBootstrapStatus = {
   setupRequired: boolean;
 };
 
+export type CurrentAuthContext = {
+  user: AuthUser;
+  analyticsDistinctId: string | null;
+};
+
 export async function signInWithCredentials(
   username: string,
   password: string,
@@ -85,8 +90,19 @@ export async function setupFirstAdmin(input: {
   return data.user;
 }
 
+export async function getCurrentAuthContext(): Promise<CurrentAuthContext> {
+  const result = await fetchApi<{
+    user: AuthUser;
+    analyticsDistinctId?: string | null;
+  }>("/auth/me");
+  return {
+    user: result.user,
+    analyticsDistinctId: result.analyticsDistinctId ?? null,
+  };
+}
+
 export async function getCurrentAuthUser(): Promise<AuthUser> {
-  const result = await fetchApi<{ user: AuthUser }>("/auth/me");
+  const result = await getCurrentAuthContext();
   return result.user;
 }
 

--- a/orchestrator/src/client/components/design-resume/DesignResumeFieldAssistant.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeFieldAssistant.tsx
@@ -20,6 +20,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { bucketQueryLength, trackProductEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 
 type FieldValue = string | string[];
@@ -223,6 +224,7 @@ export const DesignResumeFieldAssistant: React.FC<
   const contentRef = useRef<HTMLDivElement | null>(null);
   const dragSessionRef = useRef<DragSession | null>(null);
   const currentValueRef = useRef(value);
+  const lastPromptLengthBucketRef = useRef<string>("0");
   currentValueRef.current = value;
 
   useEffect(() => {
@@ -252,6 +254,8 @@ export const DesignResumeFieldAssistant: React.FC<
     if (isGenerating) return;
 
     const wasEmptyAtStart = isEmptyValue(currentValueRef.current);
+    const promptLengthBucket = bucketQueryLength(content);
+    lastPromptLengthBucketRef.current = promptLengthBucket;
     const controller = new AbortController();
     abortRef.current = controller;
     setIsGenerating(true);
@@ -281,9 +285,23 @@ export const DesignResumeFieldAssistant: React.FC<
       };
       assistantMessage.suggestion = suggestion;
       setMessages((current) => [...current, assistantMessage]);
+      trackProductEvent("resume_studio_ai_field_suggestion_completed", {
+        section: section ?? "unknown",
+        field_type: valueType,
+        result: "generated",
+        was_empty: wasEmptyAtStart,
+        prompt_length_bucket: promptLengthBucket,
+      });
 
       if (wasEmptyAtStart && isEmptyValue(currentValueRef.current)) {
         onApply(result.suggestion);
+        trackProductEvent("resume_studio_ai_field_suggestion_completed", {
+          section: section ?? "unknown",
+          field_type: valueType,
+          result: "auto_applied",
+          was_empty: wasEmptyAtStart,
+          prompt_length_bucket: promptLengthBucket,
+        });
         toast.success(`${label} filled with AI draft.`);
         return;
       }
@@ -291,6 +309,13 @@ export const DesignResumeFieldAssistant: React.FC<
       setPendingSuggestion(suggestion);
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") return;
+      trackProductEvent("resume_studio_ai_field_suggestion_completed", {
+        section: section ?? "unknown",
+        field_type: valueType,
+        result: "error",
+        was_empty: wasEmptyAtStart,
+        prompt_length_bucket: promptLengthBucket,
+      });
       showErrorToast(error, "AI field edit failed");
     } finally {
       abortRef.current = null;
@@ -301,6 +326,13 @@ export const DesignResumeFieldAssistant: React.FC<
   const applySuggestion = (suggestion: PendingSuggestion) => {
     onApply(suggestion.value);
     setPendingSuggestion(null);
+    trackProductEvent("resume_studio_ai_field_suggestion_completed", {
+      section: section ?? "unknown",
+      field_type: valueType,
+      result: "applied",
+      was_empty: isEmptyValue(currentValueRef.current),
+      prompt_length_bucket: lastPromptLengthBucketRef.current,
+    });
     toast.success(`${label} updated.`);
   };
 

--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
@@ -27,6 +27,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { bucketCount, trackProductEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { DesignResumeSection } from "./DesignResumeSection";
 import type { ItemDefinition } from "./definitions";
@@ -64,6 +65,12 @@ function getItemPreview(
     .map((entry) => toText(entry))
     .filter(Boolean)
     .join(", ");
+}
+
+function getDeviceLayout(): "mobile" | "desktop" {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+    return "desktop";
+  return window.matchMedia("(max-width: 639px)").matches ? "mobile" : "desktop";
 }
 
 type DesignResumeListSectionProps = {
@@ -389,16 +396,29 @@ export function DesignResumeListSectionContent({
     onUpdateItems(
       items.filter((_, currentIndex) => currentIndex !== pendingRemovalIndex),
     );
+    trackProductEvent("resume_studio_section_edited", {
+      section: definition.key,
+      action: "delete",
+      item_count_bucket: bucketCount(Math.max(0, items.length - 1)),
+      device_layout: getDeviceLayout(),
+    });
     setPendingRemovalIndex(null);
   };
 
   const toggleItemHidden = (index: number) => {
+    const isHidden = toBoolean(items[index]?.hidden, false);
     const nextItems = [...items];
     nextItems[index] = {
       ...nextItems[index],
-      hidden: !toBoolean(nextItems[index].hidden, false),
+      hidden: !isHidden,
     };
     onUpdateItems(nextItems);
+    trackProductEvent("resume_studio_section_edited", {
+      section: definition.key,
+      action: isHidden ? "unhide" : "hide",
+      item_count_bucket: bucketCount(nextItems.length),
+      device_layout: getDeviceLayout(),
+    });
   };
 
   const updateProjectInclusionMode = (
@@ -453,6 +473,12 @@ export function DesignResumeListSectionContent({
     }
 
     onUpdateItems(reorderItems(items, fromIndex, index));
+    trackProductEvent("resume_studio_section_edited", {
+      section: definition.key,
+      action: "reorder",
+      item_count_bucket: bucketCount(items.length),
+      device_layout: getDeviceLayout(),
+    });
     resetDragState();
   };
 

--- a/orchestrator/src/client/components/design-resume/DesignResumePdfPreview.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumePdfPreview.tsx
@@ -7,6 +7,7 @@ import type {
 } from "@shared/types";
 import { FileText, Loader2 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { trackProductEvent } from "@/lib/analytics";
 
 type DesignResumePdfPreviewProps = {
   draft: DesignResumeDocument;
@@ -18,6 +19,15 @@ type DesignResumePdfPreviewProps = {
 };
 
 type PreviewState = "idle" | "waiting-for-save" | "loading" | "ready" | "error";
+
+function bucketLatencyMs(latencyMs: number): string {
+  if (!Number.isFinite(latencyMs) || latencyMs < 0) return "unknown";
+  if (latencyMs < 500) return "lt_500ms";
+  if (latencyMs < 1_000) return "500_1000ms";
+  if (latencyMs < 2_500) return "1000_2500ms";
+  if (latencyMs < 5_000) return "2500_5000ms";
+  return "5000ms_plus";
+}
 
 export function DesignResumePdfPreview({
   draft,
@@ -61,6 +71,7 @@ export function DesignResumePdfPreview({
     }
 
     const requestId = ++requestSequence.current;
+    const startedAt = Date.now();
     lastLoadedKey.current = revisionKey;
     setPreviewState("loading");
     setPreviewError(null);
@@ -82,6 +93,12 @@ export function DesignResumePdfPreview({
         pdfObjectUrlRef.current = objectUrl;
         setPdfUrl(`${objectUrl}#toolbar=0&navpanes=0&view=FitH`);
         setPreviewState("ready");
+        trackProductEvent("resume_studio_pdf_preview_completed", {
+          renderer: pdfRenderer,
+          theme: typstTheme,
+          result: "success",
+          latency_bucket: bucketLatencyMs(Date.now() - startedAt),
+        });
       })
       .catch((error: unknown) => {
         if (requestSequence.current !== requestId) return;
@@ -93,8 +110,21 @@ export function DesignResumePdfPreview({
         );
         setPreviewState("error");
         setIsFrameLoading(false);
+        trackProductEvent("resume_studio_pdf_preview_completed", {
+          renderer: pdfRenderer,
+          theme: typstTheme,
+          result: "error",
+          latency_bucket: bucketLatencyMs(Date.now() - startedAt),
+        });
       });
-  }, [isDirty, isUpdatingRenderer, revisionKey, saveState]);
+  }, [
+    isDirty,
+    isUpdatingRenderer,
+    pdfRenderer,
+    revisionKey,
+    saveState,
+    typstTheme,
+  ]);
 
   useEffect(() => {
     return () => {

--- a/orchestrator/src/client/components/design-resume/DesignResumeRail.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeRail.tsx
@@ -10,6 +10,7 @@ import type {
   ResumeProjectsSettings,
 } from "@shared/types";
 import { Accordion } from "@/components/ui/accordion";
+import { bucketCount, trackProductEvent } from "@/lib/analytics";
 import {
   BasicsCustomFieldsSection,
   BasicsSection,
@@ -282,6 +283,7 @@ export function DesignResumeRail({
                   items,
                   settings?.resumeProjects?.value ?? null,
                 );
+                const fromMode = getProjectTailoringMode(current, projectId);
                 updateSettingsMutation.mutate({
                   resumeProjects: setProjectTailoringMode({
                     settings: current,
@@ -289,6 +291,11 @@ export function DesignResumeRail({
                     mode,
                     maxProjectsTotal: items.length,
                   }),
+                });
+                trackProductEvent("resume_studio_project_policy_changed", {
+                  from_mode: fromMode,
+                  to_mode: mode,
+                  project_count_bucket: bucketCount(items.length),
                 });
               },
               disabled: !settings || updateSettingsMutation.isPending,

--- a/orchestrator/src/client/hooks/useAnalyticsIdentity.ts
+++ b/orchestrator/src/client/hooks/useAnalyticsIdentity.ts
@@ -1,0 +1,32 @@
+import * as api from "@client/api";
+import { useEffect } from "react";
+import { identifyAnalyticsUser } from "@/lib/analytics";
+
+export function useAnalyticsIdentity(): void {
+  const hasSession = api.hasAuthenticatedSession();
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (hasSession) {
+      void api
+        .getCurrentAuthUser()
+        .then((user) => {
+          if (cancelled) return;
+          identifyAnalyticsUser(user.id);
+        })
+        .catch(() => {
+          // Ignore auth fetch errors; analytics identity is best-effort.
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    identifyAnalyticsUser(null);
+    return () => {
+      cancelled = true;
+    };
+  }, [hasSession]);
+}

--- a/orchestrator/src/client/hooks/useAnalyticsIdentity.ts
+++ b/orchestrator/src/client/hooks/useAnalyticsIdentity.ts
@@ -10,10 +10,10 @@ export function useAnalyticsIdentity(): void {
 
     if (hasSession) {
       void api
-        .getCurrentAuthUser()
-        .then((user) => {
+        .getCurrentAuthContext()
+        .then((context) => {
           if (cancelled) return;
-          identifyAnalyticsUser(user.id);
+          identifyAnalyticsUser(context.analyticsDistinctId);
         })
         .catch(() => {
           // Ignore auth fetch errors; analytics identity is best-effort.

--- a/orchestrator/src/client/pages/DesignResumePage.tsx
+++ b/orchestrator/src/client/pages/DesignResumePage.tsx
@@ -88,6 +88,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { bucketCount, trackProductEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import {
   ITEM_DEFINITIONS,
@@ -267,6 +268,43 @@ const DESIGN_RESUME_ICON_ITEM_BY_SECTION_ID = new Map(
 
 function getDesignResumeSectionIcon(sectionId: DesignResumeSectionId) {
   return DESIGN_RESUME_ICON_ITEM_BY_SECTION_ID.get(sectionId)?.icon ?? BookOpen;
+}
+
+function bucketResumeSectionItemCounts(document: DesignResumeJson): {
+  sectionCountBucket: string;
+  itemCountBucket: string;
+} {
+  const sections = asRecord(document.sections) ?? {};
+  const sectionCount = Object.keys(sections).length;
+  const itemCount = Object.values(sections).reduce<number>((count, section) => {
+    const sectionRecord = asRecord(section) ?? {};
+    return count + asArray(sectionRecord.items).length;
+  }, 0);
+  return {
+    sectionCountBucket: bucketCount(sectionCount),
+    itemCountBucket: bucketCount(itemCount),
+  };
+}
+
+function getImportFileType(file: File): "pdf" | "docx" | "unknown" {
+  const mimeType = file.type.toLowerCase();
+  if (mimeType === "application/pdf") return "pdf";
+  if (
+    mimeType ===
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  ) {
+    return "docx";
+  }
+  const fileName = file.name.toLowerCase();
+  if (fileName.endsWith(".pdf")) return "pdf";
+  if (fileName.endsWith(".docx")) return "docx";
+  return "unknown";
+}
+
+function getDeviceLayout(): "mobile" | "desktop" {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function")
+    return "desktop";
+  return window.matchMedia("(max-width: 639px)").matches ? "mobile" : "desktop";
 }
 
 const useDockItemSize = (
@@ -693,14 +731,35 @@ export const DesignResumePage: React.FC = () => {
   }, [dialogState, draft]);
 
   const handleImport = async () => {
+    const wasReimport = Boolean(status?.exists);
     try {
       setResumeImporting(true);
       const imported = await api.importDesignResumeFromRxResume();
       setDesignResume(imported);
       setSaveState("saved");
+      const counts = bucketResumeSectionItemCounts(imported.resumeJson);
+      trackProductEvent("resume_studio_import_completed", {
+        source: "rxresume",
+        result: "success",
+        was_reimport: wasReimport,
+        section_count_bucket: counts.sectionCountBucket,
+        item_count_bucket: counts.itemCountBucket,
+      });
+      if (!wasReimport) {
+        trackProductEvent("resume_studio_activation_completed", {
+          source: "rxresume",
+        });
+      }
       toast.success("Imported your resume.");
       notifyReadyPdfRefresh();
     } catch (importError) {
+      trackProductEvent("resume_studio_import_completed", {
+        source: "rxresume",
+        result: "error",
+        was_reimport: wasReimport,
+        section_count_bucket: "0",
+        item_count_bucket: "0",
+      });
       showErrorToast(importError, "Failed to import your resume.");
     } finally {
       setResumeImporting(false);
@@ -716,6 +775,8 @@ export const DesignResumePage: React.FC = () => {
   };
 
   const handleImportFile = async (file: File) => {
+    const wasReimport = Boolean(status?.exists);
+    const fileType = getImportFileType(file);
     try {
       setResumeImporting(true);
       const dataUrl = await fileToDataUrl(file);
@@ -732,10 +793,32 @@ export const DesignResumePage: React.FC = () => {
       });
       setDesignResume(imported);
       setSaveState("saved");
+      const counts = bucketResumeSectionItemCounts(imported.resumeJson);
+      trackProductEvent("resume_studio_import_completed", {
+        source: "file",
+        file_type: fileType,
+        result: "success",
+        was_reimport: wasReimport,
+        section_count_bucket: counts.sectionCountBucket,
+        item_count_bucket: counts.itemCountBucket,
+      });
+      if (!wasReimport) {
+        trackProductEvent("resume_studio_activation_completed", {
+          source: "file",
+        });
+      }
       toast.success("Imported your resume file.");
       notifyReadyPdfRefresh();
     } catch (importError) {
       setSaveState("error");
+      trackProductEvent("resume_studio_import_completed", {
+        source: "file",
+        file_type: fileType,
+        result: "error",
+        was_reimport: wasReimport,
+        section_count_bucket: "0",
+        item_count_bucket: "0",
+      });
       showErrorToast(importError, "Failed to import your resume file.");
     } finally {
       setResumeImporting(false);
@@ -749,19 +832,36 @@ export const DesignResumePage: React.FC = () => {
     try {
       const exported = await api.exportDesignResume();
       makeDownload(exported.fileName, exported.document);
+      trackProductEvent("resume_studio_export_completed", {
+        result: "success",
+      });
       toast.success("Exported your resume JSON.");
     } catch (exportError) {
+      trackProductEvent("resume_studio_export_completed", { result: "error" });
       showErrorToast(exportError, "Failed to export Resume Studio.");
     }
   };
 
   const handleDownloadPdf = async () => {
+    const downloadedAfterEdit = dirty || saveState === "saving";
     try {
       setPdfDownloading(true);
       const generated = await api.generateDesignResumePdf();
       await downloadDesignResumePdf(generated.fileName, generated.pdfUrl);
+      trackProductEvent("resume_studio_pdf_downloaded", {
+        renderer: pdfRenderer,
+        theme: typstTheme,
+        after_edit: downloadedAfterEdit,
+        result: "success",
+      });
       toast.success("Your PDF is ready.");
     } catch (downloadError) {
+      trackProductEvent("resume_studio_pdf_downloaded", {
+        renderer: pdfRenderer,
+        theme: typstTheme,
+        after_edit: downloadedAfterEdit,
+        result: "error",
+      });
       showErrorToast(downloadError, "Failed to generate a PDF.");
     } finally {
       setPdfDownloading(false);
@@ -1391,6 +1491,13 @@ export const DesignResumePage: React.FC = () => {
             if (!open) setDialogState(null);
           }}
           onSave={(item) => {
+            const currentItems = asArray(
+              asRecord(
+                asRecord(draft.resumeJson.sections)?.[
+                  dialogState.definition.key
+                ],
+              )?.items,
+            );
             updateResumeJson((current) => {
               const next = structuredClone(current);
               const sections = (asRecord(next.sections) ?? {}) as Record<
@@ -1419,11 +1526,28 @@ export const DesignResumePage: React.FC = () => {
               } as DesignResumeJson["sections"];
               return next;
             });
+            trackProductEvent("resume_studio_section_edited", {
+              section: dialogState.definition.key,
+              action: dialogState.index == null ? "add" : "edit",
+              item_count_bucket: bucketCount(
+                dialogState.index == null
+                  ? currentItems.length + 1
+                  : currentItems.length,
+              ),
+              device_layout: getDeviceLayout(),
+            });
           }}
           onDelete={
             dialogState.index == null
               ? undefined
               : () => {
+                  const currentItems = asArray(
+                    asRecord(
+                      asRecord(draft.resumeJson.sections)?.[
+                        dialogState.definition.key
+                      ],
+                    )?.items,
+                  );
                   updateResumeJson((current) => {
                     const next = structuredClone(current);
                     const sections = (asRecord(next.sections) ?? {}) as Record<
@@ -1446,6 +1570,14 @@ export const DesignResumePage: React.FC = () => {
                       },
                     } as DesignResumeJson["sections"];
                     return next;
+                  });
+                  trackProductEvent("resume_studio_section_edited", {
+                    section: dialogState.definition.key,
+                    action: "delete",
+                    item_count_bucket: bucketCount(
+                      Math.max(0, currentItems.length - 1),
+                    ),
+                    device_layout: getDeviceLayout(),
                   });
                   setDialogState(null);
                 }

--- a/orchestrator/src/lib/analytics-metadata.ts
+++ b/orchestrator/src/lib/analytics-metadata.ts
@@ -1,0 +1,24 @@
+type Primitive = string | number | boolean | null;
+
+export type AnalyticsPayload = Record<string, Primitive>;
+
+export function withAnalyticsMetadata(
+  payload: AnalyticsPayload | undefined,
+  metadata: {
+    analyticsUserId?: string | null;
+    appVersion?: string | null;
+  },
+): AnalyticsPayload | undefined {
+  const analyticsUserId = metadata.analyticsUserId?.trim() || null;
+  const appVersion = metadata.appVersion?.trim() || null;
+
+  if (!analyticsUserId && !appVersion) {
+    return payload;
+  }
+
+  return {
+    ...(payload ?? {}),
+    ...(analyticsUserId ? { analytics_user_id: analyticsUserId } : {}),
+    ...(appVersion ? { app_version: appVersion } : {}),
+  };
+}

--- a/orchestrator/src/lib/analytics.test.ts
+++ b/orchestrator/src/lib/analytics.test.ts
@@ -2,24 +2,27 @@ import {
   __resetAnalyticsTestState,
   bucketQueryLength,
   getAnalyticsRequestHeaders,
+  identifyAnalyticsUser,
   trackEvent,
   trackProductEvent,
 } from "./analytics";
 
 describe("analytics", () => {
   const track = vi.fn();
+  const identify = vi.fn();
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-25T12:00:00Z"));
     track.mockReset();
+    identify.mockReset();
     __resetAnalyticsTestState();
     window.localStorage.clear();
     window.sessionStorage.clear();
     (globalThis as any).__APP_VERSION__ = "abc1234-dev";
     Object.defineProperty(window, "umami", {
       configurable: true,
-      value: { track },
+      value: { track, identify },
     });
   });
 
@@ -102,5 +105,33 @@ describe("analytics", () => {
     expect(
       window.sessionStorage.getItem("jobops.analytics.session_id.v1"),
     ).toBe(firstHeaders["x-jobops-analytics-session-id"]);
+  });
+
+  it("identifies authenticated users with Umami distinct IDs", () => {
+    identifyAnalyticsUser("user-123");
+    identifyAnalyticsUser("user-123");
+
+    expect(identify).toHaveBeenCalledTimes(1);
+    expect(identify).toHaveBeenCalledWith("user-123");
+  });
+
+  it("uses identified distinct IDs in event metadata", () => {
+    identifyAnalyticsUser("user-123");
+
+    trackEvent("star_repo_click", { location: "demo_mode_banner" });
+
+    expect(track).toHaveBeenCalledWith("star_repo_click", {
+      location: "demo_mode_banner",
+      analytics_user_id: "user-123",
+      app_version: "abc1234-dev",
+    });
+  });
+
+  it("truncates distinct IDs to Umami's 50-character limit", () => {
+    const longDistinctId = "a".repeat(64);
+
+    identifyAnalyticsUser(longDistinctId);
+
+    expect(identify).toHaveBeenCalledWith("a".repeat(50));
   });
 });

--- a/orchestrator/src/lib/analytics.test.ts
+++ b/orchestrator/src/lib/analytics.test.ts
@@ -10,12 +10,14 @@ import {
 describe("analytics", () => {
   const track = vi.fn();
   const identify = vi.fn();
+  const op = vi.fn();
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-02-25T12:00:00Z"));
     track.mockReset();
     identify.mockReset();
+    op.mockReset();
     __resetAnalyticsTestState();
     window.localStorage.clear();
     window.sessionStorage.clear();
@@ -23,6 +25,10 @@ describe("analytics", () => {
     Object.defineProperty(window, "umami", {
       configurable: true,
       value: { track, identify },
+    });
+    Object.defineProperty(window, "op", {
+      configurable: true,
+      value: op,
     });
   });
 
@@ -60,6 +66,19 @@ describe("analytics", () => {
     expect(storedId).toBe(firstPayload.analytics_user_id);
     expect(firstPayload.app_version).toBe("abc1234-dev");
     expect(secondPayload.app_version).toBe("abc1234-dev");
+
+    expect(op).toHaveBeenNthCalledWith(
+      1,
+      "track",
+      "star_repo_click",
+      firstPayload,
+    );
+    expect(op).toHaveBeenNthCalledWith(
+      2,
+      "track",
+      "tracer_drilldown_mode_changed",
+      secondPayload,
+    );
   });
 
   it("drops disallowed keys and non-primitive payload values", () => {
@@ -113,6 +132,7 @@ describe("analytics", () => {
 
     expect(identify).toHaveBeenCalledTimes(1);
     expect(identify).toHaveBeenCalledWith("user-123");
+    expect(op).toHaveBeenCalledWith("identify", { profileId: "user-123" });
   });
 
   it("uses identified distinct IDs in event metadata", () => {
@@ -133,5 +153,8 @@ describe("analytics", () => {
     identifyAnalyticsUser(longDistinctId);
 
     expect(identify).toHaveBeenCalledWith("a".repeat(50));
+    expect(op).toHaveBeenCalledWith("identify", {
+      profileId: "a".repeat(50),
+    });
   });
 });

--- a/orchestrator/src/lib/analytics.test.ts
+++ b/orchestrator/src/lib/analytics.test.ts
@@ -133,6 +133,9 @@ describe("analytics", () => {
     expect(identify).toHaveBeenCalledTimes(1);
     expect(identify).toHaveBeenCalledWith("user-123");
     expect(op).toHaveBeenCalledWith("identify", { profileId: "user-123" });
+    expect(window.localStorage.getItem("jobops.analytics.user_id.v1")).toBe(
+      "user-123",
+    );
   });
 
   it("uses identified distinct IDs in event metadata", () => {

--- a/orchestrator/src/lib/analytics.ts
+++ b/orchestrator/src/lib/analytics.ts
@@ -407,6 +407,14 @@ export function identifyAnalyticsUser(
       ...(appVersion ? { app_version: appVersion } : {}),
     });
   }
+  if (typeof window !== "undefined") {
+    try {
+      window.localStorage.setItem(ANALYTICS_USER_ID_STORAGE_KEY, normalized);
+      cachedAnalyticsUserId = normalized;
+    } catch {
+      // Ignore storage failures; identify is best-effort.
+    }
+  }
   cachedDistinctId = normalized;
 }
 

--- a/orchestrator/src/lib/analytics.ts
+++ b/orchestrator/src/lib/analytics.ts
@@ -11,9 +11,25 @@ type UmamiTracker = {
   identify?: (id: string) => void;
 };
 
+type OpenPanelTracker = {
+  q?: unknown[][];
+  (
+    command:
+      | "init"
+      | "track"
+      | "identify"
+      | "setGlobalProperties"
+      | "increment"
+      | "decrement"
+      | "clear",
+    ...args: unknown[]
+  ): void;
+};
+
 declare global {
   interface Window {
     umami?: UmamiTracker;
+    op?: OpenPanelTracker;
   }
 }
 
@@ -24,6 +40,14 @@ export function trackEvent(event: string, data?: Record<string, unknown>) {
     appVersion: getAnalyticsAppVersion(),
   });
   window.umami?.track(event, payload);
+  const openPanel = window.op;
+  if (typeof openPanel === "function") {
+    if (payload) {
+      openPanel("track", event, payload);
+    } else {
+      openPanel("track", event);
+    }
+  }
 }
 
 type ProductEventMap = {
@@ -360,8 +384,11 @@ export function identifyAnalyticsUser(
   distinctId: string | null | undefined,
 ): void {
   if (typeof window === "undefined") return;
-  const identify = window.umami?.identify;
-  if (typeof identify !== "function") return;
+  const umamiIdentify = window.umami?.identify;
+  const openPanel = window.op;
+  const hasOpenPanel = typeof openPanel === "function";
+  const hasUmami = typeof umamiIdentify === "function";
+  if (!hasOpenPanel && !hasUmami) return;
 
   const normalized =
     normalizeDistinctId(distinctId) ??
@@ -369,7 +396,17 @@ export function identifyAnalyticsUser(
     null;
   if (!normalized || normalized === cachedDistinctId) return;
 
-  identify(normalized);
+  if (hasUmami) {
+    umamiIdentify(normalized);
+  }
+  if (hasOpenPanel) {
+    openPanel("identify", { profileId: normalized });
+    const appVersion = getAnalyticsAppVersion();
+    openPanel("setGlobalProperties", {
+      analytics_user_id: normalized,
+      ...(appVersion ? { app_version: appVersion } : {}),
+    });
+  }
   cachedDistinctId = normalized;
 }
 

--- a/orchestrator/src/lib/analytics.ts
+++ b/orchestrator/src/lib/analytics.ts
@@ -1,4 +1,8 @@
 import type { ApplicationStage } from "@shared/types";
+import {
+  type AnalyticsPayload,
+  withAnalyticsMetadata,
+} from "@/lib/analytics-metadata";
 
 declare const __APP_VERSION__: string;
 
@@ -14,16 +18,10 @@ declare global {
 
 export function trackEvent(event: string, data?: Record<string, unknown>) {
   if (typeof window === "undefined") return;
-  const analyticsUserId = getAnalyticsUserId();
-  const appVersion = getAnalyticsAppVersion();
-  const payload =
-    analyticsUserId === null && appVersion === null
-      ? data
-      : {
-          ...(data ?? {}),
-          ...(analyticsUserId ? { analytics_user_id: analyticsUserId } : {}),
-          ...(appVersion ? { app_version: appVersion } : {}),
-        };
+  const payload = withAnalyticsMetadata(data as AnalyticsPayload | undefined, {
+    analyticsUserId: getAnalyticsUserId(),
+    appVersion: getAnalyticsAppVersion(),
+  });
   window.umami?.track(event, payload);
 }
 
@@ -140,11 +138,55 @@ type ProductEventMap = {
     min_score?: number;
     country?: string;
   };
+  resume_studio_import_completed: {
+    source: "file" | "rxresume";
+    file_type?: "pdf" | "docx" | "unknown";
+    result: "success" | "error";
+    was_reimport: boolean;
+    section_count_bucket: string;
+    item_count_bucket: string;
+  };
+  resume_studio_activation_completed: {
+    source: "file" | "rxresume";
+  };
+  resume_studio_section_edited: {
+    section: string;
+    action: "add" | "edit" | "delete" | "reorder" | "hide" | "unhide";
+    item_count_bucket: string;
+    device_layout: "mobile" | "desktop";
+  };
+  resume_studio_ai_field_suggestion_completed: {
+    section: string;
+    field_type: "plain_text" | "html" | "string_list";
+    result: "generated" | "applied" | "auto_applied" | "error";
+    was_empty: boolean;
+    prompt_length_bucket: string;
+  };
+  resume_studio_pdf_preview_completed: {
+    renderer: string;
+    theme: string;
+    result: "success" | "error";
+    latency_bucket: string;
+  };
+  resume_studio_pdf_downloaded: {
+    renderer: string;
+    theme: string;
+    after_edit: boolean;
+    result: "success" | "error";
+  };
+  resume_studio_export_completed: {
+    result: "success" | "error";
+  };
+  resume_studio_project_policy_changed: {
+    from_mode: "manual" | "ai-selectable" | "must-include";
+    to_mode: "manual" | "ai-selectable" | "must-include";
+    project_count_bucket: string;
+  };
 };
 
 type ProductEventName = keyof ProductEventMap;
 type Primitive = string | number | boolean | null;
-type SanitizedPayload = Record<string, Primitive>;
+type SanitizedPayload = AnalyticsPayload;
 
 function generateAnalyticsUserId() {
   if (

--- a/orchestrator/src/lib/analytics.ts
+++ b/orchestrator/src/lib/analytics.ts
@@ -8,6 +8,7 @@ declare const __APP_VERSION__: string;
 
 type UmamiTracker = {
   track: (event: string, data?: Record<string, unknown>) => void;
+  identify?: (id: string) => void;
 };
 
 declare global {
@@ -19,7 +20,7 @@ declare global {
 export function trackEvent(event: string, data?: Record<string, unknown>) {
   if (typeof window === "undefined") return;
   const payload = withAnalyticsMetadata(data as AnalyticsPayload | undefined, {
-    analyticsUserId: getAnalyticsUserId(),
+    analyticsUserId: getEventAnalyticsUserId(),
     appVersion: getAnalyticsAppVersion(),
   });
   window.umami?.track(event, payload);
@@ -228,6 +229,10 @@ function getAnalyticsUserId(): string | null {
   }
 }
 
+function getEventAnalyticsUserId(): string | null {
+  return cachedDistinctId ?? getAnalyticsUserId();
+}
+
 function getAnalyticsAppVersion(): string | null {
   try {
     return __APP_VERSION__?.trim() || null;
@@ -268,11 +273,13 @@ export function getAnalyticsRequestHeaders(): Record<string, string> {
 }
 
 const DEDUPE_WINDOW_MS = 3_000;
+const UMAMI_DISTINCT_ID_MAX_LENGTH = 50;
 const ANALYTICS_USER_ID_STORAGE_KEY = "jobops.analytics.user_id.v1";
 const ANALYTICS_SESSION_ID_STORAGE_KEY = "jobops.analytics.session_id.v1";
 const recentEventCache = new Map<string, number>();
 let cachedAnalyticsUserId: string | null = null;
 let cachedAnalyticsSessionId: string | null = null;
+let cachedDistinctId: string | null = null;
 const DISALLOWED_KEY_PARTS = [
   "query",
   "url",
@@ -343,6 +350,29 @@ export function trackProductEvent<T extends ProductEventName>(
   trackEvent(event, sanitized);
 }
 
+function normalizeDistinctId(id: string | null | undefined): string | null {
+  const trimmed = id?.trim() ?? "";
+  if (!trimmed) return null;
+  return trimmed.slice(0, UMAMI_DISTINCT_ID_MAX_LENGTH);
+}
+
+export function identifyAnalyticsUser(
+  distinctId: string | null | undefined,
+): void {
+  if (typeof window === "undefined") return;
+  const identify = window.umami?.identify;
+  if (typeof identify !== "function") return;
+
+  const normalized =
+    normalizeDistinctId(distinctId) ??
+    normalizeDistinctId(getAnalyticsUserId()) ??
+    null;
+  if (!normalized || normalized === cachedDistinctId) return;
+
+  identify(normalized);
+  cachedDistinctId = normalized;
+}
+
 export function bucketCount(value: number): string {
   if (!Number.isFinite(value) || value <= 0) return "0";
   if (value === 1) return "1";
@@ -380,4 +410,5 @@ export function __resetAnalyticsTestState() {
   recentEventCache.clear();
   cachedAnalyticsUserId = null;
   cachedAnalyticsSessionId = null;
+  cachedDistinctId = null;
 }

--- a/orchestrator/src/server/api/routes/auth.test.ts
+++ b/orchestrator/src/server/api/routes/auth.test.ts
@@ -130,6 +130,37 @@ describe.sequential("Auth routes", () => {
 
       expect(res.status).toBe(401);
     });
+
+    it("returns a stable backend analytics distinct id from /api/auth/me", async () => {
+      const loginRes = await fetch(`${baseUrl}/api/auth/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: "admin", password: "secret" }),
+      });
+      const { data } = await loginRes.json();
+      const token = data.token as string;
+
+      const firstMeRes = await fetch(`${baseUrl}/api/auth/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(firstMeRes.status).toBe(200);
+      const firstMeBody = await firstMeRes.json();
+      expect(firstMeBody.ok).toBe(true);
+      expect(firstMeBody.data.user.id).toBeTruthy();
+      expect(firstMeBody.data.analyticsDistinctId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+
+      const secondMeRes = await fetch(`${baseUrl}/api/auth/me`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      expect(secondMeRes.status).toBe(200);
+      const secondMeBody = await secondMeRes.json();
+      expect(secondMeBody.ok).toBe(true);
+      expect(secondMeBody.data.analyticsDistinctId).toBe(
+        firstMeBody.data.analyticsDistinctId,
+      );
+    });
   });
 
   describe("POST /api/auth/setup", () => {

--- a/orchestrator/src/server/api/routes/auth.ts
+++ b/orchestrator/src/server/api/routes/auth.ts
@@ -3,6 +3,7 @@ import { asyncRoute, fail, ok } from "@infra/http";
 import { blacklistToken, signToken, verifyToken } from "@server/auth/jwt";
 import { verifyPassword } from "@server/auth/password";
 import { isDemoMode } from "@server/config/demo";
+import { getOrCreateAnalyticsInstallState } from "@server/repositories/product-analytics";
 import * as usersRepo from "@server/repositories/users";
 import type { Request, Response } from "express";
 import { Router } from "express";
@@ -179,7 +180,11 @@ authRouter.get(
       fail(res, unauthorized("Authentication required"));
       return;
     }
-    ok(res, { user });
+    const installState = await getOrCreateAnalyticsInstallState();
+    ok(res, {
+      user,
+      analyticsDistinctId: installState.distinctId,
+    });
   }),
 );
 

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -339,6 +339,7 @@ describe.sequential("Pipeline API routes", () => {
       "jobs_pipeline_run_started",
       expect.objectContaining({
         source_count: 1,
+        selected_sources: "gradcracker",
         top_n: 5,
         min_suitability_score: 65,
         country: "united kingdom",

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -53,6 +53,13 @@ import { z } from "zod";
 export const pipelineRouter = Router();
 const WORKPLACE_TYPE_VALUES = ["remote", "hybrid", "onsite"] as const;
 
+function toSelectedSourcesValue(
+  sources: readonly string[] | undefined,
+): string | undefined {
+  if (!Array.isArray(sources) || sources.length === 0) return undefined;
+  return [...sources].sort((left, right) => left.localeCompare(right)).join("|");
+}
+
 function resolveRequestOrigin(req: Request): string | null {
   const configuredBaseUrl = process.env.JOBOPS_PUBLIC_BASE_URL?.trim();
   if (configuredBaseUrl) {
@@ -319,6 +326,7 @@ pipelineRouter.post("/run", async (req: Request, res: Response) => {
       "jobs_pipeline_run_started",
       {
         source_count: config.sources?.length,
+        selected_sources: toSelectedSourcesValue(config.sources),
         top_n: config.topN,
         min_suitability_score: config.minSuitabilityScore,
         country: config.country,

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -57,7 +57,9 @@ function toSelectedSourcesValue(
   sources: readonly string[] | undefined,
 ): string | undefined {
   if (!Array.isArray(sources) || sources.length === 0) return undefined;
-  return [...sources].sort((left, right) => left.localeCompare(right)).join("|");
+  return [...sources]
+    .sort((left, right) => left.localeCompare(right))
+    .join("|");
 }
 
 function resolveRequestOrigin(req: Request): string | null {

--- a/orchestrator/src/server/infra/product-analytics.test.ts
+++ b/orchestrator/src/server/infra/product-analytics.test.ts
@@ -30,6 +30,7 @@ describe("server product analytics", () => {
   const originalNodeEnv = process.env.NODE_ENV;
   const originalBaseUrl = process.env.JOBOPS_PUBLIC_BASE_URL;
   const originalAppVersion = process.env.JOBOPS_APP_VERSION;
+  const fetchMock = vi.fn<typeof fetch>();
   const getMockUmami = () =>
     (typeof umamiModule === "object" &&
     umamiModule !== null &&
@@ -44,7 +45,14 @@ describe("server product analytics", () => {
     process.env.NODE_ENV = "development";
     process.env.JOBOPS_PUBLIC_BASE_URL = "https://jobops.example";
     process.env.JOBOPS_APP_VERSION = "v0.test";
+    process.env.JOBOPS_OPENPANEL_API_URL =
+      "https://openpanel.dakheera47.com/api";
+    process.env.JOBOPS_OPENPANEL_CLIENT_ID =
+      "6a953241-309b-4e5a-be1b-412c5d7b6544";
     vi.clearAllMocks();
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
     vi.mocked(getMockUmami().track).mockResolvedValue(
       new Response(null, { status: 202 }),
     );
@@ -105,6 +113,34 @@ describe("server product analytics", () => {
         app_version: "v0.test",
       },
     });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://openpanel.dakheera47.com/api/track",
+      {
+        method: "POST",
+        headers: expect.objectContaining({
+          "content-type": "application/json",
+          "openpanel-client-id": "6a953241-309b-4e5a-be1b-412c5d7b6544",
+          "user-agent":
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+        }),
+        body: JSON.stringify({
+          type: "track",
+          payload: {
+            name: "application_offer_detected",
+            profileId: "install-distinct-id",
+            properties: {
+              source: "tracking_inbox_auto",
+              stage: "offer",
+              sessionId: "session-123",
+              analytics_user_id: "install-distinct-id",
+              app_version: "v0.test",
+              __path: "/applications/in-progress",
+              __timestamp: "2024-04-01T00:00:00.000Z",
+            },
+          },
+        }),
+      },
+    );
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
@@ -118,9 +154,10 @@ describe("server product analytics", () => {
     expect(delivered).toBe(false);
     expect(getMockUmami().init).not.toHaveBeenCalled();
     expect(getMockUmami().track).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("logs a warning when Umami returns a non-ok response", async () => {
+  it("returns delivered when OpenPanel succeeds even if Umami fails", async () => {
     vi.mocked(getMockUmami().track).mockResolvedValue(
       new Response(null, { status: 500 }),
     );
@@ -136,11 +173,12 @@ describe("server product analytics", () => {
       },
     );
 
-    expect(delivered).toBe(false);
+    expect(delivered).toBe(true);
 
     expect(logger.warn).toHaveBeenCalledWith(
       "Server product analytics request failed",
       {
+        provider: "umami",
         event: "resume_generated",
         status: 500,
         requestOrigin: "https://app.jobops.example",
@@ -198,5 +236,45 @@ describe("server product analytics", () => {
         app_version: "v0.test",
       },
     });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://openpanel.dakheera47.com/api/track",
+      expect.objectContaining({
+        method: "POST",
+      }),
+    );
+  });
+
+  it("logs and returns false when both providers fail", async () => {
+    vi.mocked(getMockUmami().track).mockResolvedValue(
+      new Response(null, { status: 500 }),
+    );
+    fetchMock.mockResolvedValue(new Response(null, { status: 500 }));
+
+    const delivered = await trackServerProductEvent(
+      "application_marked_applied",
+      { source: "jobs_page" },
+      {
+        requestOrigin: "https://app.jobops.example",
+        urlPath: "/jobs/all",
+      },
+    );
+
+    expect(delivered).toBe(false);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Server product analytics request failed",
+      expect.objectContaining({
+        provider: "openpanel",
+        event: "application_marked_applied",
+        status: 500,
+      }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Server product analytics request failed",
+      expect.objectContaining({
+        provider: "umami",
+        event: "application_marked_applied",
+        status: 500,
+      }),
+    );
   });
 });

--- a/orchestrator/src/server/infra/product-analytics.test.ts
+++ b/orchestrator/src/server/infra/product-analytics.test.ts
@@ -187,6 +187,32 @@ describe("server product analytics", () => {
     );
   });
 
+  it("returns delivered when OpenPanel succeeds even if Umami throws", async () => {
+    vi.mocked(getMockUmami().track).mockRejectedValue(new Error("umami down"));
+
+    const delivered = await trackServerProductEvent(
+      "resume_generated",
+      {
+        origin: "move_to_ready",
+      },
+      {
+        requestOrigin: "https://app.jobops.example",
+        urlPath: "/jobs",
+      },
+    );
+
+    expect(delivered).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Server product analytics request errored",
+      expect.objectContaining({
+        provider: "umami",
+        event: "resume_generated",
+        requestOrigin: "https://app.jobops.example",
+        urlPath: "/jobs",
+      }),
+    );
+  });
+
   it("supports the commonjs module-object shape exposed at runtime", async () => {
     vi.doMock("@umami/node", () => ({
       default: {

--- a/orchestrator/src/server/infra/product-analytics.test.ts
+++ b/orchestrator/src/server/infra/product-analytics.test.ts
@@ -29,6 +29,7 @@ vi.mock("@server/repositories/product-analytics", () => ({
 describe("server product analytics", () => {
   const originalNodeEnv = process.env.NODE_ENV;
   const originalBaseUrl = process.env.JOBOPS_PUBLIC_BASE_URL;
+  const originalAppVersion = process.env.JOBOPS_APP_VERSION;
   const getMockUmami = () =>
     (typeof umamiModule === "object" &&
     umamiModule !== null &&
@@ -42,6 +43,7 @@ describe("server product analytics", () => {
   beforeEach(() => {
     process.env.NODE_ENV = "development";
     process.env.JOBOPS_PUBLIC_BASE_URL = "https://jobops.example";
+    process.env.JOBOPS_APP_VERSION = "v0.test";
     vi.clearAllMocks();
     vi.mocked(getMockUmami().track).mockResolvedValue(
       new Response(null, { status: 202 }),
@@ -54,6 +56,11 @@ describe("server product analytics", () => {
       delete process.env.JOBOPS_PUBLIC_BASE_URL;
     } else {
       process.env.JOBOPS_PUBLIC_BASE_URL = originalBaseUrl;
+    }
+    if (originalAppVersion === undefined) {
+      delete process.env.JOBOPS_APP_VERSION;
+    } else {
+      process.env.JOBOPS_APP_VERSION = originalAppVersion;
     }
   });
 
@@ -94,6 +101,8 @@ describe("server product analytics", () => {
         source: "tracking_inbox_auto",
         stage: "offer",
         sessionId: "session-123",
+        analytics_user_id: "install-distinct-id",
+        app_version: "v0.test",
       },
     });
     expect(logger.warn).not.toHaveBeenCalled();
@@ -185,6 +194,8 @@ describe("server product analytics", () => {
       name: "application_marked_applied",
       data: {
         sessionId: "session-commonjs",
+        analytics_user_id: "install-distinct-id",
+        app_version: "v0.test",
       },
     });
   });

--- a/orchestrator/src/server/infra/product-analytics.ts
+++ b/orchestrator/src/server/infra/product-analytics.ts
@@ -310,6 +310,15 @@ export async function trackServerProductEvent(
         url: page.url,
         name: event,
         ...(payload ? { data: payload } : {}),
+      }).catch((error) => {
+        logger.warn("Server product analytics request errored", {
+          provider: "umami",
+          event,
+          requestOrigin: options?.requestOrigin ?? null,
+          urlPath: options?.urlPath ?? "/",
+          error: sanitizeUnknown(error),
+        });
+        return null;
       }),
       trackOpenPanelProductEvent({
         event,
@@ -331,8 +340,8 @@ export async function trackServerProductEvent(
       }),
     ]);
 
-    const umamiDelivered = umamiResponse.ok;
-    if (!umamiDelivered) {
+    const umamiDelivered = umamiResponse?.ok ?? false;
+    if (umamiResponse && !umamiDelivered) {
       logger.warn("Server product analytics request failed", {
         provider: "umami",
         event,

--- a/orchestrator/src/server/infra/product-analytics.ts
+++ b/orchestrator/src/server/infra/product-analytics.ts
@@ -10,6 +10,7 @@ const UMAMI_HOST_URL = "https://umami.dakheera47.com";
 const UMAMI_WEBSITE_ID = "0dc42ed1-87c3-4ac0-9409-5a9b9588fe66";
 const OPENPANEL_API_BASE_URL = "https://openpanel.dakheera47.com/api";
 const OPENPANEL_CLIENT_ID = "6a953241-309b-4e5a-be1b-412c5d7b6544";
+const OPENPANEL_CLIENT_SECRET = "sec_906d37f958321fef9adb";
 const UMAMI_FALLBACK_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36";
 const OPENPANEL_FALLBACK_USER_AGENT = "jobops-orchestrator/1.0";
@@ -187,6 +188,11 @@ function getOpenPanelClientId(): string | null {
   return configured || OPENPANEL_CLIENT_ID;
 }
 
+function getOpenPanelClientSecret(): string | null {
+  const configured = process.env.JOBOPS_OPENPANEL_CLIENT_SECRET?.trim();
+  return configured || OPENPANEL_CLIENT_SECRET;
+}
+
 async function trackOpenPanelProductEvent(args: {
   event: string;
   profileId: string;
@@ -198,7 +204,8 @@ async function trackOpenPanelProductEvent(args: {
 }): Promise<boolean> {
   const trackUrl = getOpenPanelTrackUrl();
   const clientId = getOpenPanelClientId();
-  if (!trackUrl || !clientId) {
+  const clientSecret = getOpenPanelClientSecret();
+  if (!trackUrl || !clientId || !clientSecret) {
     return false;
   }
 
@@ -217,12 +224,7 @@ async function trackOpenPanelProductEvent(args: {
     headers: {
       "content-type": "application/json",
       "openpanel-client-id": clientId,
-      ...(process.env.JOBOPS_OPENPANEL_CLIENT_SECRET?.trim()
-        ? {
-            "openpanel-client-secret":
-              process.env.JOBOPS_OPENPANEL_CLIENT_SECRET.trim(),
-          }
-        : {}),
+      "openpanel-client-secret": clientSecret,
       "user-agent":
         args.requestUserAgent?.trim() ||
         requestContext?.requestUserAgent?.trim() ||

--- a/orchestrator/src/server/infra/product-analytics.ts
+++ b/orchestrator/src/server/infra/product-analytics.ts
@@ -303,23 +303,25 @@ export async function trackServerProductEvent(
         UMAMI_FALLBACK_USER_AGENT,
     });
     const [umamiResponse, openPanelDelivered] = await Promise.all([
-      umami.track({
-        id: installState.distinctId,
-        ...(timestamp !== null ? { timestamp } : {}),
-        hostname: page.hostname,
-        url: page.url,
-        name: event,
-        ...(payload ? { data: payload } : {}),
-      }).catch((error) => {
-        logger.warn("Server product analytics request errored", {
-          provider: "umami",
-          event,
-          requestOrigin: options?.requestOrigin ?? null,
-          urlPath: options?.urlPath ?? "/",
-          error: sanitizeUnknown(error),
-        });
-        return null;
-      }),
+      umami
+        .track({
+          id: installState.distinctId,
+          ...(timestamp !== null ? { timestamp } : {}),
+          hostname: page.hostname,
+          url: page.url,
+          name: event,
+          ...(payload ? { data: payload } : {}),
+        })
+        .catch((error) => {
+          logger.warn("Server product analytics request errored", {
+            provider: "umami",
+            event,
+            requestOrigin: options?.requestOrigin ?? null,
+            urlPath: options?.urlPath ?? "/",
+            error: sanitizeUnknown(error),
+          });
+          return null;
+        }),
       trackOpenPanelProductEvent({
         event,
         profileId: installState.distinctId,

--- a/orchestrator/src/server/infra/product-analytics.ts
+++ b/orchestrator/src/server/infra/product-analytics.ts
@@ -8,8 +8,11 @@ import { sanitizeUnknown } from "./sanitize";
 
 const UMAMI_HOST_URL = "https://umami.dakheera47.com";
 const UMAMI_WEBSITE_ID = "0dc42ed1-87c3-4ac0-9409-5a9b9588fe66";
+const OPENPANEL_API_BASE_URL = "https://openpanel.dakheera47.com/api";
+const OPENPANEL_CLIENT_ID = "6a953241-309b-4e5a-be1b-412c5d7b6544";
 const UMAMI_FALLBACK_USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36";
+const OPENPANEL_FALLBACK_USER_AGENT = "jobops-orchestrator/1.0";
 const DISALLOWED_KEY_PARTS = [
   "query",
   "url",
@@ -151,6 +154,104 @@ function toUnixTimestampSeconds(
   return Math.floor(epochMs / 1000);
 }
 
+function toIsoTimestamp(
+  value: Date | number | string | null | undefined,
+): string | null {
+  if (value === null || value === undefined) return null;
+
+  let date: Date | null = null;
+  if (value instanceof Date) {
+    date = value;
+  } else if (typeof value === "number") {
+    if (!Number.isFinite(value)) return null;
+    const epochMs = value < 1_000_000_000_000 ? value * 1000 : value;
+    date = new Date(epochMs);
+  } else if (typeof value === "string" && value.trim().length > 0) {
+    date = new Date(value);
+  }
+
+  if (!date || Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function getOpenPanelTrackUrl(): string | null {
+  const configuredBaseUrl = normalizeBaseUrl(
+    process.env.JOBOPS_OPENPANEL_API_URL ?? OPENPANEL_API_BASE_URL,
+  );
+  if (!configuredBaseUrl) return null;
+  return `${configuredBaseUrl}/track`;
+}
+
+function getOpenPanelClientId(): string | null {
+  const configured = process.env.JOBOPS_OPENPANEL_CLIENT_ID?.trim();
+  return configured || OPENPANEL_CLIENT_ID;
+}
+
+async function trackOpenPanelProductEvent(args: {
+  event: string;
+  profileId: string;
+  data?: AnalyticsPayload;
+  occurredAt?: Date | number | string | null;
+  requestUserAgent?: string | null;
+  requestOrigin?: string | null;
+  urlPath: string;
+}): Promise<boolean> {
+  const trackUrl = getOpenPanelTrackUrl();
+  const clientId = getOpenPanelClientId();
+  if (!trackUrl || !clientId) {
+    return false;
+  }
+
+  const properties: AnalyticsPayload = {
+    ...(args.data ?? {}),
+    __path: args.urlPath,
+  };
+  const timestamp = toIsoTimestamp(args.occurredAt);
+  if (timestamp) {
+    properties.__timestamp = timestamp;
+  }
+
+  const requestContext = getRequestContext();
+  const response = await fetch(trackUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "openpanel-client-id": clientId,
+      ...(process.env.JOBOPS_OPENPANEL_CLIENT_SECRET?.trim()
+        ? {
+            "openpanel-client-secret":
+              process.env.JOBOPS_OPENPANEL_CLIENT_SECRET.trim(),
+          }
+        : {}),
+      "user-agent":
+        args.requestUserAgent?.trim() ||
+        requestContext?.requestUserAgent?.trim() ||
+        OPENPANEL_FALLBACK_USER_AGENT,
+    },
+    body: JSON.stringify({
+      type: "track",
+      payload: {
+        name: args.event,
+        profileId: args.profileId,
+        properties,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    logger.warn("Server product analytics request failed", {
+      provider: "openpanel",
+      event: args.event,
+      status: response.status,
+      requestOrigin: args.requestOrigin ?? null,
+      urlPath: args.urlPath,
+    });
+    return false;
+  }
+
+  return true;
+}
+
 export async function trackServerProductEvent(
   event: string,
   data?: Record<string, unknown>,
@@ -180,6 +281,7 @@ export async function trackServerProductEvent(
     urlPath: options?.urlPath,
   });
   const timestamp = toUnixTimestampSeconds(options?.occurredAt);
+  const isoTimestamp = toIsoTimestamp(options?.occurredAt);
 
   try {
     const installState = options?.distinctId
@@ -198,28 +300,50 @@ export async function trackServerProductEvent(
         requestContext?.requestUserAgent?.trim() ||
         UMAMI_FALLBACK_USER_AGENT,
     });
-    const response = await umami.track({
-      id: installState.distinctId,
-      ...(timestamp !== null ? { timestamp } : {}),
-      hostname: page.hostname,
-      url: page.url,
-      name: event,
-      ...(payload ? { data: payload } : {}),
-    });
-
-    if (!response.ok) {
-      logger.warn("Server product analytics request failed", {
+    const [umamiResponse, openPanelDelivered] = await Promise.all([
+      umami.track({
+        id: installState.distinctId,
+        ...(timestamp !== null ? { timestamp } : {}),
+        hostname: page.hostname,
+        url: page.url,
+        name: event,
+        ...(payload ? { data: payload } : {}),
+      }),
+      trackOpenPanelProductEvent({
         event,
-        status: response.status,
+        profileId: installState.distinctId,
+        data: payload,
+        occurredAt: isoTimestamp,
+        requestUserAgent: options?.requestUserAgent,
+        requestOrigin: options?.requestOrigin,
+        urlPath: page.url,
+      }).catch((error) => {
+        logger.warn("Server product analytics request errored", {
+          provider: "openpanel",
+          event,
+          requestOrigin: options?.requestOrigin ?? null,
+          urlPath: options?.urlPath ?? "/",
+          error: sanitizeUnknown(error),
+        });
+        return false;
+      }),
+    ]);
+
+    const umamiDelivered = umamiResponse.ok;
+    if (!umamiDelivered) {
+      logger.warn("Server product analytics request failed", {
+        provider: "umami",
+        event,
+        status: umamiResponse.status,
         requestOrigin: options?.requestOrigin ?? null,
         urlPath: options?.urlPath ?? "/",
       });
-      return false;
     }
 
-    return true;
+    return umamiDelivered || openPanelDelivered;
   } catch (error) {
     logger.warn("Server product analytics request errored", {
+      provider: "umami",
       event,
       requestOrigin: options?.requestOrigin ?? null,
       urlPath: options?.urlPath ?? "/",

--- a/orchestrator/src/server/infra/product-analytics.ts
+++ b/orchestrator/src/server/infra/product-analytics.ts
@@ -1,5 +1,6 @@
 import { getOrCreateAnalyticsInstallState } from "@server/repositories/product-analytics";
 import umamiModule from "@umami/node";
+import { withAnalyticsMetadata } from "@/lib/analytics-metadata";
 
 import { logger } from "./logger";
 import { getRequestContext } from "./request-context";
@@ -101,6 +102,14 @@ function sanitizeAnalyticsPayload(
   return Object.keys(sanitized).length > 0 ? sanitized : undefined;
 }
 
+function getServerAnalyticsAppVersion(): string | null {
+  const envVersion = process.env.JOBOPS_APP_VERSION?.trim();
+  if (envVersion) return envVersion;
+  const npmVersion = process.env.npm_package_version?.trim();
+  if (!npmVersion) return null;
+  return npmVersion.startsWith("v") ? npmVersion : `v${npmVersion}`;
+}
+
 function resolveBaseUrl(requestOrigin?: string | null): string {
   return (
     normalizeBaseUrl(process.env.JOBOPS_PUBLIC_BASE_URL) ??
@@ -176,6 +185,10 @@ export async function trackServerProductEvent(
     const installState = options?.distinctId
       ? { distinctId: options.distinctId }
       : await getOrCreateAnalyticsInstallState();
+    const payload = withAnalyticsMetadata(sanitized, {
+      analyticsUserId: installState.distinctId,
+      appVersion: getServerAnalyticsAppVersion(),
+    });
     const umami = getUmamiClient();
     umami.init({
       websiteId: UMAMI_WEBSITE_ID,
@@ -191,7 +204,7 @@ export async function trackServerProductEvent(
       hostname: page.hostname,
       url: page.url,
       name: event,
-      ...(sanitized ? { data: sanitized } : {}),
+      ...(payload ? { data: payload } : {}),
     });
 
     if (!response.ok) {

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -731,6 +731,11 @@ export async function generateFinalPdf(
         {
           origin: analyticsOrigin,
           generation_kind: generationKind,
+          renderer: fingerprintContext.pdfRenderer,
+          theme:
+            fingerprintContext.pdfRenderer === "typst"
+              ? fingerprintContext.typstTheme
+              : null,
           tracer_links_enabled: job.tracerLinksEnabled,
           has_tailored_summary: Boolean(job.tailoredSummary),
           has_tailored_skills: Boolean(job.tailoredSkills),

--- a/orchestrator/src/server/tailoring-flow.test.ts
+++ b/orchestrator/src/server/tailoring-flow.test.ts
@@ -1,9 +1,9 @@
+import { trackServerProductEvent } from "@infra/product-analytics";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { generateFinalPdf } from "./pipeline/orchestrator";
 import * as jobsRepo from "./repositories/jobs";
 import * as pdfService from "./services/pdf";
 import * as pdfFingerprint from "./services/pdf-fingerprint";
-import { trackServerProductEvent } from "@infra/product-analytics";
 
 // Mock dependencies
 vi.mock("./repositories/jobs");

--- a/orchestrator/src/server/tailoring-flow.test.ts
+++ b/orchestrator/src/server/tailoring-flow.test.ts
@@ -3,10 +3,14 @@ import { generateFinalPdf } from "./pipeline/orchestrator";
 import * as jobsRepo from "./repositories/jobs";
 import * as pdfService from "./services/pdf";
 import * as pdfFingerprint from "./services/pdf-fingerprint";
+import { trackServerProductEvent } from "@infra/product-analytics";
 
 // Mock dependencies
 vi.mock("./repositories/jobs");
 vi.mock("./services/pdf");
+vi.mock("@infra/product-analytics", () => ({
+  trackServerProductEvent: vi.fn().mockResolvedValue(true),
+}));
 vi.mock("./services/pdf-fingerprint", () => ({
   createJobPdfFingerprint: vi.fn().mockReturnValue("test-pdf-fingerprint"),
   resolvePdfFingerprintContext: vi.fn().mockResolvedValue({
@@ -38,6 +42,7 @@ describe("Tailoring Flow", () => {
     vi.mocked(jobsRepo.finalizeGeneratedPdfIfCurrent).mockResolvedValue(
       {} as any,
     );
+    vi.mocked(trackServerProductEvent).mockClear();
   });
 
   it("should use manual overrides (tailoring) when generating PDF", async () => {
@@ -97,6 +102,16 @@ describe("Tailoring Flow", () => {
       pdfFingerprint: "test-pdf-fingerprint",
       pdfGeneratedAt: expect.any(String),
     });
+    expect(trackServerProductEvent).toHaveBeenCalledWith(
+      "resume_generated",
+      expect.objectContaining({
+        renderer: "latex",
+        theme: null,
+      }),
+      expect.objectContaining({
+        urlPath: "/jobs",
+      }),
+    );
   });
 
   it("should fall back to defaults if no tailoring is present", async () => {


### PR DESCRIPTION
## Summary
- Add shared analytics metadata helpers and OpenPanel browser/server tracking alongside existing Umami events
- Identify authenticated users via `/api/auth/me` and propagate a stable analytics distinct ID
- Instrument Resume Studio import, edit, export, PDF preview/download, and AI suggestion flows
- Update server analytics delivery to fan out to OpenPanel and harden delivery handling

## Testing
- Added and updated unit coverage for analytics metadata, auth identity, and server product analytics delivery
- Added route coverage for returning the analytics distinct ID from `/api/auth/me`
- Validation run for the targeted product analytics test set passed locally