### PR TITLE
Let env backed verified LLM onboarding continue without resaving credentials

### DIFF
--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -402,6 +402,48 @@ describe("OnboardingPage", () => {
     });
   });
 
+  it("lets a verified unchanged LLM setup continue without saving credentials again", async () => {
+    vi.mocked(useOnboardingRequirement).mockReturnValue({
+      checking: false,
+      complete: false,
+    });
+    currentSettings = {
+      ...baseSettings,
+      searchTerms: {
+        value: ["Platform Engineer"],
+        default: ["web developer"],
+        override: ["Platform Engineer"],
+      },
+    };
+    vi.mocked(api.validateLlm).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateRxresume).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+    vi.mocked(api.validateResumeConfig).mockResolvedValue({
+      valid: true,
+      message: null,
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^continue$/i }),
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /^continue$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("ready page")).toBeInTheDocument();
+    });
+    expect(api.updateSettings).not.toHaveBeenCalled();
+  });
+
   it("renders the three active onboarding steps in the rail", async () => {
     vi.mocked(api.validateLlm).mockResolvedValue({
       valid: true,
@@ -690,7 +732,7 @@ describe("OnboardingPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not auto-advance after saving the LLM step", async () => {
+  it("does not auto-advance after continuing past a verified LLM step", async () => {
     vi.mocked(api.validateLlm).mockResolvedValue({
       valid: true,
       message: null,
@@ -703,8 +745,6 @@ describe("OnboardingPage", () => {
       valid: true,
       message: null,
     });
-    vi.mocked(api.updateSettings).mockResolvedValue(baseSettings as any);
-
     renderPage();
 
     await waitFor(() => {
@@ -713,18 +753,14 @@ describe("OnboardingPage", () => {
       ).toBeInTheDocument();
     });
 
-    fireEvent.click(
-      screen.getByRole("button", { name: /revalidate connection/i }),
-    );
+    fireEvent.click(screen.getByRole("button", { name: /^continue$/i }));
 
     await waitFor(() => {
-      expect(api.updateSettings).toHaveBeenCalled();
+      expect(
+        screen.getByText("Choose the LLM connection Job Ops should use."),
+      ).toBeInTheDocument();
     });
-    expect(api.updateSettings).toHaveBeenCalledWith(
-      expect.objectContaining({
-        model: null,
-      }),
-    );
+    expect(api.updateSettings).not.toHaveBeenCalled();
 
     expect(
       screen.getByText("Choose the LLM connection Job Ops should use."),

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -135,6 +135,9 @@ export function useOnboardingFlow() {
   }, [reset, settings, syncBaseResumeId]);
 
   const llmProvider = watch("llmProvider");
+  const llmBaseUrlValue = watch("llmBaseUrl");
+  const llmApiKeyValue = watch("llmApiKey");
+  const modelDraftValue = watch("model");
   const selectedProvider = normalizeLlmProvider(
     llmProvider || settings?.llmProvider?.value || "openrouter",
   );
@@ -707,6 +710,27 @@ export function useOnboardingFlow() {
   const baseResumeValue = watch("rxresumeBaseResumeId");
   const hasRxResumeAccess =
     rxresumeValidation.valid || Boolean(settings?.rxresumeApiKeyHint);
+  const hasPendingLlmChanges = useMemo(() => {
+    if (!settings) return true;
+
+    const normalizedProviderDraft = normalizeLlmProvider(
+      llmProvider || settings.llmProvider?.value || "openrouter",
+    );
+    const normalizedSavedProvider = normalizeLlmProvider(
+      settings.llmProvider?.value || "openrouter",
+    );
+    const draftBaseUrl = llmBaseUrlValue.trim();
+    const savedBaseUrl = settings.llmBaseUrl?.value?.trim() ?? "";
+    const draftModel = modelDraftValue.trim();
+    const savedModelOverride = settings.model?.override?.trim() ?? "";
+
+    return (
+      normalizedProviderDraft !== normalizedSavedProvider ||
+      draftBaseUrl !== savedBaseUrl ||
+      draftModel !== savedModelOverride ||
+      llmApiKeyValue.trim().length > 0
+    );
+  }, [llmApiKeyValue, llmBaseUrlValue, llmProvider, modelDraftValue, settings]);
 
   const handleConfirmRxresumeTemplate = useCallback(async () => {
     const selectedResumeId = getValues().rxresumeBaseResumeId;
@@ -733,6 +757,9 @@ export function useOnboardingFlow() {
   const handlePrimaryAction = useCallback(async () => {
     if (!currentStep) return null;
     if (currentStep === "llm") {
+      if (llmValidated && !hasPendingLlmChanges) {
+        return settings ?? null;
+      }
       return await handleSaveLlm();
     }
     if (currentStep === "baseresume") {
@@ -757,7 +784,10 @@ export function useOnboardingFlow() {
     handleSaveSearchTerms,
     handleSaveRxresume,
     hasRxResumeAccess,
+    hasPendingLlmChanges,
+    llmValidated,
     resumeSetupMode,
+    settings,
   ]);
 
   const stepIndex = currentStep
@@ -778,7 +808,9 @@ export function useOnboardingFlow() {
   const primaryLabel =
     currentStep === "llm"
       ? llmValidated
-        ? "Revalidate connection"
+        ? hasPendingLlmChanges
+          ? "Revalidate connection"
+          : "Continue"
         : "Save connection"
       : currentStep === "baseresume"
         ? resumeSetupMode === "rxresume"


### PR DESCRIPTION
## Summary
- Treat an already verified, unchanged LLM onboarding setup as ready to continue instead of forcing the save/revalidate path.
- Detect pending LLM changes from the live onboarding form state so only real edits keep the credential flow active.
- Update onboarding tests to cover the verified-unchanged path and the existing non-auto-advance behavior.

## Testing
- `./orchestrator/node_modules/.bin/biome ci .` 
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run`
- Targeted onboarding test file passed locally