### PR TITLE
Fetch Hiring Cafe detail pages for full job descriptions

### DIFF
--- a/docs-site/docs/extractors/hiring-cafe.md
+++ b/docs-site/docs/extractors/hiring-cafe.md
@@ -15,7 +15,7 @@ Hiring Cafe is a browser-backed extractor that queries Hiring Cafe search APIs a
 
 Implementation split:
 
-1. `extractors/hiringcafe/src/main.ts` builds search state, calls Hiring Cafe APIs, and writes dataset JSON.
+1. `extractors/hiringcafe/src/main.ts` builds search state, calls Hiring Cafe APIs, fetches job detail pages when search hits omit full descriptions, and writes dataset JSON.
 2. `orchestrator/src/server/services/hiring-cafe.ts` runs the extractor, streams progress events, and maps rows for pipeline import.
 
 ## Why it exists
@@ -41,6 +41,7 @@ Defaults and constraints:
 - No new Hiring Cafe settings fields were added.
 - `worldwide` and `usa/ca` run in broad mode without a strict country location filter.
 - Hiring Cafe is enabled by default in source selection.
+- Full job descriptions are loaded from Hiring Cafe detail pages when the search result payload only includes summary fields.
 - The normalized job payload now preserves structured location evidence from the formatted workplace and city/state/country fields.
 - `HIRING_CAFE_DATE_FETCHED_PAST_N_DAYS` controls recency window when running extractor directly (default `7`).
 - When a city is provided via `searchCities`, Hiring Cafe uses city radius search (default `1` mile) and strict city post-filtering.

--- a/extractors/hiringcafe/src/run.ts
+++ b/extractors/hiringcafe/src/run.ts
@@ -100,9 +100,12 @@ export interface HiringCafeResult {
 }
 
 class HiringCafeChallengeError extends Error {
-  constructor() {
+  readonly challengeUrl: string;
+
+  constructor(challengeUrl = BASE_URL) {
     super("Hiring Cafe returned a challenge page instead of search data.");
     this.name = "HiringCafeChallengeError";
+    this.challengeUrl = challengeUrl;
   }
 }
 
@@ -310,13 +313,13 @@ function parseRawJobs(value: unknown): HiringCafeRawJob[] {
   );
 }
 
-function parseNextData(html: string): unknown {
+function parseNextData(html: string, challengeUrl = BASE_URL): unknown {
   const match = html.match(
     /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>\s*([\s\S]*?)\s*<\/script>/i,
   );
   if (!match) {
     if (/cloudflare|cf-browser-verification|challenge-platform/i.test(html)) {
-      throw new HiringCafeChallengeError();
+      throw new HiringCafeChallengeError(challengeUrl);
     }
     throw new Error(
       "Hiring Cafe response did not include Next.js search data.",
@@ -355,8 +358,9 @@ export function parseHiringCafeSsrPage(html: string): HiringCafeSsrPage {
 
 export function parseHiringCafeJobDetailPage(
   html: string,
+  challengeUrl = BASE_URL,
 ): HiringCafeRawJob | null {
-  const data = parseNextData(html);
+  const data = parseNextData(html, challengeUrl);
 
   const props = asRecord(asRecord(data)?.props);
   const pageProps = asRecord(props?.pageProps);
@@ -401,7 +405,7 @@ async function fetchHiringCafeSearchPage(args: {
   const body = await response.text();
   if (!response.ok) {
     if (/cloudflare|cf-browser-verification|challenge-platform/i.test(body)) {
-      throw new HiringCafeChallengeError();
+      throw new HiringCafeChallengeError(url);
     }
     const statusText = response.statusText ? ` ${response.statusText}` : "";
     throw new Error(
@@ -409,7 +413,14 @@ async function fetchHiringCafeSearchPage(args: {
     );
   }
 
-  return parseHiringCafeSsrPage(body);
+  try {
+    return parseHiringCafeSsrPage(body);
+  } catch (error) {
+    if (error instanceof HiringCafeChallengeError) {
+      throw new HiringCafeChallengeError(url);
+    }
+    throw error;
+  }
 }
 
 async function fetchHiringCafeJobDetail(args: {
@@ -432,13 +443,13 @@ async function fetchHiringCafeJobDetail(args: {
   const body = await response.text();
   if (!response.ok) {
     if (/cloudflare|cf-browser-verification|challenge-platform/i.test(body)) {
-      throw new HiringCafeChallengeError();
+      throw new HiringCafeChallengeError(url.toString());
     }
     return null;
   }
 
   try {
-    return parseHiringCafeJobDetailPage(body);
+    return parseHiringCafeJobDetailPage(body, url.toString());
   } catch (error) {
     if (error instanceof HiringCafeChallengeError) throw error;
     return null;
@@ -768,7 +779,9 @@ export async function runHiringCafe(
       jobs: [],
       error: message,
       challengeRequired:
-        error instanceof HiringCafeChallengeError ? BASE_URL : undefined,
+        error instanceof HiringCafeChallengeError
+          ? error.challengeUrl
+          : undefined,
     };
   }
 }

--- a/extractors/hiringcafe/src/run.ts
+++ b/extractors/hiringcafe/src/run.ts
@@ -15,6 +15,7 @@ import {
 import { createDefaultSearchState } from "./default-search-state.js";
 
 const BASE_URL = "https://hiring.cafe/";
+const JOB_DETAIL_BASE_URL = "https://hiring.cafe/job/";
 const DEFAULT_MAX_JOBS_PER_TERM = 200;
 const DEFAULT_SEARCH_TERM = "web developer";
 const DEFAULT_DATE_FETCHED_PAST_N_DAYS = 30;
@@ -213,18 +214,36 @@ function buildLocationEvidence(args: {
   };
 }
 
+function getHiringCafeSourceJobId(raw: HiringCafeRawJob): string | undefined {
+  return (
+    toStringOrNull(raw.id) ??
+    toStringOrNull(raw.objectID) ??
+    toStringOrNull(raw.original_source_id) ??
+    toStringOrNull(raw.requisition_id) ??
+    undefined
+  );
+}
+
+function getHiringCafeRequisitionId(raw: HiringCafeRawJob): string | null {
+  return toStringOrNull(raw.requisition_id);
+}
+
+function hasJobDescription(raw: HiringCafeRawJob): boolean {
+  const jobInformation = asRecord(raw.job_information);
+  return Boolean(toStringOrNull(jobInformation?.description));
+}
+
+function getHiringCafeDedupeKey(raw: HiringCafeRawJob): string | null {
+  return getHiringCafeSourceJobId(raw) ?? toStringOrNull(raw.apply_url);
+}
+
 function mapHiringCafeJob(raw: HiringCafeRawJob): CreateJobInput | null {
   const jobInformation = asRecord(raw.job_information);
   const processed = asRecord(raw.v5_processed_job_data);
   const companyInfo = asRecord(jobInformation?.company_info);
   const enrichedCompanyData = asRecord(raw.enriched_company_data);
 
-  const sourceJobId =
-    toStringOrNull(raw.id) ??
-    toStringOrNull(raw.objectID) ??
-    toStringOrNull(raw.original_source_id) ??
-    toStringOrNull(raw.requisition_id) ??
-    undefined;
+  const sourceJobId = getHiringCafeSourceJobId(raw);
 
   const jobUrl = toStringOrNull(raw.apply_url);
   if (!jobUrl) return null;
@@ -291,7 +310,7 @@ function parseRawJobs(value: unknown): HiringCafeRawJob[] {
   );
 }
 
-export function parseHiringCafeSsrPage(html: string): HiringCafeSsrPage {
+function parseNextData(html: string): unknown {
   const match = html.match(
     /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>\s*([\s\S]*?)\s*<\/script>/i,
   );
@@ -304,12 +323,15 @@ export function parseHiringCafeSsrPage(html: string): HiringCafeSsrPage {
     );
   }
 
-  let data: unknown;
   try {
-    data = JSON.parse(match[1] ?? "");
+    return JSON.parse(match[1] ?? "");
   } catch {
     throw new Error("Hiring Cafe Next.js search data was not valid JSON.");
   }
+}
+
+export function parseHiringCafeSsrPage(html: string): HiringCafeSsrPage {
+  const data = parseNextData(html);
 
   const props = asRecord(asRecord(data)?.props);
   const pageProps = asRecord(props?.pageProps);
@@ -329,6 +351,21 @@ export function parseHiringCafeSsrPage(html: string): HiringCafeSsrPage {
     pageSize: toNumberOrNull(pageProps.ssrPageSize),
     isLastPage: Boolean(pageProps.ssrIsLastPage),
   };
+}
+
+export function parseHiringCafeJobDetailPage(
+  html: string,
+): HiringCafeRawJob | null {
+  const data = parseNextData(html);
+
+  const props = asRecord(asRecord(data)?.props);
+  const pageProps = asRecord(props?.pageProps);
+  if (!pageProps) {
+    throw new Error("Hiring Cafe job detail data was missing page props.");
+  }
+
+  const job = asRecord(pageProps.job);
+  return job ? (job as HiringCafeRawJob) : null;
 }
 
 export function buildHiringCafeSearchUrl(args: {
@@ -373,6 +410,56 @@ async function fetchHiringCafeSearchPage(args: {
   }
 
   return parseHiringCafeSsrPage(body);
+}
+
+async function fetchHiringCafeJobDetail(args: {
+  requisitionId: string;
+  fetchImpl: typeof fetch;
+}): Promise<HiringCafeRawJob | null> {
+  const url = new URL(
+    encodeURIComponent(args.requisitionId),
+    JOB_DETAIL_BASE_URL,
+  );
+  const response = await args.fetchImpl(url.toString(), {
+    headers: {
+      accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "accept-language": "en-US,en;q=0.9",
+      "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",
+    },
+    signal: AbortSignal.timeout(20_000),
+  });
+
+  const body = await response.text();
+  if (!response.ok) {
+    if (/cloudflare|cf-browser-verification|challenge-platform/i.test(body)) {
+      throw new HiringCafeChallengeError();
+    }
+    return null;
+  }
+
+  try {
+    return parseHiringCafeJobDetailPage(body);
+  } catch (error) {
+    if (error instanceof HiringCafeChallengeError) throw error;
+    return null;
+  }
+}
+
+async function enrichHiringCafeJobWithDetail(args: {
+  rawJob: HiringCafeRawJob;
+  fetchImpl: typeof fetch;
+}): Promise<HiringCafeRawJob> {
+  if (hasJobDescription(args.rawJob)) return args.rawJob;
+
+  const requisitionId = getHiringCafeRequisitionId(args.rawJob);
+  if (!requisitionId) return args.rawJob;
+
+  const detailJob = await fetchHiringCafeJobDetail({
+    requisitionId,
+    fetchImpl: args.fetchImpl,
+  });
+
+  return detailJob ?? args.rawJob;
 }
 
 function buildCityLocationId(input: string): string {
@@ -630,12 +717,20 @@ export async function runHiringCafe(
           for (const rawJob of page.jobs) {
             if (termCollected >= maxJobsPerTerm) break;
 
-            const mapped = mapHiringCafeJob(rawJob);
+            const dedupeKey = getHiringCafeDedupeKey(rawJob);
+            if (dedupeKey && seen.has(dedupeKey)) continue;
+
+            const enrichedRawJob = await enrichHiringCafeJobWithDetail({
+              rawJob,
+              fetchImpl,
+            });
+            const mapped = mapHiringCafeJob(enrichedRawJob);
             if (!mapped) continue;
 
-            const dedupeKey = mapped.sourceJobId || mapped.jobUrl;
-            if (seen.has(dedupeKey)) continue;
-            seen.add(dedupeKey);
+            const finalDedupeKey =
+              dedupeKey ?? mapped.sourceJobId ?? mapped.jobUrl;
+            if (seen.has(finalDedupeKey)) continue;
+            seen.add(finalDedupeKey);
             jobs.push(mapped);
             termCollected += 1;
             mappedOnPage += 1;

--- a/extractors/hiringcafe/tests/run.test.ts
+++ b/extractors/hiringcafe/tests/run.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildHiringCafeSearchUrl,
+  parseHiringCafeJobDetailPage,
   parseHiringCafeSsrPage,
   runHiringCafe,
 } from "../src/run";
@@ -50,6 +51,25 @@ function createSearchHtml(hits: unknown[], isLastPage = true): string {
   `;
 }
 
+function createJobDetailHtml(job: unknown): string {
+  return `
+    <!doctype html>
+    <script id="__NEXT_DATA__" type="application/json">
+      ${JSON.stringify({
+        props: {
+          pageProps: {
+            job,
+          },
+        },
+        page: "/job/[requisitionId]",
+        query: {
+          requisitionId: "req-1",
+        },
+      })}
+    </script>
+  `;
+}
+
 function createRawJob(overrides: Record<string, unknown> = {}) {
   return {
     original_source_id: "job-1",
@@ -84,6 +104,25 @@ describe("Hiring Cafe SSR parser", () => {
     expect(page.jobs).toHaveLength(1);
     expect(page.totalCount).toBe(1);
     expect(page.isLastPage).toBe(true);
+  });
+
+  it("extracts the job payload from a rendered detail page", () => {
+    const job = createRawJob({
+      requisition_id: "req-1",
+      job_information: {
+        title: "Web Developer",
+        description: "<p>Full job description.</p>",
+      },
+    });
+
+    const parsed = parseHiringCafeJobDetailPage(createJobDetailHtml(job));
+
+    expect(parsed).toMatchObject({
+      requisition_id: "req-1",
+      job_information: expect.objectContaining({
+        description: "<p>Full job description.</p>",
+      }),
+    });
   });
 
   it("builds the public search URL with url-encoded JSON state", () => {
@@ -132,6 +171,57 @@ describe("runHiringCafe", () => {
     ]);
     expect(fetchMock).toHaveBeenCalledWith(
       expect.stringContaining("https://hiring.cafe/"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",
+        }),
+      }),
+    );
+  });
+
+  it("fetches the job detail page when the search hit omits the full description", async () => {
+    const baseJob = createRawJob();
+    const searchHit = createRawJob({
+      requisition_id: "req-1",
+      job_information: {
+        title: "Web Developer",
+      },
+      v5_processed_job_data: {
+        ...baseJob.v5_processed_job_data,
+        requirements_summary: "Short requirements summary.",
+      },
+    });
+    const detailJob = {
+      ...searchHit,
+      job_information: {
+        title: "Web Developer",
+        description: "<p>Full detail page description.</p>",
+      },
+    };
+    const fetchMock = vi.fn((url: string) => {
+      if (url === "https://hiring.cafe/job/req-1") {
+        return Promise.resolve(
+          createTextResponse(createJobDetailHtml(detailJob)),
+        );
+      }
+
+      return Promise.resolve(createTextResponse(createSearchHtml([searchHit])));
+    });
+
+    const result = await runHiringCafe({
+      searchTerms: ["web developer"],
+      country: "worldwide",
+      maxJobsPerTerm: 1,
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.jobs[0]).toMatchObject({
+      sourceJobId: "job-1",
+      jobDescription: "<p>Full detail page description.</p>",
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://hiring.cafe/job/req-1",
       expect.objectContaining({
         headers: expect.objectContaining({
           "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",

--- a/extractors/hiringcafe/tests/run.test.ts
+++ b/extractors/hiringcafe/tests/run.test.ts
@@ -230,6 +230,36 @@ describe("runHiringCafe", () => {
     );
   });
 
+  it("surfaces the challenged detail page URL when enrichment hits a challenge", async () => {
+    const searchHit = createRawJob({
+      requisition_id: "req-1",
+      job_information: {
+        title: "Web Developer",
+      },
+    });
+    const fetchMock = vi.fn((url: string) => {
+      if (url === "https://hiring.cafe/job/req-1") {
+        return Promise.resolve(
+          createTextResponse("<html>cloudflare challenge-platform</html>"),
+        );
+      }
+
+      return Promise.resolve(createTextResponse(createSearchHtml([searchHit])));
+    });
+
+    const result = await runHiringCafe({
+      searchTerms: ["web developer"],
+      country: "worldwide",
+      maxJobsPerTerm: 1,
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    expect(result).toMatchObject({
+      success: false,
+      challengeRequired: "https://hiring.cafe/job/req-1",
+    });
+  });
+
   it("serializes locality search state for strict city filters", async () => {
     const fetchMock = vi.fn((url: string) => {
       if (url.startsWith("https://nominatim.openstreetmap.org/search")) {


### PR DESCRIPTION
## Summary
- Added a second Hiring Cafe fetch against `/job/<requisition_id>` when the search payload only includes summary fields.
- Parse the job detail page `__NEXT_DATA__` and prefer the full HTML description from the detail payload.
- Preserve challenge surfacing for both search and detail requests, including the exact challenged URL.
- Updated docs to note the new description enrichment behavior.

## Testing
- Added unit coverage for detail-page parsing, description enrichment, and challenge surfacing.
- Ran the Hiring Cafe extractor tests and type checks.
- Ran repo formatting/biome checks and the full orchestrator test suite successfully.