### PR TITLE
fix: show offline screen instead of onboarding on network failure (#533)

### DIFF
--- a/orchestrator/src/client/App.tsx
+++ b/orchestrator/src/client/App.tsx
@@ -24,6 +24,7 @@ import { GmailOauthCallbackPage } from "./pages/GmailOauthCallbackPage";
 import { HomePage } from "./pages/HomePage";
 import { InProgressBoardPage } from "./pages/InProgressBoardPage";
 import { JobPage } from "./pages/JobPage";
+import { OfflinePage } from "./pages/OfflinePage";
 import { OnboardingPage } from "./pages/OnboardingPage";
 import { OrchestratorPage } from "./pages/OrchestratorPage";
 import { SettingsPage } from "./pages/SettingsPage";
@@ -188,6 +189,7 @@ export const App: React.FC = () => {
                   element={<DesignResumePage />}
                 />
                 <Route path="/onboarding" element={<OnboardingPage />} />
+                <Route path="/offline" element={<OfflinePage />} />
                 <Route path="/sign-in" element={<SignInPage />} />
                 <Route path="/settings" element={<SettingsPage />} />
                 <Route path="/tracer-links" element={<TracerLinksPage />} />

--- a/orchestrator/src/client/components/OnboardingGate.test.tsx
+++ b/orchestrator/src/client/components/OnboardingGate.test.tsx
@@ -1,5 +1,7 @@
 import { useOnboardingRequirement } from "@client/hooks/useOnboardingRequirement";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
+import type React from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { OnboardingGate } from "./OnboardingGate";
@@ -7,6 +9,22 @@ import { OnboardingGate } from "./OnboardingGate";
 vi.mock("@client/hooks/useOnboardingRequirement", () => ({
   useOnboardingRequirement: vi.fn(),
 }));
+
+vi.mock("@client/hooks/useSettings", () => ({
+  useSettings: () => ({
+    error: null,
+  }),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+};
 
 describe("OnboardingGate", () => {
   beforeEach(() => {
@@ -27,6 +45,7 @@ describe("OnboardingGate", () => {
           <Route path="/onboarding" element={<div>onboarding</div>} />
         </Routes>
       </MemoryRouter>,
+      { wrapper: createWrapper() },
     );
 
     expect(screen.getByText("onboarding")).toBeInTheDocument();
@@ -45,6 +64,7 @@ describe("OnboardingGate", () => {
           <Route path="/onboarding" element={<div>onboarding</div>} />
         </Routes>
       </MemoryRouter>,
+      { wrapper: createWrapper() },
     );
 
     expect(screen.getByText("onboarding")).toBeInTheDocument();
@@ -58,6 +78,7 @@ describe("OnboardingGate", () => {
           <Route path="/sign-in" element={<div>sign-in</div>} />
         </Routes>
       </MemoryRouter>,
+      { wrapper: createWrapper() },
     );
 
     expect(screen.getByText("sign-in")).toBeInTheDocument();
@@ -78,6 +99,7 @@ describe("OnboardingGate", () => {
           <Route path="/onboarding" element={<div>onboarding</div>} />
         </Routes>
       </MemoryRouter>,
+      { wrapper: createWrapper() },
     );
 
     expect(screen.getByText("overview")).toBeInTheDocument();

--- a/orchestrator/src/client/components/OnboardingGate.tsx
+++ b/orchestrator/src/client/components/OnboardingGate.tsx
@@ -1,11 +1,30 @@
 import { useOnboardingRequirement } from "@client/hooks/useOnboardingRequirement";
 import type React from "react";
-import { Navigate, useLocation } from "react-router-dom";
+import { useEffect } from "react";
+import { Navigate, useLocation, useNavigate } from "react-router-dom";
+import { useSettings } from "@/client/hooks/useSettings";
 
 export const OnboardingGate: React.FC = () => {
   const location = useLocation();
+  const navigate = useNavigate();
 
-  if (location.pathname === "/onboarding" || location.pathname === "/sign-in") {
+  useEffect(() => {
+    const handleOffline = () => {
+      navigate("/offline", { replace: true });
+    };
+    window.addEventListener("offline", handleOffline);
+    return () => window.removeEventListener("offline", handleOffline);
+  }, [navigate]);
+
+  if (location.pathname === "/onboarding" && !navigator.onLine) {
+    return <Navigate to="/offline" replace />;
+  }
+
+  if (
+    location.pathname === "/onboarding" ||
+    location.pathname === "/sign-in" ||
+    location.pathname === "/offline"
+  ) {
     return null;
   }
 
@@ -13,7 +32,15 @@ export const OnboardingGate: React.FC = () => {
 };
 
 const OnboardingRedirect: React.FC = () => {
+  const { error } = useSettings();
   const { checking, complete } = useOnboardingRequirement();
+
+  if (error) {
+    if (!navigator.onLine) {
+      return <Navigate to="/offline" replace />;
+    }
+    return <Navigate to="/onboarding" replace />;
+  }
 
   if (checking || complete) {
     return null;

--- a/orchestrator/src/client/pages/OfflinePage.tsx
+++ b/orchestrator/src/client/pages/OfflinePage.tsx
@@ -1,0 +1,49 @@
+import { WifiOff } from "lucide-react";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+
+export function OfflinePage() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const handleOnline = () => {
+      navigate("/", { replace: true });
+    };
+
+    window.addEventListener("online", handleOnline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+    };
+  }, [navigate]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-background px-4 py-10 text-foreground">
+      <section className="w-full max-w-2xl space-y-6 rounded-lg border border-border bg-card p-10 shadow-sm sm:p-12">
+        <div className="flex items-start gap-4">
+          <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-full border border-border bg-muted/40 text-muted-foreground">
+            <WifiOff className="h-12 w-12" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 space-y-2">
+            <h1 className="text-3xl font-semibold tracking-normal sm:text-4xl">
+              You seem offline
+            </h1>
+            <p className="max-w-prose text-sm leading-6 text-muted-foreground">
+              Check your internet connection and try again.
+            </p>
+            <p className="max-w-prose text-sm leading-6 text-muted-foreground">
+              This page will automatically redirect when your connection is
+              restored.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" onClick={() => window.location.reload()}>
+            Try again
+          </Button>
+        </div>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
Fixes #533

When a user loses internet connection, the failed /api/settings fetch 
was incorrectly redirecting to /onboarding. This PR adds a dedicated 
offline screen instead.

Changes:
- Added OfflinePage.tsx with WifiOff icon, retry button, and auto-
  redirect when connection restores
- Added /offline route in App.tsx
- Excluded /offline from OnboardingGate to prevent redirect loops
- Added navigator.onLine check in OnboardingRedirect: offline errors 
  go to /offline, other errors still go to /onboarding

<img width="1919" height="942" alt="image" src="https://github.com/user-attachments/assets/1a9b3ae1-71c7-4266-b3a3-9f8ae7dd2165" />
