### PR TITLE
Fix: Kanban horizontal auto-scroll while dragging cards.

### DIFF
--- a/orchestrator/src/client/pages/InProgressBoardPage.tsx
+++ b/orchestrator/src/client/pages/InProgressBoardPage.tsx
@@ -312,7 +312,12 @@ export const InProgressBoardPage: React.FC = () => {
                       </Badge>
                     </header>
 
-                    <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2.5">
+                    <div
+                      className={cn(
+                        "min-h-0 flex-1 space-y-2 p-2.5 [scrollbar-gutter:stable]",
+                        dragging ? "overflow-hidden" : "overflow-y-auto",
+                      )}
+                    >
                       {laneCards.length === 0 ? (
                         <div className="rounded-md border border-dashed border-border/35 bg-background/20 px-2.5 py-2 text-[11px] text-muted-foreground/80">
                           Drop a card here or log a stage.


### PR DESCRIPTION
## Summary

Fixes the Kanban board issue where horizontal auto-scroll could get stuck while dragging a card across columns.

When dragging cards across long columns, vertical lane scrolling was interfering with horizontal board auto-scroll, preventing access to columns further left/right.

This PR flxes [#522](https://github.com/DaKheera47/job-ops/issues/522).

## Changes

* Disables vertical scrolling on lanes during drag.
* Restores vertical scrolling after dragging ends.
* Adds stable scrollbar gutter spacing to reduce layout shift during drag.

## Notes

Since vertical lanes aren't reorderable (there is no functionality to rearrange jobs within a single column), disabling lane scrolling during drag does not impact user behavior.

Video attached.

https://github.com/user-attachments/assets/645fd184-2c0b-4b1a-8902-b48cc183c64c

