### PR TITLE
Add Reactive Resume JSON upload to onboarding

### DIFF
--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -974,6 +974,79 @@ describe("OnboardingPage", () => {
     });
   });
 
+  it("lets onboarding upload a Reactive Resume JSON file", async () => {
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateRxresume).mockResolvedValue({
+      valid: false,
+      message: "Reactive Resume is not configured",
+    });
+    vi.mocked(api.validateResumeConfig)
+      .mockResolvedValueOnce({
+        valid: false,
+        message: "No resume yet",
+      })
+      .mockResolvedValueOnce({
+        valid: true,
+        message: null,
+      });
+    vi.mocked(api.importDesignResumeFromFile).mockResolvedValue({
+      id: "primary",
+      title: "Taylor Resume",
+      resumeJson: {} as any,
+      revision: 1,
+      sourceResumeId: null,
+      sourceMode: "v5",
+      importedAt: "2026-04-11T00:00:00.000Z",
+      createdAt: "2026-04-11T00:00:00.000Z",
+      updatedAt: "2026-04-11T00:00:00.000Z",
+      assets: [],
+    });
+    vi.mocked(api.updateSettings).mockResolvedValue({
+      ...currentSettings,
+      pdfRenderer: {
+        value: "latex",
+        default: "rxresume",
+        override: null,
+      },
+    });
+
+    const { container } = renderPage();
+
+    fireEvent.click(getStepButton(/^Resume$/i));
+
+    const input = container.querySelector(
+      'input[type="file"][accept*=".json"]',
+    ) as HTMLInputElement | null;
+    if (!input) {
+      throw new Error("Expected resume upload input to accept JSON");
+    }
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(
+            [JSON.stringify({ data: { basics: {}, sections: {} } })],
+            "resume.json",
+            {
+              type: "application/json",
+            },
+          ),
+        ],
+      },
+    });
+
+    await waitFor(() => {
+      expect(api.importDesignResumeFromFile).toHaveBeenCalledWith({
+        fileName: "resume.json",
+        mediaType: "application/json",
+        dataBase64: expect.any(String),
+      });
+    });
+  });
+
   it("marks the search terms step stale after the resume changes", async () => {
     vi.mocked(api.validateLlm).mockResolvedValue({
       valid: true,

--- a/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.tsx
@@ -54,7 +54,7 @@ export const BaseResumeStep: React.FC<{
       <input
         ref={fileInputRef}
         type="file"
-        accept="application/pdf,.pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.docx"
+        accept="application/pdf,.pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.docx,application/json,.json"
         className="hidden"
         onChange={(event) => {
           const file = event.currentTarget.files?.[0];
@@ -75,9 +75,9 @@ export const BaseResumeStep: React.FC<{
         {[
           {
             value: "upload",
-            title: "Upload a PDF or DOCX",
+            title: "Upload a file",
             description:
-              "Create a local Resume Studio document directly in Job Ops from your existing file.",
+              "Create a local Resume Studio document from a resume PDF, DOCX, or Reactive Resume JSON.",
           },
           {
             value: "rxresume",
@@ -121,13 +121,11 @@ export const BaseResumeStep: React.FC<{
         <>
           <div className="rounded-xl border border-border/60 bg-muted/10 p-5">
             <div className="space-y-2">
-              <div className="text-sm font-medium">
-                Upload a PDF or DOCX resume
-              </div>
+              <div className="text-sm font-medium">Upload a resume file</div>
               <p className="text-sm text-muted-foreground">
-                Job Ops will send the file directly to your configured AI model
-                and store the validated structured result as your local Design
-                Resume.
+                Job Ops imports Reactive Resume JSON directly. PDF and DOCX
+                files are sent to your configured AI model and stored as a local
+                Design Resume.
               </p>
             </div>
 
@@ -143,7 +141,7 @@ export const BaseResumeStep: React.FC<{
                   : "Upload resume file"}
               </Button>
               <div className="text-xs text-muted-foreground">
-                Supported formats: PDF and DOCX.
+                Supported formats: PDF, DOCX, and Reactive Resume JSON.
               </div>
             </div>
           </div>

--- a/orchestrator/src/client/pages/onboarding/content.ts
+++ b/orchestrator/src/client/pages/onboarding/content.ts
@@ -25,7 +25,7 @@ export const STEP_COPY: Record<
     eyebrow: "Step 2",
     title: "Import your current resume.",
     description:
-      "Choose how to bring your base resume into Job Ops. Upload a PDF or DOCX to create a local Resume Studio document, or connect Reactive Resume with a v5 API key and select an existing resume there.",
+      "Choose how to bring your base resume into Job Ops. Upload a PDF, DOCX, or Reactive Resume JSON to create a local Resume Studio document, or connect Reactive Resume with a v5 API key and select an existing resume there.",
   },
   searchterms: {
     eyebrow: "Step 3",

--- a/orchestrator/src/server/api/routes/onboarding.ts
+++ b/orchestrator/src/server/api/routes/onboarding.ts
@@ -107,7 +107,7 @@ async function validateResumeConfig(): Promise<ValidationResponse> {
       return {
         valid: false,
         message:
-          "No local resume is ready yet. Upload a PDF or DOCX resume, or connect Reactive Resume and select a template resume.",
+          "No local resume is ready yet. Upload a PDF, DOCX, or Reactive Resume JSON, or connect Reactive Resume and select a template resume.",
       };
     }
 

--- a/orchestrator/src/server/services/design-resume/import-file.test.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.test.ts
@@ -101,6 +101,78 @@ describe("importDesignResumeFromFile", () => {
     );
   });
 
+  it("imports Reactive Resume JSON directly without model extraction", async () => {
+    const resumeJson = buildDefaultReactiveResumeDocument() as DesignResumeJson;
+    resumeJson.basics.name = "Jordan Park";
+
+    const result = await importDesignResumeFromFile({
+      fileName: "resume.json",
+      mediaType: "application/json",
+      dataBase64: Buffer.from(JSON.stringify(resumeJson), "utf8").toString(
+        "base64",
+      ),
+    });
+
+    expect(modelSelection.resolveLlmRuntimeSettings).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+    expect(
+      designResumeService.replaceCurrentDesignResumeDocument,
+    ).toHaveBeenCalledWith({
+      importedAt: expect.any(String),
+      resumeJson: expect.objectContaining({
+        basics: expect.objectContaining({ name: "Jordan Park" }),
+      }),
+      sourceMode: "v5",
+      sourceResumeId: null,
+    });
+    expect(result.resumeJson.basics.name).toBe("Jordan Park");
+  });
+
+  it("accepts data-wrapped Reactive Resume JSON exports", async () => {
+    const resumeJson = buildDefaultReactiveResumeDocument() as DesignResumeJson;
+    resumeJson.basics.name = "Sam Rivera";
+
+    const result = await importDesignResumeFromFile({
+      fileName: "resume.json",
+      mediaType: "",
+      dataBase64: Buffer.from(
+        JSON.stringify({ data: resumeJson }),
+        "utf8",
+      ).toString("base64"),
+    });
+
+    expect(result.resumeJson.basics.name).toBe("Sam Rivera");
+    expect(
+      designResumeService.replaceCurrentDesignResumeDocument,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceMode: "v5",
+        sourceResumeId: null,
+      }),
+    );
+  });
+
+  it("rejects non Reactive Resume JSON files", async () => {
+    await expect(
+      importDesignResumeFromFile({
+        fileName: "not-a-resume.json",
+        mediaType: "application/json",
+        dataBase64: Buffer.from(
+          JSON.stringify({ hello: "world" }),
+          "utf8",
+        ).toString("base64"),
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      message:
+        "Reactive Resume JSON must contain a v5 resume document or a data-wrapped v5 resume document.",
+    });
+
+    expect(
+      designResumeService.replaceCurrentDesignResumeDocument,
+    ).not.toHaveBeenCalled();
+  });
+
   it("sends the attached file directly to the configured model and saves the normalized document", async () => {
     vi.mocked(fetch).mockResolvedValue(
       new Response(

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -30,7 +30,8 @@ import { replaceCurrentDesignResumeDocument } from "./index";
 
 type SupportedImportMediaType =
   | "application/pdf"
-  | "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+  | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  | "application/json";
 
 type SupportedRuntimeProvider =
   | "openai"
@@ -85,6 +86,7 @@ const SUPPORTED_EXTENSION_TO_MEDIA_TYPE: Record<
 > = {
   pdf: "application/pdf",
   docx: DOCX_MIME,
+  json: "application/json",
 };
 
 const SYSTEM_PROMPT = `
@@ -162,6 +164,12 @@ function normalizeImportMediaType(input: {
   const normalizedMediaType = input.mediaType?.trim().toLowerCase() ?? "";
   if (normalizedMediaType === "application/pdf") return "application/pdf";
   if (normalizedMediaType === DOCX_MIME) return DOCX_MIME;
+  if (
+    normalizedMediaType === "application/json" ||
+    normalizedMediaType === "text/json"
+  ) {
+    return "application/json";
+  }
 
   if (
     (!normalizedMediaType ||
@@ -171,7 +179,9 @@ function normalizeImportMediaType(input: {
     return fromExtension;
   }
 
-  throw badRequest("Only PDF and DOCX resumes are supported.");
+  throw badRequest(
+    "Only PDF, DOCX, and Reactive Resume JSON files are supported.",
+  );
 }
 
 function normalizeBase64Payload(dataBase64: string): string {
@@ -801,6 +811,46 @@ function sanitizeNormalizedResume(input: unknown): DesignResumeJson {
   return parsed.data as DesignResumeJson;
 }
 
+function asReactiveResumeExportObject(input: unknown): RecordLike | null {
+  const record = asRecord(input);
+  if (!record) return null;
+  if (asRecord(record.basics) && asRecord(record.sections)) return record;
+
+  const data = asRecord(record.data);
+  if (data && asRecord(data.basics) && asRecord(data.sections)) return data;
+
+  const resume = asRecord(record.resume);
+  const resumeData = asRecord(resume?.data);
+  if (
+    resumeData &&
+    asRecord(resumeData.basics) &&
+    asRecord(resumeData.sections)
+  ) {
+    return resumeData;
+  }
+
+  return null;
+}
+
+function parseReactiveResumeJsonFile(content: string): DesignResumeJson {
+  const parsed = parseImportedResumeJson(content);
+  const candidate = asReactiveResumeExportObject(parsed);
+  if (!candidate) {
+    throw badRequest(
+      "Reactive Resume JSON must contain a v5 resume document or a data-wrapped v5 resume document.",
+    );
+  }
+
+  const validation = safeParseV5ResumeData(candidate);
+  if (!validation.success) {
+    throw badRequest(
+      `Reactive Resume JSON must be a valid v5 resume document. ${getResumeSchemaValidationMessage(validation.error)}`,
+    );
+  }
+
+  return validation.data as DesignResumeJson;
+}
+
 function buildCapabilityErrorMessage(provider: string): string {
   return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, Gemini, Gemini (CLI), OpenAI-compatible, Ollama, or LM Studio to import resumes. PDF and DOCX files can be converted to plain text locally before extraction when native file upload is unavailable.`;
 }
@@ -1370,6 +1420,51 @@ export async function importDesignResumeFromFile(
   });
   const { decoded, normalizedBase64 } = decodeBase64Payload(input.dataBase64);
   const requestId = getRequestId();
+
+  if (mediaType === "application/json") {
+    logger.info("Reactive Resume JSON import started", {
+      requestId: requestId ?? null,
+      fileName,
+      mediaType,
+      byteSize: decoded.byteLength,
+    });
+
+    try {
+      const resumeJson = parseReactiveResumeJsonFile(decoded.toString("utf8"));
+      const saved = await replaceCurrentDesignResumeDocument({
+        importedAt: new Date().toISOString(),
+        resumeJson,
+        sourceMode: "v5",
+        sourceResumeId: null,
+      });
+
+      logger.info("Reactive Resume JSON import completed", {
+        requestId: requestId ?? null,
+        fileName,
+        mediaType,
+        documentId: saved.id,
+      });
+
+      return saved;
+    } catch (error) {
+      logger.warn("Reactive Resume JSON import failed", {
+        requestId: requestId ?? null,
+        fileName,
+        mediaType,
+        error: sanitizeUnknown(error),
+      });
+
+      if (error instanceof AppError) {
+        throw error;
+      }
+
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Reactive Resume JSON import failed.";
+      throw badRequest(truncate(message, 400));
+    }
+  }
 
   const runtime = await resolveLlmRuntimeSettings();
   const provider = normalizeRuntimeProvider(runtime.provider);


### PR DESCRIPTION
## Summary
- Added direct onboarding support for Reactive Resume JSON uploads alongside PDF and DOCX.
- Routed JSON imports through existing Reactive Resume v5 validation and Resume Studio storage, without AI extraction.
- Updated onboarding copy and validation messaging to reflect the new import path.
- Added coverage for JSON import success, wrapped export shapes, and invalid JSON rejection.

## Testing
- `./orchestrator/node_modules/.bin/biome ci .` (passes; existing warnings remain in `orchestrator/index.html`)
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `DATA_DIR=/private/tmp/job-ops-json-import-full-test npm --workspace orchestrator run test:run -- --maxWorkers=1`