### PR TITLE
Fix: enable timeline event edit/delete actions for closed jobs

### DIFF
--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -534,8 +534,8 @@ export const JobPage: React.FC = () => {
         : null))
     : null;
   const isClosedStage = currentStage === "closed";
-  const canTrackStages = job?.status === "in_progress";
-  const canLogEvents = canTrackStages && !isClosedStage;
+  const isInProgress = job?.status === "in_progress";
+  const canLogEvents = isInProgress && !isClosedStage;
   const jobLink = job ? job.applicationLink || job.jobUrl : null;
   const isBusy = activeAction !== null;
   const isRegeneratingPdf = isPdfRegenerating(job);
@@ -548,7 +548,6 @@ export const JobPage: React.FC = () => {
   const isDiscovered = job?.status === "discovered";
   const isReady = job?.status === "ready";
   const isApplied = job?.status === "applied";
-  const isInProgress = job?.status === "in_progress";
   const baseJobPath = id ? `/job/${id}` : "";
   const latestNote = notes[0] ?? null;
   const latestEvent = events.at(-1) ?? null;
@@ -876,20 +875,20 @@ export const JobPage: React.FC = () => {
                   </div>
                 </div>
                 <div className="p-4">
-                  {!canTrackStages && (
+                  {!isInProgress && (
                     <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
                       Move this job to In Progress to track application stages.
                     </div>
                   )}
-                  {canTrackStages && isClosedStage && (
+                  {isInProgress && isClosedStage && (
                     <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
                       This application is closed. Stage logging is disabled.
                     </div>
                   )}
                   <JobTimeline
                     events={events}
-                    onEdit={canLogEvents ? handleEditEvent : undefined}
-                    onDelete={canLogEvents ? confirmDeleteEvent : undefined}
+                    onEdit={isInProgress ? handleEditEvent : undefined}
+                    onDelete={isInProgress ? confirmDeleteEvent : undefined}
                   />
                 </div>
               </section>


### PR DESCRIPTION
## Summary

Fixes a bug where timeline events became immutable once a job entered the `closed` stage.

Previously, timeline edit/delete actions were tied to `canLogEvents`, which becomes `false` for closed jobs. As a result, users could not recover.

This change decouples timeline event management permissions from timeline event creation permissions.

## Changes

- Enables editing/deleting timeline events for jobs in all active application states

## Testing

Tested the following scenarios:

- Editing/deleting timeline events
- Verified that job event logging remains disabled for the `closed` stage.

Fixes #520

Video attached.


https://github.com/user-attachments/assets/95fb41cd-9fc8-4135-8989-1855e2da7ac2

