### PR TITLE
feat(manual-import): add option to skip auto-tailoring on import

### DIFF
--- a/docs-site/docs/extractors/manual.md
+++ b/docs-site/docs/extractors/manual.md
@@ -9,7 +9,7 @@ Manual import lets users add jobs that automated scrapers miss.
 
 ## Big picture
 
-User pastes raw description, AI infers structure, user reviews edits, then import saves and scores the job.
+User pastes raw description, AI infers structure, user reviews edits, then import saves the job. By default the import also tailors and scores the job; this can be skipped per-import (or globally via Settings) so the job lands in Discovered and can be tailored later.
 
 ## 1) Input
 
@@ -53,9 +53,18 @@ Import endpoint:
 
 - `POST /api/manual-jobs/import`
 
-On import:
+Request body accepts an optional `skipTailoring` boolean. When omitted, the route falls back to the `autoTailorOnManualImport` workspace setting (default: `true`). The review step in the UI exposes this as the "Tailor automatically after import" checkbox.
+
+On import with tailoring enabled:
 
 - Generates unique job ID if URL absent
 - Stores source as `manual`
-- Triggers async suitability scoring
-- Persists score and reason
+- Runs the tailoring pipeline (resume + PDF) and persists score and reason
+- Job ends in `processing` and progresses to `ready` when tailoring completes
+
+On import with tailoring skipped (`skipTailoring: true` or workspace setting off):
+
+- Generates unique job ID if URL absent
+- Stores source as `manual`
+- Job lands in `discovered` immediately; no LLM scoring, no PDF render
+- Tailoring can be triggered later from the job detail view

--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -80,6 +80,8 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 - Toggle visa sponsor badge visibility in job lists/details
 - Toggle `Render Markdown in job descriptions` to control whether expanded job descriptions show formatted headings, lists, bold text, and code blocks
 - Default: Markdown rendering is enabled
+- Toggle `Auto-tailor manually imported jobs` to control whether jobs created through Manual Import immediately run tailoring + suitability scoring + PDF generation, or land in Discovered so you can tailor them later
+- Default: Auto-tailor on import is enabled. The per-import "Tailor automatically after import" checkbox in the Manual Import review step defaults to this setting and can override it for a single import
 
 ### Writing Style & Language
 

--- a/orchestrator/src/client/api/admin.ts
+++ b/orchestrator/src/client/api/admin.ts
@@ -36,6 +36,7 @@ export async function inferManualJob(input: {
 
 export async function importManualJob(input: {
   job: ManualJobDraft;
+  skipTailoring?: boolean;
 }): Promise<Job> {
   return fetchApi<Job>("/manual-jobs/import", {
     method: "POST",

--- a/orchestrator/src/client/components/ManualImportFlow.tsx
+++ b/orchestrator/src/client/components/ManualImportFlow.tsx
@@ -1,4 +1,5 @@
 import * as api from "@client/api";
+import { useSettings } from "@client/hooks/useSettings";
 import type { ManualJobDraft } from "@shared/types.js";
 import {
   ArrowDown,
@@ -25,6 +26,7 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { showErrorToast } from "@/client/lib/error-toast";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
@@ -326,6 +328,10 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
     useState<ManualImportTrackingSource>("pasted_description");
   const [importSourceHost, setImportSourceHost] = useState<string | null>(null);
   const [fetchedSourceUrl, setFetchedSourceUrl] = useState<string | null>(null);
+  const { autoTailorOnManualImport } = useSettings();
+  const [tailorAfterImport, setTailorAfterImport] = useState<boolean>(
+    autoTailorOnManualImport,
+  );
 
   useEffect(() => {
     if (active) {
@@ -351,6 +357,7 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
           getSourceHost(normalized.applicationLink),
       );
       setFetchedSourceUrl(normalized.jobUrl || null);
+      setTailorAfterImport(autoTailorOnManualImport);
       return;
     }
     setStep("paste");
@@ -365,7 +372,14 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
     setImportSource("pasted_description");
     setImportSourceHost(null);
     setFetchedSourceUrl(null);
-  }, [active, initialDraft, initialSource, initialSourceHost]);
+    setTailorAfterImport(autoTailorOnManualImport);
+  }, [
+    active,
+    initialDraft,
+    initialSource,
+    initialSourceHost,
+    autoTailorOnManualImport,
+  ]);
 
   const progressStep: ManualImportProgressStep =
     step === "review" ? "review" : "paste";
@@ -469,9 +483,15 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
     try {
       setIsImporting(true);
       const payload = toPayload(draft);
-      const created = await api.importManualJob({ job: payload });
+      const skipTailoring = !tailorAfterImport;
+      const created = await api.importManualJob({
+        job: payload,
+        skipTailoring,
+      });
       toast.success("Job imported", {
-        description: "The job was tailored and moved to the ready column.",
+        description: skipTailoring
+          ? "Saved to Discovered without tailoring. You can tailor it anytime from the job detail view."
+          : "The job was tailored and moved to the ready column.",
       });
       await onImported({
         jobId: created.id,
@@ -683,6 +703,31 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
               </div>
             </ReviewSection>
 
+            <div className="flex items-start gap-3 rounded-lg border border-border/70 bg-card/40 px-3 py-3">
+              <Checkbox
+                id="tailor-after-import"
+                checked={tailorAfterImport}
+                onCheckedChange={(checked) => {
+                  setTailorAfterImport(checked === true);
+                }}
+                disabled={isImporting}
+                className="mt-0.5"
+              />
+              <div className="flex flex-col gap-1">
+                <label
+                  htmlFor="tailor-after-import"
+                  className="cursor-pointer text-sm font-medium leading-none"
+                >
+                  Tailor automatically after import
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  Off saves LLM tokens — the job lands in Discovered and you can
+                  tailor it later from the job detail view. Default comes from
+                  Settings → Display.
+                </p>
+              </div>
+            </div>
+
             <div className="sticky bottom-0 -mx-1 flex gap-3 border-t border-border/70 bg-background/95 px-1 py-4 backdrop-blur">
               <Button
                 type="button"
@@ -703,7 +748,11 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
                 ) : (
                   <Sparkles className="h-4 w-4" />
                 )}
-                {isImporting ? "Importing..." : "Import job"}
+                {isImporting
+                  ? "Importing..."
+                  : tailorAfterImport
+                    ? "Import & tailor"
+                    : "Import without tailoring"}
               </Button>
             </div>
           </div>

--- a/orchestrator/src/client/components/ManualImportSheet.test.tsx
+++ b/orchestrator/src/client/components/ManualImportSheet.test.tsx
@@ -10,6 +10,11 @@ vi.mock("../api", () => ({
   importManualJob: vi.fn(),
 }));
 
+const mockedUseSettings = vi.fn(() => ({ autoTailorOnManualImport: true }));
+vi.mock("@client/hooks/useSettings", () => ({
+  useSettings: () => mockedUseSettings(),
+}));
+
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -20,6 +25,7 @@ vi.mock("sonner", () => ({
 describe("ManualImportSheet", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockedUseSettings.mockReturnValue({ autoTailorOnManualImport: true });
   });
 
   it("runs analyze -> review -> import on the happy path", async () => {
@@ -67,7 +73,11 @@ describe("ManualImportSheet", () => {
       target: { value: "  120k  " },
     });
 
-    fireEvent.click(screen.getByRole("button", { name: /import job/i }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /^(import & tailor|import without tailoring)$/i,
+      }),
+    );
 
     await waitFor(() => expect(api.importManualJob).toHaveBeenCalled());
     expect(api.importManualJob).toHaveBeenCalledWith({
@@ -79,6 +89,7 @@ describe("ManualImportSheet", () => {
         salary: "120k",
         jobDescription: rawDescription.trim(),
       }),
+      skipTailoring: false,
     });
 
     await waitFor(() =>
@@ -119,7 +130,9 @@ describe("ManualImportSheet", () => {
 
     await screen.findByText("AI inference failed. Fill details manually.");
 
-    const importButton = screen.getByRole("button", { name: /import job/i });
+    const importButton = screen.getByRole("button", {
+      name: /^(import & tailor|import without tailoring)$/i,
+    });
     expect(importButton).toBeDisabled();
 
     fireEvent.change(
@@ -201,13 +214,109 @@ describe("ManualImportSheet", () => {
 
     await screen.findByPlaceholderText("e.g. Junior Backend Engineer");
 
-    fireEvent.click(screen.getByRole("button", { name: /import job/i }));
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /^(import & tailor|import without tailoring)$/i,
+      }),
+    );
 
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith("Import failed"),
     );
     expect(onOpenChange).not.toHaveBeenCalled();
-    expect(screen.getByRole("button", { name: /import job/i })).toBeEnabled();
+    expect(
+      screen.getByRole("button", {
+        name: /^(import & tailor|import without tailoring)$/i,
+      }),
+    ).toBeEnabled();
+  });
+
+  it("sends skipTailoring: true when the user unchecks 'Tailor automatically after import'", async () => {
+    vi.mocked(api.inferManualJob).mockResolvedValue({
+      job: {
+        title: "Backend Engineer",
+        employer: "Acme Labs",
+        jobUrl: "https://example.com/jobs/skip",
+        jobDescription: "Role description",
+      },
+    });
+    vi.mocked(api.importManualJob).mockResolvedValue({ id: "job-3" } as any);
+
+    render(
+      <ManualImportSheet open onOpenChange={vi.fn()} onImported={vi.fn()} />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Paste the full job description here, or fetch it from a URL above...",
+      ),
+      { target: { value: "Backend Engineer role." } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /analyze jd/i }));
+
+    await screen.findByPlaceholderText("e.g. Junior Backend Engineer");
+
+    const tailorCheckbox = screen.getByLabelText(
+      /tailor automatically after import/i,
+    );
+    fireEvent.click(tailorCheckbox);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /import without tailoring/i }),
+    );
+
+    await waitFor(() => expect(api.importManualJob).toHaveBeenCalled());
+    expect(api.importManualJob).toHaveBeenCalledWith(
+      expect.objectContaining({ skipTailoring: true }),
+    );
+    expect(toast.success).toHaveBeenCalledWith(
+      "Job imported",
+      expect.objectContaining({
+        description: expect.stringMatching(/discovered/i),
+      }),
+    );
+  });
+
+  it("defaults the tailor checkbox to off when autoTailorOnManualImport setting is false", async () => {
+    mockedUseSettings.mockReturnValue({ autoTailorOnManualImport: false });
+
+    vi.mocked(api.inferManualJob).mockResolvedValue({
+      job: {
+        title: "Backend Engineer",
+        employer: "Acme Labs",
+        jobUrl: "https://example.com/jobs/default-off",
+        jobDescription: "Role description",
+      },
+    });
+    vi.mocked(api.importManualJob).mockResolvedValue({ id: "job-4" } as any);
+
+    render(
+      <ManualImportSheet open onOpenChange={vi.fn()} onImported={vi.fn()} />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "Paste the full job description here, or fetch it from a URL above...",
+      ),
+      { target: { value: "Backend Engineer role." } },
+    );
+    fireEvent.click(screen.getByRole("button", { name: /analyze jd/i }));
+
+    await screen.findByPlaceholderText("e.g. Junior Backend Engineer");
+
+    expect(
+      screen.getByLabelText(/tailor automatically after import/i),
+    ).not.toBeChecked();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /import without tailoring/i }),
+    );
+
+    await waitFor(() =>
+      expect(api.importManualJob).toHaveBeenCalledWith(
+        expect.objectContaining({ skipTailoring: true }),
+      ),
+    );
   });
 
   describe("URL fetch functionality", () => {
@@ -346,7 +455,11 @@ describe("ManualImportSheet", () => {
       fireEvent.click(screen.getByRole("button", { name: /analyze jd/i }));
 
       await screen.findByPlaceholderText("e.g. Junior Backend Engineer");
-      fireEvent.click(screen.getByRole("button", { name: /import job/i }));
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: /^(import & tailor|import without tailoring)$/i,
+        }),
+      );
 
       await waitFor(() =>
         expect(onImported).toHaveBeenCalledWith({

--- a/orchestrator/src/client/hooks/useOnboardingRequirement.test.ts
+++ b/orchestrator/src/client/hooks/useOnboardingRequirement.test.ts
@@ -70,6 +70,7 @@ describe("useOnboardingRequirement", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     const { result, rerender } = renderHookWithQueryClient(() =>
@@ -124,6 +125,7 @@ describe("useOnboardingRequirement", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     const { result } = renderHookWithQueryClient(() =>
@@ -183,6 +185,7 @@ describe("useOnboardingRequirement", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     const { result, rerender } = renderHookWithQueryClient(() =>
@@ -253,6 +256,7 @@ describe("useOnboardingRequirement", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     const { result } = renderHookWithQueryClient(() =>
@@ -304,6 +308,7 @@ describe("useOnboardingRequirement", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     const { result } = renderHookWithQueryClient(() =>
@@ -351,6 +356,7 @@ describe("useOnboardingRequirement", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     const { result } = renderHookWithQueryClient(() =>
@@ -397,6 +403,7 @@ describe("useOnboardingRequirement", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     const { result } = renderHookWithQueryClient(() =>

--- a/orchestrator/src/client/hooks/useSettings.ts
+++ b/orchestrator/src/client/hooks/useSettings.ts
@@ -29,6 +29,7 @@ export function useSettings() {
     showSponsorInfo: settings?.showSponsorInfo?.value ?? true,
     renderMarkdownInJobDescriptions:
       settings?.renderMarkdownInJobDescriptions?.value ?? true,
+    autoTailorOnManualImport: settings?.autoTailorOnManualImport?.value ?? true,
     refreshSettings,
   };
 }

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -136,6 +136,7 @@ describe("OnboardingPage", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     vi.mocked(useRxResumeConfigState).mockReturnValue({
@@ -796,6 +797,7 @@ describe("OnboardingPage", () => {
       error: null,
       showSponsorInfo: true,
       renderMarkdownInJobDescriptions: true,
+      autoTailorOnManualImport: true,
     }));
 
     renderPage();

--- a/orchestrator/src/client/pages/SettingsPage.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.tsx
@@ -83,6 +83,7 @@ const DEFAULT_FORM_VALUES: UpdateSettingsInput = {
   rxresumeBaseResumeId: null,
   showSponsorInfo: null,
   renderMarkdownInJobDescriptions: null,
+  autoTailorOnManualImport: null,
   chatStyleTone: "",
   chatStyleFormality: "",
   chatStyleConstraints: "",
@@ -334,7 +335,11 @@ const SECTION_FIELD_MAP: Record<
     "adzunaAppId",
     "adzunaAppKey",
   ],
-  display: ["showSponsorInfo", "renderMarkdownInJobDescriptions"],
+  display: [
+    "showSponsorInfo",
+    "renderMarkdownInJobDescriptions",
+    "autoTailorOnManualImport",
+  ],
   backup: ["backupEnabled", "backupHour", "backupMaxCount"],
   "danger-zone": [],
 };
@@ -408,6 +413,7 @@ const NULL_SETTINGS_PAYLOAD: UpdateSettingsInput = {
   rxresumeBaseResumeId: null,
   showSponsorInfo: null,
   renderMarkdownInJobDescriptions: null,
+  autoTailorOnManualImport: null,
   chatStyleTone: null,
   chatStyleFormality: null,
   chatStyleConstraints: null,
@@ -459,6 +465,7 @@ const mapSettingsToForm = (data: AppSettings): UpdateSettingsInput => ({
   showSponsorInfo: data.showSponsorInfo.override,
   renderMarkdownInJobDescriptions:
     data.renderMarkdownInJobDescriptions.override,
+  autoTailorOnManualImport: data.autoTailorOnManualImport.override,
   chatStyleTone: data.chatStyleTone.override ?? "",
   chatStyleFormality: data.chatStyleFormality.override ?? "",
   chatStyleConstraints: data.chatStyleConstraints.override ?? "",
@@ -630,6 +637,10 @@ const getDerivedSettings = (settings: AppSettings | null) => {
       renderMarkdownInJobDescriptions: {
         effective: settings?.renderMarkdownInJobDescriptions?.value ?? true,
         default: settings?.renderMarkdownInJobDescriptions?.default ?? true,
+      },
+      autoTailorOnManualImport: {
+        effective: settings?.autoTailorOnManualImport?.value ?? true,
+        default: settings?.autoTailorOnManualImport?.default ?? true,
       },
     },
     chat: {
@@ -1177,6 +1188,10 @@ export const SettingsPage: React.FC = () => {
         renderMarkdownInJobDescriptions: nullIfSame(
           data.renderMarkdownInJobDescriptions,
           display.renderMarkdownInJobDescriptions.default,
+        ),
+        autoTailorOnManualImport: nullIfSame(
+          data.autoTailorOnManualImport,
+          display.autoTailorOnManualImport.default,
         ),
         chatStyleTone: normalizeString(data.chatStyleTone),
         chatStyleFormality: normalizeString(data.chatStyleFormality),

--- a/orchestrator/src/client/pages/settings/components/DisplaySettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/DisplaySettingsSection.tsx
@@ -19,7 +19,11 @@ export const DisplaySettingsSection: React.FC<DisplaySettingsSectionProps> = ({
   isSaving,
   layoutMode,
 }) => {
-  const { showSponsorInfo, renderMarkdownInJobDescriptions } = values;
+  const {
+    showSponsorInfo,
+    renderMarkdownInJobDescriptions,
+    autoTailorOnManualImport,
+  } = values;
   const { control } = useFormContext<UpdateSettingsInput>();
 
   return (
@@ -97,6 +101,41 @@ export const DisplaySettingsSection: React.FC<DisplaySettingsSectionProps> = ({
 
         <Separator />
 
+        <div className="flex items-start space-x-3">
+          <Controller
+            name="autoTailorOnManualImport"
+            control={control}
+            render={({ field }) => (
+              <Checkbox
+                id="autoTailorOnManualImport"
+                checked={field.value ?? autoTailorOnManualImport.default}
+                onCheckedChange={(checked) => {
+                  field.onChange(
+                    checked === "indeterminate" ? null : checked === true,
+                  );
+                }}
+                disabled={isLoading || isSaving}
+              />
+            )}
+          />
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor="autoTailorOnManualImport"
+              className="text-sm font-medium leading-none cursor-pointer"
+            >
+              Auto-tailor manually imported jobs
+            </label>
+            <p className="text-xs text-muted-foreground">
+              When enabled, jobs added via Manual Import are immediately scored
+              and have a tailored resume PDF generated. Turn off to save LLM
+              tokens and tailor later from the job detail view. You can override
+              this per import in the review step.
+            </p>
+          </div>
+        </div>
+
+        <Separator />
+
         <div className="grid gap-3 text-sm sm:grid-cols-2">
           <div>
             <div className="text-xs text-muted-foreground">
@@ -130,6 +169,22 @@ export const DisplaySettingsSection: React.FC<DisplaySettingsSectionProps> = ({
             </div>
             <div className="break-words font-mono text-xs font-semibold">
               {renderMarkdownInJobDescriptions.default ? "Enabled" : "Disabled"}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">
+              Auto-tailor on import effective
+            </div>
+            <div className="break-words font-mono text-xs">
+              {autoTailorOnManualImport.effective ? "Enabled" : "Disabled"}
+            </div>
+          </div>
+          <div>
+            <div className="text-xs text-muted-foreground">
+              Auto-tailor on import default
+            </div>
+            <div className="break-words font-mono text-xs font-semibold">
+              {autoTailorOnManualImport.default ? "Enabled" : "Disabled"}
             </div>
           </div>
         </div>

--- a/orchestrator/src/client/pages/settings/types.ts
+++ b/orchestrator/src/client/pages/settings/types.ts
@@ -25,6 +25,7 @@ export type WebhookValues = EffectiveDefault<string>;
 export type DisplayValues = {
   showSponsorInfo: EffectiveDefault<boolean>;
   renderMarkdownInJobDescriptions: EffectiveDefault<boolean>;
+  autoTailorOnManualImport: EffectiveDefault<boolean>;
 };
 export type ChatValues = {
   tone: EffectiveDefault<string>;

--- a/orchestrator/src/server/api/routes/manual-jobs.test.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.test.ts
@@ -177,4 +177,95 @@ describe.sequential("Manual jobs API routes", () => {
 
     expect(res.status).toBe(400);
   });
+
+  it("skips tailoring and scoring when skipTailoring is true", async () => {
+    const { processJob } = await import("@server/pipeline/index");
+    const { scoreJobSuitability } = await import("@server/services/scorer");
+    vi.mocked(processJob).mockClear();
+    vi.mocked(scoreJobSuitability).mockClear();
+
+    const res = await fetch(`${baseUrl}/api/manual-jobs/import`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        skipTailoring: true,
+        job: {
+          title: "Backend Engineer",
+          employer: "Acme",
+          jobUrl: "https://example.com/jobs/skip-tailor",
+          jobDescription: "Great role",
+        },
+      }),
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.data.status).toBe("discovered");
+    expect(vi.mocked(processJob)).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(vi.mocked(scoreJobSuitability)).not.toHaveBeenCalled();
+
+    const followupRes = await fetch(`${baseUrl}/api/jobs/${body.data.id}`);
+    const followupBody = await followupRes.json();
+    expect(followupBody.data.status).toBe("discovered");
+    expect(followupBody.data.suitabilityScore).toBeNull();
+    expect(followupBody.data.tailoredSummary ?? null).toBeNull();
+  });
+
+  it("falls back to autoTailorOnManualImport setting when skipTailoring is omitted", async () => {
+    const { processJob } = await import("@server/pipeline/index");
+    const { setSetting } = await import("@server/repositories/settings");
+    vi.mocked(processJob).mockClear();
+    await setSetting("autoTailorOnManualImport", "0");
+
+    const res = await fetch(`${baseUrl}/api/manual-jobs/import`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        job: {
+          title: "Backend Engineer",
+          employer: "Acme",
+          jobUrl: "https://example.com/jobs/setting-default",
+          jobDescription: "Great role",
+        },
+      }),
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data.status).toBe("discovered");
+    expect(vi.mocked(processJob)).not.toHaveBeenCalled();
+  });
+
+  it("still tailors when skipTailoring is explicitly false even if setting is off", async () => {
+    const { processJob } = await import("@server/pipeline/index");
+    const { setSetting } = await import("@server/repositories/settings");
+    const { scoreJobSuitability } = await import("@server/services/scorer");
+    vi.mocked(processJob).mockClear();
+    vi.mocked(scoreJobSuitability).mockResolvedValue({
+      score: 70,
+      reason: "Fit",
+    });
+    await setSetting("autoTailorOnManualImport", "0");
+
+    const res = await fetch(`${baseUrl}/api/manual-jobs/import`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        skipTailoring: false,
+        job: {
+          title: "Backend Engineer",
+          employer: "Acme",
+          jobUrl: "https://example.com/jobs/explicit-tailor",
+          jobDescription: "Great role",
+        },
+      }),
+    });
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.data.status).toBe("processing");
+    expect(vi.mocked(processJob)).toHaveBeenCalledWith(body.data.id, {
+      analyticsOrigin: "manual_job_create",
+    });
+  });
 });

--- a/orchestrator/src/server/api/routes/manual-jobs.ts
+++ b/orchestrator/src/server/api/routes/manual-jobs.ts
@@ -10,10 +10,12 @@ import { fail, ok } from "@infra/http";
 import { logger } from "@infra/logger";
 import { processJob } from "@server/pipeline/index";
 import * as jobsRepo from "@server/repositories/jobs";
+import { getSetting } from "@server/repositories/settings";
 import { generateJobBrief } from "@server/services/job-brief";
 import { inferManualJobDetails } from "@server/services/manualJob";
 import { getProfile } from "@server/services/profile";
 import { scoreJobSuitability } from "@server/services/scorer";
+import { settingsRegistry } from "@shared/settings-registry";
 import { type Request, type Response, Router } from "express";
 import { JSDOM } from "jsdom";
 import { z } from "zod";
@@ -29,6 +31,7 @@ const manualJobInferenceSchema = z.object({
 });
 
 const manualJobImportSchema = z.object({
+  skipTailoring: z.boolean().optional(),
   job: z.object({
     source: z
       .string()
@@ -60,6 +63,19 @@ const cleanOptional = (value?: string | null) => {
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
 };
+
+async function resolveSkipTailoring(
+  explicit: boolean | undefined,
+): Promise<boolean> {
+  if (typeof explicit === "boolean") return explicit;
+  const raw = await getSetting("autoTailorOnManualImport");
+  const parsed = settingsRegistry.autoTailorOnManualImport.parse(
+    raw ?? undefined,
+  );
+  const autoTailor =
+    parsed ?? settingsRegistry.autoTailorOnManualImport.default();
+  return !autoTailor;
+}
 
 const BLOCKED_AUTOFETCH_HOSTS: Array<{
   label: string;
@@ -300,6 +316,12 @@ manualJobsRouter.post("/import", async (req: Request, res: Response) => {
       degreeRequired: cleanOptional(job.degreeRequired) ?? undefined,
       starting: cleanOptional(job.starting) ?? undefined,
     });
+
+    const skipTailoring = await resolveSkipTailoring(input.skipTailoring);
+    if (skipTailoring) {
+      ok(res, createdJob);
+      return;
+    }
 
     const processResult = await processJob(createdJob.id, {
       analyticsOrigin: "manual_job_create",

--- a/shared/src/settings-registry.ts
+++ b/shared/src/settings-registry.ts
@@ -631,6 +631,13 @@ export const settingsRegistry = {
     parse: parseBitBoolOrNull,
     serialize: serializeBitBool,
   },
+  autoTailorOnManualImport: {
+    kind: "typed" as const,
+    schema: z.boolean(),
+    default: (): boolean => true,
+    parse: parseBitBoolOrNull,
+    serialize: serializeBitBool,
+  },
   chatStyleTone: {
     kind: "typed" as const,
     schema: z.string().trim().max(100),

--- a/shared/src/testing/factories.ts
+++ b/shared/src/testing/factories.ts
@@ -244,6 +244,11 @@ export const createAppSettings = (
     default: true,
     override: null,
   },
+  autoTailorOnManualImport: {
+    value: true,
+    default: true,
+    override: null,
+  },
   chatStyleTone: {
     value: "professional",
     default: "professional",

--- a/shared/src/types/settings.ts
+++ b/shared/src/types/settings.ts
@@ -232,6 +232,7 @@ export interface AppSettings {
   jobspyCountryIndeed: Resolved<string>;
   showSponsorInfo: Resolved<boolean>;
   renderMarkdownInJobDescriptions: Resolved<boolean>;
+  autoTailorOnManualImport: Resolved<boolean>;
   chatStyleTone: Resolved<string>;
   chatStyleFormality: Resolved<string>;
   chatStyleConstraints: Resolved<string>;


### PR DESCRIPTION
## Summary
- Adds an `autoTailorOnManualImport` workspace setting (default `true`, exposed in **Settings → Display**) so manual job imports can stop running the full tailoring + PDF pipeline by default.
- Adds a per-import **"Tailor automatically after import"** checkbox in the Manual Import review step, defaulting to the workspace setting; the import button label and success toast reflect whether tailoring ran.
- Server `/api/manual-jobs/import` accepts an optional `skipTailoring` flag. When skipped, the job is created in `discovered` and the route returns immediately — no `processJob`, no async scoring, no PDF generation. Falls back to the workspace setting when the flag is omitted.
- Updates `docs-site/docs/extractors/manual.md` and `docs-site/docs/features/settings.md` to document both behavior paths and the new toggle.

Closes #564.

### Why
Importing a job currently always burns LLM tokens on tailoring + scoring + a PDF render, even when you're bulk-capturing jobs to triage later, iterating on your profile first, or planning to drive tailoring manually from the job detail view.

### Behaviour
- Workspace toggle ON (default), no per-import override → same as today.
- Workspace toggle ON, per-import override OFF → job lands in `discovered`, no LLM/PDF work.
- Workspace toggle OFF, no per-import override → job lands in `discovered` by default; check the box to tailor that one.
- Workspace toggle OFF, per-import override ON → tailoring still runs.
- Tailoring can be triggered later from the existing job detail flow.

## Test plan
- [x] `npm run check:types` clean
- [x] `npm run check:all` (biome) clean
- [x] Full vitest suite — 239 files / 1572 passing / 0 failures
- [x] New route tests for explicit skip, setting-driven default, and explicit `false` overriding an "off" setting
- [x] New UI tests for unchecking the per-import checkbox and the setting-defaults-to-off case
- [x] Manual smoke: import a job with the checkbox off and confirm it lands in Discovered without a tailored PDF
- [x] Manual smoke: flip the workspace toggle off in Settings → Display and confirm the checkbox defaults to off on the next import