### PR TITLE
fix: show unscored discovered jobs as awaiting scoring

### DIFF
--- a/orchestrator/src/client/components/JobHeader.test.tsx
+++ b/orchestrator/src/client/components/JobHeader.test.tsx
@@ -171,6 +171,27 @@ describe("JobHeader", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows discovered jobs without scores as awaiting AI scoring", () => {
+    renderWithRouter(
+      <JobHeader
+        job={{
+          ...mockJob,
+          suitabilityScore: null,
+          suitabilityReason: null,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole("img", { name: "Waiting for AI scoring to finish." }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", {
+        name: "AI misconfiguration or service error. Please check your settings and AI service status.",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows a tooltip for ready jobs", () => {
     const readyJob = {
       ...mockJob,

--- a/orchestrator/src/client/components/ScoreRing.tsx
+++ b/orchestrator/src/client/components/ScoreRing.tsx
@@ -26,7 +26,7 @@ const getSuitabilityScoreTokens = (
     return {
       shell: "border-blue-300/55 bg-blue-500/10 text-blue-200",
       value: "loading",
-      label: "AI is still tailoring and scoring this job.",
+      label: "Waiting for AI scoring to finish.",
     };
   }
 
@@ -66,7 +66,7 @@ export function isAwaitingAiScore(
   job: Pick<Job, "status" | "suitabilityScore">,
 ): boolean {
   if (job.suitabilityScore != null) return false;
-  return job.status === "processing";
+  return job.status === "discovered" || job.status === "processing";
 }
 
 export const ScoreRing: React.FC<{

--- a/orchestrator/src/client/pages/orchestrator/JobListPanel.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobListPanel.test.tsx
@@ -173,6 +173,39 @@ describe("JobListPanel", () => {
     expect(onSelectJob).toHaveBeenCalledWith("job-2");
   });
 
+  it("shows discovered jobs without scores as awaiting AI scoring", () => {
+    const jobs = [
+      createJob({
+        id: "job-1",
+        title: "Backend Engineer",
+        status: "discovered",
+        suitabilityScore: null,
+        suitabilityReason: null,
+      }),
+    ];
+
+    render(
+      <JobListPanel
+        isLoading={false}
+        jobs={jobs}
+        activeJobs={jobs}
+        selectedJobId={null}
+        selectedJobIds={new Set()}
+        activeTab="discovered"
+        onSelectJob={vi.fn()}
+        onToggleSelectJob={vi.fn()}
+        onToggleSelectAll={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByLabelText("Waiting for AI scoring to finish."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("AI misconfiguration or service error."),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows a yellow status dot for flagged reposts without an inline badge", () => {
     const jobs = [
       createJob({

--- a/orchestrator/src/client/pages/orchestrator/JobRowContent.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobRowContent.tsx
@@ -1,3 +1,4 @@
+import { isAwaitingAiScore } from "@client/components";
 import type { JobListItem } from "@shared/types.js";
 import { Loader2, XCircle } from "lucide-react";
 import { isPdfRegenerating, isPdfStale } from "@/client/lib/pdf-freshness";
@@ -23,11 +24,6 @@ function getSuitabilityScoreTone(score: number): string {
   if (score >= 70) return "text-emerald-400/90";
   if (score >= 50) return "text-foreground/60";
   return "text-muted-foreground/60";
-}
-
-function isAwaitingAiScore(job: JobListItem): boolean {
-  if (job.suitabilityScore != null) return false;
-  return job.status === "discovered" || job.status === "processing";
 }
 
 export const JobRowContent = ({

--- a/orchestrator/src/client/pages/orchestrator/JobRowContent.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobRowContent.tsx
@@ -27,7 +27,7 @@ function getSuitabilityScoreTone(score: number): string {
 
 function isAwaitingAiScore(job: JobListItem): boolean {
   if (job.suitabilityScore != null) return false;
-  return job.status === "processing";
+  return job.status === "discovered" || job.status === "processing";
 }
 
 export const JobRowContent = ({
@@ -106,10 +106,13 @@ export const JobRowContent = ({
           <TooltipProvider delayDuration={0}>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                <Loader2
+                  aria-label="Waiting for AI scoring to finish."
+                  className="h-4 w-4 animate-spin text-muted-foreground"
+                />
               </TooltipTrigger>
               <TooltipContent side="top" className="max-w-60 text-xs">
-                AI is still tailoring and scoring this job.
+                Waiting for AI scoring to finish.
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -119,7 +122,10 @@ export const JobRowContent = ({
           <TooltipProvider delayDuration={0}>
             <Tooltip>
               <TooltipTrigger asChild>
-                <XCircle className="h-4 w-4 text-destructive" />
+                <XCircle
+                  aria-label="AI misconfiguration or service error."
+                  className="h-4 w-4 text-destructive"
+                />
               </TooltipTrigger>
               <TooltipContent side="top" className="max-w-60 text-xs">
                 AI misconfiguration or service error. Please check your settings


### PR DESCRIPTION
## Summary

- Show unscored discovered jobs as waiting for AI scoring instead of an AI service error.
- Keep the existing error state for non-awaiting jobs with missing scores.
- Add regression coverage for the job header and list row score states.

## Testing

- `npm --workspace orchestrator run test:run -- src/client/components/JobHeader.test.tsx src/client/pages/orchestrator/JobListPanel.test.tsx`
- `npm --workspace orchestrator run ci -- src/client/components/ScoreRing.tsx src/client/pages/orchestrator/JobRowContent.tsx src/client/components/JobHeader.test.tsx src/client/pages/orchestrator/JobListPanel.test.tsx`
- `npm run check:types`
- `npm --workspace orchestrator run build:client`

Fixes #558