### PR TITLE
fix: wrap empty job detail panel in card (#526)

### DIFF
--- a/orchestrator/src/client/pages/orchestrator/JobDetailPanel.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobDetailPanel.tsx
@@ -505,16 +505,18 @@ export const JobDetailPanel: React.FC<JobDetailPanelProps> = ({
 
   if (!selectedJob) {
     return (
-      <div className="flex h-full min-h-[260px] flex-col items-center justify-center gap-2 text-center">
-        <div className="flex h-11 w-11 items-center justify-center rounded-lg border border-border/50 bg-muted/20">
-          <FileText className="h-5 w-5 text-muted-foreground" />
+      <div className="min-w-0 rounded-xl border border-border bg-card p-4 shadow-sm">
+        <div className="flex h-full min-h-[260px] flex-col items-center justify-center gap-2 text-center">
+          <div className="flex h-11 w-11 items-center justify-center rounded-lg border border-border/50 bg-muted/20">
+            <FileText className="h-5 w-5 text-muted-foreground" />
+          </div>
+          <div className="text-sm font-medium text-muted-foreground">
+            No job selected
+          </div>
+          <p className="max-w-[220px] text-xs text-muted-foreground/70">
+            Select a job to see the brief, tailoring, and application kit.
+          </p>
         </div>
-        <div className="text-sm font-medium text-muted-foreground">
-          No job selected
-        </div>
-        <p className="max-w-[220px] text-xs text-muted-foreground/70">
-          Select a job to see the brief, tailoring, and application kit.
-        </p>
       </div>
     );
   }


### PR DESCRIPTION
Fixes #526

The empty state of the job detail panel was rendering without a Card 
wrapper, making it look visually inconsistent with the populated state. 
Wrapped the empty/null state in the same Card component.

<img width="1919" height="944" alt="image" src="https://github.com/user-attachments/assets/2de534fc-a2f3-470f-bdb3-26f13459c115" />
