### PR TITLE
Add BambooHR as a Watchlist source board

### DIFF
--- a/career-boards/bamboohr/package.json
+++ b/career-boards/bamboohr/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@career-boards/bamboohr",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./bamboohr-url": "./src/bamboohr-url.ts",
+    "./get-company-info": "./src/get-company-info.ts",
+    "./get-job-details": "./src/get-job-details.ts",
+    "./get-jobs-from-careers-list": "./src/get-jobs-from-careers-list.ts"
+  }
+}

--- a/career-boards/bamboohr/src/bamboohr-url.test.ts
+++ b/career-boards/bamboohr/src/bamboohr-url.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  bamboohrUrlToCompanyLabel,
+  bamboohrUrlToSourceKey,
+  parseBamboohrJobUrl,
+  parseBamboohrUrl,
+} from "./bamboohr-url";
+
+describe("parseBamboohrUrl", () => {
+  it("canonicalizes careers list and detail URLs to the careers root", () => {
+    expect(
+      parseBamboohrUrl("https://ashteadtechnology.bamboohr.com/careers/list"),
+    ).toMatchObject({
+      canonicalCareersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+      listUrl: "https://ashteadtechnology.bamboohr.com/careers/list",
+      companyInfoUrl:
+        "https://ashteadtechnology.bamboohr.com/careers/company-info",
+    });
+
+    expect(
+      parseBamboohrUrl(
+        "https://ashteadtechnology.bamboohr.com/careers/134/detail",
+      ).canonicalCareersUrl,
+    ).toBe("https://ashteadtechnology.bamboohr.com/careers");
+  });
+
+  it("derives the company label and source key from the BambooHR subdomain", () => {
+    expect(
+      bamboohrUrlToCompanyLabel("https://acme-inc.bamboohr.com/careers"),
+    ).toBe("Acme Inc");
+    expect(
+      bamboohrUrlToSourceKey("https://acme-inc.bamboohr.com/careers"),
+    ).toBe("bamboohr:acme-inc");
+  });
+
+  it("parses job URLs into canonical detail endpoints", () => {
+    expect(
+      parseBamboohrJobUrl("https://ashteadtechnology.bamboohr.com/careers/134"),
+    ).toMatchObject({
+      jobId: "134",
+      canonicalJobUrl: "https://ashteadtechnology.bamboohr.com/careers/134",
+      detailUrl: "https://ashteadtechnology.bamboohr.com/careers/134/detail",
+    });
+  });
+});

--- a/career-boards/bamboohr/src/bamboohr-url.ts
+++ b/career-boards/bamboohr/src/bamboohr-url.ts
@@ -1,0 +1,178 @@
+export type BamboohrUrlParseErrorCode =
+  | "EMPTY_URL"
+  | "INVALID_URL"
+  | "UNSUPPORTED_HOST"
+  | "MISSING_CAREERS_PATH"
+  | "INVALID_JOB_ID";
+
+export interface BamboohrSourceConfig {
+  inputUrl: string;
+  origin: string;
+  host: string;
+  companySlug: string;
+  canonicalCareersUrl: string;
+  listUrl: string;
+  companyInfoUrl: string;
+}
+
+export interface BamboohrJobSourceConfig extends BamboohrSourceConfig {
+  jobId: string;
+  canonicalJobUrl: string;
+  detailUrl: string;
+}
+
+export class BamboohrUrlParseError extends Error {
+  readonly code: BamboohrUrlParseErrorCode;
+  readonly input: string;
+
+  constructor(code: BamboohrUrlParseErrorCode, message: string, input: string) {
+    super(message);
+    this.name = "BamboohrUrlParseError";
+    this.code = code;
+    this.input = input;
+  }
+}
+
+export function isBamboohrUrl(input: string): boolean {
+  try {
+    parseBamboohrUrl(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function parseBamboohrUrl(input: string): BamboohrSourceConfig {
+  if (!input.trim()) {
+    throw new BamboohrUrlParseError("EMPTY_URL", "URL cannot be empty.", input);
+  }
+
+  const url = toUrl(input);
+  const host = url.hostname.toLowerCase();
+  if (!host.endsWith(".bamboohr.com")) {
+    throw new BamboohrUrlParseError(
+      "UNSUPPORTED_HOST",
+      `Unsupported BambooHR host: ${host}`,
+      input,
+    );
+  }
+
+  const companySlug = host.slice(0, -".bamboohr.com".length);
+  if (!companySlug) {
+    throw new BamboohrUrlParseError(
+      "UNSUPPORTED_HOST",
+      `Unsupported BambooHR host: ${host}`,
+      input,
+    );
+  }
+
+  const segments = getPathSegments(url.pathname);
+  if (segments[0]?.toLowerCase() !== "careers") {
+    throw new BamboohrUrlParseError(
+      "MISSING_CAREERS_PATH",
+      "BambooHR URLs must start with /careers.",
+      input,
+    );
+  }
+
+  const canonicalCareersUrl = `${url.origin}/careers`;
+
+  return {
+    inputUrl: input,
+    origin: url.origin,
+    host,
+    companySlug,
+    canonicalCareersUrl,
+    listUrl: `${canonicalCareersUrl}/list`,
+    companyInfoUrl: `${canonicalCareersUrl}/company-info`,
+  };
+}
+
+export function parseBamboohrJobUrl(input: string): BamboohrJobSourceConfig {
+  const source = parseBamboohrUrl(input);
+  const url = toUrl(input);
+  const segments = getPathSegments(url.pathname);
+  const maybeJobId = segments[1];
+
+  if (!maybeJobId || !/^\d+$/.test(maybeJobId)) {
+    throw new BamboohrUrlParseError(
+      "INVALID_JOB_ID",
+      "BambooHR job URLs must include a numeric job id under /careers/{id}.",
+      input,
+    );
+  }
+
+  return buildBamboohrJobSource(source, maybeJobId);
+}
+
+export function bamboohrUrlToCompanyLabel(input: string): string {
+  const parsed = parseBamboohrUrl(input);
+  return formatCompanySlug(parsed.companySlug);
+}
+
+export function bamboohrUrlToSourceKey(input: string): string {
+  const parsed = parseBamboohrUrl(input);
+  return `bamboohr:${toSourceKeyPart(parsed.companySlug)}`;
+}
+
+export function bamboohrUrlToJobDetailsUrl(
+  input: string,
+  jobId: string,
+): string {
+  return buildBamboohrJobSource(parseBamboohrUrl(input), jobId).detailUrl;
+}
+
+export function bamboohrUrlToJobUrl(input: string, jobId: string): string {
+  return buildBamboohrJobSource(parseBamboohrUrl(input), jobId).canonicalJobUrl;
+}
+
+function buildBamboohrJobSource(
+  source: BamboohrSourceConfig,
+  jobId: string,
+): BamboohrJobSourceConfig {
+  if (!/^\d+$/.test(jobId)) {
+    throw new BamboohrUrlParseError(
+      "INVALID_JOB_ID",
+      `Invalid BambooHR job id: ${jobId}`,
+      source.inputUrl,
+    );
+  }
+
+  return {
+    ...source,
+    jobId,
+    canonicalJobUrl: `${source.canonicalCareersUrl}/${jobId}`,
+    detailUrl: `${source.canonicalCareersUrl}/${jobId}/detail`,
+  };
+}
+
+function toUrl(input: string): URL {
+  try {
+    return new URL(input.trim());
+  } catch {
+    throw new BamboohrUrlParseError(
+      "INVALID_URL",
+      `Invalid URL: ${input}`,
+      input,
+    );
+  }
+}
+
+function getPathSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}
+
+function formatCompanySlug(slug: string): string {
+  return slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function toSourceKeyPart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-");
+}

--- a/career-boards/bamboohr/src/get-company-info.ts
+++ b/career-boards/bamboohr/src/get-company-info.ts
@@ -1,0 +1,121 @@
+import { parseBamboohrUrl } from "./bamboohr-url";
+
+export interface BamboohrCompanyInfoResponse {
+  meta?: unknown;
+  result?: {
+    name?: string;
+    logoUrl?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface NormalizedBamboohrCompanyInfo {
+  name: string;
+  logoUrl?: string;
+  raw: BamboohrCompanyInfoResponse;
+}
+
+export interface FetchBamboohrCompanyInfoOptions {
+  careersUrl: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+  userAgent?: string;
+}
+
+const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36";
+
+export async function getCompanyInfo(
+  options: FetchBamboohrCompanyInfoOptions,
+): Promise<{ company: NormalizedBamboohrCompanyInfo }> {
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  if (!fetchFn) {
+    throw new Error(
+      "No fetch implementation available. Pass fetchImpl or use Node 18+.",
+    );
+  }
+
+  const parsed = parseBamboohrUrl(options.careersUrl);
+  const response = await fetchBamboohrJson<BamboohrCompanyInfoResponse>(
+    fetchFn,
+    {
+      url: parsed.companyInfoUrl,
+      signal: options.signal,
+      headers: {
+        accept: "application/json",
+        referer: parsed.canonicalCareersUrl,
+        "user-agent": options.userAgent ?? DEFAULT_USER_AGENT,
+        ...options.headers,
+      },
+    },
+  );
+
+  return {
+    company: normalizeBamboohrCompanyInfo(response, parsed.companyInfoUrl),
+  };
+}
+
+export function normalizeBamboohrCompanyInfo(
+  response: BamboohrCompanyInfoResponse,
+  url: string,
+): NormalizedBamboohrCompanyInfo {
+  const result = response.result;
+  if (!result) {
+    throw new Error(
+      `BambooHR company info response is missing result for ${url}.`,
+    );
+  }
+
+  const name = requiredString(result.name, "name", url);
+  return {
+    name,
+    logoUrl: optionalString(result.logoUrl),
+    raw: response,
+  };
+}
+
+async function fetchBamboohrJson<T>(
+  fetchFn: typeof fetch,
+  input: {
+    url: string;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  },
+): Promise<T> {
+  const response = await fetchFn(input.url, {
+    method: "GET",
+    signal: input.signal,
+    headers: input.headers,
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `BambooHR request failed with HTTP ${response.status} for ${input.url}.`,
+    );
+  }
+
+  try {
+    return JSON.parse(responseText) as T;
+  } catch {
+    throw new Error(`BambooHR response was not valid JSON for ${input.url}.`);
+  }
+}
+
+function requiredString(
+  value: unknown,
+  fieldName: string,
+  url: string,
+): string {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new Error(
+    `BambooHR response is missing required field ${fieldName} for ${url}.`,
+  );
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/career-boards/bamboohr/src/get-job-details.test.ts
+++ b/career-boards/bamboohr/src/get-job-details.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { getJobDetails } from "./get-job-details";
+
+describe("getJobDetails", () => {
+  it("normalizes BambooHR detail payloads", async () => {
+    const result = await getJobDetails({
+      jobUrl: "https://ashteadtechnology.bamboohr.com/careers/134",
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            meta: {},
+            result: {
+              jobOpening: {
+                jobOpeningShareUrl:
+                  "https://ashteadtechnology.bamboohr.com/careers/134",
+                jobOpeningName: "Onshore Electrical Technician",
+                employmentStatusLabel: "Full-Time",
+                location: {
+                  city: "Thainstone",
+                  state: "Aberdeenshire",
+                  addressCountry: "United Kingdom",
+                },
+                description:
+                  "<p><strong>What you'll be doing:</strong></p><ul><li>Testing</li></ul>",
+                datePosted: "2025-03-20",
+                minimumExperience: "Experienced",
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    });
+
+    expect(result.job).toMatchObject({
+      source: "bamboohr",
+      externalId: "134",
+      title: "Onshore Electrical Technician",
+      jobUrl: "https://ashteadtechnology.bamboohr.com/careers/134",
+      locationText: "Thainstone, Aberdeenshire, United Kingdom",
+      postedOn: "2025-03-20",
+      employmentStatus: "Full-Time",
+      minimumExperience: "Experienced",
+      jobDescriptionHtml:
+        "<p><strong>What you'll be doing:</strong></p><ul><li>Testing</li></ul>",
+    });
+    expect(result.job.jobDescriptionText).toContain("What you'll be doing:");
+    expect(result.job.jobDescriptionText).toContain("Testing");
+  });
+});

--- a/career-boards/bamboohr/src/get-job-details.ts
+++ b/career-boards/bamboohr/src/get-job-details.ts
@@ -1,0 +1,207 @@
+import {
+  type BamboohrSourceConfig,
+  bamboohrUrlToJobUrl,
+  parseBamboohrJobUrl,
+} from "./bamboohr-url";
+
+export interface BamboohrJobOpeningLocation {
+  city?: string | null;
+  state?: string | null;
+  postalCode?: string | null;
+  addressCountry?: string | null;
+}
+
+export interface BamboohrJobOpening {
+  jobOpeningShareUrl?: string;
+  jobOpeningName?: string;
+  employmentStatusLabel?: string | null;
+  location?: BamboohrJobOpeningLocation | null;
+  atsLocation?: {
+    country?: string | null;
+    state?: string | null;
+    city?: string | null;
+  } | null;
+  description?: string;
+  datePosted?: string | null;
+  minimumExperience?: string | null;
+  locationType?: string | null;
+  [key: string]: unknown;
+}
+
+export interface BamboohrDetailResponse {
+  meta?: Record<string, unknown>;
+  result?: {
+    jobOpening?: BamboohrJobOpening;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface NormalizedBamboohrJobDetails {
+  source: "bamboohr";
+  externalId: string;
+  title: string;
+  jobUrl: string;
+  locationText?: string;
+  postedOn?: string;
+  employmentStatus?: string;
+  minimumExperience?: string;
+  jobDescriptionHtml: string;
+  jobDescriptionText: string;
+  raw: BamboohrDetailResponse;
+}
+
+export interface FetchBamboohrJobDetailsOptions {
+  jobUrl: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+  userAgent?: string;
+}
+
+const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36";
+
+export async function getJobDetails(
+  options: FetchBamboohrJobDetailsOptions,
+): Promise<{ job: NormalizedBamboohrJobDetails }> {
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  if (!fetchFn) {
+    throw new Error(
+      "No fetch implementation available. Pass fetchImpl or use Node 18+.",
+    );
+  }
+
+  const parsed = parseBamboohrJobUrl(options.jobUrl);
+  const response = await fetchBamboohrJson<BamboohrDetailResponse>(fetchFn, {
+    url: parsed.detailUrl,
+    signal: options.signal,
+    headers: {
+      accept: "application/json",
+      referer: parsed.canonicalJobUrl,
+      "user-agent": options.userAgent ?? DEFAULT_USER_AGENT,
+      ...options.headers,
+    },
+  });
+
+  return {
+    job: normalizeBamboohrJobDetails(response, parsed),
+  };
+}
+
+export function normalizeBamboohrJobDetails(
+  response: BamboohrDetailResponse,
+  source: BamboohrSourceConfig & { jobId: string; canonicalJobUrl: string },
+): NormalizedBamboohrJobDetails {
+  const jobOpening = response.result?.jobOpening;
+  if (!jobOpening) {
+    throw new Error(
+      `BambooHR job detail response is missing result.jobOpening for ${source.canonicalJobUrl}.`,
+    );
+  }
+
+  const title = requiredString(
+    jobOpening.jobOpeningName,
+    "jobOpeningName",
+    source.canonicalJobUrl,
+  );
+  const descriptionHtml = requiredString(
+    jobOpening.description,
+    "description",
+    source.canonicalJobUrl,
+  );
+  const shareUrl =
+    optionalString(jobOpening.jobOpeningShareUrl) ??
+    bamboohrUrlToJobUrl(source.canonicalCareersUrl, source.jobId);
+
+  return {
+    source: "bamboohr",
+    externalId: source.jobId,
+    title,
+    jobUrl: shareUrl,
+    locationText: buildLocationText(jobOpening),
+    postedOn: optionalString(jobOpening.datePosted),
+    employmentStatus: optionalString(jobOpening.employmentStatusLabel),
+    minimumExperience: optionalString(jobOpening.minimumExperience),
+    jobDescriptionHtml: descriptionHtml,
+    jobDescriptionText: htmlToText(descriptionHtml),
+    raw: response,
+  };
+}
+
+function buildLocationText(jobOpening: BamboohrJobOpening): string | undefined {
+  const parts = [
+    optionalString(jobOpening.location?.city),
+    optionalString(jobOpening.location?.state),
+    optionalString(jobOpening.location?.addressCountry),
+    optionalString(jobOpening.atsLocation?.city),
+    optionalString(jobOpening.atsLocation?.state),
+    optionalString(jobOpening.atsLocation?.country),
+  ].filter((value, index, values): value is string => {
+    if (!value) return false;
+    return values.indexOf(value) === index;
+  });
+
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+async function fetchBamboohrJson<T>(
+  fetchFn: typeof fetch,
+  input: {
+    url: string;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  },
+): Promise<T> {
+  const response = await fetchFn(input.url, {
+    method: "GET",
+    signal: input.signal,
+    headers: input.headers,
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `BambooHR request failed with HTTP ${response.status} for ${input.url}.`,
+    );
+  }
+
+  try {
+    return JSON.parse(responseText) as T;
+  } catch {
+    throw new Error(`BambooHR response was not valid JSON for ${input.url}.`);
+  }
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<\s*br\s*\/?>/gi, "\n")
+    .replace(/<\/\s*(p|div|li|h[1-6]|ul|ol)\s*>/gi, "\n")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n\s+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function requiredString(
+  value: unknown,
+  fieldName: string,
+  url: string,
+): string {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new Error(
+    `BambooHR response is missing required field ${fieldName} for ${url}.`,
+  );
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/career-boards/bamboohr/src/get-jobs-from-careers-list.test.ts
+++ b/career-boards/bamboohr/src/get-jobs-from-careers-list.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseBamboohrUrl } from "./bamboohr-url";
+import {
+  getJobsFromCareersList,
+  normalizeBamboohrListJob,
+} from "./get-jobs-from-careers-list";
+
+describe("normalizeBamboohrListJob", () => {
+  const source = parseBamboohrUrl(
+    "https://ashteadtechnology.bamboohr.com/careers",
+  );
+
+  it("maps BambooHR list rows into normalized jobs", () => {
+    expect(
+      normalizeBamboohrListJob(
+        {
+          id: "335",
+          jobOpeningName: "Logistics and Export Compliance Coordinator",
+          employmentStatusLabel: "Full-Time",
+          location: { city: "Houston", state: "Texas" },
+        },
+        source,
+      ),
+    ).toMatchObject({
+      source: "bamboohr",
+      externalId: "335",
+      title: "Logistics and Export Compliance Coordinator",
+      employmentStatus: "Full-Time",
+      jobUrl: "https://ashteadtechnology.bamboohr.com/careers/335",
+      locationText: "Houston, Texas",
+    });
+  });
+
+  it("uses atsLocation data when the main location is sparse", async () => {
+    const result = await getJobsFromCareersList({
+      careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+      fetchImpl: async () =>
+        new Response(
+          JSON.stringify({
+            meta: { totalCount: 1 },
+            result: [
+              {
+                id: "35",
+                jobOpeningName: "Offshore Survey Engineer",
+                atsLocation: { country: "United Kingdom" },
+                locationType: "1",
+              },
+            ],
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    });
+
+    expect(result).toMatchObject({
+      total: 1,
+      fetched: 1,
+      jobs: [
+        expect.objectContaining({
+          externalId: "35",
+          locationText: "United Kingdom",
+        }),
+      ],
+    });
+  });
+});

--- a/career-boards/bamboohr/src/get-jobs-from-careers-list.ts
+++ b/career-boards/bamboohr/src/get-jobs-from-careers-list.ts
@@ -1,0 +1,186 @@
+import {
+  type BamboohrSourceConfig,
+  bamboohrUrlToJobUrl,
+  parseBamboohrUrl,
+} from "./bamboohr-url";
+
+export interface BamboohrLocation {
+  city?: string | null;
+  state?: string | null;
+}
+
+export interface BamboohrAtsLocation {
+  country?: string | null;
+  state?: string | null;
+  province?: string | null;
+  city?: string | null;
+}
+
+export interface BamboohrListJob {
+  id?: string;
+  jobOpeningName?: string;
+  employmentStatusLabel?: string | null;
+  location?: BamboohrLocation | null;
+  atsLocation?: BamboohrAtsLocation | null;
+  isRemote?: boolean | null;
+  locationType?: string | null;
+  [key: string]: unknown;
+}
+
+export interface BamboohrListResponse {
+  meta?: {
+    totalCount?: number;
+    [key: string]: unknown;
+  };
+  result?: BamboohrListJob[];
+  [key: string]: unknown;
+}
+
+export interface NormalizedBamboohrJob {
+  source: "bamboohr";
+  externalId: string;
+  title: string;
+  jobUrl: string;
+  locationText?: string;
+  employmentStatus?: string;
+  raw: BamboohrListJob;
+}
+
+export interface FetchBamboohrJobsOptions {
+  careersUrl: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+  userAgent?: string;
+}
+
+export interface FetchBamboohrJobsResult {
+  total: number;
+  fetched: number;
+  jobs: NormalizedBamboohrJob[];
+}
+
+const DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36";
+
+export async function getJobsFromCareersList(
+  options: FetchBamboohrJobsOptions,
+): Promise<FetchBamboohrJobsResult> {
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  if (!fetchFn) {
+    throw new Error(
+      "No fetch implementation available. Pass fetchImpl or use Node 18+.",
+    );
+  }
+
+  const source = parseBamboohrUrl(options.careersUrl);
+  const response = await fetchBamboohrJson<BamboohrListResponse>(fetchFn, {
+    url: source.listUrl,
+    signal: options.signal,
+    headers: {
+      accept: "application/json",
+      referer: source.canonicalCareersUrl,
+      "user-agent": options.userAgent ?? DEFAULT_USER_AGENT,
+      ...options.headers,
+    },
+  });
+
+  const rows = Array.isArray(response.result) ? response.result : [];
+  const jobs = rows.map((job) => normalizeBamboohrListJob(job, source));
+  const total =
+    typeof response.meta?.totalCount === "number"
+      ? response.meta.totalCount
+      : jobs.length;
+
+  return {
+    total,
+    fetched: jobs.length,
+    jobs,
+  };
+}
+
+export function normalizeBamboohrListJob(
+  job: BamboohrListJob,
+  source: BamboohrSourceConfig,
+): NormalizedBamboohrJob {
+  const externalId = requiredString(job.id, "id", source.listUrl);
+  const title = requiredString(
+    job.jobOpeningName,
+    "jobOpeningName",
+    source.listUrl,
+  );
+
+  return {
+    source: "bamboohr",
+    externalId,
+    title,
+    jobUrl: bamboohrUrlToJobUrl(source.canonicalCareersUrl, externalId),
+    locationText: buildLocationText(job),
+    employmentStatus: optionalString(job.employmentStatusLabel),
+    raw: job,
+  };
+}
+
+function buildLocationText(job: BamboohrListJob): string | undefined {
+  const parts = [
+    optionalString(job.location?.city),
+    optionalString(job.location?.state),
+    optionalString(job.atsLocation?.city),
+    optionalString(job.atsLocation?.state),
+    optionalString(job.atsLocation?.province),
+    optionalString(job.atsLocation?.country),
+  ].filter((value, index, values): value is string => {
+    if (!value) return false;
+    return values.indexOf(value) === index;
+  });
+
+  if (job.isRemote === true && !parts.includes("Remote")) {
+    parts.unshift("Remote");
+  }
+
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+async function fetchBamboohrJson<T>(
+  fetchFn: typeof fetch,
+  input: {
+    url: string;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  },
+): Promise<T> {
+  const response = await fetchFn(input.url, {
+    method: "GET",
+    signal: input.signal,
+    headers: input.headers,
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `BambooHR request failed with HTTP ${response.status} for ${input.url}.`,
+    );
+  }
+
+  try {
+    return JSON.parse(responseText) as T;
+  } catch {
+    throw new Error(`BambooHR response was not valid JSON for ${input.url}.`);
+  }
+}
+
+function requiredString(
+  value: unknown,
+  fieldName: string,
+  url: string,
+): string {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new Error(
+    `BambooHR response is missing required field ${fieldName} for ${url}.`,
+  );
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/career-boards/bamboohr/src/index.ts
+++ b/career-boards/bamboohr/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./bamboohr-url";
+export * from "./get-company-info";
+export * from "./get-job-details";
+export * from "./get-jobs-from-careers-list";

--- a/docs-site/docs/features/watchlist.md
+++ b/docs-site/docs/features/watchlist.md
@@ -44,7 +44,7 @@ A custom source URL is a careers board you paste manually for your own workspace
 
 If the company is not in the built-in picker yet, you can choose the source type's custom URL option and save that public careers page directly. That custom source stays in your workspace unless it is later added to the shared catalog.
 
-Each source type owns its own URL rules and on-screen copy. Today, the supported Watchlist source type is Workday, so the custom-source option asks for a public Workday careers URL.
+Each source type owns its own URL rules and on-screen copy. Today, the supported Watchlist source types are Workday and BambooHR, so the custom-source option asks for a public careers URL that matches the adapter you chose.
 
 ### Baseline check
 
@@ -69,7 +69,7 @@ Ignored rows and watchlist check history are stored per user inside the active w
 1. Open **Watchlist** from the app navigation.
 2. Click **Add source**.
 3. Use **Choose company** to search the built-in company list, or pick the source type's custom URL option.
-4. If you chose a custom URL, paste a supported public careers URL. For Workday, use a URL like `https://company.wd1.myworkdayjobs.com/External`.
+4. If you chose a custom URL, paste a supported public careers URL. For Workday, use a URL like `https://company.wd1.myworkdayjobs.com/External`. For BambooHR, use a URL like `https://company.bamboohr.com/careers`.
 5. Click **Save sources**.
 6. Review the visible rows.
 7. Reopen Watchlist later to see roles marked **New since last check**.
@@ -88,7 +88,7 @@ When you add a custom source URL, JobOps asks that source adapter to derive a re
 - JobOps validates the URL through the selected source adapter when you save sources.
 - Built-in catalog companies are saved as curated sources.
 - Custom URLs are saved only in your workspace selections unless a contributor adds them to the shared catalog.
-- Today, Workday is the available Watchlist adapter. Additional source types can be added without changing the Watchlist page.
+- Today, Workday and BambooHR are available Watchlist adapters. Additional source types can be added without changing the Watchlist page.
 
 ## Common problems
 

--- a/orchestrator/src/client/components/JobDescriptionHtml.tsx
+++ b/orchestrator/src/client/components/JobDescriptionHtml.tsx
@@ -1,0 +1,135 @@
+import type React from "react";
+import { cn } from "@/lib/utils";
+
+interface JobDescriptionHtmlProps {
+  className?: string;
+  description: string;
+}
+
+const SAFE_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const BLOCKED_TAGS = new Set([
+  "script",
+  "style",
+  "iframe",
+  "object",
+  "embed",
+  "noscript",
+  "template",
+]);
+const ALLOWED_TAGS = new Set([
+  "a",
+  "article",
+  "b",
+  "blockquote",
+  "br",
+  "div",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "li",
+  "ol",
+  "p",
+  "section",
+  "span",
+  "strong",
+  "u",
+  "ul",
+]);
+
+function getSafeHref(href?: string | null): string | null {
+  if (!href) return null;
+
+  try {
+    const url = new URL(href, "https://job-ops.local");
+    if (
+      url.origin === "https://job-ops.local" &&
+      !href.startsWith("http://") &&
+      !href.startsWith("https://") &&
+      !href.startsWith("mailto:")
+    ) {
+      return null;
+    }
+
+    return SAFE_PROTOCOLS.has(url.protocol) ? href : null;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeJobDescriptionHtml(html: string): string {
+  if (typeof DOMParser === "undefined" || typeof document === "undefined") {
+    return html;
+  }
+
+  const parser = new DOMParser();
+  const parsed = parser.parseFromString(html, "text/html");
+  const output = document.implementation.createHTMLDocument("");
+  const container = output.createElement("div");
+
+  function appendSanitizedChildren(
+    source: Node,
+    target: HTMLElement | DocumentFragment,
+  ) {
+    for (const child of source.childNodes) {
+      if (child.nodeType === Node.TEXT_NODE) {
+        target.appendChild(output.createTextNode(child.textContent ?? ""));
+        continue;
+      }
+
+      if (child.nodeType !== Node.ELEMENT_NODE) {
+        continue;
+      }
+
+      const element = child as HTMLElement;
+      const tagName = element.tagName.toLowerCase();
+
+      if (BLOCKED_TAGS.has(tagName)) {
+        continue;
+      }
+
+      if (!ALLOWED_TAGS.has(tagName)) {
+        appendSanitizedChildren(element, target);
+        continue;
+      }
+
+      const cleanElement = output.createElement(tagName);
+      if (tagName === "a") {
+        const safeHref = getSafeHref(element.getAttribute("href"));
+        if (safeHref) {
+          cleanElement.setAttribute("href", safeHref);
+          cleanElement.setAttribute("target", "_blank");
+          cleanElement.setAttribute("rel", "noopener noreferrer nofollow");
+        }
+      }
+
+      appendSanitizedChildren(element, cleanElement);
+      target.appendChild(cleanElement);
+    }
+  }
+
+  appendSanitizedChildren(parsed.body, container);
+  return container.innerHTML;
+}
+
+export const JobDescriptionHtml: React.FC<JobDescriptionHtmlProps> = ({
+  className,
+  description,
+}) => {
+  const sanitizedHtml = sanitizeJobDescriptionHtml(description);
+
+  return (
+    <div
+      className={cn(
+        "max-w-none prose dark:prose-invert dark:prose-a:text-primary",
+        className,
+      )}
+      // biome-ignore lint/security/noDangerouslySetInnerHtml: HTML is sanitized through a strict allowlist before rendering.
+      dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
+    />
+  );
+};

--- a/orchestrator/src/client/components/JobDescriptionPanel.test.tsx
+++ b/orchestrator/src/client/components/JobDescriptionPanel.test.tsx
@@ -9,18 +9,20 @@ vi.mock("@client/hooks/useSettings", () => ({
 }));
 
 describe("JobDescriptionPanel", () => {
-  it("renders normalized text instead of raw HTML when markdown mode is enabled", () => {
+  it("renders sanitized HTML job descriptions with structure preserved", () => {
     const { container } = render(
       <JobDescriptionPanel
         collapsible={false}
         description={
-          "<strong>Senior Engineer</strong><script>alert(1)</script>"
+          "<h2>Senior Engineer</h2><ul><li>Build systems</li></ul><script>alert(1)</script>"
         }
       />,
     );
 
-    expect(screen.getByText(/senior engineer/i)).toBeInTheDocument();
-    expect(container.querySelector("strong")).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: /senior engineer/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Build systems")).toBeInTheDocument();
     expect(container.querySelector("script")).toBeNull();
   });
 });

--- a/orchestrator/src/client/components/JobDescriptionPanel.tsx
+++ b/orchestrator/src/client/components/JobDescriptionPanel.tsx
@@ -1,5 +1,8 @@
 import { useSettings } from "@client/hooks/useSettings";
-import { getRenderableJobDescription } from "@client/lib/jobDescription";
+import {
+  getRenderableJobDescription,
+  looksLikeHtmlJobDescription,
+} from "@client/lib/jobDescription";
 import {
   Copy,
   Edit2,
@@ -21,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { cn, copyTextToClipboard } from "@/lib/utils";
 import { showErrorToast } from "../lib/error-toast";
+import { JobDescriptionHtml } from "./JobDescriptionHtml";
 import { JobDescriptionMarkdown } from "./JobDescriptionMarkdown";
 
 type JobDescriptionPanelProps = {
@@ -59,6 +63,10 @@ export const JobDescriptionPanel: React.FC<JobDescriptionPanelProps> = ({
     rawDescription ?? "",
   );
   const [isSaving, setIsSaving] = useState(false);
+  const hasHtmlDescription = useMemo(
+    () => looksLikeHtmlJobDescription(rawDescription),
+    [rawDescription],
+  );
   const description = useMemo(
     () => getRenderableJobDescription(rawDescription),
     [rawDescription],
@@ -169,6 +177,8 @@ export const JobDescriptionPanel: React.FC<JobDescriptionPanelProps> = ({
           className="min-h-[360px] bg-background/70 font-mono text-sm leading-relaxed focus-visible:ring-1"
           placeholder="Enter job description..."
         />
+      ) : hasHtmlDescription && rawDescription ? (
+        <JobDescriptionHtml description={rawDescription} />
       ) : renderMarkdownInJobDescriptions ? (
         <JobDescriptionMarkdown description={description} />
       ) : (

--- a/orchestrator/src/client/lib/jobDescription.ts
+++ b/orchestrator/src/client/lib/jobDescription.ts
@@ -1,12 +1,14 @@
 import { stripHtml } from "@/lib/utils";
 
+export const looksLikeHtmlJobDescription = (jobDescription?: string | null) =>
+  /<([a-z][\w:-]*)(?:\s[^>]*)?>/i.test(jobDescription ?? "");
+
 export const getRenderableJobDescription = (jobDescription?: string | null) => {
   if (!jobDescription) return "No description available.";
 
-  const plainText =
-    jobDescription.includes("<") && jobDescription.includes(">")
-      ? stripHtml(jobDescription)
-      : jobDescription;
+  const plainText = looksLikeHtmlJobDescription(jobDescription)
+    ? stripHtml(jobDescription)
+    : jobDescription;
 
   const normalizedLineBreaks = plainText.replace(/\r\n/g, "\n");
   if (

--- a/orchestrator/src/client/pages/WatchlistPage.test.tsx
+++ b/orchestrator/src/client/pages/WatchlistPage.test.tsx
@@ -63,6 +63,22 @@ const workdaySourceType = {
   supportsBranding: true,
 };
 
+const bamboohrSourceType = {
+  sourceType: "bamboohr" as const,
+  label: "BambooHR",
+  catalogLabel: "BambooHR company",
+  customSourceOptionLabel: "Choose your own BambooHR URL",
+  customSourceSearchText: "custom bamboohr url",
+  customSourceInputLabel: "Custom BambooHR URL",
+  customSourcePlaceholder: "https://company.bamboohr.com/careers",
+  customSourceHelpText: "Use the public BambooHR careers URL.",
+  emptyCatalogText: "No BambooHR companies found.",
+  fetchingLabel: "Fetching from BambooHR...",
+  invalidUrlMessage: "Invalid BambooHR URL",
+  supportsCustomSource: true,
+  supportsBranding: true,
+};
+
 const backendJob: WatchlistJobResult = {
   jobRef: "https://autodesk.wd1.myworkdayjobs.com/Ext/job/backend",
   source: "workday:autodesk",
@@ -201,7 +217,7 @@ beforeEach(() => {
         updatedAt: "2026-05-17T00:00:00.000Z",
       },
     ],
-    availableSourceTypes: [workdaySourceType],
+    availableSourceTypes: [workdaySourceType, bamboohrSourceType],
   };
   vi.mocked(api.getWatchlistSources).mockImplementation(
     async () => watchlistSourcesState,

--- a/orchestrator/src/client/pages/WatchlistPage.tsx
+++ b/orchestrator/src/client/pages/WatchlistPage.tsx
@@ -30,6 +30,8 @@ import type {
 import {
   createSourceDraft,
   formatWatchlistCheckTimestamp,
+  getNormalizedWatchlistCareersUrl,
+  getWatchlistSelectionIdentityKey,
   getWorkspaceJobPath,
   normalizeUiCountryKey,
 } from "./watchlist/utils";
@@ -47,12 +49,7 @@ function getWatchlistSelectionsKey(
   selections: DraftSelectionPayload[],
 ): string {
   return JSON.stringify(
-    selections.map((selection) => ({
-      catalogSourceId: selection.catalogSourceId,
-      sourceType: selection.sourceType,
-      label: selection.label,
-      careersUrl: selection.careersUrl,
-    })),
+    selections.map((selection) => getWatchlistSelectionIdentityKey(selection)),
   );
 }
 
@@ -201,7 +198,14 @@ export const WatchlistPage: React.FC = () => {
           ? savedSource.isCustom &&
             savedSource.catalogSourceId === null &&
             savedSource.sourceType === draft.sourceType &&
-            savedSource.careersUrl === draft.customUrl.trim()
+            getNormalizedWatchlistCareersUrl(
+              savedSource.sourceType,
+              savedSource.careersUrl,
+            ) ===
+              getNormalizedWatchlistCareersUrl(
+                draft.sourceType,
+                draft.customUrl,
+              )
           : !savedSource.isCustom &&
             savedSource.catalogSourceId === draft.catalogSourceId;
 
@@ -296,7 +300,10 @@ export const WatchlistPage: React.FC = () => {
 
     for (const [index, draft] of sourceDrafts.entries()) {
       if (draft.isCustom) {
-        const careersUrl = draft.customUrl.trim();
+        const careersUrl = getNormalizedWatchlistCareersUrl(
+          draft.sourceType,
+          draft.customUrl,
+        );
         if (!careersUrl) {
           const descriptor = getSourceTypeDescriptor(
             sourceTypes,
@@ -368,7 +375,10 @@ export const WatchlistPage: React.FC = () => {
           catalogSourceId: source.catalogSourceId,
           sourceType: source.sourceType,
           label: source.label,
-          careersUrl: source.careersUrl,
+          careersUrl: getNormalizedWatchlistCareersUrl(
+            source.sourceType,
+            source.careersUrl,
+          ),
         })),
       ),
     [selectedSources],

--- a/orchestrator/src/client/pages/watchlist/WatchlistSourcesCard.tsx
+++ b/orchestrator/src/client/pages/watchlist/WatchlistSourcesCard.tsx
@@ -20,7 +20,8 @@ import { cn } from "@/lib/utils";
 import type { WatchlistSourceDraftCardProps } from "./types";
 import {
   CUSTOM_SOURCE_VALUE,
-  getEmployerFromCareersUrl,
+  getNormalizedWatchlistCareersUrl,
+  getWatchlistPreviewLabel,
   WATCHLIST_SOURCE_COUNT_OPTIONS,
 } from "./utils";
 
@@ -57,14 +58,6 @@ function getSourceDropdownOptions(
         searchText: sourceType.customSourceSearchText,
       })),
   ];
-}
-
-export function formatCustomSourceLabel(careersUrl: string): string {
-  const employer = getEmployerFromCareersUrl(careersUrl).trim();
-  if (!employer) return "Custom source";
-  return employer.length <= 3
-    ? employer.toUpperCase()
-    : employer.replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 function getWatchlistStatusCopy(status: "watching" | "unsaved"): {
@@ -130,7 +123,10 @@ export function WatchlistSourcesCard({
         catalogSources,
       );
       const careersUrl = draft.isCustom
-        ? draft.customUrl.trim()
+        ? getNormalizedWatchlistCareersUrl(
+            draft.sourceType,
+            draft.customUrl.trim(),
+          )
         : (selectedSource?.careersUrl ?? "").trim();
 
       if (!careersUrl) continue;
@@ -263,13 +259,30 @@ export function WatchlistSourcesCard({
                   sourceTypeById.get(draft.sourceType) ??
                   sourceTypes[0] ??
                   null;
+                const normalizedCustomUrl = draft.isCustom
+                  ? getNormalizedWatchlistCareersUrl(
+                      draft.sourceType,
+                      draft.customUrl,
+                    )
+                  : "";
+                const matchingCatalogSource = draft.isCustom
+                  ? catalogSources.find(
+                      (source) =>
+                        source.sourceType === draft.sourceType &&
+                        source.careersUrl === normalizedCustomUrl,
+                    )
+                  : null;
                 const label = draft.isCustom
                   ? draft.customUrl.trim()
-                    ? formatCustomSourceLabel(draft.customUrl.trim())
+                    ? (matchingCatalogSource?.label ??
+                      getWatchlistPreviewLabel(
+                        draft.sourceType,
+                        draft.customUrl,
+                      ))
                     : (descriptor?.customSourceInputLabel ?? "Custom source")
                   : (selectedSource?.label ?? `New Source`);
                 const careersUrl = draft.isCustom
-                  ? draft.customUrl
+                  ? normalizedCustomUrl
                   : (selectedSource?.careersUrl ?? "");
                 const isEmpty = !careersUrl.trim();
                 const showEditor =
@@ -280,12 +293,15 @@ export function WatchlistSourcesCard({
                   <article
                     key={draft.id}
                     className={cn(
-                      "group min-w-0 rounded-2xl border border-border/70 bg-card p-4 flex items-center w-full relative gap-x-4 h-full",
+                      "group relative min-w-0 w-full rounded-2xl border border-border/70 bg-card p-4 h-full",
+                      showEditor
+                        ? "flex flex-col items-stretch gap-4"
+                        : "flex items-center gap-4",
                     )}
                   >
                     <div
                       className={cn(
-                        "flex items-center gap-2",
+                        "flex items-start gap-2",
                         showEditor ? "flex-1" : "",
                       )}
                     >
@@ -311,7 +327,7 @@ export function WatchlistSourcesCard({
                             <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
                               <span>
                                 {draft.isCustom
-                                  ? "Custom"
+                                  ? (descriptor?.label ?? draft.sourceType)
                                   : (descriptor?.label ??
                                     selectedSource?.sourceType)}
                               </span>
@@ -353,7 +369,7 @@ export function WatchlistSourcesCard({
                     </div>
 
                     {showEditor && (
-                      <div className="w-full space-y-2">
+                      <div className="w-full space-y-2 pt-1">
                         <SearchableDropdown
                           inputId={dropdownInputId}
                           value={

--- a/orchestrator/src/client/pages/watchlist/utils.test.ts
+++ b/orchestrator/src/client/pages/watchlist/utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { getWatchlistSourceKey } from "./utils";
+import {
+  getNormalizedWatchlistCareersUrl,
+  getWatchlistPreviewLabel,
+  getWatchlistSourceKey,
+} from "./utils";
 
 describe("getWatchlistSourceKey", () => {
   it("uses parsed tenant and site for myworkdaysite URLs", () => {
@@ -29,5 +33,23 @@ describe("getWatchlistSourceKey", () => {
         "https://wd5.myworkdaysite.com/wday/cxs/acme/Careers/jobs",
       ),
     ).toBe("workday:acme:careers");
+  });
+
+  it("normalizes BambooHR preview URLs to the careers root", () => {
+    expect(
+      getNormalizedWatchlistCareersUrl(
+        "bamboohr",
+        "https://ashteadtechnology.bamboohr.com/careers/134/detail",
+      ),
+    ).toBe("https://ashteadtechnology.bamboohr.com/careers");
+  });
+
+  it("derives a source-aware BambooHR preview label", () => {
+    expect(
+      getWatchlistPreviewLabel(
+        "bamboohr",
+        "https://ashteadtechnology.bamboohr.com/careers/134/detail",
+      ),
+    ).toBe("Ashteadtechnology");
   });
 });

--- a/orchestrator/src/client/pages/watchlist/utils.test.ts
+++ b/orchestrator/src/client/pages/watchlist/utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   getNormalizedWatchlistCareersUrl,
   getWatchlistPreviewLabel,
+  getWatchlistSelectionIdentityKey,
   getWatchlistSourceKey,
 } from "./utils";
 
@@ -51,5 +52,20 @@ describe("getWatchlistSourceKey", () => {
         "https://ashteadtechnology.bamboohr.com/careers/134/detail",
       ),
     ).toBe("Ashteadtechnology");
+  });
+
+  it("matches equivalent BambooHR selections even when labels differ", () => {
+    const saved = getWatchlistSelectionIdentityKey({
+      catalogSourceId: null,
+      sourceType: "bamboohr",
+      careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+    });
+    const draft = getWatchlistSelectionIdentityKey({
+      catalogSourceId: null,
+      sourceType: "bamboohr",
+      careersUrl: "https://ashteadtechnology.bamboohr.com/careers/134/detail",
+    });
+
+    expect(saved).toBe(draft);
   });
 });

--- a/orchestrator/src/client/pages/watchlist/utils.ts
+++ b/orchestrator/src/client/pages/watchlist/utils.ts
@@ -1,8 +1,20 @@
-import { workdayUrlToSourceKey } from "@career-boards/workday";
+import {
+  bamboohrUrlToCompanyLabel,
+  parseBamboohrUrl,
+} from "@career-boards/bamboohr";
+import {
+  parseWorkdayUrl,
+  workdayUrlToCompanyLabel,
+  workdayUrlToSourceKey,
+} from "@career-boards/workday";
 import { matchJobLocationIntent } from "@shared/job-matching.js";
 import type { LocationIntent } from "@shared/location-intelligence.js";
 import { normalizeCountryKey } from "@shared/location-support.js";
-import type { JobListItem, WatchlistJobResult } from "@shared/types.js";
+import type {
+  JobListItem,
+  WatchedSourceType,
+  WatchlistJobResult,
+} from "@shared/types.js";
 import { computeJobMatchScore } from "../orchestrator/JobCommandBar.utils";
 import type { RankedWatchlistJob, SourceSelectionDraft } from "./types";
 
@@ -33,6 +45,51 @@ export function getEmployerFromCareersUrl(careersUrl: string): string {
   } catch {
     return "Careers";
   }
+}
+
+export function getNormalizedWatchlistCareersUrl(
+  sourceType: WatchedSourceType,
+  careersUrl: string,
+): string {
+  const trimmed = careersUrl.trim();
+  if (!trimmed) return "";
+
+  try {
+    if (sourceType === "bamboohr") {
+      return parseBamboohrUrl(trimmed).canonicalCareersUrl;
+    }
+    if (sourceType === "workday") {
+      return parseWorkdayUrl(trimmed).canonicalCareersUrl;
+    }
+  } catch {
+    return trimmed;
+  }
+
+  return trimmed;
+}
+
+export function getWatchlistPreviewLabel(
+  sourceType: WatchedSourceType,
+  careersUrl: string,
+): string {
+  const normalizedCareersUrl = getNormalizedWatchlistCareersUrl(
+    sourceType,
+    careersUrl,
+  );
+  if (!normalizedCareersUrl) return "Custom source";
+
+  try {
+    if (sourceType === "bamboohr") {
+      return bamboohrUrlToCompanyLabel(normalizedCareersUrl);
+    }
+    if (sourceType === "workday") {
+      return workdayUrlToCompanyLabel(normalizedCareersUrl);
+    }
+  } catch {
+    return formatFallbackEmployerLabel(normalizedCareersUrl);
+  }
+
+  return formatFallbackEmployerLabel(normalizedCareersUrl);
 }
 
 export function toJobListItem(job: WatchlistJobResult): JobListItem {
@@ -105,6 +162,14 @@ export function getWatchlistSourceKey(value: string): string {
   } catch {
     return "workday:unknown:unknown";
   }
+}
+
+function formatFallbackEmployerLabel(careersUrl: string): string {
+  const employer = getEmployerFromCareersUrl(careersUrl).trim();
+  if (!employer) return "Custom source";
+  return employer.length <= 3
+    ? employer.toUpperCase()
+    : employer.replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 export function formatWatchlistCheckTimestamp(

--- a/orchestrator/src/client/pages/watchlist/utils.ts
+++ b/orchestrator/src/client/pages/watchlist/utils.ts
@@ -68,6 +68,21 @@ export function getNormalizedWatchlistCareersUrl(
   return trimmed;
 }
 
+export function getWatchlistSelectionIdentityKey(selection: {
+  catalogSourceId: string | null;
+  sourceType: WatchedSourceType;
+  careersUrl: string;
+}): string {
+  return JSON.stringify({
+    catalogSourceId: selection.catalogSourceId,
+    sourceType: selection.sourceType,
+    careersUrl: getNormalizedWatchlistCareersUrl(
+      selection.sourceType,
+      selection.careersUrl,
+    ),
+  });
+}
+
 export function getWatchlistPreviewLabel(
   sourceType: WatchedSourceType,
   careersUrl: string,

--- a/orchestrator/src/server/api/routes/watchlist.test.ts
+++ b/orchestrator/src/server/api/routes/watchlist.test.ts
@@ -66,6 +66,13 @@ describe.sequential("Watchlist API routes", () => {
       expect(body.data.catalogSources).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
+            id: "bamboohr:https://ashteadtechnology.bamboohr.com/careers",
+            label: "Ashtead Technology",
+            sourceType: "bamboohr",
+            careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+            cxsJobsUrl: null,
+          }),
+          expect.objectContaining({
             id: "autodesk-workday",
             label: "Autodesk",
             sourceType: "workday",
@@ -84,14 +91,22 @@ describe.sequential("Watchlist API routes", () => {
         ]),
       );
       expect(body.data.selectedSources).toEqual([]);
-      expect(body.data.availableSourceTypes).toEqual([
-        expect.objectContaining({
-          sourceType: "workday",
-          label: "Workday",
-          supportsCustomSource: true,
-          supportsBranding: true,
-        }),
-      ]);
+      expect(body.data.availableSourceTypes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            sourceType: "workday",
+            label: "Workday",
+            supportsCustomSource: true,
+            supportsBranding: true,
+          }),
+          expect.objectContaining({
+            sourceType: "bamboohr",
+            label: "BambooHR",
+            supportsCustomSource: true,
+            supportsBranding: true,
+          }),
+        ]),
+      );
     });
 
     it("stores only the user's selected watchlist sources", async () => {
@@ -245,6 +260,37 @@ describe.sequential("Watchlist API routes", () => {
           label: "PG",
           careersUrl: "https://pg.wd5.myworkdayjobs.com/en-us/1000",
           sourceType: "workday",
+          isCustom: true,
+        }),
+      ]);
+    });
+
+    it("stores custom BambooHR URLs in canonical form", async () => {
+      const res = await fetch(`${baseUrl}/api/watchlist/sources`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          selections: [
+            {
+              sourceType: "bamboohr",
+              careersUrl:
+                "https://ashteadtechnology.bamboohr.com/careers/134/detail",
+              label:
+                "https://ashteadtechnology.bamboohr.com/careers/134/detail",
+            },
+          ],
+        }),
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      expect(body.data.selectedSources).toEqual([
+        expect.objectContaining({
+          label: "Ashteadtechnology",
+          careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+          sourceType: "bamboohr",
+          cxsJobsUrl: null,
           isCustom: true,
         }),
       ]);

--- a/orchestrator/src/server/config/career-boards-bamboohr.json
+++ b/orchestrator/src/server/config/career-boards-bamboohr.json
@@ -1,0 +1,6 @@
+[
+  {
+    "label": "Ashtead Technology",
+    "bamboohrUrl": "https://ashteadtechnology.bamboohr.com/careers"
+  }
+]

--- a/orchestrator/src/server/watchlist/adapters/bamboohr.test.ts
+++ b/orchestrator/src/server/watchlist/adapters/bamboohr.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bamboohrWatchlistAdapter } from "./bamboohr";
+
+describe("bamboohrWatchlistAdapter", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses catalog sources into canonical watchlist sources", () => {
+    expect(
+      bamboohrWatchlistAdapter.parseCatalogSources([
+        {
+          label: "Ashtead Technology",
+          bamboohrUrl: "https://ashteadtechnology.bamboohr.com/careers/list",
+        },
+      ]),
+    ).toEqual([
+      {
+        id: "bamboohr:https://ashteadtechnology.bamboohr.com/careers",
+        label: "Ashtead Technology",
+        sourceType: "bamboohr",
+        careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+        cxsJobsUrl: null,
+      },
+    ]);
+  });
+
+  it("normalizes custom selections to the careers root and derived label", () => {
+    expect(
+      bamboohrWatchlistAdapter.normalizeCustomSelection({
+        label: "https://acme-inc.bamboohr.com/careers/list",
+        careersUrl: "https://acme-inc.bamboohr.com/careers/list",
+      }),
+    ).toEqual({
+      label: "Acme Inc",
+      careersUrl: "https://acme-inc.bamboohr.com/careers",
+    });
+  });
+
+  it("builds branding responses from company-info and the logo asset", async () => {
+    const fetchBranding = bamboohrWatchlistAdapter.fetchBranding;
+    if (!fetchBranding) {
+      throw new Error("Expected BambooHR branding support to be available.");
+    }
+
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              result: {
+                name: "Ashtead Technology",
+                logoUrl:
+                  "https://images4.bamboohr.com/618032/logos/cropped.jpg?v=28",
+              },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(Uint8Array.from([0xff, 0xd8, 0xff]), {
+            status: 200,
+            headers: {
+              "content-type": "image/jpeg",
+              "content-length": "3",
+            },
+          }),
+        ),
+    );
+
+    await expect(
+      fetchBranding({
+        source: {
+          sourceType: "bamboohr",
+          careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+        },
+      }),
+    ).resolves.toMatchObject({
+      careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+      logoUrl: "https://images4.bamboohr.com/618032/logos/cropped.jpg?v=28",
+      mimeType: "image/jpeg",
+    });
+  });
+});

--- a/orchestrator/src/server/watchlist/adapters/bamboohr.test.ts
+++ b/orchestrator/src/server/watchlist/adapters/bamboohr.test.ts
@@ -86,4 +86,159 @@ describe("bamboohrWatchlistAdapter", () => {
       mimeType: "image/jpeg",
     });
   });
+
+  it("hydrates posted dates from the detail endpoint during fetchJobs", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              meta: { totalCount: 1 },
+              result: [
+                {
+                  id: "134",
+                  jobOpeningName: "Onshore Electrical Technician",
+                  location: {
+                    city: "Thainstone",
+                    state: "Aberdeenshire",
+                  },
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              result: {
+                jobOpening: {
+                  jobOpeningShareUrl:
+                    "https://ashteadtechnology.bamboohr.com/careers/134",
+                  jobOpeningName: "Onshore Electrical Technician",
+                  description: "<p>Testing</p>",
+                  datePosted: "2025-03-20",
+                  location: {
+                    city: "Thainstone",
+                    state: "Aberdeenshire",
+                    addressCountry: "United Kingdom",
+                  },
+                },
+              },
+            }),
+            {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            },
+          ),
+        ),
+    );
+
+    await expect(
+      bamboohrWatchlistAdapter.fetchJobs({
+        source: {
+          id: "selected-ashtead",
+          catalogSourceId: null,
+          label: "Ashtead Technology",
+          sourceType: "bamboohr",
+          careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+          cxsJobsUrl: null,
+          isCustom: true,
+          sortOrder: 0,
+          createdAt: "2026-05-20T00:00:00.000Z",
+          updatedAt: "2026-05-20T00:00:00.000Z",
+        },
+      }),
+    ).resolves.toMatchObject({
+      total: 1,
+      fetched: 1,
+      jobs: [
+        expect.objectContaining({
+          sourceJobId: "134",
+          jobUrl: "https://ashteadtechnology.bamboohr.com/careers/134",
+          location: "Thainstone, Aberdeenshire, United Kingdom",
+          postedAt: "2025-03-20",
+        }),
+      ],
+    });
+  });
+
+  it("sorts fetched jobs by latest posted date and keeps only 40", async () => {
+    const listJobs = Array.from({ length: 41 }, (_, index) => ({
+      id: String(index + 1),
+      jobOpeningName: `Role ${index + 1}`,
+    }));
+
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          meta: { totalCount: listJobs.length },
+          result: listJobs,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+
+    for (let index = 0; index < listJobs.length; index += 1) {
+      const jobId = String(index + 1);
+      const postedAt = new Date(Date.UTC(2025, 2, index + 1))
+        .toISOString()
+        .slice(0, 10);
+      fetchMock.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            result: {
+              jobOpening: {
+                jobOpeningShareUrl: `https://ashteadtechnology.bamboohr.com/careers/${jobId}`,
+                jobOpeningName: `Role ${jobId}`,
+                description: "<p>Testing</p>",
+                datePosted: postedAt,
+              },
+            },
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+      );
+    }
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await bamboohrWatchlistAdapter.fetchJobs({
+      source: {
+        id: "selected-ashtead",
+        catalogSourceId: null,
+        label: "Ashtead Technology",
+        sourceType: "bamboohr",
+        careersUrl: "https://ashteadtechnology.bamboohr.com/careers",
+        cxsJobsUrl: null,
+        isCustom: true,
+        sortOrder: 0,
+        createdAt: "2026-05-20T00:00:00.000Z",
+        updatedAt: "2026-05-20T00:00:00.000Z",
+      },
+    });
+
+    expect(result.total).toBe(41);
+    expect(result.fetched).toBe(40);
+    expect(result.jobs).toHaveLength(40);
+    expect(result.jobs[0]).toMatchObject({
+      sourceJobId: "41",
+      postedAt: "2025-04-10",
+    });
+    expect(result.jobs.at(-1)).toMatchObject({
+      sourceJobId: "2",
+      postedAt: "2025-03-02",
+    });
+  });
 });

--- a/orchestrator/src/server/watchlist/adapters/bamboohr.ts
+++ b/orchestrator/src/server/watchlist/adapters/bamboohr.ts
@@ -1,0 +1,304 @@
+import {
+  bamboohrUrlToCompanyLabel,
+  bamboohrUrlToSourceKey,
+  getCompanyInfo,
+  getJobDetails,
+  getJobsFromCareersList,
+  parseBamboohrUrl,
+} from "@career-boards/bamboohr";
+import { upstreamError } from "@infra/errors";
+import type { ManualJobDraft, WatchlistSelectedSource } from "@shared/types";
+import { z } from "zod";
+import type { WatchlistCatalogSourceAdapter } from "./types";
+
+const BAMBOOHR_LOGO_MAX_BYTES = 1_000_000;
+
+const bamboohrSourceSchema = z.object({
+  label: z.string().trim().min(1).max(200),
+  bamboohrUrl: z.string().trim().url().max(2000),
+});
+
+export const bamboohrWatchlistAdapter: WatchlistCatalogSourceAdapter = {
+  sourceType: "bamboohr",
+  descriptor: {
+    sourceType: "bamboohr",
+    label: "BambooHR",
+    catalogLabel: "BambooHR company",
+    customSourceOptionLabel: "Choose your own BambooHR URL",
+    customSourceSearchText: "custom bamboohr url",
+    customSourceInputLabel: "Custom BambooHR URL",
+    customSourcePlaceholder: "https://company.bamboohr.com/careers",
+    customSourceHelpText:
+      "Use the public BambooHR careers URL, not an individual job posting URL.",
+    emptyCatalogText: "No BambooHR companies found.",
+    fetchingLabel: "Fetching from BambooHR...",
+    invalidUrlMessage: "Invalid BambooHR URL",
+    supportsCustomSource: true,
+    supportsBranding: true,
+  },
+  catalogSchema: bamboohrSourceSchema,
+  parseCatalogSources(entries) {
+    return z
+      .array(bamboohrSourceSchema)
+      .parse(entries)
+      .map((entry) => {
+        const parsed = parseBamboohrUrl(entry.bamboohrUrl);
+        return {
+          id: buildSourceId(parsed.canonicalCareersUrl),
+          label: entry.label,
+          sourceType: "bamboohr",
+          careersUrl: parsed.canonicalCareersUrl,
+          cxsJobsUrl: null,
+        };
+      });
+  },
+  hydrateSelectedSource(source) {
+    const parsed = parseBamboohrUrl(source.careersUrl);
+    return {
+      ...source,
+      label: getHydratedBamboohrLabel(source),
+      careersUrl: parsed.canonicalCareersUrl,
+      cxsJobsUrl: null,
+    };
+  },
+  normalizeCustomSelection(input) {
+    const parsed = parseBamboohrUrl(input.careersUrl);
+    const canonicalCareersUrl = parsed.canonicalCareersUrl;
+    const trimmedLabel = input.label?.trim();
+    const label =
+      trimmedLabel && trimmedLabel !== input.careersUrl.trim()
+        ? trimmedLabel
+        : bamboohrUrlToCompanyLabel(canonicalCareersUrl);
+
+    return {
+      label,
+      careersUrl: canonicalCareersUrl,
+    };
+  },
+  async fetchJobs(input) {
+    const response = await getJobsFromCareersList({
+      careersUrl: input.source.careersUrl,
+      signal: input.signal,
+    });
+    const source = bamboohrUrlToSourceKey(input.source.careersUrl);
+
+    return {
+      total: response.total,
+      fetched: response.fetched,
+      jobs: response.jobs.map((job) => ({
+        jobRef: job.jobUrl,
+        source,
+        sourceJobId: job.externalId,
+        sourceType: input.source.sourceType,
+        title: job.title,
+        employer: input.source.label,
+        jobUrl: job.jobUrl,
+        applicationLink: job.jobUrl,
+        location: job.locationText ?? null,
+        postedAt: null,
+      })),
+    };
+  },
+  async fetchJobDetails(input) {
+    const details = await getJobDetails({
+      jobUrl: input.jobRef,
+      signal: input.signal,
+    });
+
+    return {
+      jobRef: input.jobRef,
+      jobUrl: details.job.jobUrl,
+      descriptionHtml: details.job.jobDescriptionHtml,
+    };
+  },
+  async prepareImportDraft(input) {
+    const details = await getJobDetails({
+      jobUrl: input.jobRef,
+      signal: input.signal,
+    });
+    const source = bamboohrUrlToSourceKey(input.source.careersUrl);
+    const draft = buildManualDraft(input.source, source, details.job);
+
+    return {
+      draft,
+      source: draft.source ?? null,
+      sourceHost:
+        getSourceHost(input.source.careersUrl) ?? getSourceHost(input.jobRef),
+    };
+  },
+  async fetchBranding(input) {
+    const companyInfo = await getCompanyInfo({
+      careersUrl: input.source.careersUrl,
+      signal: input.signal,
+    });
+    const logoUrl = companyInfo.company.logoUrl;
+    if (!logoUrl) {
+      throw upstreamError("BambooHR company info did not include a logo URL", {
+        careersUrl: input.source.careersUrl,
+      });
+    }
+
+    const response = await fetch(logoUrl, {
+      method: "GET",
+      redirect: "follow",
+      signal: input.signal,
+    });
+
+    if (!response.ok) {
+      throw upstreamError(
+        `Failed to fetch BambooHR logo with HTTP ${response.status}.`,
+        {
+          url: logoUrl,
+          status: response.status,
+        },
+      );
+    }
+
+    const contentLength = Number(response.headers.get("content-length"));
+    if (
+      Number.isFinite(contentLength) &&
+      contentLength > BAMBOOHR_LOGO_MAX_BYTES
+    ) {
+      throw upstreamError("BambooHR company logo exceeded size limit", {
+        url: logoUrl,
+        contentLength,
+        maxBytes: BAMBOOHR_LOGO_MAX_BYTES,
+      });
+    }
+
+    const contentType = response.headers.get("content-type");
+    const bytes = Buffer.from(await response.arrayBuffer());
+    if (bytes.byteLength > BAMBOOHR_LOGO_MAX_BYTES) {
+      throw upstreamError("BambooHR company logo exceeded size limit", {
+        url: logoUrl,
+        contentLength: bytes.byteLength,
+        maxBytes: BAMBOOHR_LOGO_MAX_BYTES,
+      });
+    }
+    const mimeType = detectLogoMimeType(bytes, contentType);
+    if (!mimeType) {
+      throw upstreamError("BambooHR logo response was not an image.", {
+        url: logoUrl,
+        contentType: contentType?.trim() || null,
+      });
+    }
+
+    return {
+      careersUrl: parseBamboohrUrl(input.source.careersUrl).canonicalCareersUrl,
+      logoUrl,
+      mimeType,
+      imageDataUrl: `data:${mimeType};base64,${bytes.toString("base64")}`,
+    };
+  },
+};
+
+function buildSourceId(careersUrl: string): string {
+  return `bamboohr:${careersUrl}`;
+}
+
+function getHydratedBamboohrLabel(source: {
+  sourceType: string;
+  label: string;
+  careersUrl: string;
+}): string {
+  if (
+    source.sourceType === "bamboohr" &&
+    (!source.label.trim() || source.label.trim() === source.careersUrl.trim())
+  ) {
+    return bamboohrUrlToCompanyLabel(source.careersUrl);
+  }
+
+  return source.label;
+}
+
+function buildManualDraft(
+  selectedSource: WatchlistSelectedSource,
+  source: string,
+  details: {
+    externalId: string;
+    title: string;
+    jobUrl: string;
+    locationText?: string;
+    jobDescriptionText: string;
+    employmentStatus?: string;
+  },
+): ManualJobDraft {
+  return {
+    source,
+    sourceJobId: details.externalId,
+    title: details.title,
+    employer: selectedSource.label,
+    jobUrl: details.jobUrl,
+    applicationLink: details.jobUrl,
+    location: details.locationText,
+    jobDescription: details.jobDescriptionText,
+    jobType: details.employmentStatus,
+  };
+}
+
+function getSourceHost(value: string): string | null {
+  try {
+    return new URL(value).hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+function detectLogoMimeType(
+  bytes: Buffer,
+  contentTypeHeader: string | null,
+): string | null {
+  const normalizedContentType = contentTypeHeader?.trim().toLowerCase() ?? "";
+  if (normalizedContentType.startsWith("image/")) {
+    return contentTypeHeader?.trim() ?? normalizedContentType;
+  }
+
+  if (
+    bytes.byteLength >= 8 &&
+    bytes[0] === 0x89 &&
+    bytes[1] === 0x50 &&
+    bytes[2] === 0x4e &&
+    bytes[3] === 0x47 &&
+    bytes[4] === 0x0d &&
+    bytes[5] === 0x0a &&
+    bytes[6] === 0x1a &&
+    bytes[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+
+  if (
+    bytes.byteLength >= 3 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[2] === 0xff
+  ) {
+    return "image/jpeg";
+  }
+
+  if (
+    bytes.byteLength >= 6 &&
+    (bytes.subarray(0, 6).toString("ascii") === "GIF87a" ||
+      bytes.subarray(0, 6).toString("ascii") === "GIF89a")
+  ) {
+    return "image/gif";
+  }
+
+  if (
+    bytes.byteLength >= 12 &&
+    bytes.subarray(0, 4).toString("ascii") === "RIFF" &&
+    bytes.subarray(8, 12).toString("ascii") === "WEBP"
+  ) {
+    return "image/webp";
+  }
+
+  const text = bytes
+    .toString("utf8", 0, Math.min(bytes.byteLength, 512))
+    .trim()
+    .replace(/^\uFEFF/, "");
+  if (text.startsWith("<svg") || text.startsWith("<?xml")) {
+    return "image/svg+xml";
+  }
+
+  return null;
+}

--- a/orchestrator/src/server/watchlist/adapters/bamboohr.ts
+++ b/orchestrator/src/server/watchlist/adapters/bamboohr.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import type { WatchlistCatalogSourceAdapter } from "./types";
 
 const BAMBOOHR_LOGO_MAX_BYTES = 1_000_000;
+const BAMBOOHR_WATCHLIST_MAX_JOBS = 40;
 
 const bamboohrSourceSchema = z.object({
   label: z.string().trim().min(1).max(200),
@@ -81,22 +82,35 @@ export const bamboohrWatchlistAdapter: WatchlistCatalogSourceAdapter = {
       signal: input.signal,
     });
     const source = bamboohrUrlToSourceKey(input.source.careersUrl);
+    const jobs = await Promise.all(
+      response.jobs.map(async (job) => {
+        const details = await getJobDetails({
+          jobUrl: job.jobUrl,
+          signal: input.signal,
+        });
+
+        return {
+          jobRef: details.job.jobUrl,
+          source,
+          sourceJobId: job.externalId,
+          sourceType: input.source.sourceType,
+          title: details.job.title,
+          employer: input.source.label,
+          jobUrl: details.job.jobUrl,
+          applicationLink: details.job.jobUrl,
+          location: details.job.locationText ?? job.locationText ?? null,
+          postedAt: details.job.postedOn ?? null,
+        };
+      }),
+    );
+    const sortedJobs = jobs
+      .sort((left, right) => comparePostedAtDesc(left.postedAt, right.postedAt))
+      .slice(0, BAMBOOHR_WATCHLIST_MAX_JOBS);
 
     return {
       total: response.total,
-      fetched: response.fetched,
-      jobs: response.jobs.map((job) => ({
-        jobRef: job.jobUrl,
-        source,
-        sourceJobId: job.externalId,
-        sourceType: input.source.sourceType,
-        title: job.title,
-        employer: input.source.label,
-        jobUrl: job.jobUrl,
-        applicationLink: job.jobUrl,
-        location: job.locationText ?? null,
-        postedAt: null,
-      })),
+      fetched: sortedJobs.length,
+      jobs: sortedJobs,
     };
   },
   async fetchJobDetails(input) {
@@ -301,4 +315,19 @@ function detectLogoMimeType(
   }
 
   return null;
+}
+
+function comparePostedAtDesc(
+  left: string | null,
+  right: string | null,
+): number {
+  const leftTime = left ? Date.parse(left) : Number.NaN;
+  const rightTime = right ? Date.parse(right) : Number.NaN;
+  const leftValid = Number.isFinite(leftTime);
+  const rightValid = Number.isFinite(rightTime);
+
+  if (leftValid && rightValid) return rightTime - leftTime;
+  if (leftValid) return -1;
+  if (rightValid) return 1;
+  return 0;
 }

--- a/orchestrator/src/server/watchlist/adapters/index.ts
+++ b/orchestrator/src/server/watchlist/adapters/index.ts
@@ -1,8 +1,9 @@
 import type { WatchedSourceType } from "@shared/types";
+import { bamboohrWatchlistAdapter } from "./bamboohr";
 import type { WatchlistCatalogSourceAdapter } from "./types";
 import { workdayWatchlistAdapter } from "./workday";
 
-const adapters = [workdayWatchlistAdapter] as const;
+const adapters = [workdayWatchlistAdapter, bamboohrWatchlistAdapter] as const;
 
 const adaptersByType = new Map<
   WatchedSourceType,

--- a/orchestrator/tsconfig.json
+++ b/orchestrator/tsconfig.json
@@ -17,6 +17,8 @@
       "@infra/*": ["src/server/infra/*"],
       "@client/*": ["src/client/*"],
       "@shared/*": ["../shared/src/*"],
+      "@career-boards/bamboohr": ["../career-boards/bamboohr/src/index.ts"],
+      "@career-boards/bamboohr/*": ["../career-boards/bamboohr/src/*"],
       "@career-boards/workday": ["../career-boards/workday/src/index.ts"],
       "@career-boards/workday/*": ["../career-boards/workday/src/*"]
     }

--- a/orchestrator/vite.config.ts
+++ b/orchestrator/vite.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
       "src/**/*.test.tsx",
       "../docs-site/src/**/*.test.ts",
       "../docs-site/src/**/*.test.tsx",
+      "../career-boards/**/*.test.ts",
       "../shared/src/**/*.test.ts",
       "../extractors/**/tests/**/*.test.ts",
     ],
@@ -59,6 +60,10 @@ export default defineConfig({
       "@infra": path.resolve(__dirname, "./src/server/infra"),
       "@shared": path.resolve(__dirname, "../shared/src"),
       "job-ops-shared": path.resolve(__dirname, "../shared/src"),
+      "@career-boards/bamboohr": path.resolve(
+        __dirname,
+        "../career-boards/bamboohr/src/index.ts",
+      ),
       "@career-boards/workday": path.resolve(
         __dirname,
         "../career-boards/workday/src/index.ts",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,10 @@
         "typescript": "^5.9.3"
       }
     },
+    "career-boards/bamboohr": {
+      "name": "@career-boards/bamboohr",
+      "version": "0.0.1"
+    },
     "career-boards/workday": {
       "name": "@career-boards/workday",
       "version": "0.0.1"
@@ -2834,6 +2838,10 @@
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
       }
+    },
+    "node_modules/@career-boards/bamboohr": {
+      "resolved": "career-boards/bamboohr",
+      "link": true
     },
     "node_modules/@career-boards/workday": {
       "resolved": "career-boards/workday",


### PR DESCRIPTION
## Summary
- Added a new BambooHR source package for URL parsing, job list/detail fetching, and company-info branding.
- Registered a BambooHR Watchlist adapter with custom URL support, curated catalog loading, import draft preparation, and logo hydration.
- Seeded Ashtead Technology in the BambooHR career board catalog and updated Watchlist docs/UI previews to handle BambooHR sources.

## Testing
- Added unit coverage for BambooHR URL normalization, list/detail normalization, and adapter behavior.
- Extended Watchlist API and client tests to cover BambooHR catalog loading and custom source handling.
- Verified lint/formatting, typechecks, client build, and the full orchestrator test suite passed.