### PR TITLE
fix(jobs): move discovered job to ready after manual PDF upload

### DIFF
--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -640,10 +640,40 @@ describe.sequential("Jobs API routes", () => {
     expect(res.status).toBe(201);
     expect(body.ok).toBe(true);
     expect(body.data.pdfPath).toBe(storedPath);
+    expect(body.data.status).toBe("ready");
+    expect(body.data.readyAt).toBeTruthy();
     expect(typeof body.meta.requestId).toBe("string");
     await expect(readFile(storedPath, "utf8")).resolves.toContain(
       "Uploaded resume",
     );
+  });
+
+  it("does not regress job status when uploading a PDF for an applied job", async () => {
+    const { createJob, updateJob } = await import("@server/repositories/jobs");
+    const job = await createJob({
+      source: "manual",
+      title: "Replace PDF Role",
+      employer: "Acme",
+      jobUrl: "https://example.com/job/replace-pdf",
+      jobDescription: "Test description",
+    });
+    await updateJob(job.id, { status: "applied" });
+
+    const pdfContent = Buffer.from("%PDF-1.7\nReplacement resume\n");
+    const res = await fetch(`${baseUrl}/api/jobs/${job.id}/pdf`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        fileName: "replacement-resume.pdf",
+        mediaType: "application/pdf",
+        dataBase64: pdfContent.toString("base64"),
+      }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(201);
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe("applied");
   });
 
   it("rejects uploaded files that are not valid PDFs", async () => {

--- a/orchestrator/src/server/api/routes/jobs/documents.ts
+++ b/orchestrator/src/server/api/routes/jobs/documents.ts
@@ -2,6 +2,7 @@ import { rm } from "node:fs/promises";
 import { AppError, badRequest } from "@infra/errors";
 import { fail, ok, okWithMeta } from "@infra/http";
 import { logger } from "@infra/logger";
+import { trackServerProductEvent } from "@infra/product-analytics";
 import { isDemoMode } from "@server/config/demo";
 import { resolveRequestOrigin } from "@server/infra/request-origin";
 import { generateFinalPdf, summarizeJob } from "@server/pipeline/index";
@@ -135,12 +136,14 @@ jobsDocumentsRouter.post("/:id/pdf", async (req: Request, res: Response) => {
     });
     uploadedPath = uploaded.outputPath;
 
+    const promotingToReady = currentJob.status === "discovered";
     const job = await jobsRepo.updateJob(req.params.id, {
       pdfPath: uploaded.outputPath,
       pdfSource: "uploaded",
       pdfRegenerating: false,
       pdfFingerprint: null,
       pdfGeneratedAt: new Date().toISOString(),
+      ...(promotingToReady ? { status: "ready" } : {}),
     });
 
     if (!job) {
@@ -173,6 +176,20 @@ jobsDocumentsRouter.post("/:id/pdf", async (req: Request, res: Response) => {
       fileName: input.fileName,
       byteLength: uploaded.byteLength,
     });
+
+    if (promotingToReady) {
+      void trackServerProductEvent(
+        "job_moved_to_ready",
+        {
+          origin: "pdf_upload",
+          tracer_links_enabled: job.tracerLinksEnabled,
+        },
+        {
+          requestOrigin: resolveRequestOrigin(req),
+          urlPath: "/jobs",
+        },
+      );
+    }
 
     ok(res, await hydrateJobPdfFreshness(job), 201);
   } catch (error) {


### PR DESCRIPTION
## Summary
- Uploading a PDF for a `discovered` job left status as `discovered`, so the action menu never surfaced **Mark Applied** (gated on `status === "ready"` — see `JobDetailPanel.tsx:173`, `JobPage.tsx:550`).
- `POST /api/jobs/:id/pdf` now transitions a `discovered` job to `ready` after a valid PDF is stored. Statuses past `discovered` (`applied`, `in_progress`, `processing`, `skipped`, `expired`) are not regressed. `readyAt` is set automatically by the repository's existing coalesce logic on the transition.
- Emits `job_moved_to_ready` (origin `pdf_upload`) so manual uploads are counted alongside the tailoring pipeline's existing event.

Closes #563

## Test plan
- [x] `npm --workspace orchestrator run check:types`
- [x] `npm --workspace orchestrator run test:run` — full suite passes
- [x] New regression test: upload on an `applied` job does not regress status
- [x] Updated existing upload test to assert `status === "ready"` and a populated `readyAt`
- [x] Manually verified in fork: discovered job + manual PDF upload now exposes "Mark Applied"