### PR TITLE
feat: Add Codex resume file import support

### DIFF
--- a/orchestrator/src/server/services/design-resume/import-file.codex.test.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.codex.test.ts
@@ -1,0 +1,99 @@
+import type { DesignResumeJson } from "@shared/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDefaultReactiveResumeDocument } from "../rxresume/document";
+
+const modelSelection = vi.hoisted(() => ({
+  resolveLlmRuntimeSettings: vi.fn(),
+}));
+
+const designResumeService = vi.hoisted(() => ({
+  replaceCurrentDesignResumeDocument: vi.fn(),
+}));
+
+const requestContext = vi.hoisted(() => ({
+  getRequestContext: vi.fn(() => ({ requestId: "req-codex" })),
+  getRequestId: vi.fn(() => "req-codex"),
+}));
+
+const { callJsonMock, MockCodexClass } = vi.hoisted(() => {
+  const callJson = vi.fn();
+  class MockCodexClass {
+    callJson = callJson;
+  }
+  return { callJsonMock: callJson, MockCodexClass };
+});
+
+vi.mock("@server/services/modelSelection", () => modelSelection);
+vi.mock("./index", () => designResumeService);
+vi.mock("@server/infra/request-context", () => requestContext);
+vi.mock("pdf-parse", () => ({
+  default: vi.fn().mockResolvedValue({ text: "Jane Doe\nSoftware Engineer" }),
+}));
+vi.mock("@server/services/llm/codex/client", () => ({
+  CodexClient: MockCodexClass,
+}));
+
+import pdfParse from "pdf-parse";
+import { importDesignResumeFromFile } from "./import-file";
+
+describe("importDesignResumeFromFile (codex)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callJsonMock.mockResolvedValue({
+      text: JSON.stringify({
+        resumeJson: JSON.stringify(buildDefaultReactiveResumeDocument()),
+      }),
+    });
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValue({
+      provider: "codex",
+      model: "gpt-5",
+      baseUrl: null,
+      apiKey: null,
+    });
+    designResumeService.replaceCurrentDesignResumeDocument.mockImplementation(
+      async ({ resumeJson }: { resumeJson: DesignResumeJson }) => ({
+        id: "primary",
+        title: "Imported",
+        resumeJson,
+        revision: 1,
+        sourceResumeId: null,
+        sourceMode: null,
+        importedAt: "2026-04-27T00:00:00.000Z",
+        createdAt: "2026-04-27T00:00:00.000Z",
+        updatedAt: "2026-04-27T00:00:00.000Z",
+        assets: [],
+      }),
+    );
+  });
+
+  it("extracts PDF text locally and calls Codex without an HTTP API key", async () => {
+    await importDesignResumeFromFile({
+      fileName: "resume.pdf",
+      mediaType: "application/pdf",
+      dataBase64: Buffer.from("%PDF-1.4 fake").toString("base64"),
+    });
+
+    expect(callJsonMock).toHaveBeenCalledOnce();
+    expect(vi.mocked(pdfParse)).toHaveBeenCalledOnce();
+    expect(callJsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "gpt-5",
+        jsonSchema: expect.objectContaining({
+          name: "design_resume_import_codex_wrapper",
+          schema: expect.objectContaining({
+            additionalProperties: false,
+            required: ["resumeJson"],
+          }),
+        }),
+        messages: expect.arrayContaining([
+          expect.objectContaining({
+            role: "user",
+            content: expect.stringContaining(
+              "The resume file was uploaded as PDF and converted locally to plain text before extraction.",
+            ),
+          }),
+        ]),
+      }),
+    );
+  });
+});

--- a/orchestrator/src/server/services/design-resume/import-file.test.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.test.ts
@@ -889,7 +889,7 @@ describe("importDesignResumeFromFile", () => {
 
   it("returns a capability error when the configured provider is unsupported", async () => {
     modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
-      provider: "codex",
+      provider: "anthropic",
       model: "gpt-5",
       baseUrl: null,
       apiKey: null,

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -13,6 +13,7 @@ import {
   extractPdfText,
   PdfTextExtractionError,
 } from "@server/services/document-text-extraction";
+import { CodexClient } from "@server/services/llm/codex/client";
 import { GeminiCliClient } from "@server/services/llm/gemini-cli/client";
 import type { JsonSchemaDefinition } from "@server/services/llm/types";
 import { resolveLlmRuntimeSettings } from "@server/services/modelSelection";
@@ -40,6 +41,7 @@ type SupportedRuntimeProvider =
   | "glm"
   | "gemini"
   | "gemini_cli"
+  | "codex"
   | "openai_compatible"
   | "ollama"
   | "lmstudio";
@@ -65,6 +67,22 @@ const DESIGN_RESUME_IMPORT_CLI_JSON_SCHEMA: JsonSchemaDefinition = {
       "customSections",
     ],
     additionalProperties: true,
+  },
+};
+
+const DESIGN_RESUME_IMPORT_CODEX_WRAPPER_JSON_SCHEMA: JsonSchemaDefinition = {
+  name: "design_resume_import_codex_wrapper",
+  schema: {
+    type: "object",
+    properties: {
+      resumeJson: {
+        type: "string",
+        description:
+          "The complete extracted resume document as a JSON string matching the requested target shape.",
+      },
+    },
+    required: ["resumeJson"],
+    additionalProperties: false,
   },
 };
 
@@ -138,6 +156,7 @@ function normalizeRuntimeProvider(
   if (mapped === "glm") return "glm";
   if (mapped === "gemini") return "gemini";
   if (mapped === "gemini_cli") return "gemini_cli";
+  if (normalized === "codex") return "codex";
   if (mapped === "openai_compatible") return "openai_compatible";
   if (mapped === "ollama") return "ollama";
   if (mapped === "lmstudio") return "lmstudio";
@@ -637,6 +656,21 @@ ${buildUserPrompt()}
 `.trim();
 }
 
+function buildCodexTextExtractPrompt(
+  documentText: string,
+  fileName: string,
+  source: "DOCX" | "PDF",
+): string {
+  return `
+${buildTextExtractPrompt(documentText, fileName, source)}
+
+Codex structured-output requirement:
+- Return a wrapper object with exactly one key: resumeJson.
+- The resumeJson value must be a JSON string containing the final target-shaped resume object.
+- The resumeJson string must be parseable by JSON.parse.
+`.trim();
+}
+
 function buildDocumentTextPrompt(
   documentText: string,
   fileName: string,
@@ -733,6 +767,24 @@ function parseImportedResumeJson(content: string): unknown {
       );
     }
   }
+}
+
+function parseCodexResumeJsonWrapper(content: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(extractProbablyJsonObject(content)) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Codex returned an invalid resume import wrapper. ${error instanceof Error ? error.message : "Unknown parsing error."}`,
+    );
+  }
+
+  const resumeJson = asRecord(parsed)?.resumeJson;
+  if (typeof resumeJson !== "string" || !resumeJson.trim()) {
+    throw new Error("Codex resume import wrapper did not include resumeJson.");
+  }
+
+  return resumeJson;
 }
 
 function filterRequiredItems(items: unknown, requiredField: string): unknown[] {
@@ -863,7 +915,7 @@ function parseReactiveResumeJsonFile(content: string): DesignResumeJson {
 }
 
 function buildCapabilityErrorMessage(provider: string): string {
-  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, Gemini, Gemini (CLI), OpenAI-compatible, Ollama, or LM Studio to import resumes. PDF and DOCX files can be converted to plain text locally before extraction when native file upload is unavailable.`;
+  return `Resume file import is not available for the current AI provider (${provider}). Connect Codex, OpenAI, OpenRouter, Gemini, Gemini (CLI), OpenAI-compatible, Ollama, or LM Studio to import resumes. PDF and DOCX files can be converted to plain text locally before extraction when native file upload is unavailable.`;
 }
 
 function isFileCapabilityError(message: string): boolean {
@@ -943,6 +995,7 @@ async function extractInitialDocumentText(input: {
   if (
     input.mediaType === "application/pdf" &&
     (input.provider === "gemini_cli" ||
+      input.provider === "codex" ||
       isTextOnlyImportProvider(input.provider))
   ) {
     return extractResumePdfText(input.decoded);
@@ -1331,7 +1384,7 @@ async function extractWithGeminiCli(args: {
 }): Promise<string> {
   const source: "DOCX" | "PDF" =
     args.mediaType === "application/pdf" ? "PDF" : "DOCX";
-  const userContent = buildTextExtractPrompt(
+  const userContent = buildCodexTextExtractPrompt(
     args.documentText,
     args.fileName,
     source,
@@ -1370,6 +1423,54 @@ async function extractWithGeminiCli(args: {
   }
 }
 
+async function extractWithCodex(args: {
+  model: string;
+  mediaType: SupportedImportMediaType;
+  fileName: string;
+  documentText: string;
+  requestId: string | undefined;
+}): Promise<string> {
+  const source: "DOCX" | "PDF" =
+    args.mediaType === "application/pdf" ? "PDF" : "DOCX";
+  const userContent = buildTextExtractPrompt(
+    args.documentText,
+    args.fileName,
+    source,
+  );
+  const client = new CodexClient();
+  try {
+    const { text } = await client.callJson({
+      model: args.model,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: userContent },
+      ],
+      jsonSchema: DESIGN_RESUME_IMPORT_CODEX_WRAPPER_JSON_SCHEMA,
+    });
+    if (!text?.trim()) {
+      throw upstreamError(
+        "Codex returned an empty response for resume import.",
+      );
+    }
+    return parseCodexResumeJsonWrapper(text);
+  } catch (error) {
+    if (error instanceof AppError) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw upstreamError(
+      truncate(message, 500),
+      args.requestId
+        ? {
+            provider: "codex",
+            model: args.model,
+            requestId: args.requestId,
+          }
+        : { provider: "codex", model: args.model },
+    );
+  }
+}
+
 async function extractResumeFromProvider(args: {
   provider: SupportedRuntimeProvider;
   apiKey: string;
@@ -1389,6 +1490,21 @@ async function extractResumeFromProvider(args: {
       );
     }
     return extractWithGeminiCli({
+      model: args.model,
+      mediaType: args.mediaType,
+      fileName: args.fileName,
+      documentText: text,
+      requestId: args.requestId,
+    });
+  }
+  if (args.provider === "codex") {
+    const text = args.documentText?.trim();
+    if (!text) {
+      throw badRequest(
+        "Codex resume import requires plain-text resume content (DOCX or extracted PDF text).",
+      );
+    }
+    return extractWithCodex({
       model: args.model,
       mediaType: args.mediaType,
       fileName: args.fileName,

--- a/orchestrator/src/server/services/document-text-extraction.test.ts
+++ b/orchestrator/src/server/services/document-text-extraction.test.ts
@@ -4,6 +4,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("pdf-parse", () => ({
   default: vi.fn(),
 }));
+const pdfjsMock = vi.hoisted(() => ({
+  getDocument: vi.fn(),
+  AnnotationType: { LINK: 2 },
+}));
+
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", () => pdfjsMock);
 
 import pdfParse from "pdf-parse";
 import {
@@ -21,6 +27,18 @@ function makePdfParseResult(text: string) {
     version: "default" as const,
     text,
   };
+}
+
+function mockPdfAnnotations(annotations: unknown[]) {
+  pdfjsMock.getDocument.mockReturnValueOnce({
+    promise: Promise.resolve({
+      numPages: 1,
+      destroy: vi.fn().mockResolvedValue(undefined),
+      getPage: vi.fn().mockResolvedValue({
+        getAnnotations: vi.fn().mockResolvedValue(annotations),
+      }),
+    }),
+  });
 }
 
 function escapeXml(value: string): string {
@@ -53,6 +71,7 @@ async function makeDocxBuffer(text: string): Promise<Buffer> {
 describe("document text extraction", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPdfAnnotations([]);
   });
 
   it("extracts readable PDF text", async () => {
@@ -62,6 +81,36 @@ describe("document text extraction", () => {
 
     await expect(extractPdfText(Buffer.from("%PDF-1.4"))).resolves.toBe(
       "Taylor Quinn\nSenior Engineer",
+    );
+  });
+
+  it("appends embedded PDF link annotations to extracted text", async () => {
+    vi.mocked(pdfParse).mockResolvedValueOnce(
+      makePdfParseResult("  Taylor Quinn\nLinkedIn\nGitHub  "),
+    );
+    pdfjsMock.getDocument.mockReset();
+    mockPdfAnnotations([
+      {
+        annotationType: pdfjsMock.AnnotationType.LINK,
+        url: "https://linkedin.com/in/taylor",
+      },
+      {
+        subtype: "Link",
+        unsafeUrl: "https://github.com/taylor",
+      },
+      {
+        annotationType: pdfjsMock.AnnotationType.LINK,
+        url: "https://github.com/taylor",
+      },
+    ]);
+
+    await expect(extractPdfText(Buffer.from("%PDF-1.4"))).resolves.toBe(
+      [
+        "Taylor Quinn\nLinkedIn\nGitHub",
+        "Embedded PDF hyperlinks:",
+        "- https://linkedin.com/in/taylor",
+        "- https://github.com/taylor",
+      ].join("\n"),
     );
   });
 

--- a/orchestrator/src/server/services/document-text-extraction.ts
+++ b/orchestrator/src/server/services/document-text-extraction.ts
@@ -89,6 +89,115 @@ export async function extractDocxText(buffer: Buffer): Promise<string> {
   return normalizeDocxXmlText(xml);
 }
 
+function isHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function getRecordString(
+  record: Record<string, unknown> | null | undefined,
+  key: string,
+): string | null {
+  const value = record?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function getPdfAnnotationString(
+  annotation: Record<string, unknown>,
+  key: string,
+): string | null {
+  const direct = getRecordString(annotation, key);
+  if (direct) return direct;
+
+  const objectValue = annotation[key];
+  if (objectValue && typeof objectValue === "object") {
+    return getRecordString(objectValue as Record<string, unknown>, "str");
+  }
+
+  return null;
+}
+
+async function extractPdfLinkTargets(buffer: Buffer): Promise<string[]> {
+  const pdfjs = (await import("pdfjs-dist/legacy/build/pdf.mjs")) as {
+    getDocument: (options: { data: Uint8Array; disableWorker: boolean }) => {
+      promise: Promise<{
+        destroy?: () => Promise<void>;
+        numPages: number;
+        getPage: (pageNumber: number) => Promise<{
+          getAnnotations: (options?: {
+            intent?: "display" | "print" | "any";
+          }) => Promise<unknown[]>;
+        }>;
+      }>;
+    };
+    AnnotationType: { LINK: number };
+  };
+
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(buffer),
+    disableWorker: true,
+  });
+  const document = await loadingTask.promise;
+
+  try {
+    const links: string[] = [];
+    const seen = new Set<string>();
+
+    for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber++) {
+      const page = await document.getPage(pageNumber);
+      const annotations = await page.getAnnotations({ intent: "display" });
+
+      for (const rawAnnotation of annotations) {
+        if (
+          !rawAnnotation ||
+          typeof rawAnnotation !== "object" ||
+          Array.isArray(rawAnnotation)
+        ) {
+          continue;
+        }
+
+        const annotation = rawAnnotation as Record<string, unknown>;
+        const annotationType =
+          typeof annotation.annotationType === "number"
+            ? annotation.annotationType
+            : null;
+        const subtype = getRecordString(annotation, "subtype")?.toLowerCase();
+        const isLink =
+          annotationType === pdfjs.AnnotationType.LINK || subtype === "link";
+        if (!isLink) continue;
+
+        const url =
+          getPdfAnnotationString(annotation, "url") ||
+          getPdfAnnotationString(annotation, "unsafeUrl");
+        if (!url || !isHttpUrl(url)) continue;
+
+        const normalized = url.replace(/\/+$/, "");
+        if (seen.has(normalized)) continue;
+        seen.add(normalized);
+        links.push(url);
+      }
+    }
+
+    return links;
+  } finally {
+    await document.destroy?.();
+  }
+}
+
+function appendPdfLinkTargets(text: string, links: string[]): string {
+  if (links.length === 0) return text;
+
+  return [
+    text,
+    "Embedded PDF hyperlinks:",
+    ...links.map((link) => `- ${link}`),
+  ].join("\n");
+}
+
 export async function extractPdfText(buffer: Buffer): Promise<string> {
   try {
     const { default: pdfParse } = await import("pdf-parse");
@@ -100,7 +209,13 @@ export async function extractPdfText(buffer: Buffer): Promise<string> {
         "PDF file did not contain readable text.",
       );
     }
-    return text;
+    let linkTargets: string[] = [];
+    try {
+      linkTargets = await extractPdfLinkTargets(buffer);
+    } catch {
+      linkTargets = [];
+    }
+    return appendPdfLinkTargets(text, linkTargets);
   } catch (error) {
     if (error instanceof PdfTextExtractionError) {
       throw error;

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -605,6 +605,7 @@ function getPreferredModel(provider: LlmProvider): string | null {
   if (provider === "gemini" || provider === "gemini_cli") {
     return "google/gemini-3-flash-preview";
   }
+  if (provider === "codex") return "gpt-5.4";
   return null;
 }
 

--- a/orchestrator/src/server/services/modelSelection.test.ts
+++ b/orchestrator/src/server/services/modelSelection.test.ts
@@ -402,12 +402,12 @@ describe("Model Selection Logic", () => {
         },
       } as any);
 
-      await expect(resolveLlmModel("tailoring")).resolves.toBe("");
+      await expect(resolveLlmModel("tailoring")).resolves.toBe("gpt-5.4");
       await expect(
         resolveLlmRuntimeSettings("tailoring"),
       ).resolves.toMatchObject({
         provider: "codex",
-        model: "",
+        model: "gpt-5.4",
       });
     });
   });

--- a/shared/src/settings-registry.test.ts
+++ b/shared/src/settings-registry.test.ts
@@ -356,7 +356,7 @@ describe("settingsRegistry helpers", () => {
       expect(getDefaultModelForProvider("gemini_cli")).toBe(
         "google/gemini-3-flash-preview",
       );
-      expect(getDefaultModelForProvider("codex")).toBe("");
+      expect(getDefaultModelForProvider("codex")).toBe("gpt-5.4");
       expect(getDefaultModelForProvider("openrouter")).toBe(
         "google/gemini-3-flash-preview",
       );

--- a/shared/src/settings-registry.ts
+++ b/shared/src/settings-registry.ts
@@ -75,7 +75,7 @@ function normalizeLlmProviderOrNull(raw: string | undefined): string | null {
 export const DEFAULT_GEMINI_MODEL = "google/gemini-3-flash-preview";
 export const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini";
 export const DEFAULT_GLM_MODEL = "glm-5.1";
-export const DEFAULT_CODEX_MODEL = "";
+export const DEFAULT_CODEX_MODEL = "gpt-5.4";
 
 export function getDefaultModelForProvider(
   provider: string | null | undefined,


### PR DESCRIPTION
## Summary

Adds Codex support for Resume Studio file imports.

This lets the `codex` provider import PDF/DOCX resumes by extracting document text locally first, then sending plain text to Codex for structured resume JSON extraction. It also fixes PDF hyperlink loss by extracting embedded PDF link annotations and appending them to the text sent to the model, so labeled links like LinkedIn/GitHub/Upwork survive import.

## Changes

- Add `codex` as a supported resume file import provider.
- Route Codex imports through local PDF/DOCX text extraction instead of native file upload.
- Use a strict Codex structured-output wrapper schema to satisfy Codex JSON schema requirements.
- Set Codex’s default JobOps model to `gpt-5.4`, avoiding the unsupported blank/default CLI model path for ChatGPT-authenticated Codex accounts.
- Extract embedded PDF link annotations with `pdfjs-dist` and append them to extracted PDF text.
- Add focused tests for Codex resume import and PDF hyperlink extraction.

## Testing

Ran:

- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types -- --pretty false`
- `./orchestrator/node_modules/.bin/biome check ...`
- `npm --workspace orchestrator run test:run -- src/server/services/document-text-extraction.test.ts src/server/services/design-resume/import-file.codex.test.ts src/server/services/design-resume/import-file.gemini-cli.test.ts`
- Additional focused import/model-selection tests during development

## Notes

Codex still does not receive raw uploaded files. PDF/DOCX content is converted locally to text first, which matches the existing local-provider import path and avoids requiring native file upload support from Codex.

related #499 