### PR TITLE
fix(llm): respect Retry-After header and add jittered backoff to retries

### DIFF
--- a/orchestrator/src/server/services/llm/policies/retry-policy.test.ts
+++ b/orchestrator/src/server/services/llm/policies/retry-policy.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { getRetryDelayMs, shouldRetryAttempt } from "./retry-policy";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getRetryDelayMs,
+  parseRetryAfterMs,
+  shouldRetryAttempt,
+} from "./retry-policy";
 
-describe("retry-policy", () => {
+describe("shouldRetryAttempt", () => {
   it("retries parse errors", () => {
     expect(
       shouldRetryAttempt({ message: "Failed to parse JSON", status: 200 }),
@@ -34,9 +38,69 @@ describe("retry-policy", () => {
       }),
     ).toBe(false);
   });
+});
 
-  it("preserves backoff multiplier behavior", () => {
-    expect(getRetryDelayMs(500, 1)).toBe(500);
-    expect(getRetryDelayMs(500, 2)).toBe(1000);
+describe("getRetryDelayMs", () => {
+  beforeEach(() => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("uses exponential backoff with jitter (Math.random mocked to 0.5)", () => {
+    // attempt 1: base * 2^0 = 500, jittered = 500 * 0.5 = 250
+    expect(getRetryDelayMs(500, 1)).toBe(250);
+    // attempt 2: base * 2^1 = 1000, jittered = 1000 * 0.5 = 500
+    expect(getRetryDelayMs(500, 2)).toBe(500);
+    // attempt 3: base * 2^2 = 2000, jittered = 2000 * 0.5 = 1000
+    expect(getRetryDelayMs(500, 3)).toBe(1000);
+  });
+
+  it("caps exponential backoff at 60s", () => {
+    // attempt 10 would be 500 * 2^9 = 256000, capped to 60000, jittered to 30000
+    expect(getRetryDelayMs(500, 10)).toBe(30_000);
+  });
+
+  it("layers jittered backoff on top of Retry-After floor", () => {
+    // retryAfter = 3000, base * 2^0 = 500, jittered = 250, total = 3250
+    expect(getRetryDelayMs(500, 1, 3000)).toBe(3250);
+  });
+
+  it("ignores zero or negative Retry-After", () => {
+    expect(getRetryDelayMs(500, 1, 0)).toBe(250);
+    expect(getRetryDelayMs(500, 1, -100)).toBe(250);
+  });
+
+  it("returns at least 1ms", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    expect(getRetryDelayMs(0, 1)).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("parseRetryAfterMs", () => {
+  it("parses integer seconds", () => {
+    expect(parseRetryAfterMs("5")).toBe(5000);
+    expect(parseRetryAfterMs("0")).toBe(0);
+  });
+
+  it("parses fractional seconds", () => {
+    expect(parseRetryAfterMs("1.5")).toBe(1500);
+  });
+
+  it("parses HTTP-date format", () => {
+    const future = new Date(Date.now() + 10_000).toUTCString();
+    const result = parseRetryAfterMs(future);
+    expect(result).toBeGreaterThan(9_000);
+    expect(result).toBeLessThanOrEqual(10_000);
+  });
+
+  it("returns undefined for missing/empty/garbage values", () => {
+    expect(parseRetryAfterMs(null)).toBeUndefined();
+    expect(parseRetryAfterMs(undefined)).toBeUndefined();
+    expect(parseRetryAfterMs("")).toBeUndefined();
+    expect(parseRetryAfterMs("   ")).toBeUndefined();
+    expect(parseRetryAfterMs("not-a-number")).toBeUndefined();
   });
 });

--- a/orchestrator/src/server/services/llm/policies/retry-policy.ts
+++ b/orchestrator/src/server/services/llm/policies/retry-policy.ts
@@ -12,6 +12,46 @@ export function shouldRetryAttempt(args: {
   );
 }
 
-export function getRetryDelayMs(baseDelayMs: number, attempt: number): number {
-  return baseDelayMs * attempt;
+const MAX_RETRY_DELAY_MS = 60_000;
+
+/**
+ * Exponential backoff with full jitter. Returns at least 1ms.
+ * If `retryAfterMs` is provided (from a 429 Retry-After header), it's used as
+ * the floor — jittered exponential is layered on top to avoid thundering herd
+ * when many concurrent requests share the same Retry-After value.
+ */
+export function getRetryDelayMs(
+  baseDelayMs: number,
+  attempt: number,
+  retryAfterMs?: number,
+): number {
+  const expBackoff = baseDelayMs * 2 ** (attempt - 1);
+  const capped = Math.min(expBackoff, MAX_RETRY_DELAY_MS);
+  const jittered = Math.random() * capped;
+  const floor = retryAfterMs && retryAfterMs > 0 ? retryAfterMs : 0;
+  return Math.max(1, Math.floor(floor + jittered));
+}
+
+/**
+ * Parse a `Retry-After` header value (seconds or HTTP-date) into milliseconds.
+ * Returns undefined for missing/invalid values.
+ */
+export function parseRetryAfterMs(
+  headerValue: string | null | undefined,
+): number | undefined {
+  if (!headerValue) return undefined;
+  const trimmed = headerValue.trim();
+  if (trimmed === "") return undefined;
+
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.floor(seconds * 1000);
+  }
+
+  const dateMs = Date.parse(trimmed);
+  if (Number.isFinite(dateMs)) {
+    return Math.max(0, dateMs - Date.now());
+  }
+
+  return undefined;
 }

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -9,7 +9,11 @@ import {
   getOrderedModes,
   rememberSuccessfulMode,
 } from "./policies/mode-selection";
-import { getRetryDelayMs, shouldRetryAttempt } from "./policies/retry-policy";
+import {
+  getRetryDelayMs,
+  parseRetryAfterMs,
+  shouldRetryAttempt,
+} from "./policies/retry-policy";
 import { strategies } from "./providers";
 import type {
   JsonSchemaDefinition,
@@ -352,16 +356,24 @@ export class LlmService {
     } = args;
     const jobId = args.jobId;
     const model = normalizeModelForProvider(this.provider, rawModel);
+    let lastRetryAfterMs: number | undefined;
 
     for (let attempt = 0; attempt <= maxRetries; attempt++) {
       try {
         if (attempt > 0) {
+          const delayMs = getRetryDelayMs(
+            retryDelayMs,
+            attempt,
+            lastRetryAfterMs,
+          );
           logger.info("LLM retry attempt", {
             jobId: jobId ?? "unknown",
             attempt,
             maxRetries,
+            delayMs,
+            retryAfterMs: lastRetryAfterMs ?? "none",
           });
-          await sleep(getRetryDelayMs(retryDelayMs, attempt));
+          await sleep(delayMs);
         }
 
         const { url, headers, body } = this.strategy.buildRequest({
@@ -389,6 +401,9 @@ export class LlmService {
           ) as LlmApiError;
           err.status = response.status;
           err.body = truncate(errorBody, 600);
+          err.retryAfterMs = parseRetryAfterMs(
+            response.headers?.get?.("retry-after"),
+          );
           throw err;
         }
 
@@ -405,6 +420,7 @@ export class LlmService {
         const message = error instanceof Error ? error.message : String(error);
         const status = (error as LlmApiError).status;
         const body = (error as LlmApiError).body;
+        lastRetryAfterMs = (error as LlmApiError).retryAfterMs;
 
         if (
           this.strategy.isCapabilityError({

--- a/orchestrator/src/server/services/llm/types.ts
+++ b/orchestrator/src/server/services/llm/types.ts
@@ -107,6 +107,7 @@ export type ProviderStrategy = {
 export interface LlmApiError extends Error {
   status?: number;
   body?: string;
+  retryAfterMs?: number;
 }
 
 export function getLlmMessageText(content: LlmMessageContent): string {


### PR DESCRIPTION
## Summary

Under concurrent batch actions (e.g. rescoring many jobs at once), the LLM retry path was creating a thundering-herd of retries that cascaded into further 429s. Two related issues:

1. **`Retry-After` was ignored.** When a provider returns 429 with a `Retry-After` header (seconds or HTTP-date), the existing retry path threw away that signal and slept for `base * attempt`. The provider's hint about *when* it's safe to retry was never used.
2. **No jitter.** Backoff was linear (`base * attempt`) so every concurrent retry woke up at the same moment and slammed the rate limit again. This is the classic thundering-herd pattern.

## Changes

- **`retry-policy.ts`**: replaces linear backoff with exponential backoff + full jitter, capped at 60s. New optional `retryAfterMs` parameter acts as a floor — jittered exponential is layered on top so concurrent requests don't unblock simultaneously.
- **`retry-policy.ts`**: new `parseRetryAfterMs()` helper handles both `Retry-After: 5` (seconds) and `Retry-After: <HTTP-date>` formats, with safe handling for missing/garbage values.
- **`service.ts`** (HTTP retry path): reads `Retry-After` from the failed response, stores it on `LlmApiError`, and threads it into the next sleep via `getRetryDelayMs`. Also logs the chosen delay and retry-after value on each retry attempt.
- **`types.ts`**: adds optional `retryAfterMs?: number` to `LlmApiError`.

Defensive `response.headers?.get?.(...)` chain keeps existing tests that mock `fetch` without a `headers` field working.

## Why this matters even for paid providers

Free-tier OpenRouter is the obvious trigger, but the same pattern affects paid Anthropic / OpenAI / DeepSeek under sustained concurrent batch load. Respecting `Retry-After` is the HTTP spec for rate limits — and jitter is best practice for any concurrent retry workload.

## Test plan

- [x] New unit tests in `retry-policy.test.ts` cover:
  - exponential backoff math with `Math.random` mocked
  - cap at 60s
  - jittered backoff layered on top of `Retry-After` floor
  - zero/negative `Retry-After` ignored
  - `parseRetryAfterMs` for integer seconds, fractional seconds, HTTP-date, and malformed input
- [x] Existing `llm-service.test.ts` (14 tests) still passes after defensive header access
- [x] Full LLM test suite (51 tests) passes
- [x] `tsc --noEmit` clean