### PR TITLE
Fix Reactive Resume onboarding state and template persistence

### DIFF
--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -1253,6 +1253,12 @@ describe("OnboardingPage", () => {
     expect(screen.getByText("Template resume")).toBeInTheDocument();
     expect(screen.getByText("Base resume selection")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Enter v5 API key")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /recheck reactive resume/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /connect reactive resume/i }),
+    ).not.toBeInTheDocument();
   });
 
   it("persists a changed Reactive Resume template before search terms are refreshed", async () => {

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -53,7 +53,16 @@ vi.mock("@client/components/ReactiveResumeConfigPanel", () => ({
 }));
 
 vi.mock("@client/pages/settings/components/BaseResumeSelection", () => ({
-  BaseResumeSelection: () => <div>Base resume selection</div>,
+  BaseResumeSelection: (props: {
+    onValueChange: (value: string | null) => void;
+  }) => (
+    <div>
+      Base resume selection
+      <button type="button" onClick={() => props.onValueChange("resume-2")}>
+        Choose alternate resume
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("sonner", () => ({
@@ -1244,5 +1253,65 @@ describe("OnboardingPage", () => {
     expect(screen.getByText("Template resume")).toBeInTheDocument();
     expect(screen.getByText("Base resume selection")).toBeInTheDocument();
     expect(screen.getByPlaceholderText("Enter v5 API key")).toBeInTheDocument();
+  });
+
+  it("persists a changed Reactive Resume template before search terms are refreshed", async () => {
+    currentSettings = {
+      ...baseSettings,
+      rxresumeApiKeyHint: "rx-k",
+      rxresumeBaseResumeId: "resume-1",
+      pdfRenderer: { value: "rxresume", default: "rxresume", override: null },
+      searchTerms: {
+        value: ["Platform Engineer"],
+        default: ["web developer"],
+        override: null,
+      },
+    };
+
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateResumeConfig).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.updateSettings).mockImplementation(async (update) => {
+      currentSettings = {
+        ...currentSettings,
+        ...("pdfRenderer" in update
+          ? {
+              pdfRenderer: {
+                value: update.pdfRenderer,
+                default: "rxresume",
+                override: null,
+              },
+            }
+          : {}),
+        ...("rxresumeBaseResumeId" in update
+          ? { rxresumeBaseResumeId: update.rxresumeBaseResumeId }
+          : {}),
+      };
+      return currentSettings;
+    });
+
+    renderPage();
+
+    fireEvent.click(getStepButton(/^Resume$/i));
+    fireEvent.click(screen.getByRole("button", { name: /choose alternate/i }));
+
+    await waitFor(() => {
+      expect(api.updateSettings).toHaveBeenCalledWith({
+        pdfRenderer: "rxresume",
+        rxresumeBaseResumeId: "resume-2",
+      });
+    });
+
+    fireEvent.click(getStepButton(/^Search terms$/i));
+
+    await waitFor(() => {
+      expect(api.suggestOnboardingSearchTerms).toHaveBeenCalled();
+    });
+    expect(currentSettings.rxresumeBaseResumeId).toBe("resume-2");
   });
 });

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -1259,6 +1259,17 @@ describe("OnboardingPage", () => {
     expect(
       screen.queryByRole("button", { name: /connect reactive resume/i }),
     ).not.toBeInTheDocument();
+
+    vi.mocked(validateAndMaybePersistRxResumeMode).mockClear();
+    vi.mocked(api.validateResumeConfig).mockClear();
+    fireEvent.click(
+      screen.getByRole("button", { name: /recheck reactive resume/i }),
+    );
+
+    await waitFor(() => {
+      expect(api.validateResumeConfig).toHaveBeenCalled();
+    });
+    expect(validateAndMaybePersistRxResumeMode).not.toHaveBeenCalled();
   });
 
   it("persists a changed Reactive Resume template before search terms are refreshed", async () => {

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -1202,4 +1202,47 @@ describe("OnboardingPage", () => {
     });
     expect(screen.getByText("Base resume selection")).toBeInTheDocument();
   });
+
+  it("keeps the Reactive Resume picker visible when returning with saved credentials", async () => {
+    currentSettings = {
+      ...baseSettings,
+      rxresumeApiKeyHint: "rx-k",
+      rxresumeBaseResumeId: "resume-1",
+      pdfRenderer: { value: "rxresume", default: "rxresume", override: null },
+      searchTerms: {
+        value: ["Platform Engineer"],
+        default: ["web developer"],
+        override: null,
+      },
+    };
+
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateResumeConfig).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(validateAndMaybePersistRxResumeMode).mockResolvedValue({
+      validation: {
+        valid: false,
+        message: "Validation has not refreshed yet.",
+      },
+    } as any);
+
+    renderPage();
+
+    fireEvent.click(getStepButton(/^Search terms$/i));
+    fireEvent.click(getStepButton(/^Resume$/i));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your base resume is loaded and ready."),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Template resume")).toBeInTheDocument();
+    expect(screen.getByText("Base resume selection")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Enter v5 API key")).toBeInTheDocument();
+  });
 });

--- a/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.tsx
@@ -166,6 +166,7 @@ export const BaseResumeStep: React.FC<{
         <>
           <RxResumeStep
             baseResumeValue={baseResumeValue}
+            hasRxResumeAccess={hasRxResumeAccess}
             isBusy={isBusy}
             isResumeReady={isResumeReady}
             isSelfHosted={isRxResumeSelfHosted}

--- a/orchestrator/src/client/pages/onboarding/components/OnboardingStepContent.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/OnboardingStepContent.tsx
@@ -72,11 +72,15 @@ export const OnboardingStepContent: React.FC<{
   }
 
   if (props.currentStep === "baseresume") {
+    const hasSavedRxResumeAccess = Boolean(props.rxresumeApiKeyHint);
+    const hasRxResumeAccess =
+      props.rxresumeValidation.valid || hasSavedRxResumeAccess;
+
     return (
       <BaseResumeStep
         baseResumeValidation={props.baseResumeValidation}
         baseResumeValue={props.baseResumeValue}
-        hasRxResumeAccess={props.rxresumeValidation.valid}
+        hasRxResumeAccess={hasRxResumeAccess}
         isBusy={props.isBusy}
         isImportingResume={props.isImportingResume}
         isResumeReady={props.isResumeReady}

--- a/orchestrator/src/client/pages/onboarding/components/RxResumeStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/RxResumeStep.tsx
@@ -9,6 +9,7 @@ export const RxResumeStep: React.FC<{
   baseResumeValue: string | null;
   isBusy: boolean;
   isResumeReady: boolean;
+  hasRxResumeAccess: boolean;
   isSelfHosted: boolean;
   rxresumeApiKey: string;
   rxresumeUrl: string;
@@ -20,6 +21,7 @@ export const RxResumeStep: React.FC<{
   onRxresumeUrlChange: (value: string) => void;
 }> = ({
   baseResumeValue,
+  hasRxResumeAccess,
   isBusy,
   isResumeReady,
   isSelfHosted,
@@ -95,7 +97,7 @@ export const RxResumeStep: React.FC<{
         />
       ) : null}
 
-      {rxresumeValidation.valid ? (
+      {hasRxResumeAccess ? (
         <div className="space-y-3 rounded-lg border border-border/60 bg-background/70 p-4">
           <div className="space-y-1">
             <div className="text-sm font-medium">Template resume</div>
@@ -107,7 +109,7 @@ export const RxResumeStep: React.FC<{
           <BaseResumeSelection
             value={baseResumeValue}
             onValueChange={onTemplateResumeChange}
-            hasRxResumeAccess={rxresumeValidation.valid}
+            hasRxResumeAccess={hasRxResumeAccess}
             disabled={isBusy}
           />
           {isResumeReady ? (

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -704,6 +704,32 @@ export function useOnboardingFlow() {
     }
   }, [getValues, setValue, syncSettingsCache]);
 
+  const baseResumeValue = watch("rxresumeBaseResumeId");
+  const hasRxResumeAccess =
+    rxresumeValidation.valid || Boolean(settings?.rxresumeApiKeyHint);
+
+  const handleConfirmRxresumeTemplate = useCallback(async () => {
+    const selectedResumeId = getValues().rxresumeBaseResumeId;
+    if (!selectedResumeId) {
+      toast.info("Choose a template resume to continue");
+      return null;
+    }
+
+    try {
+      const validation = await validateBaseResume();
+      if (!validation.valid) {
+        toast.error(validation.message || "Base resume validation failed");
+        return null;
+      }
+
+      toast.success("Resume source is ready");
+      return settings ?? null;
+    } catch (error) {
+      showErrorToast(error, "Failed to validate resume");
+      return null;
+    }
+  }, [getValues, settings, validateBaseResume]);
+
   const handlePrimaryAction = useCallback(async () => {
     if (!currentStep) return null;
     if (currentStep === "llm") {
@@ -711,6 +737,9 @@ export function useOnboardingFlow() {
     }
     if (currentStep === "baseresume") {
       if (resumeSetupMode === "rxresume") {
+        if (hasRxResumeAccess && !getValues().rxresumeApiKey.trim()) {
+          return await handleConfirmRxresumeTemplate();
+        }
         return await handleSaveRxresume();
       }
       return await handleSaveBaseResume();
@@ -721,10 +750,13 @@ export function useOnboardingFlow() {
     return null;
   }, [
     currentStep,
+    getValues,
     handleSaveBaseResume,
+    handleConfirmRxresumeTemplate,
     handleSaveLlm,
     handleSaveSearchTerms,
     handleSaveRxresume,
+    hasRxResumeAccess,
     resumeSetupMode,
   ]);
 
@@ -742,9 +774,6 @@ export function useOnboardingFlow() {
     isValidatingBaseResume;
 
   const currentCopy = currentStep ? STEP_COPY[currentStep] : STEP_COPY.llm;
-  const baseResumeValue = watch("rxresumeBaseResumeId");
-  const hasRxResumeAccess =
-    rxresumeValidation.valid || Boolean(settings?.rxresumeApiKeyHint);
 
   const primaryLabel =
     currentStep === "llm"

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -743,6 +743,8 @@ export function useOnboardingFlow() {
 
   const currentCopy = currentStep ? STEP_COPY[currentStep] : STEP_COPY.llm;
   const baseResumeValue = watch("rxresumeBaseResumeId");
+  const hasRxResumeAccess =
+    rxresumeValidation.valid || Boolean(settings?.rxresumeApiKeyHint);
 
   const primaryLabel =
     currentStep === "llm"
@@ -751,7 +753,7 @@ export function useOnboardingFlow() {
         : "Save connection"
       : currentStep === "baseresume"
         ? resumeSetupMode === "rxresume"
-          ? rxresumeValidation.valid
+          ? hasRxResumeAccess
             ? baseResumeValue
               ? "Recheck Reactive Resume"
               : "Confirm Resume Template"

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -810,11 +810,31 @@ export function useOnboardingFlow() {
     handlePrimaryAction,
     handleTemplateResumeChange: (value: string | null) => {
       const currentValue = getValues().rxresumeBaseResumeId;
+      if (currentValue === value) return;
+
       if (currentValue !== value) {
         markSearchTermsStale();
       }
       setBaseResumeId(value);
       setValue("rxresumeBaseResumeId", value);
+
+      void (async () => {
+        try {
+          setIsSaving(true);
+          const nextSettings = await api.updateSettings({
+            pdfRenderer: "rxresume",
+            rxresumeBaseResumeId: value,
+          });
+          syncSettingsCache(nextSettings);
+          await validateBaseResume();
+        } catch (error) {
+          setBaseResumeId(currentValue);
+          setValue("rxresumeBaseResumeId", currentValue);
+          showErrorToast(error, "Failed to save selected resume");
+        } finally {
+          setIsSaving(false);
+        }
+      })();
     },
   };
 }


### PR DESCRIPTION
## Summary
- Keep the Reactive Resume picker visible when saved credentials already exist, even after navigating away and back.
- Separate the connected-template action from credential validation so the primary button no longer tries to resubmit a blank API key.
- Persist template resume changes immediately so later search-term refreshes use the newly selected CV.
- Add regression coverage for returning to the Resume step, rechecking without a typed key, and switching templates before refreshing search terms.

## Testing
- `npm --workspace orchestrator run test:run -- OnboardingPage "Reactive Resume"`
- `npm --workspace orchestrator run check:types`
- Biome formatting/checks passed on touched files