### PR TITLE
Show posting date

### DIFF
--- a/extractors/jobspy/verify_date_posted.py
+++ b/extractors/jobspy/verify_date_posted.py
@@ -1,0 +1,122 @@
+import argparse
+import json
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a tiny JobSpy scrape and print date_posted coverage.",
+    )
+    parser.add_argument(
+        "--site",
+        default="indeed",
+        choices=["indeed", "linkedin", "glassdoor"],
+        help="JobSpy site to query.",
+    )
+    parser.add_argument(
+        "--search-term",
+        default="software engineer",
+        help="Search term to pass to JobSpy.",
+    )
+    parser.add_argument(
+        "--location",
+        default="London",
+        help="Location to pass to JobSpy.",
+    )
+    parser.add_argument(
+        "--country-indeed",
+        default="UK",
+        help="Country for Indeed and Glassdoor.",
+    )
+    parser.add_argument(
+        "--results-wanted",
+        type=int,
+        default=5,
+        help="Small result cap for the smoke test.",
+    )
+    parser.add_argument(
+        "--hours-old",
+        type=int,
+        default=24,
+        help="Only ask JobSpy for postings newer than this many hours.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print sample rows as JSON instead of a compact text table.",
+    )
+    return parser.parse_args()
+
+
+def compact_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        if value != value:
+            return None
+    except TypeError:
+        pass
+    text = str(value).strip()
+    return text or None
+
+
+def main() -> int:
+    args = parse_args()
+
+    from jobspy import scrape_jobs
+
+    kwargs: dict[str, Any] = {
+        "site_name": [args.site],
+        "search_term": args.search_term,
+        "location": args.location,
+        "results_wanted": args.results_wanted,
+        "hours_old": args.hours_old,
+    }
+    if args.site in {"indeed", "glassdoor"}:
+        kwargs["country_indeed"] = args.country_indeed
+
+    print("Running JobSpy with:")
+    print(json.dumps(kwargs, indent=2, sort_keys=True))
+
+    jobs = scrape_jobs(**kwargs)
+    print(f"\nRows returned: {len(jobs)}")
+    print(f"Columns: {', '.join(map(str, jobs.columns))}")
+
+    has_date_posted = "date_posted" in jobs.columns
+    print(f"Has date_posted column: {has_date_posted}")
+    if not has_date_posted:
+        return 1
+
+    non_empty = jobs["date_posted"].notna().sum()
+    print(f"Rows with date_posted: {non_empty}/{len(jobs)}")
+
+    sample_columns = [
+        column
+        for column in [
+            "site",
+            "title",
+            "company",
+            "location",
+            "date_posted",
+            "job_url",
+        ]
+        if column in jobs.columns
+    ]
+    samples = jobs[sample_columns].head(args.results_wanted).to_dict("records")
+
+    print("\nSample rows:")
+    if args.json:
+        print(json.dumps(samples, indent=2, default=str, ensure_ascii=False))
+    else:
+        for index, row in enumerate(samples, start=1):
+            title = compact_value(row.get("title")) or "(no title)"
+            company = compact_value(row.get("company")) or "(no company)"
+            posted = compact_value(row.get("date_posted")) or "(missing)"
+            site = compact_value(row.get("site")) or args.site
+            print(f"{index}. [{site}] {title} @ {company} | date_posted={posted}")
+
+    return 0 if non_empty > 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/orchestrator/src/client/components/JobHeader.test.tsx
+++ b/orchestrator/src/client/components/JobHeader.test.tsx
@@ -141,6 +141,15 @@ describe("JobHeader", () => {
     ).toBeInTheDocument();
   });
 
+  it("shows posting age when the source provides a posting date", () => {
+    renderWithRouter(
+      <JobHeader job={{ ...mockJob, datePosted: "1 hour ago" }} />,
+    );
+
+    expect(screen.getByText("Posted 1 hour ago")).toBeInTheDocument();
+    expect(screen.getByText("Source reported: 1 hour ago")).toBeInTheDocument();
+  });
+
   it("shows contextual tooltips for discovered, tracer off, and suitability score", () => {
     const jobWithTooltips = {
       ...mockJob,

--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn, formatDate, formatJobSourceLabel, sourceLabel } from "@/lib/utils";
 import { useSettings } from "../hooks/useSettings";
+import { formatPostingAgeLabel } from "../lib/job-posting-age";
 import { appliedDuplicateIndicator } from "../pages/orchestrator/constants";
 import {
   getJobStatusIndicator,
@@ -179,6 +180,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
     ? undefined
     : { jobPageBackTo: `${location.pathname}${location.search}` };
   const deadline = formatDate(job.deadline);
+  const postingAge = formatPostingAgeLabel(job.datePosted);
   const jobStatusTooltip =
     job.status === "discovered" ? (
       <p className="text-xs">Found by the pipeline. Not tailored yet.</p>
@@ -273,6 +275,16 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
               label={
                 sourceLabel[job.source] ?? formatJobSourceLabel(job.source)
               }
+            />
+          )}
+
+          {postingAge && (
+            <StatusIndicator
+              dotColor="bg-cyan-500"
+              label={postingAge.inlineLabel}
+              tooltip={postingAge.tooltip}
+              tooltipClassName="max-w-xs"
+              className="cursor-help"
             />
           )}
 

--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -164,6 +164,12 @@ const AppliedDuplicatePill: React.FC<{
   );
 };
 
+const postingAgeDotColor = {
+  fresh: "bg-emerald-500",
+  aging: "bg-amber-500",
+  old: "bg-slate-500",
+};
+
 export const JobHeader: React.FC<JobHeaderProps> = ({
   job,
   className,
@@ -280,7 +286,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
 
           {postingAge && (
             <StatusIndicator
-              dotColor="bg-cyan-500"
+              dotColor={postingAgeDotColor[postingAge.tone]}
               label={postingAge.inlineLabel}
               tooltip={postingAge.tooltip}
               tooltipClassName="max-w-xs"

--- a/orchestrator/src/client/lib/job-posting-age.test.ts
+++ b/orchestrator/src/client/lib/job-posting-age.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { formatPostingAgeLabel } from "./job-posting-age";
+import {
+  formatPostingAgeLabel,
+  getPostingDateSortValue,
+} from "./job-posting-age";
 
 const NOW = new Date("2026-05-27T12:00:00.000Z");
 
@@ -60,5 +63,19 @@ describe("formatPostingAgeLabel", () => {
 
   it("hides unrecognized source strings", () => {
     expect(formatPostingAgeLabel("not a useful date", NOW)).toBeNull();
+  });
+});
+
+describe("getPostingDateSortValue", () => {
+  it("returns timestamps for absolute posting dates", () => {
+    expect(getPostingDateSortValue("2026-05-26T12:00:00.000Z", NOW)).toBe(
+      new Date("2026-05-26T12:00:00.000Z").getTime(),
+    );
+  });
+
+  it("approximates source-provided relative posting ages", () => {
+    expect(getPostingDateSortValue("5 days ago", NOW)).toBe(
+      NOW.getTime() - 5 * 86_400_000,
+    );
   });
 });

--- a/orchestrator/src/client/lib/job-posting-age.test.ts
+++ b/orchestrator/src/client/lib/job-posting-age.test.ts
@@ -9,6 +9,7 @@ describe("formatPostingAgeLabel", () => {
       expect.objectContaining({
         label: "3h ago",
         inlineLabel: "Posted 3h ago",
+        tone: "fresh",
       }),
     );
   });
@@ -18,6 +19,7 @@ describe("formatPostingAgeLabel", () => {
       expect.objectContaining({
         label: "2d ago",
         inlineLabel: "Posted 2d ago",
+        tone: "fresh",
       }),
     );
   });
@@ -27,7 +29,33 @@ describe("formatPostingAgeLabel", () => {
       label: "1 hour ago",
       inlineLabel: "Posted 1 hour ago",
       tooltip: "Source reported: 1 hour ago",
+      tone: "fresh",
     });
+  });
+
+  it("marks jobs from 5 to 14 days old as aging", () => {
+    expect(formatPostingAgeLabel("2026-05-22", NOW)).toEqual(
+      expect.objectContaining({
+        label: "5d ago",
+        tone: "aging",
+      }),
+    );
+
+    expect(formatPostingAgeLabel("2026-05-13", NOW)).toEqual(
+      expect.objectContaining({
+        label: "2w ago",
+        tone: "aging",
+      }),
+    );
+  });
+
+  it("marks jobs from 15 days onward as old", () => {
+    expect(formatPostingAgeLabel("2026-05-12", NOW)).toEqual(
+      expect.objectContaining({
+        label: "2w ago",
+        tone: "old",
+      }),
+    );
   });
 
   it("hides unrecognized source strings", () => {

--- a/orchestrator/src/client/lib/job-posting-age.test.ts
+++ b/orchestrator/src/client/lib/job-posting-age.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { formatPostingAgeLabel } from "./job-posting-age";
+
+const NOW = new Date("2026-05-27T12:00:00.000Z");
+
+describe("formatPostingAgeLabel", () => {
+  it("formats recent ISO timestamps as hours ago", () => {
+    expect(formatPostingAgeLabel("2026-05-27T09:00:00.000Z", NOW)).toEqual(
+      expect.objectContaining({
+        label: "3h ago",
+        inlineLabel: "Posted 3h ago",
+      }),
+    );
+  });
+
+  it("formats date-only values by calendar age", () => {
+    expect(formatPostingAgeLabel("2026-05-25", NOW)).toEqual(
+      expect.objectContaining({
+        label: "2d ago",
+        inlineLabel: "Posted 2d ago",
+      }),
+    );
+  });
+
+  it("keeps source-provided relative labels when they are not parseable dates", () => {
+    expect(formatPostingAgeLabel("1 hour ago", NOW)).toEqual({
+      label: "1 hour ago",
+      inlineLabel: "Posted 1 hour ago",
+      tooltip: "Source reported: 1 hour ago",
+    });
+  });
+
+  it("hides unrecognized source strings", () => {
+    expect(formatPostingAgeLabel("not a useful date", NOW)).toBeNull();
+  });
+});

--- a/orchestrator/src/client/lib/job-posting-age.ts
+++ b/orchestrator/src/client/lib/job-posting-age.ts
@@ -61,6 +61,22 @@ function parseRelativeAgeDays(value: string): number | null {
   return null;
 }
 
+export function getPostingDateSortValue(
+  datePosted: string | null | undefined,
+  now = new Date(),
+): number | null {
+  const raw = datePosted?.trim();
+  if (!raw) return null;
+
+  const parsed = parsePostingDate(raw);
+  if (parsed) return parsed.getTime();
+
+  const ageDays = parseRelativeAgeDays(raw);
+  if (ageDays == null) return null;
+
+  return now.getTime() - ageDays * 86_400_000;
+}
+
 function plural(value: number, unit: string): string {
   return `${value}${unit}`;
 }

--- a/orchestrator/src/client/lib/job-posting-age.ts
+++ b/orchestrator/src/client/lib/job-posting-age.ts
@@ -4,7 +4,10 @@ export interface PostingAgeLabel {
   label: string;
   inlineLabel: string;
   tooltip: string;
+  tone: PostingAgeTone;
 }
+
+export type PostingAgeTone = "fresh" | "aging" | "old";
 
 const RELATIVE_SOURCE_PATTERN =
   /\b(ago|today|yesterday|minute|hour|day|week|month|year)s?\b/i;
@@ -19,6 +22,45 @@ function startOfLocalDay(date: Date): Date {
   return new Date(date.getFullYear(), date.getMonth(), date.getDate());
 }
 
+function getCalendarAgeDays(date: Date, now: Date): number {
+  return Math.max(
+    0,
+    Math.floor(
+      (startOfLocalDay(now).getTime() - startOfLocalDay(date).getTime()) /
+        86_400_000,
+    ),
+  );
+}
+
+function getPostingAgeTone(ageDays: number | null): PostingAgeTone {
+  if (ageDays === null) return "old";
+  if (ageDays <= 4) return "fresh";
+  if (ageDays <= 14) return "aging";
+  return "old";
+}
+
+function parseRelativeAgeDays(value: string): number | null {
+  const normalized = value.trim().toLowerCase();
+  if (/\btoday\b/.test(normalized)) return 0;
+  if (/\byesterday\b/.test(normalized)) return 1;
+
+  const match = /(\d+)\s*(minute|hour|day|week|month|year)s?\s+ago\b/.exec(
+    normalized,
+  );
+  if (!match) return null;
+
+  const amount = Number.parseInt(match[1] ?? "", 10);
+  if (!Number.isFinite(amount)) return null;
+
+  const unit = match[2];
+  if (unit === "minute" || unit === "hour") return 0;
+  if (unit === "day") return amount;
+  if (unit === "week") return amount * 7;
+  if (unit === "month") return amount * 30;
+  if (unit === "year") return amount * 365;
+  return null;
+}
+
 function plural(value: number, unit: string): string {
   return `${value}${unit}`;
 }
@@ -27,10 +69,7 @@ function formatRelativePostingAge(date: Date, now: Date): string {
   const elapsedMs = Math.max(0, now.getTime() - date.getTime());
   const elapsedMinutes = Math.floor(elapsedMs / 60_000);
   const elapsedHours = Math.floor(elapsedMs / 3_600_000);
-  const calendarDays = Math.floor(
-    (startOfLocalDay(now).getTime() - startOfLocalDay(date).getTime()) /
-      86_400_000,
-  );
+  const calendarDays = getCalendarAgeDays(date, now);
 
   if (elapsedMinutes < 1) return "just now";
   if (elapsedMinutes < 60) return plural(elapsedMinutes, "m ago");
@@ -57,14 +96,17 @@ export function formatPostingAgeLabel(
   const parsed = parsePostingDate(raw);
   if (!parsed) {
     if (!RELATIVE_SOURCE_PATTERN.test(raw) || raw.length > 48) return null;
+    const ageDays = parseRelativeAgeDays(raw);
     return {
       label: raw,
       inlineLabel: `Posted ${raw}`,
       tooltip: `Source reported: ${raw}`,
+      tone: getPostingAgeTone(ageDays),
     };
   }
 
   const label = formatRelativePostingAge(parsed, now);
+  const ageDays = getCalendarAgeDays(parsed, now);
   const absolute =
     raw.length === 10
       ? (formatDate(raw) ?? raw)
@@ -74,5 +116,6 @@ export function formatPostingAgeLabel(
     label,
     inlineLabel: `Posted ${label}`,
     tooltip: `Source posting date: ${absolute}`,
+    tone: getPostingAgeTone(ageDays),
   };
 }

--- a/orchestrator/src/client/lib/job-posting-age.ts
+++ b/orchestrator/src/client/lib/job-posting-age.ts
@@ -1,0 +1,78 @@
+import { formatDate, formatDateTime } from "@/lib/utils";
+
+export interface PostingAgeLabel {
+  label: string;
+  inlineLabel: string;
+  tooltip: string;
+}
+
+const RELATIVE_SOURCE_PATTERN =
+  /\b(ago|today|yesterday|minute|hour|day|week|month|year)s?\b/i;
+
+function parsePostingDate(value: string): Date | null {
+  const normalized = value.includes("T") ? value : value.replace(" ", "T");
+  const parsed = new Date(normalized);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function startOfLocalDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function plural(value: number, unit: string): string {
+  return `${value}${unit}`;
+}
+
+function formatRelativePostingAge(date: Date, now: Date): string {
+  const elapsedMs = Math.max(0, now.getTime() - date.getTime());
+  const elapsedMinutes = Math.floor(elapsedMs / 60_000);
+  const elapsedHours = Math.floor(elapsedMs / 3_600_000);
+  const calendarDays = Math.floor(
+    (startOfLocalDay(now).getTime() - startOfLocalDay(date).getTime()) /
+      86_400_000,
+  );
+
+  if (elapsedMinutes < 1) return "just now";
+  if (elapsedMinutes < 60) return plural(elapsedMinutes, "m ago");
+  if (calendarDays === 0 && elapsedHours < 24) {
+    return plural(elapsedHours, "h ago");
+  }
+  if (calendarDays === 0) return "today";
+  if (calendarDays === 1) return "yesterday";
+  if (calendarDays < 7) return plural(calendarDays, "d ago");
+  if (calendarDays < 30) return plural(Math.floor(calendarDays / 7), "w ago");
+  if (calendarDays < 365) {
+    return plural(Math.floor(calendarDays / 30), "mo ago");
+  }
+  return plural(Math.floor(calendarDays / 365), "y ago");
+}
+
+export function formatPostingAgeLabel(
+  datePosted: string | null | undefined,
+  now = new Date(),
+): PostingAgeLabel | null {
+  const raw = datePosted?.trim();
+  if (!raw) return null;
+
+  const parsed = parsePostingDate(raw);
+  if (!parsed) {
+    if (!RELATIVE_SOURCE_PATTERN.test(raw) || raw.length > 48) return null;
+    return {
+      label: raw,
+      inlineLabel: `Posted ${raw}`,
+      tooltip: `Source reported: ${raw}`,
+    };
+  }
+
+  const label = formatRelativePostingAge(parsed, now);
+  const absolute =
+    raw.length === 10
+      ? (formatDate(raw) ?? raw)
+      : (formatDateTime(parsed.toISOString()) ?? raw);
+
+  return {
+    label,
+    inlineLabel: `Posted ${label}`,
+    tooltip: `Source posting date: ${absolute}`,
+  };
+}

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.test.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.test.tsx
@@ -69,4 +69,11 @@ describe("JobPageLeftSidebar application details", () => {
     expect(screen.getByText("Applied")).toBeInTheDocument();
     expect(screen.getByText(/1 May 2026/)).toBeInTheDocument();
   });
+
+  it("shows the source posting age when available", () => {
+    renderSidebar({ datePosted: "1 hour ago" });
+
+    expect(screen.getByText("Posted")).toBeInTheDocument();
+    expect(screen.getByText("1 hour ago")).toBeInTheDocument();
+  });
 });

--- a/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageLeftSidebar.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import type React from "react";
 import { Link } from "react-router-dom";
+import { formatPostingAgeLabel } from "@/client/lib/job-posting-age";
 import { Button } from "@/components/ui/button";
 import { cn, formatDateTime } from "@/lib/utils";
 
@@ -65,6 +66,22 @@ const memoryLinks = [
   },
 ];
 
+const PostingAgeRow: React.FC<{ datePosted: Job["datePosted"] }> = ({
+  datePosted,
+}) => {
+  const postingAge = formatPostingAgeLabel(datePosted);
+  if (!postingAge) return null;
+
+  return (
+    <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
+      <span className="text-muted-foreground">Posted</span>
+      <span className="text-right font-medium" title={postingAge.tooltip}>
+        {postingAge.label}
+      </span>
+    </div>
+  );
+};
+
 export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
   job,
   activeMemoryView,
@@ -106,6 +123,7 @@ export const JobPageLeftSidebar: React.FC<JobPageLeftSidebarProps> = ({
             {job.location || "Unknown"}
           </span>
         </div>
+        <PostingAgeRow datePosted={job.datePosted} />
         <div className="flex items-start justify-between gap-4 border-t border-border/50 pt-3">
           <span className="text-muted-foreground">Found</span>
           <span className="text-right font-medium">

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
@@ -119,9 +119,9 @@ describe("OrchestratorFilters", () => {
     });
 
     fireEvent.click(screen.getByRole("combobox", { name: "Sort field" }));
-    fireEvent.click(await screen.findByText("Date"));
+    fireEvent.click(await screen.findByText("Posted"));
     expect(props.onSortChange).toHaveBeenCalledWith({
-      key: "date",
+      key: "datePosted",
       direction: "desc",
     });
 

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
@@ -1,9 +1,26 @@
 import type { JobSource } from "@shared/types.js";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ComponentProps } from "react";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { trackProductEvent } from "@/lib/analytics";
 import type { FilterTab, JobSort, SponsorFilter } from "./constants";
 import { OrchestratorFilters } from "./OrchestratorFilters";
+
+vi.mock("@/lib/analytics", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/analytics")>();
+  return {
+    ...actual,
+    trackProductEvent: vi.fn(),
+  };
+});
 
 const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
 
@@ -19,6 +36,10 @@ afterAll(() => {
     configurable: true,
     value: originalScrollIntoView,
   });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
 });
 
 const renderFilters = (
@@ -124,12 +145,28 @@ describe("OrchestratorFilters", () => {
       key: "datePosted",
       direction: "desc",
     });
+    expect(trackProductEvent).toHaveBeenCalledWith("jobs_sort_changed", {
+      sort_key: "datePosted",
+      sort_direction: "desc",
+      previous_sort_key: "score",
+      previous_sort_direction: "desc",
+      tab: "ready",
+      filtered_count_bucket: "2_5",
+    });
 
     fireEvent.click(screen.getByRole("combobox", { name: "Sort order" }));
     fireEvent.click(await screen.findByText("Smallest first"));
     expect(props.onSortChange).toHaveBeenCalledWith({
       key: "score",
       direction: "asc",
+    });
+    expect(trackProductEvent).toHaveBeenCalledWith("jobs_sort_changed", {
+      sort_key: "score",
+      sort_direction: "asc",
+      previous_sort_key: "score",
+      previous_sort_direction: "desc",
+      tab: "ready",
+      filtered_count_bucket: "2_5",
     });
   });
 

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
@@ -31,6 +31,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { bucketCount, trackProductEvent } from "@/lib/analytics";
 import { sourceLabel } from "@/lib/utils";
 import type {
   DateFilterDimension,
@@ -237,6 +238,22 @@ export const OrchestratorFilters: React.FC<OrchestratorFiltersProps> = ({
   const showSalaryMax =
     salaryFilter.mode === "at_most" || salaryFilter.mode === "between";
   const commandShortcutLabel = getDisplayKey(SHORTCUTS.search);
+
+  const applySortChange = (nextSort: JobSort) => {
+    if (nextSort.key === sort.key && nextSort.direction === sort.direction) {
+      return;
+    }
+
+    trackProductEvent("jobs_sort_changed", {
+      sort_key: nextSort.key,
+      sort_direction: nextSort.direction,
+      previous_sort_key: sort.key,
+      previous_sort_direction: sort.direction,
+      tab: activeTab,
+      filtered_count_bucket: bucketCount(filteredCount),
+    });
+    onSortChange(nextSort);
+  };
 
   return (
     <Tabs
@@ -625,7 +642,7 @@ export const OrchestratorFilters: React.FC<OrchestratorFiltersProps> = ({
                           <Select
                             value={sort.key}
                             onValueChange={(value) =>
-                              onSortChange({
+                              applySortChange({
                                 key: value as JobSort["key"],
                                 direction:
                                   defaultSortDirection[value as JobSort["key"]],
@@ -656,7 +673,7 @@ export const OrchestratorFilters: React.FC<OrchestratorFiltersProps> = ({
                           <Select
                             value={sort.direction}
                             onValueChange={(value) =>
-                              onSortChange({
+                              applySortChange({
                                 ...sort,
                                 direction: value as JobSort["direction"],
                               })

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
@@ -94,6 +94,7 @@ const salaryModeOptions: Array<{
 
 const sortFieldOrder: JobSort["key"][] = [
   "score",
+  "datePosted",
   "date",
   "discoveredAt",
   "salary",
@@ -103,7 +104,8 @@ const sortFieldOrder: JobSort["key"][] = [
 
 const sortFieldLabels: Record<JobSort["key"], string> = {
   score: "Score",
-  date: "Date",
+  datePosted: "Posted",
+  date: "Workflow date",
   discoveredAt: "Discovered",
   salary: "Salary",
   title: "Title",
@@ -149,7 +151,7 @@ const getDateRangeForPreset = (preset: Exclude<DateFilterPreset, "custom">) => {
 const getDirectionOptions = (
   key: JobSort["key"],
 ): Array<{ value: JobSort["direction"]; label: string }> => {
-  if (key === "date" || key === "discoveredAt") {
+  if (key === "date" || key === "datePosted" || key === "discoveredAt") {
     return [
       { value: "desc", label: "Most recent" },
       { value: "asc", label: "Least recent" },

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
@@ -95,7 +95,6 @@ const salaryModeOptions: Array<{
 const sortFieldOrder: JobSort["key"][] = [
   "score",
   "datePosted",
-  "date",
   "discoveredAt",
   "salary",
   "title",
@@ -105,7 +104,6 @@ const sortFieldOrder: JobSort["key"][] = [
 const sortFieldLabels: Record<JobSort["key"], string> = {
   score: "Score",
   datePosted: "Posted",
-  date: "Workflow date",
   discoveredAt: "Discovered",
   salary: "Salary",
   title: "Title",
@@ -151,7 +149,7 @@ const getDateRangeForPreset = (preset: Exclude<DateFilterPreset, "custom">) => {
 const getDirectionOptions = (
   key: JobSort["key"],
 ): Array<{ value: JobSort["direction"]; label: string }> => {
-  if (key === "date" || key === "datePosted" || key === "discoveredAt") {
+  if (key === "datePosted" || key === "discoveredAt") {
     return [
       { value: "desc", label: "Most recent" },
       { value: "asc", label: "Least recent" },

--- a/orchestrator/src/client/pages/orchestrator/constants.ts
+++ b/orchestrator/src/client/pages/orchestrator/constants.ts
@@ -83,7 +83,6 @@ export type DateFilterPreset = "7" | "14" | "30" | "90" | "custom";
 export type DateFilterDimension = "ready" | "applied" | "closed" | "discovered";
 
 export type SortKey =
-  | "date"
   | "datePosted"
   | "discoveredAt"
   | "score"
@@ -108,7 +107,6 @@ export interface SalaryFilter {
 export interface JobSort {
   key: SortKey;
   direction: SortDirection;
-  datePriority?: DateFilterDimension[];
 }
 
 export interface JobDateFilter {
@@ -127,7 +125,6 @@ export const DEFAULT_DATE_FILTER: JobDateFilter = {
 };
 
 export const sortLabels: Record<JobSort["key"], string> = {
-  date: "Workflow date",
   datePosted: "Posted",
   discoveredAt: "Discovered",
   score: "Score",
@@ -137,7 +134,6 @@ export const sortLabels: Record<JobSort["key"], string> = {
 };
 
 export const defaultSortDirection: Record<JobSort["key"], SortDirection> = {
-  date: "desc",
   datePosted: "desc",
   discoveredAt: "desc",
   score: "desc",

--- a/orchestrator/src/client/pages/orchestrator/constants.ts
+++ b/orchestrator/src/client/pages/orchestrator/constants.ts
@@ -84,6 +84,7 @@ export type DateFilterDimension = "ready" | "applied" | "closed" | "discovered";
 
 export type SortKey =
   | "date"
+  | "datePosted"
   | "discoveredAt"
   | "score"
   | "salary"
@@ -126,7 +127,8 @@ export const DEFAULT_DATE_FILTER: JobDateFilter = {
 };
 
 export const sortLabels: Record<JobSort["key"], string> = {
-  date: "Date",
+  date: "Workflow date",
+  datePosted: "Posted",
   discoveredAt: "Discovered",
   score: "Score",
   salary: "Salary",
@@ -136,6 +138,7 @@ export const sortLabels: Record<JobSort["key"], string> = {
 
 export const defaultSortDirection: Record<JobSort["key"], SortDirection> = {
   date: "desc",
+  datePosted: "desc",
   discoveredAt: "desc",
   score: "desc",
   salary: "desc",

--- a/orchestrator/src/client/pages/orchestrator/useFilteredJobs.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/useFilteredJobs.test.ts
@@ -254,6 +254,56 @@ describe("useFilteredJobs", () => {
     expect(result.current.map((job) => job.id)).toEqual(["newer", "older"]);
   });
 
+  it("sorts by posting date while keeping missing values last", () => {
+    const jobs: Job[] = [
+      {
+        ...baseJob,
+        id: "missing",
+        datePosted: null,
+      },
+      {
+        ...baseJob,
+        id: "older",
+        datePosted: "2026-05-24",
+      },
+      {
+        ...baseJob,
+        id: "newer",
+        datePosted: "2026-05-26",
+      },
+    ];
+
+    const { result, rerender } = renderHook(
+      ({ direction }: { direction: "asc" | "desc" }) =>
+        useFilteredJobs(
+          jobs,
+          "all",
+          defaultDateFilter,
+          "all",
+          "all",
+          { mode: "at_least", min: null, max: null },
+          { key: "datePosted", direction },
+        ),
+      {
+        initialProps: { direction: "desc" as "asc" | "desc" },
+      },
+    );
+
+    expect(result.current.map((job) => job.id)).toEqual([
+      "newer",
+      "older",
+      "missing",
+    ]);
+
+    rerender({ direction: "asc" });
+
+    expect(result.current.map((job) => job.id)).toEqual([
+      "older",
+      "newer",
+      "missing",
+    ]);
+  });
+
   it("falls back through the date sort priority when the primary timestamp is missing", () => {
     const jobs: Job[] = [
       {

--- a/orchestrator/src/client/pages/orchestrator/useFilteredJobs.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/useFilteredJobs.test.ts
@@ -220,40 +220,6 @@ describe("useFilteredJobs", () => {
     expect(result.current.map((job) => job.id)).toEqual(["match"]);
   });
 
-  it("sorts by date using the active date context", () => {
-    const jobs: Job[] = [
-      {
-        ...baseJob,
-        id: "older",
-        appliedAt: "2026-04-03T14:00:00.000Z",
-      },
-      {
-        ...baseJob,
-        id: "newer",
-        appliedAt: "2026-04-05T14:00:00.000Z",
-      },
-    ];
-
-    const { result } = renderHook(() =>
-      useFilteredJobs(
-        jobs,
-        "all",
-        {
-          dimensions: ["applied"],
-          startDate: null,
-          endDate: null,
-          preset: null,
-        },
-        "all",
-        "all",
-        { mode: "at_least", min: null, max: null },
-        { key: "date", direction: "desc" },
-      ),
-    );
-
-    expect(result.current.map((job) => job.id)).toEqual(["newer", "older"]);
-  });
-
   it("sorts by posting date while keeping missing values last", () => {
     const jobs: Job[] = [
       {
@@ -302,41 +268,5 @@ describe("useFilteredJobs", () => {
       "newer",
       "missing",
     ]);
-  });
-
-  it("falls back through the date sort priority when the primary timestamp is missing", () => {
-    const jobs: Job[] = [
-      {
-        ...baseJob,
-        id: "fallback",
-        appliedAt: "2026-04-05T14:00:00.000Z",
-        readyAt: null,
-      },
-      {
-        ...baseJob,
-        id: "ready",
-        readyAt: "2026-04-04T14:00:00.000Z",
-        appliedAt: "2026-04-03T14:00:00.000Z",
-      },
-    ];
-
-    const { result } = renderHook(() =>
-      useFilteredJobs(
-        jobs,
-        "all",
-        {
-          dimensions: ["ready", "applied"],
-          startDate: null,
-          endDate: null,
-          preset: null,
-        },
-        "all",
-        "all",
-        { mode: "at_least", min: null, max: null },
-        { key: "date", direction: "desc" },
-      ),
-    );
-
-    expect(result.current.map((job) => job.id)).toEqual(["fallback", "ready"]);
   });
 });

--- a/orchestrator/src/client/pages/orchestrator/useFilteredJobs.ts
+++ b/orchestrator/src/client/pages/orchestrator/useFilteredJobs.ts
@@ -17,13 +17,6 @@ const getSponsorCategory = (score: number | null): SponsorFilter => {
   return "not_found";
 };
 
-const dateSortPriorityOrder: DateFilterDimension[] = [
-  "ready",
-  "applied",
-  "closed",
-  "discovered",
-];
-
 export const useFilteredJobs = (
   jobs: JobListItem[],
   activeTab: FilterTab,
@@ -109,12 +102,7 @@ export const useFilteredJobs = (
       });
     }
 
-    const effectiveSort =
-      sort.key === "date"
-        ? { ...sort, datePriority: getDatePriority(dateFilter.dimensions) }
-        : sort;
-
-    return [...filtered].sort((a, b) => compareJobs(a, b, effectiveSort));
+    return [...filtered].sort((a, b) => compareJobs(a, b, sort));
   }, [
     jobs,
     activeTab,
@@ -139,13 +127,6 @@ const matchesDateDimension = (
   if (filter.startDate && localDate < filter.startDate) return false;
   if (filter.endDate && localDate > filter.endDate) return false;
   return true;
-};
-
-const getDatePriority = (dimensions: DateFilterDimension[]) => {
-  const enabled = dateSortPriorityOrder.filter((dimension) =>
-    dimensions.includes(dimension),
-  );
-  return enabled.length > 0 ? enabled : dateSortPriorityOrder;
 };
 
 const toLocalDateKey = (value: number): string | null => {

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorFilters.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorFilters.test.tsx
@@ -26,13 +26,13 @@ const createWrapper = (initialEntry: string) => {
 
 describe("useOrchestratorFilters", () => {
   it("parses a valid sort query param", () => {
-    const { Wrapper } = createWrapper("/ready?sort=date-asc");
+    const { Wrapper } = createWrapper("/ready?sort=datePosted-asc");
     const { result } = renderHook(() => useOrchestratorFilters(), {
       wrapper: Wrapper,
     });
 
     expect(result.current.sort).toEqual({
-      key: "date",
+      key: "datePosted",
       direction: "asc",
     });
   });

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorFilters.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorFilters.ts
@@ -26,6 +26,7 @@ const allowedSalaryModes: SalaryFilterMode[] = [
 ];
 const allowedSortKeys: JobSort["key"][] = [
   "date",
+  "datePosted",
   "discoveredAt",
   "score",
   "salary",

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorFilters.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorFilters.ts
@@ -25,7 +25,6 @@ const allowedSalaryModes: SalaryFilterMode[] = [
   "between",
 ];
 const allowedSortKeys: JobSort["key"][] = [
-  "date",
   "datePosted",
   "discoveredAt",
   "score",

--- a/orchestrator/src/client/pages/orchestrator/utils.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.ts
@@ -1,3 +1,4 @@
+import { getPostingDateSortValue } from "@client/lib/job-posting-age";
 import type { AppSettings, JobListItem, JobSource } from "@shared/types";
 import type { DateFilterDimension, FilterTab, JobSort } from "./constants";
 import {
@@ -100,6 +101,18 @@ export const compareJobs = (a: JobListItem, b: JobListItem, sort: JobSort) => {
     case "discoveredAt": {
       const aDate = dateValue(a.discoveredAt);
       const bDate = dateValue(b.discoveredAt);
+      if (aDate == null && bDate == null) {
+        value = 0;
+        break;
+      }
+      if (aDate == null) return 1;
+      if (bDate == null) return -1;
+      value = compareNumber(aDate, bDate);
+      break;
+    }
+    case "datePosted": {
+      const aDate = getPostingDateSortValue(a.datePosted);
+      const bDate = getPostingDateSortValue(b.datePosted);
       if (aDate == null && bDate == null) {
         value = 0;
         break;

--- a/orchestrator/src/client/pages/orchestrator/utils.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.ts
@@ -122,18 +122,6 @@ export const compareJobs = (a: JobListItem, b: JobListItem, sort: JobSort) => {
       value = compareNumber(aDate, bDate);
       break;
     }
-    case "date": {
-      const aDate = getSortDateValue(a, sort);
-      const bDate = getSortDateValue(b, sort);
-      if (aDate == null && bDate == null) {
-        value = 0;
-        break;
-      }
-      if (aDate == null) return 1;
-      if (bDate == null) return -1;
-      value = compareNumber(aDate, bDate);
-      break;
-    }
     default:
       value = 0;
   }
@@ -156,15 +144,6 @@ export const getJobDateValue = (
     case "discovered":
       return dateValue(job.discoveredAt);
   }
-};
-
-const getSortDateValue = (job: JobListItem, sort: JobSort): number | null => {
-  for (const dimension of sort.datePriority ?? []) {
-    const value = getJobDateValue(job, dimension);
-    if (value != null) return value;
-  }
-
-  return dateValue(job.discoveredAt);
 };
 
 export const jobMatchesQuery = (job: JobListItem, query: string) => {

--- a/orchestrator/src/lib/analytics.ts
+++ b/orchestrator/src/lib/analytics.ts
@@ -97,6 +97,14 @@ type ProductEventMap = {
     result_group: string;
     query_length_bucket: string;
   };
+  jobs_sort_changed: {
+    sort_key: string;
+    sort_direction: "asc" | "desc";
+    previous_sort_key: string;
+    previous_sort_direction: "asc" | "desc";
+    tab: string;
+    filtered_count_bucket: string;
+  };
   tracking_inbox_connect_started: {
     provider: string;
     account_key_is_default: boolean;


### PR DESCRIPTION
## Screenshots
<img width="1118" height="214" alt="image" src="https://github.com/user-attachments/assets/cdc46c36-e671-414a-821c-477ab55c8fd4" />


## Summary
- Show posting date in UI
- Allow sorting by posted date

## Caveats
- Some sources don't report a posting date accurately the biggest offender being LinkedIn this is noted in [JobSpy's](https://github.com/speedyapply/JobSpy/issues/276) issues and has not been fixed for at least the past one year...

Current extractors that don't support date posted:
- linkedin
- gradcracker
- startup.jobs
- khamsat

## Testing
- Focused client tests passed for `OrchestratorFilters`, sorting, and filter parsing
- Typecheck passed for the orchestrator workspace
- Client build passed