### PR TITLE
feat(timeline): surface stage rollback in delete-event confirmation

### DIFF
--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -72,6 +72,7 @@ import {
   type LogEventFormValues,
   LogEventModal,
 } from "../components/LogEventModal";
+import { getDeleteEventDescription } from "./job/deleteEventDescription";
 import { JobTimeline } from "./job/Timeline";
 import { JobDocumentsPanel } from "./job-page/JobDocumentsPanel";
 import { JobEmailsPanel } from "./job-page/JobEmailsPanel";
@@ -977,6 +978,7 @@ export const JobPage: React.FC = () => {
           setEventToDelete(null);
         }}
         onConfirm={handleDeleteEvent}
+        description={getDeleteEventDescription(events, eventToDelete)}
       />
 
       <JobDetailsEditDrawer

--- a/orchestrator/src/client/pages/job/deleteEventDescription.test.ts
+++ b/orchestrator/src/client/pages/job/deleteEventDescription.test.ts
@@ -1,0 +1,54 @@
+import type { StageEvent } from "@shared/types.js";
+import { describe, expect, it } from "vitest";
+import { getDeleteEventDescription } from "./deleteEventDescription";
+
+const makeEvent = (id: string, toStage: StageEvent["toStage"]): StageEvent => ({
+  id,
+  applicationId: "job-1",
+  title: "",
+  groupId: null,
+  fromStage: null,
+  toStage,
+  occurredAt: 0,
+  metadata: null,
+  outcome: null,
+});
+
+describe("getDeleteEventDescription", () => {
+  it("returns the default description when no event is targeted", () => {
+    expect(getDeleteEventDescription([], null)).toMatch(/cannot be undone/i);
+  });
+
+  it("returns the default description when deleting a non-latest event", () => {
+    const events = [
+      makeEvent("a", "applied"),
+      makeEvent("b", "recruiter_screen"),
+      makeEvent("c", "technical_interview"),
+    ];
+    expect(getDeleteEventDescription(events, "a")).toMatch(/cannot be undone/i);
+    expect(getDeleteEventDescription(events, "b")).toMatch(/cannot be undone/i);
+  });
+
+  it("warns about rolling back when deleting the latest event", () => {
+    const events = [
+      makeEvent("a", "applied"),
+      makeEvent("b", "recruiter_screen"),
+    ];
+    const description = getDeleteEventDescription(events, "b");
+    expect(description.toLowerCase()).toContain("roll");
+    expect(description).toContain("Applied");
+  });
+
+  it("warns about resetting when deleting the only event", () => {
+    const events = [makeEvent("a", "applied")];
+    const description = getDeleteEventDescription(events, "a");
+    expect(description.toLowerCase()).toContain("discovered");
+  });
+
+  it("returns the default when the targeted event does not exist", () => {
+    const events = [makeEvent("a", "applied")];
+    expect(getDeleteEventDescription(events, "nonexistent")).toMatch(
+      /cannot be undone/i,
+    );
+  });
+});

--- a/orchestrator/src/client/pages/job/deleteEventDescription.ts
+++ b/orchestrator/src/client/pages/job/deleteEventDescription.ts
@@ -1,0 +1,31 @@
+import { STAGE_LABELS, type StageEvent } from "@shared/types.js";
+
+const DEFAULT_DESCRIPTION =
+  "This action cannot be undone. This will permanently delete this event from the timeline.";
+
+/**
+ * Build a delete-confirmation description for a stage event.
+ *
+ * When the deleted event is the latest in the timeline, removing it will roll
+ * the job's stage/status back to the previous event (or to "discovered" if it
+ * was the only event). Surface that so the user knows derived state will move.
+ */
+export function getDeleteEventDescription(
+  events: StageEvent[],
+  eventToDelete: string | null,
+): string {
+  if (!eventToDelete) return DEFAULT_DESCRIPTION;
+
+  const lastEvent = events.at(-1);
+  if (!lastEvent || lastEvent.id !== eventToDelete) {
+    return DEFAULT_DESCRIPTION;
+  }
+
+  const previousEvent = events.at(-2);
+  if (!previousEvent) {
+    return "This is the only event on this job. Deleting it will reset the job to its initial discovered state.";
+  }
+
+  const previousLabel = STAGE_LABELS[previousEvent.toStage];
+  return `Deleting this event will roll the job's stage back to "${previousLabel}".`;
+}


### PR DESCRIPTION
## Summary

Follow-up to #556 — addresses the second acceptance criterion of #520:

> Deleting an event reverts any derived state it caused (e.g. if the event drove a stage change, the stage rolls back to the previous one, **or this is at least clearly surfaced**).

#556 enabled the edit/delete affordances. The server-side reversion already works correctly via `deleteStageEvent()` in `applicationTracking.ts`. The remaining gap is **discoverability**: the delete confirmation currently shows a generic "this will permanently delete this event" message and doesn't tell the user that deleting the latest event will also roll the job's stage back.

## Changes

- **New pure helper** `getDeleteEventDescription(events, eventToDelete)` in `orchestrator/src/client/pages/job/deleteEventDescription.ts`:
  - Returns the existing generic message for non-latest events (deletion is a clean removal).
  - For the latest event with prior events: `Deleting this event will roll the job's stage back to "<previous stage>".`
  - For the only event: `This is the only event on this job. Deleting it will reset the job to its initial discovered state.`
- **`JobPage.tsx`**: passes the computed description to `<ConfirmDelete>` (2-line diff).
- **Unit tests** cover all four branches of the helper.

## Why a separate helper

The logic is pure (`events × eventToDelete → string`), trivially testable in isolation, and keeps `JobPage.tsx` from growing further. `JobPage.tsx` is already 1000+ lines.

## Test plan

- [x] `getDeleteEventDescription.test.ts` — 5 tests, all pass
- [x] `JobPage.test.tsx` — existing 10 tests still pass
- [x] `tsc --noEmit` clean
- [x] biome check clean