### PR TITLE
Add saved pipeline search presets with dropdown selection

### DIFF
--- a/orchestrator/src/client/api/pipeline.ts
+++ b/orchestrator/src/client/api/pipeline.ts
@@ -1,11 +1,15 @@
 import type {
+  CreatePipelineSearchPresetInput,
   JobSource,
   LocationMatchStrictness,
   LocationSearchScope,
   PipelineProgressState,
   PipelineRun,
   PipelineRunInsights,
+  PipelineSearchPreset,
+  PipelineSearchPresetsResponse,
   PipelineStatusResponse,
+  UpdatePipelineSearchPresetInput,
 } from "@shared/types";
 import { fetchApi } from "./core";
 
@@ -61,6 +65,54 @@ export async function getPipelineRunInsights(
 ): Promise<PipelineRunInsights> {
   return fetchApi<PipelineRunInsights>(
     `/pipeline/runs/${encodeURIComponent(id)}/insights`,
+  );
+}
+
+export async function getPipelineSearchPresets(): Promise<PipelineSearchPresetsResponse> {
+  return fetchApi<PipelineSearchPresetsResponse>("/pipeline/search-presets");
+}
+
+export async function createPipelineSearchPreset(
+  input: CreatePipelineSearchPresetInput,
+): Promise<PipelineSearchPreset> {
+  return fetchApi<PipelineSearchPreset>("/pipeline/search-presets", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function updatePipelineSearchPreset(
+  id: string,
+  input: UpdatePipelineSearchPresetInput,
+): Promise<PipelineSearchPreset> {
+  return fetchApi<PipelineSearchPreset>(
+    `/pipeline/search-presets/${encodeURIComponent(id)}`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export async function markPipelineSearchPresetUsed(
+  id: string,
+): Promise<PipelineSearchPreset> {
+  return fetchApi<PipelineSearchPreset>(
+    `/pipeline/search-presets/${encodeURIComponent(id)}/used`,
+    {
+      method: "POST",
+    },
+  );
+}
+
+export async function deletePipelineSearchPreset(
+  id: string,
+): Promise<{ deleted: true }> {
+  return fetchApi<{ deleted: true }>(
+    `/pipeline/search-presets/${encodeURIComponent(id)}`,
+    {
+      method: "DELETE",
+    },
   );
 }
 

--- a/orchestrator/src/client/lib/queryKeys.ts
+++ b/orchestrator/src/client/lib/queryKeys.ts
@@ -55,6 +55,7 @@ export const queryKeys = {
     all: ["pipeline"] as const,
     status: () => [...queryKeys.pipeline.all, "status"] as const,
     runs: () => [...queryKeys.pipeline.all, "runs"] as const,
+    searchPresets: () => [...queryKeys.pipeline.all, "search-presets"] as const,
     runInsights: (id: string) =>
       [...queryKeys.pipeline.all, "run-insights", id] as const,
   },

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -24,6 +24,11 @@ Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
 vi.mock("../api", () => ({
   updateSettings: vi.fn().mockResolvedValue({}),
   runPipeline: vi.fn().mockResolvedValue({ message: "ok" }),
+  getPipelineSearchPresets: vi.fn().mockResolvedValue({ searches: [] }),
+  createPipelineSearchPreset: vi.fn().mockResolvedValue({}),
+  updatePipelineSearchPreset: vi.fn().mockResolvedValue({}),
+  markPipelineSearchPresetUsed: vi.fn().mockResolvedValue({}),
+  deletePipelineSearchPreset: vi.fn().mockResolvedValue({ deleted: true }),
   cancelPipeline: vi.fn().mockResolvedValue({
     message: "Pipeline cancellation requested",
     pipelineRunId: "run-1",

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -1,8 +1,13 @@
+import * as api from "@client/api";
 import { useKeyboardAvailability } from "@client/hooks/useKeyboardAvailability";
 import { useSettings } from "@client/hooks/useSettings";
+import { showErrorToast } from "@client/lib/error-toast";
+import { queryKeys } from "@client/lib/queryKeys";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
 import type { VirtualListHandle } from "@/client/lib/virtual-list";
 import { Button } from "@/components/ui/button";
 import { Drawer, DrawerClose, DrawerContent } from "@/components/ui/drawer";
@@ -36,6 +41,7 @@ export const OrchestratorPage: React.FC = () => {
   const { tab, jobId } = useParams<{ tab: string; jobId?: string }>();
   const navigate = useNavigate();
   const location = useLocation();
+  const queryClient = useQueryClient();
   const {
     searchParams,
     sourceFilter,
@@ -155,6 +161,67 @@ export const OrchestratorPage: React.FC = () => {
     pipelineSources,
     loadJobs,
     navigateWithContext,
+  });
+
+  const savedSearchesQuery = useQuery({
+    queryKey: queryKeys.pipeline.searchPresets(),
+    queryFn: api.getPipelineSearchPresets,
+    enabled: isRunModeModalOpen && runMode === "automatic",
+    staleTime: 30_000,
+  });
+
+  const createSavedSearchMutation = useMutation({
+    mutationFn: api.createPipelineSearchPreset,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.pipeline.searchPresets(),
+      });
+      toast.success("Saved search created");
+    },
+    onError: (error) => {
+      showErrorToast(error, "Failed to create saved search");
+    },
+  });
+
+  const updateSavedSearchMutation = useMutation({
+    mutationFn: ({
+      id,
+      input,
+    }: {
+      id: string;
+      input: Parameters<typeof api.updatePipelineSearchPreset>[1];
+    }) => api.updatePipelineSearchPreset(id, input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.pipeline.searchPresets(),
+      });
+      toast.success("Saved search updated");
+    },
+    onError: (error) => {
+      showErrorToast(error, "Failed to update saved search");
+    },
+  });
+
+  const deleteSavedSearchMutation = useMutation({
+    mutationFn: api.deletePipelineSearchPreset,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.pipeline.searchPresets(),
+      });
+      toast.success("Saved search deleted");
+    },
+    onError: (error) => {
+      showErrorToast(error, "Failed to delete saved search");
+    },
+  });
+
+  const markSavedSearchUsedMutation = useMutation({
+    mutationFn: api.markPipelineSearchPresetUsed,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.pipeline.searchPresets(),
+      });
+    },
   });
 
   const activeJobs = useFilteredJobs(
@@ -521,6 +588,22 @@ export const OrchestratorPage: React.FC = () => {
         onModeChange={setRunMode}
         onSaveAndRunAutomatic={handleSaveAndRunAutomatic}
         onManualImported={handleManualImported}
+        savedSearches={savedSearchesQuery.data?.searches ?? []}
+        isSavedSearchesLoading={savedSearchesQuery.isFetching}
+        onCreateSavedSearch={(input) =>
+          createSavedSearchMutation.mutateAsync(input)
+        }
+        onUpdateSavedSearch={(id, input) =>
+          updateSavedSearchMutation.mutateAsync({ id, input })
+        }
+        onDeleteSavedSearch={(id) =>
+          deleteSavedSearchMutation.mutateAsync(id).then(() => undefined)
+        }
+        onApplySavedSearch={(preset) =>
+          markSavedSearchUsedMutation
+            .mutateAsync(preset.id)
+            .then(() => undefined)
+        }
       />
 
       {!isDesktop && (

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
@@ -1,5 +1,5 @@
 import { createAppSettings } from "@shared/testing/factories.js";
-import type { JobSource } from "@shared/types";
+import type { JobSource, PipelineSearchPreset } from "@shared/types";
 import {
   fireEvent,
   render,
@@ -28,6 +28,41 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipContent: ({ children }: { children: React.ReactNode }) => (
     <>{children}</>
   ),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    value,
+    onValueChange,
+    disabled,
+    children,
+  }: {
+    value: string;
+    onValueChange: (value: string) => void;
+    disabled?: boolean;
+    children: React.ReactNode;
+  }) => (
+    <select
+      aria-label="Saved searches"
+      disabled={disabled}
+      value={value}
+      onChange={(event) => onValueChange(event.currentTarget.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  SelectItem: ({
+    value,
+    children,
+  }: {
+    value: string;
+    children: React.ReactNode;
+  }) => <option value={value}>{children}</option>,
 }));
 
 vi.mock("@/lib/user-location", () => ({
@@ -102,6 +137,9 @@ describe("AutomaticRunTab", () => {
     getDetectedCountryKeyMock.mockReset();
     getDetectedCountryKeyMock.mockReturnValue(null);
     ensureStorage().clear();
+    Element.prototype.hasPointerCapture ??= vi.fn(() => false);
+    Element.prototype.setPointerCapture ??= vi.fn();
+    Element.prototype.releasePointerCapture ??= vi.fn();
   });
 
   it("shows detected country as a suggestion when location settings are still defaults", () => {
@@ -557,9 +595,7 @@ describe("AutomaticRunTab", () => {
     fireEvent.focus(input);
     fireEvent.keyDown(input, { key: "Backspace" });
 
-    expect(
-      screen.getByRole("button", { name: "Remove backend engineer" }),
-    ).toBeInTheDocument();
+    expect(screen.getAllByText("backend engineer").length).toBeGreaterThan(0);
     expect(
       screen.getByRole("button", { name: "Remove frontend engineer" }),
     ).toBeInTheDocument();
@@ -1025,5 +1061,130 @@ describe("AutomaticRunTab", () => {
         /You'll get (hybrid and onsite|onsite and hybrid) jobs in Zagreb in Croatia plus remote jobs worldwide\. Likely matches are included\./i,
       ),
     ).toBeInTheDocument();
+  });
+
+  it("applies a saved pipeline search in one selection", async () => {
+    const onSetPipelineSources = vi.fn();
+    const onApplySavedSearch = vi.fn().mockResolvedValue(undefined);
+    const savedSearch: PipelineSearchPreset = {
+      id: "search-1",
+      name: "London backend",
+      createdAt: "2026-05-30T10:00:00.000Z",
+      updatedAt: "2026-05-30T10:00:00.000Z",
+      lastUsedAt: null,
+      config: {
+        searchTerms: ["backend engineer"],
+        sources: ["linkedin", "glassdoor"],
+        country: "united kingdom",
+        cityLocations: ["London"],
+        workplaceTypes: ["remote"],
+        searchScope: "selected_only",
+        matchStrictness: "exact_only",
+        topN: 5,
+        minSuitabilityScore: 75,
+        runBudget: 300,
+        automaticPresetId: "fast",
+      },
+    };
+
+    render(
+      <AutomaticRunTab
+        open
+        settings={createAppSettings({
+          jobspyCountryIndeed: {
+            value: "croatia",
+            default: "",
+            override: "croatia",
+          },
+          searchTerms: {
+            value: ["frontend engineer"],
+            default: ["frontend engineer"],
+            override: null,
+          },
+        })}
+        enabledSources={["linkedin", "glassdoor"]}
+        pipelineSources={["linkedin"]}
+        onToggleSource={vi.fn()}
+        onSetPipelineSources={onSetPipelineSources}
+        isPipelineRunning={false}
+        onSaveAndRun={vi.fn().mockResolvedValue(undefined)}
+        savedSearches={[savedSearch]}
+        onApplySavedSearch={onApplySavedSearch}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("combobox", { name: "Saved searches" }), {
+      target: { value: "search-1" },
+    });
+
+    expect(
+      screen.getByRole("button", { name: "United Kingdom" }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("backend engineer").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("London").length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: "Fast" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(onSetPipelineSources).toHaveBeenCalledWith([
+      "linkedin",
+      "glassdoor",
+    ]);
+    expect(onApplySavedSearch).toHaveBeenCalledWith(savedSearch);
+  });
+
+  it("saves the current pipeline search state", async () => {
+    const onCreateSavedSearch = vi.fn().mockResolvedValue({
+      id: "created-search",
+      name: "Croatia frontend",
+    });
+
+    render(
+      <AutomaticRunTab
+        open
+        settings={createAppSettings({
+          jobspyCountryIndeed: {
+            value: "croatia",
+            default: "",
+            override: "croatia",
+          },
+          searchTerms: {
+            value: ["frontend engineer"],
+            default: ["frontend engineer"],
+            override: null,
+          },
+          workplaceTypes: {
+            value: ["remote"],
+            default: ["remote", "hybrid", "onsite"],
+            override: ["remote"],
+          },
+        })}
+        enabledSources={["linkedin"]}
+        pipelineSources={["linkedin"]}
+        onToggleSource={vi.fn()}
+        onSetPipelineSources={vi.fn()}
+        isPipelineRunning={false}
+        onSaveAndRun={vi.fn().mockResolvedValue(undefined)}
+        onCreateSavedSearch={onCreateSavedSearch}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save as" }));
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "Croatia frontend" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(onCreateSavedSearch).toHaveBeenCalledWith({
+        name: "Croatia frontend",
+        config: expect.objectContaining({
+          country: "croatia",
+          searchTerms: ["frontend engineer"],
+          sources: ["linkedin"],
+          workplaceTypes: ["remote"],
+        }),
+      });
+    });
   });
 });

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
@@ -16,9 +16,24 @@ import {
   normalizeCountryKey,
   SUPPORTED_COUNTRY_KEYS,
 } from "@shared/location-support.js";
-import type { AppSettings, JobSource } from "@shared/types";
+import type {
+  AppSettings,
+  CreatePipelineSearchPresetInput,
+  JobSource,
+  PipelineSearchPreset,
+  PipelineSearchPresetConfig,
+  UpdatePipelineSearchPresetInput,
+} from "@shared/types";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
-import { Info, Loader2, Sparkles } from "lucide-react";
+import {
+  BookmarkPlus,
+  Check,
+  Info,
+  Loader2,
+  Save,
+  Sparkles,
+  Trash2,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import {
@@ -32,10 +47,25 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { SearchableDropdown } from "@/components/ui/searchable-dropdown";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
 import { getDetectedCountryKey } from "@/lib/user-location";
 import { sourceLabel } from "@/lib/utils";
@@ -68,6 +98,17 @@ interface AutomaticRunTabProps {
   onSetPipelineSources: (sources: JobSource[]) => void;
   isPipelineRunning: boolean;
   onSaveAndRun: (values: AutomaticRunValues) => Promise<void>;
+  savedSearches?: PipelineSearchPreset[];
+  isSavedSearchesLoading?: boolean;
+  onCreateSavedSearch?: (
+    input: CreatePipelineSearchPresetInput,
+  ) => Promise<PipelineSearchPreset>;
+  onUpdateSavedSearch?: (
+    id: string,
+    input: UpdatePipelineSearchPresetInput,
+  ) => Promise<PipelineSearchPreset>;
+  onDeleteSavedSearch?: (id: string) => Promise<void>;
+  onApplySavedSearch?: (preset: PipelineSearchPreset) => Promise<void>;
 }
 
 const DEFAULT_VALUES: AutomaticRunValues = {
@@ -247,9 +288,24 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
   onSetPipelineSources,
   isPipelineRunning,
   onSaveAndRun,
+  savedSearches = [],
+  isSavedSearchesLoading = false,
+  onCreateSavedSearch,
+  onUpdateSavedSearch,
+  onDeleteSavedSearch,
+  onApplySavedSearch,
 }) => {
   const [isSaving, setIsSaving] = useState(false);
+  const [isSavingSearch, setIsSavingSearch] = useState(false);
   const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [saveDialogMode, setSaveDialogMode] = useState<"create" | "update">(
+    "create",
+  );
+  const [saveName, setSaveName] = useState("");
+  const [selectedSavedSearchId, setSelectedSavedSearchId] = useState<
+    string | null
+  >(null);
   const prefersReducedMotion = useReducedMotion();
   const [sourceDisplayOrder, setSourceDisplayOrder] =
     useState<JobSource[]>(enabledSources);
@@ -556,6 +612,38 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
     () => summarizeLocationPreferences(values),
     [values],
   );
+  const selectedSavedSearch = useMemo(
+    () =>
+      selectedSavedSearchId
+        ? (savedSearches.find(
+            (search) => search.id === selectedSavedSearchId,
+          ) ?? null)
+        : null,
+    [savedSearches, selectedSavedSearchId],
+  );
+  const savedSearchSupportEnabled = Boolean(
+    onCreateSavedSearch ||
+      onUpdateSavedSearch ||
+      onDeleteSavedSearch ||
+      onApplySavedSearch ||
+      savedSearches.length > 0,
+  );
+  const currentSavedSearchConfig = useMemo<PipelineSearchPresetConfig>(
+    () => ({
+      searchTerms: values.searchTerms,
+      sources: pipelineSources as PipelineSearchPresetConfig["sources"],
+      country: values.country,
+      cityLocations: values.cityLocations,
+      workplaceTypes: values.workplaceTypes,
+      searchScope: values.searchScope,
+      matchStrictness: values.matchStrictness,
+      topN: values.topN,
+      minSuitabilityScore: values.minSuitabilityScore,
+      runBudget: values.runBudget,
+      automaticPresetId: selectedPreset,
+    }),
+    [pipelineSources, selectedPreset, values],
+  );
 
   const runDisabled =
     isPipelineRunning ||
@@ -612,6 +700,84 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
     }
   };
 
+  const applySavedSearch = async (preset: PipelineSearchPreset) => {
+    const config = preset.config;
+    setSelectedSavedSearchId(preset.id);
+    setSelectedPreset(config.automaticPresetId ?? "custom");
+    setValue("topN", String(config.topN), { shouldDirty: true });
+    setValue("minSuitabilityScore", String(config.minSuitabilityScore), {
+      shouldDirty: true,
+    });
+    setValue("runBudget", String(config.runBudget), { shouldDirty: true });
+    setValue("country", normalizeUiCountryKey(config.country), {
+      shouldDirty: true,
+    });
+    setValue("cityLocations", config.cityLocations, { shouldDirty: true });
+    setValue("cityLocationDraft", "");
+    setValue("workplaceTypes", normalizeWorkplaceTypes(config.workplaceTypes), {
+      shouldDirty: true,
+    });
+    setValue("searchScope", config.searchScope, { shouldDirty: true });
+    setValue("matchStrictness", config.matchStrictness, { shouldDirty: true });
+    setValue("searchTerms", config.searchTerms, { shouldDirty: true });
+    setValue("searchTermDraft", "");
+
+    const nextSources = config.sources.filter((source) =>
+      enabledSources.includes(source),
+    );
+    if (nextSources.length > 0) {
+      onSetPipelineSources(nextSources);
+    }
+
+    await onApplySavedSearch?.(preset);
+  };
+
+  const openSaveDialog = (mode: "create" | "update") => {
+    setSaveDialogMode(mode);
+    setSaveName(mode === "update" ? (selectedSavedSearch?.name ?? "") : "");
+    setSaveDialogOpen(true);
+  };
+
+  const handleSaveSearch = async () => {
+    const name = saveName.trim();
+    if (!name) return;
+
+    setIsSavingSearch(true);
+    try {
+      if (saveDialogMode === "update" && selectedSavedSearch) {
+        await onUpdateSavedSearch?.(selectedSavedSearch.id, {
+          name,
+          config: currentSavedSearchConfig,
+        });
+        setSelectedSavedSearchId(selectedSavedSearch.id);
+      } else if (onCreateSavedSearch) {
+        const created = await onCreateSavedSearch({
+          name,
+          config: currentSavedSearchConfig,
+        });
+        setSelectedSavedSearchId(created.id);
+      }
+      setSaveDialogOpen(false);
+    } finally {
+      setIsSavingSearch(false);
+    }
+  };
+
+  const handleDeleteSelectedSearch = async () => {
+    if (!selectedSavedSearch || !onDeleteSavedSearch) return;
+    const id = selectedSavedSearch.id;
+    await onDeleteSavedSearch(id);
+    setSelectedSavedSearchId(null);
+  };
+
+  useEffect(() => {
+    if (!selectedSavedSearchId) return;
+    if (savedSearches.some((search) => search.id === selectedSavedSearchId)) {
+      return;
+    }
+    setSelectedSavedSearchId(null);
+  }, [savedSearches, selectedSavedSearchId]);
+
   const countryOptions = useMemo(
     () =>
       SUPPORTED_COUNTRY_KEYS.filter(
@@ -625,7 +791,142 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
+      <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {saveDialogMode === "update"
+                ? "Update saved search"
+                : "Save search"}
+            </DialogTitle>
+            <DialogDescription>
+              Save the current pipeline search setup.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="saved-search-name">Name</Label>
+            <Input
+              id="saved-search-name"
+              value={saveName}
+              onChange={(event) => setSaveName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  void handleSaveSearch();
+                }
+              }}
+              placeholder="e.g. London platform roles"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setSaveDialogOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="gap-2"
+              disabled={isSavingSearch || saveName.trim().length === 0}
+              onClick={() => void handleSaveSearch()}
+            >
+              {isSavingSearch ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Check className="h-4 w-4" />
+              )}
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <div className="min-h-0 space-y-4 overflow-y-auto pr-1">
+        {savedSearchSupportEnabled ? (
+          <Card>
+            <CardContent className="space-y-4 pt-6">
+              <div className="grid gap-3 md:grid-cols-[120px_1fr] md:items-center">
+                <Label className="text-base font-semibold">
+                  Saved searches
+                </Label>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <Select
+                    value={selectedSavedSearchId ?? ""}
+                    onValueChange={(id) => {
+                      const preset = savedSearches.find(
+                        (search) => search.id === id,
+                      );
+                      if (preset) void applySavedSearch(preset);
+                    }}
+                    disabled={savedSearches.length === 0}
+                  >
+                    <SelectTrigger
+                      aria-label="Saved searches"
+                      className="h-9 min-w-0 flex-1"
+                    >
+                      <SelectValue
+                        placeholder={
+                          isSavedSearchesLoading
+                            ? "Loading..."
+                            : "Select saved search"
+                        }
+                      />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {savedSearches.map((search) => (
+                        <SelectItem key={search.id} value={search.id}>
+                          {search.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+
+                  <div className="flex shrink-0 flex-wrap gap-2">
+                    {onCreateSavedSearch ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="gap-2"
+                        onClick={() => openSaveDialog("create")}
+                      >
+                        <BookmarkPlus className="h-4 w-4" />
+                        Save as
+                      </Button>
+                    ) : null}
+                    {onUpdateSavedSearch && selectedSavedSearch ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline"
+                        className="gap-2"
+                        onClick={() => openSaveDialog("update")}
+                      >
+                        <Save className="h-4 w-4" />
+                        Update
+                      </Button>
+                    ) : null}
+                    {onDeleteSavedSearch && selectedSavedSearch ? (
+                      <Button
+                        type="button"
+                        size="icon"
+                        variant="ghost"
+                        aria-label="Delete saved search"
+                        title="Delete saved search"
+                        onClick={() => void handleDeleteSelectedSearch()}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+
         <Card>
           <CardContent className="space-y-6 pt-6">
             <div className="grid items-center gap-3 md:grid-cols-[120px_1fr]">

--- a/orchestrator/src/client/pages/orchestrator/RunModeModal.tsx
+++ b/orchestrator/src/client/pages/orchestrator/RunModeModal.tsx
@@ -1,6 +1,12 @@
 import type { ManualImportResult } from "@client/components/ManualImportFlow";
 import { ManualImportFlow } from "@client/components/ManualImportFlow";
-import type { AppSettings, JobSource } from "@shared/types";
+import type {
+  AppSettings,
+  CreatePipelineSearchPresetInput,
+  JobSource,
+  PipelineSearchPreset,
+  UpdatePipelineSearchPresetInput,
+} from "@shared/types";
 import type React from "react";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -28,6 +34,17 @@ interface RunModeModalProps {
   onModeChange: (mode: RunMode) => void;
   onSaveAndRunAutomatic: (values: AutomaticRunValues) => Promise<void>;
   onManualImported: (result: ManualImportResult) => Promise<void>;
+  savedSearches?: PipelineSearchPreset[];
+  isSavedSearchesLoading?: boolean;
+  onCreateSavedSearch?: (
+    input: CreatePipelineSearchPresetInput,
+  ) => Promise<PipelineSearchPreset>;
+  onUpdateSavedSearch?: (
+    id: string,
+    input: UpdatePipelineSearchPresetInput,
+  ) => Promise<PipelineSearchPreset>;
+  onDeleteSavedSearch?: (id: string) => Promise<void>;
+  onApplySavedSearch?: (preset: PipelineSearchPreset) => Promise<void>;
 }
 
 export const RunModeModal: React.FC<RunModeModalProps> = ({
@@ -43,6 +60,12 @@ export const RunModeModal: React.FC<RunModeModalProps> = ({
   onModeChange,
   onSaveAndRunAutomatic,
   onManualImported,
+  savedSearches,
+  isSavedSearchesLoading,
+  onCreateSavedSearch,
+  onUpdateSavedSearch,
+  onDeleteSavedSearch,
+  onApplySavedSearch,
 }) => {
   const isManualMode = mode === "manual";
 
@@ -83,6 +106,12 @@ export const RunModeModal: React.FC<RunModeModalProps> = ({
                 onSetPipelineSources={onSetPipelineSources}
                 isPipelineRunning={isPipelineRunning}
                 onSaveAndRun={onSaveAndRunAutomatic}
+                savedSearches={savedSearches}
+                isSavedSearchesLoading={isSavedSearchesLoading}
+                onCreateSavedSearch={onCreateSavedSearch}
+                onUpdateSavedSearch={onUpdateSavedSearch}
+                onDeleteSavedSearch={onDeleteSavedSearch}
+                onApplySavedSearch={onApplySavedSearch}
               />
             </TabsContent>
 

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -1,4 +1,5 @@
 import type { Server } from "node:http";
+import type { PipelineSearchPresetConfig } from "@shared/types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startServer, stopServer } from "./test-utils";
 
@@ -103,6 +104,194 @@ describe.sequential("Pipeline API routes", () => {
         jobsProcessed: 3,
       }),
     ]);
+  });
+
+  it("creates, applies, updates, lists, and deletes pipeline saved searches", async () => {
+    const config: PipelineSearchPresetConfig = {
+      searchTerms: ["backend engineer"],
+      sources: ["linkedin"],
+      country: "united kingdom",
+      cityLocations: ["London"],
+      workplaceTypes: ["remote", "hybrid"],
+      searchScope: "selected_only",
+      matchStrictness: "exact_only",
+      topN: 10,
+      minSuitabilityScore: 55,
+      runBudget: 250,
+      automaticPresetId: "custom",
+    };
+
+    const createRes = await fetch(`${baseUrl}/api/pipeline/search-presets`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "London backend", config }),
+    });
+    const createBody = await createRes.json();
+
+    expect(createRes.status).toBe(201);
+    expect(createBody.ok).toBe(true);
+    expect(createBody.meta.requestId).toBeTruthy();
+    expect(createBody.data).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        name: "London backend",
+        config,
+        lastUsedAt: null,
+      }),
+    );
+
+    const duplicateRes = await fetch(`${baseUrl}/api/pipeline/search-presets`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "London backend", config }),
+    });
+    const duplicateBody = await duplicateRes.json();
+    expect(duplicateRes.status).toBe(409);
+    expect(duplicateBody.error.code).toBe("CONFLICT");
+
+    const usedRes = await fetch(
+      `${baseUrl}/api/pipeline/search-presets/${createBody.data.id}/used`,
+      { method: "POST" },
+    );
+    const usedBody = await usedRes.json();
+    expect(usedRes.status).toBe(200);
+    expect(usedBody.data.lastUsedAt).toEqual(expect.any(String));
+
+    const updateRes = await fetch(
+      `${baseUrl}/api/pipeline/search-presets/${createBody.data.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: "Senior backend",
+          config: { ...config, searchTerms: ["senior backend engineer"] },
+        }),
+      },
+    );
+    const updateBody = await updateRes.json();
+    expect(updateRes.status).toBe(200);
+    expect(updateBody.data.name).toBe("Senior backend");
+    expect(updateBody.data.config.searchTerms).toEqual([
+      "senior backend engineer",
+    ]);
+
+    const listRes = await fetch(`${baseUrl}/api/pipeline/search-presets`);
+    const listBody = await listRes.json();
+    expect(listRes.status).toBe(200);
+    expect(listBody.ok).toBe(true);
+    expect(listBody.data.searches).toHaveLength(1);
+    expect(listBody.data.searches[0].name).toBe("Senior backend");
+
+    const deleteRes = await fetch(
+      `${baseUrl}/api/pipeline/search-presets/${createBody.data.id}`,
+      { method: "DELETE" },
+    );
+    const deleteBody = await deleteRes.json();
+    expect(deleteRes.status).toBe(200);
+    expect(deleteBody.data).toEqual({ deleted: true });
+
+    const missingDeleteRes = await fetch(
+      `${baseUrl}/api/pipeline/search-presets/${createBody.data.id}`,
+      { method: "DELETE" },
+    );
+    expect(missingDeleteRes.status).toBe(404);
+  });
+
+  it("scopes pipeline saved searches by tenant and user", async () => {
+    const { db, schema } = await import("@server/db");
+    const { runWithRequestContext } = await import(
+      "@server/infra/request-context"
+    );
+    const repo = await import("@server/repositories/pipeline-search-presets");
+    const config: PipelineSearchPresetConfig = {
+      searchTerms: ["platform engineer"],
+      sources: ["linkedin"],
+      country: "united states",
+      cityLocations: ["New York"],
+      workplaceTypes: ["remote"],
+      searchScope: "selected_only",
+      matchStrictness: "exact_only",
+      topN: 5,
+      minSuitabilityScore: 65,
+      runBudget: 150,
+      automaticPresetId: "fast",
+    };
+
+    await db.insert(schema.tenants).values({
+      id: "tenant-alt",
+      name: "Alt",
+      slug: "tenant-alt",
+    });
+
+    await runWithRequestContext(
+      {
+        requestId: "saved-search-user-a",
+        tenantId: "tenant_default",
+        userId: "user-a",
+      },
+      () =>
+        repo.createPipelineSearchPreset({
+          name: "Same name",
+          config,
+        }),
+    );
+    await runWithRequestContext(
+      {
+        requestId: "saved-search-user-b",
+        tenantId: "tenant_default",
+        userId: "user-b",
+      },
+      () =>
+        repo.createPipelineSearchPreset({
+          name: "Same name",
+          config,
+        }),
+    );
+    await runWithRequestContext(
+      {
+        requestId: "saved-search-tenant-alt",
+        tenantId: "tenant-alt",
+        userId: "user-a",
+      },
+      () =>
+        repo.createPipelineSearchPreset({
+          name: "Same name",
+          config,
+        }),
+    );
+
+    const userAResults = await runWithRequestContext(
+      {
+        requestId: "saved-search-list-a",
+        tenantId: "tenant_default",
+        userId: "user-a",
+      },
+      () => repo.listPipelineSearchPresets(),
+    );
+    const userBResults = await runWithRequestContext(
+      {
+        requestId: "saved-search-list-b",
+        tenantId: "tenant_default",
+        userId: "user-b",
+      },
+      () => repo.listPipelineSearchPresets(),
+    );
+    const tenantAltResults = await runWithRequestContext(
+      {
+        requestId: "saved-search-list-alt",
+        tenantId: "tenant-alt",
+        userId: "user-a",
+      },
+      () => repo.listPipelineSearchPresets(),
+    );
+
+    expect(userAResults).toHaveLength(1);
+    expect(userBResults).toHaveLength(1);
+    expect(tenantAltResults).toHaveLength(1);
+    expect(
+      new Set([userAResults[0].id, userBResults[0].id, tenantAltResults[0].id])
+        .size,
+    ).toBe(3);
   });
 
   it("returns pipeline run insights for a completed run", async () => {

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -28,6 +28,7 @@ import {
   subscribeToProgress,
 } from "@server/pipeline/index";
 import * as pipelineRepo from "@server/repositories/pipeline";
+import * as pipelineSearchPresetsRepo from "@server/repositories/pipeline-search-presets";
 import { trackCanonicalActivationEvent } from "@server/services/activation-funnel";
 import {
   buildChallengeViewerUrl,
@@ -53,6 +54,12 @@ import { z } from "zod";
 
 export const pipelineRouter = Router();
 const WORKPLACE_TYPE_VALUES = ["remote", "hybrid", "onsite"] as const;
+const pipelineSourceSchema = z.enum(
+  PIPELINE_EXTRACTOR_SOURCE_IDS as [
+    (typeof PIPELINE_EXTRACTOR_SOURCE_IDS)[number],
+    ...(typeof PIPELINE_EXTRACTOR_SOURCE_IDS)[number][],
+  ],
+);
 
 function toSelectedSourcesValue(
   sources: readonly string[] | undefined,
@@ -184,6 +191,177 @@ pipelineRouter.get("/runs", async (_req: Request, res: Response) => {
   }
 });
 
+const pipelineSearchPresetConfigSchema = z.object({
+  searchTerms: z.array(z.string().trim().min(1).max(200)).min(1).max(100),
+  sources: z.array(pipelineSourceSchema).min(1),
+  country: z.string().trim().max(100),
+  cityLocations: z.array(z.string().trim().min(1).max(100)).max(25),
+  workplaceTypes: z.array(z.enum(WORKPLACE_TYPE_VALUES)).min(1).max(3),
+  searchScope: z.enum(LOCATION_SEARCH_SCOPE_VALUES),
+  matchStrictness: z.enum(LOCATION_MATCH_STRICTNESS_VALUES),
+  topN: z.number().int().min(1).max(50),
+  minSuitabilityScore: z.number().int().min(0).max(100),
+  runBudget: z.number().int().min(50).max(1000),
+  automaticPresetId: z
+    .enum(["fast", "balanced", "detailed", "custom"])
+    .optional(),
+});
+
+const createPipelineSearchPresetSchema = z
+  .object({
+    name: z.string().trim().min(1).max(80),
+    config: pipelineSearchPresetConfigSchema,
+  })
+  .strict();
+
+const updatePipelineSearchPresetSchema = z
+  .object({
+    name: z.string().trim().min(1).max(80).optional(),
+    config: pipelineSearchPresetConfigSchema.optional(),
+  })
+  .strict()
+  .refine((value) => value.name !== undefined || value.config !== undefined, {
+    message: "Provide a name or config update",
+  });
+
+pipelineRouter.get("/search-presets", async (_req: Request, res: Response) => {
+  try {
+    ok(res, {
+      searches: await pipelineSearchPresetsRepo.listPipelineSearchPresets(),
+    });
+  } catch (error) {
+    fail(
+      res,
+      new AppError({
+        status: 500,
+        code: "INTERNAL_ERROR",
+        message: error instanceof Error ? error.message : "Unknown error",
+      }),
+    );
+  }
+});
+
+pipelineRouter.post("/search-presets", async (req: Request, res: Response) => {
+  try {
+    const input = createPipelineSearchPresetSchema.parse(req.body);
+    if (
+      await pipelineSearchPresetsRepo.pipelineSearchPresetNameExists({
+        name: input.name,
+      })
+    ) {
+      return fail(
+        res,
+        conflict("A saved search with this name already exists"),
+      );
+    }
+
+    ok(
+      res,
+      await pipelineSearchPresetsRepo.createPipelineSearchPreset(input),
+      201,
+    );
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return fail(res, badRequest(error.message, error.flatten()));
+    }
+    fail(
+      res,
+      new AppError({
+        status: 500,
+        code: "INTERNAL_ERROR",
+        message: error instanceof Error ? error.message : "Unknown error",
+      }),
+    );
+  }
+});
+
+pipelineRouter.patch(
+  "/search-presets/:id",
+  async (req: Request, res: Response) => {
+    try {
+      const input = updatePipelineSearchPresetSchema.parse(req.body);
+      if (
+        input.name !== undefined &&
+        (await pipelineSearchPresetsRepo.pipelineSearchPresetNameExists({
+          name: input.name,
+          excludingId: req.params.id,
+        }))
+      ) {
+        return fail(
+          res,
+          conflict("A saved search with this name already exists"),
+        );
+      }
+
+      const updated =
+        await pipelineSearchPresetsRepo.updatePipelineSearchPreset(
+          req.params.id,
+          input,
+        );
+      if (!updated) return fail(res, notFound("Saved search not found"));
+      ok(res, updated);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return fail(res, badRequest(error.message, error.flatten()));
+      }
+      fail(
+        res,
+        new AppError({
+          status: 500,
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "Unknown error",
+        }),
+      );
+    }
+  },
+);
+
+pipelineRouter.post(
+  "/search-presets/:id/used",
+  async (req: Request, res: Response) => {
+    try {
+      const updated =
+        await pipelineSearchPresetsRepo.markPipelineSearchPresetUsed(
+          req.params.id,
+        );
+      if (!updated) return fail(res, notFound("Saved search not found"));
+      ok(res, updated);
+    } catch (error) {
+      fail(
+        res,
+        new AppError({
+          status: 500,
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "Unknown error",
+        }),
+      );
+    }
+  },
+);
+
+pipelineRouter.delete(
+  "/search-presets/:id",
+  async (req: Request, res: Response) => {
+    try {
+      const deleted =
+        await pipelineSearchPresetsRepo.deletePipelineSearchPreset(
+          req.params.id,
+        );
+      if (deleted === 0) return fail(res, notFound("Saved search not found"));
+      ok(res, { deleted: true });
+    } catch (error) {
+      fail(
+        res,
+        new AppError({
+          status: 500,
+          code: "INTERNAL_ERROR",
+          message: error instanceof Error ? error.message : "Unknown error",
+        }),
+      );
+    }
+  },
+);
+
 /**
  * GET /api/pipeline/runs/:id/insights - Get exact and inferred metrics for a run
  */
@@ -215,17 +393,7 @@ pipelineRouter.get(
 const runPipelineSchema = z.object({
   topN: z.number().min(1).max(50).optional(),
   minSuitabilityScore: z.number().min(0).max(100).optional(),
-  sources: z
-    .array(
-      z.enum(
-        PIPELINE_EXTRACTOR_SOURCE_IDS as [
-          (typeof PIPELINE_EXTRACTOR_SOURCE_IDS)[number],
-          ...(typeof PIPELINE_EXTRACTOR_SOURCE_IDS)[number][],
-        ],
-      ),
-    )
-    .min(1)
-    .optional(),
+  sources: z.array(pipelineSourceSchema).min(1).optional(),
   runBudget: z.number().min(50).max(1000).optional(),
   searchTerms: z.array(z.string().trim().min(1)).optional(),
   country: z.string().trim().optional(),

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -317,6 +317,25 @@ const migrations = [
   `CREATE INDEX IF NOT EXISTS idx_auth_sessions_revoked_at
     ON auth_sessions(revoked_at)`,
 
+  `CREATE TABLE IF NOT EXISTS pipeline_search_presets (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL DEFAULT 'tenant_default',
+    user_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    config TEXT NOT NULL,
+    last_used_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+    UNIQUE(tenant_id, user_id, name)
+  )`,
+
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_pipeline_search_presets_tenant_user_name_unique
+    ON pipeline_search_presets(tenant_id, user_id, name)`,
+
+  `CREATE INDEX IF NOT EXISTS idx_pipeline_search_presets_tenant_user_updated
+    ON pipeline_search_presets(tenant_id, user_id, updated_at)`,
+
   `CREATE TABLE IF NOT EXISTS design_resume_documents (
     id TEXT PRIMARY KEY,
     tenant_id TEXT NOT NULL DEFAULT 'tenant_default',

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -296,6 +296,31 @@ export const pipelineRuns = sqliteTable("pipeline_runs", {
   resultSummary: text("result_summary", { mode: "json" }),
 });
 
+export const pipelineSearchPresets = sqliteTable(
+  "pipeline_search_presets",
+  {
+    id: text("id").primaryKey(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .default("tenant_default")
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").notNull(),
+    name: text("name").notNull(),
+    config: text("config", { mode: "json" }).notNull(),
+    lastUsedAt: text("last_used_at"),
+    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => ({
+    tenantUserNameUnique: uniqueIndex(
+      "idx_pipeline_search_presets_tenant_user_name_unique",
+    ).on(table.tenantId, table.userId, table.name),
+    tenantUserUpdatedIndex: index(
+      "idx_pipeline_search_presets_tenant_user_updated",
+    ).on(table.tenantId, table.userId, table.updatedAt),
+  }),
+);
+
 export const jobChatThreads = sqliteTable(
   "job_chat_threads",
   {
@@ -899,6 +924,9 @@ export type InterviewRow = typeof interviews.$inferSelect;
 export type NewInterviewRow = typeof interviews.$inferInsert;
 export type PipelineRunRow = typeof pipelineRuns.$inferSelect;
 export type NewPipelineRunRow = typeof pipelineRuns.$inferInsert;
+export type PipelineSearchPresetRow = typeof pipelineSearchPresets.$inferSelect;
+export type NewPipelineSearchPresetRow =
+  typeof pipelineSearchPresets.$inferInsert;
 export type JobChatThreadRow = typeof jobChatThreads.$inferSelect;
 export type NewJobChatThreadRow = typeof jobChatThreads.$inferInsert;
 export type JobChatMessageRow = typeof jobChatMessages.$inferSelect;

--- a/orchestrator/src/server/repositories/pipeline-search-presets.ts
+++ b/orchestrator/src/server/repositories/pipeline-search-presets.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from "node:crypto";
+import { getUserId } from "@server/infra/request-context";
+import type {
+  CreatePipelineSearchPresetInput,
+  PipelineSearchPreset,
+  PipelineSearchPresetConfig,
+  UpdatePipelineSearchPresetInput,
+} from "@shared/types";
+import { and, desc, eq, ne } from "drizzle-orm";
+import { db, schema } from "../db/index";
+import { getActiveTenantId } from "../tenancy/context";
+
+const { pipelineSearchPresets } = schema;
+
+function requireActiveUserId(): string {
+  const userId = getUserId();
+  if (!userId) {
+    throw new Error("User context is required for pipeline saved searches");
+  }
+  return userId;
+}
+
+function mapRowToSearchPreset(
+  row: typeof pipelineSearchPresets.$inferSelect,
+): PipelineSearchPreset {
+  return {
+    id: row.id,
+    name: row.name,
+    config: row.config as PipelineSearchPresetConfig,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    lastUsedAt: row.lastUsedAt,
+  };
+}
+
+export async function listPipelineSearchPresets(): Promise<
+  PipelineSearchPreset[]
+> {
+  const tenantId = getActiveTenantId();
+  const userId = requireActiveUserId();
+  const rows = await db
+    .select()
+    .from(pipelineSearchPresets)
+    .where(
+      and(
+        eq(pipelineSearchPresets.tenantId, tenantId),
+        eq(pipelineSearchPresets.userId, userId),
+      ),
+    )
+    .orderBy(
+      desc(pipelineSearchPresets.lastUsedAt),
+      desc(pipelineSearchPresets.updatedAt),
+    );
+
+  return rows.map(mapRowToSearchPreset);
+}
+
+export async function createPipelineSearchPreset(
+  input: CreatePipelineSearchPresetInput,
+): Promise<PipelineSearchPreset> {
+  const tenantId = getActiveTenantId();
+  const userId = requireActiveUserId();
+  const now = new Date().toISOString();
+  const id = randomUUID();
+
+  await db.insert(pipelineSearchPresets).values({
+    id,
+    tenantId,
+    userId,
+    name: input.name,
+    config: input.config,
+    createdAt: now,
+    updatedAt: now,
+    lastUsedAt: null,
+  });
+
+  const preset = await getPipelineSearchPreset(id);
+  if (!preset) {
+    throw new Error("Failed to retrieve created pipeline saved search");
+  }
+  return preset;
+}
+
+export async function updatePipelineSearchPreset(
+  id: string,
+  input: UpdatePipelineSearchPresetInput,
+): Promise<PipelineSearchPreset | null> {
+  const tenantId = getActiveTenantId();
+  const userId = requireActiveUserId();
+  const existing = await getPipelineSearchPreset(id);
+  if (!existing) return null;
+
+  await db
+    .update(pipelineSearchPresets)
+    .set({
+      ...(input.name !== undefined ? { name: input.name } : {}),
+      ...(input.config !== undefined ? { config: input.config } : {}),
+      updatedAt: new Date().toISOString(),
+    })
+    .where(
+      and(
+        eq(pipelineSearchPresets.tenantId, tenantId),
+        eq(pipelineSearchPresets.userId, userId),
+        eq(pipelineSearchPresets.id, id),
+      ),
+    );
+
+  return getPipelineSearchPreset(id);
+}
+
+export async function markPipelineSearchPresetUsed(
+  id: string,
+): Promise<PipelineSearchPreset | null> {
+  const tenantId = getActiveTenantId();
+  const userId = requireActiveUserId();
+  const existing = await getPipelineSearchPreset(id);
+  if (!existing) return null;
+
+  const now = new Date().toISOString();
+  await db
+    .update(pipelineSearchPresets)
+    .set({ lastUsedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(pipelineSearchPresets.tenantId, tenantId),
+        eq(pipelineSearchPresets.userId, userId),
+        eq(pipelineSearchPresets.id, id),
+      ),
+    );
+
+  return getPipelineSearchPreset(id);
+}
+
+export async function deletePipelineSearchPreset(id: string): Promise<number> {
+  const tenantId = getActiveTenantId();
+  const userId = requireActiveUserId();
+  const result = await db
+    .delete(pipelineSearchPresets)
+    .where(
+      and(
+        eq(pipelineSearchPresets.tenantId, tenantId),
+        eq(pipelineSearchPresets.userId, userId),
+        eq(pipelineSearchPresets.id, id),
+      ),
+    );
+
+  return result.changes;
+}
+
+export async function pipelineSearchPresetNameExists(input: {
+  name: string;
+  excludingId?: string;
+}): Promise<boolean> {
+  const tenantId = getActiveTenantId();
+  const userId = requireActiveUserId();
+  const clauses = [
+    eq(pipelineSearchPresets.tenantId, tenantId),
+    eq(pipelineSearchPresets.userId, userId),
+    eq(pipelineSearchPresets.name, input.name),
+  ];
+  if (input.excludingId) {
+    clauses.push(ne(pipelineSearchPresets.id, input.excludingId));
+  }
+
+  const [row] = await db
+    .select({ id: pipelineSearchPresets.id })
+    .from(pipelineSearchPresets)
+    .where(and(...clauses))
+    .limit(1);
+
+  return Boolean(row);
+}
+
+async function getPipelineSearchPreset(
+  id: string,
+): Promise<PipelineSearchPreset | null> {
+  const tenantId = getActiveTenantId();
+  const userId = requireActiveUserId();
+  const [row] = await db
+    .select()
+    .from(pipelineSearchPresets)
+    .where(
+      and(
+        eq(pipelineSearchPresets.tenantId, tenantId),
+        eq(pipelineSearchPresets.userId, userId),
+        eq(pipelineSearchPresets.id, id),
+      ),
+    )
+    .limit(1);
+
+  return row ? mapRowToSearchPreset(row) : null;
+}

--- a/shared/src/types/pipeline.ts
+++ b/shared/src/types/pipeline.ts
@@ -121,6 +121,49 @@ export interface PipelineStatusResponse {
   nextScheduledRun: string | null;
 }
 
+export type PipelineSearchPresetMode =
+  | "fast"
+  | "balanced"
+  | "detailed"
+  | "custom";
+
+export interface PipelineSearchPresetConfig {
+  searchTerms: string[];
+  sources: ExtractorSourceId[];
+  country: string;
+  cityLocations: string[];
+  workplaceTypes: Array<"remote" | "hybrid" | "onsite">;
+  searchScope: LocationSearchScope;
+  matchStrictness: LocationMatchStrictness;
+  topN: number;
+  minSuitabilityScore: number;
+  runBudget: number;
+  automaticPresetId?: PipelineSearchPresetMode;
+}
+
+export interface PipelineSearchPreset {
+  id: string;
+  name: string;
+  config: PipelineSearchPresetConfig;
+  createdAt: string;
+  updatedAt: string;
+  lastUsedAt: string | null;
+}
+
+export interface PipelineSearchPresetsResponse {
+  searches: PipelineSearchPreset[];
+}
+
+export interface CreatePipelineSearchPresetInput {
+  name: string;
+  config: PipelineSearchPresetConfig;
+}
+
+export interface UpdatePipelineSearchPresetInput {
+  name?: string;
+  config?: PipelineSearchPresetConfig;
+}
+
 export type PipelineProgressStep =
   | "idle"
   | "crawling"


### PR DESCRIPTION
## Summary
- Add tenant- and user-scoped saved pipeline search presets to persist full search state
- Expose API endpoints and client helpers to create, update, list, apply, mark used, and delete presets
- Wire the saved-search dropdown into the orchestrator pipeline settings UI and keep the selector to a single control
- Add database schema/migration support plus route, repository, and UI tests

## Testing
- Biome formatting and lint checks passed
- Type checks passed across shared and orchestrator packages
- Client build passed
- Full orchestrator test suite passed, including new saved-search coverage