### PR TITLE
[codex] Fix animated number stability

### DIFF
--- a/orchestrator/src/client/components/AnimatedNumber.stories.tsx
+++ b/orchestrator/src/client/components/AnimatedNumber.stories.tsx
@@ -1,0 +1,122 @@
+import type { Story } from "@ladle/react";
+import { Minus, Pause, Play, Plus, RotateCcw } from "lucide-react";
+import React from "react";
+import { AnimatedNumber } from "./AnimatedNumber";
+
+const CYCLE_VALUES = [92, 93, 99, 100, 8, 0, 42, 78, 122, 5, 87, 90];
+
+const buttonClassName =
+  "inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-border/70 bg-background px-3 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+const clampValue = (value: number) => Math.max(-999, Math.min(9999, value));
+
+export const Playground: Story = () => {
+  const [value, setValue] = React.useState(92);
+  const [isCycling, setIsCycling] = React.useState(true);
+  const cycleIndexRef = React.useRef(0);
+
+  React.useEffect(() => {
+    if (!isCycling) return;
+
+    const intervalId = window.setInterval(() => {
+      cycleIndexRef.current = (cycleIndexRef.current + 1) % CYCLE_VALUES.length;
+      setValue(CYCLE_VALUES[cycleIndexRef.current]);
+    }, 3000);
+
+    return () => window.clearInterval(intervalId);
+  }, [isCycling]);
+
+  const setManualValue = (nextValue: number) => {
+    setIsCycling(false);
+    setValue(clampValue(nextValue));
+  };
+
+  const reset = () => {
+    cycleIndexRef.current = 0;
+    setValue(CYCLE_VALUES[0]);
+  };
+
+  return (
+    <main className="min-h-[420px] bg-background p-6 text-foreground">
+      <section className="mx-auto flex max-w-2xl flex-col gap-6 rounded-lg border border-border bg-card p-6 shadow-sm">
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            AnimatedNumber
+          </p>
+          <div className="flex items-end justify-between gap-4">
+            <div className="text-7xl font-semibold leading-none tabular-nums">
+              <AnimatedNumber>{value}</AnimatedNumber>
+            </div>
+            <button
+              type="button"
+              className={buttonClassName}
+              onClick={() => setIsCycling((current) => !current)}
+            >
+              {isCycling ? (
+                <Pause className="h-4 w-4" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              {isCycling ? "Pause" : "Play"}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setManualValue(value - 10)}
+          >
+            <Minus className="h-4 w-4" />
+            10
+          </button>
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setManualValue(value - 1)}
+          >
+            <Minus className="h-4 w-4" />1
+          </button>
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setManualValue(value + 1)}
+          >
+            <Plus className="h-4 w-4" />1
+          </button>
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setManualValue(value + 10)}
+          >
+            <Plus className="h-4 w-4" />
+            10
+          </button>
+          <button type="button" className={buttonClassName} onClick={reset}>
+            <RotateCcw className="h-4 w-4" />
+            Reset
+          </button>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {CYCLE_VALUES.map((candidate) => (
+            <button
+              type="button"
+              key={candidate}
+              className={`${buttonClassName} justify-between`}
+              onClick={() => setManualValue(candidate)}
+            >
+              <span>{candidate}</span>
+              {candidate === value ? (
+                <span className="text-muted-foreground">active</span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+};
+
+Playground.storyName = "Playground";

--- a/orchestrator/src/client/components/AnimatedNumber.test.tsx
+++ b/orchestrator/src/client/components/AnimatedNumber.test.tsx
@@ -31,4 +31,40 @@ describe("AnimatedNumber", () => {
     const element = screen.getByRole("img");
     expect(element.getAttribute("aria-label")).toMatch(/1\.234,56/);
   });
+
+  it("keeps digit columns in stable tabular slots while values update", () => {
+    const { container, rerender } = render(
+      <AnimatedNumber>{92}</AnimatedNumber>,
+    );
+
+    rerender(<AnimatedNumber>{93}</AnimatedNumber>);
+
+    expect(screen.getByRole("img", { name: "93" })).toBeInTheDocument();
+
+    const digitSlots = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-animated-number-digit]"),
+    );
+
+    expect(digitSlots).toHaveLength(2);
+    for (const slot of digitSlots) {
+      expect(slot.style.width).toBe("1ch");
+      expect(slot.style.minWidth).toBe("1ch");
+      expect(slot.style.maxWidth).toBe("1ch");
+      expect(slot.style.flex).toBe("0 0 1ch");
+      expect(slot.style.fontVariantNumeric).toBe("tabular-nums");
+    }
+  });
+
+  it("keeps digit slots aligned when the number gains a digit", () => {
+    const { container, rerender } = render(
+      <AnimatedNumber>{99}</AnimatedNumber>,
+    );
+
+    rerender(<AnimatedNumber>{100}</AnimatedNumber>);
+
+    expect(screen.getByRole("img", { name: "100" })).toBeInTheDocument();
+    expect(
+      container.querySelectorAll("[data-animated-number-digit]"),
+    ).toHaveLength(3);
+  });
 });

--- a/orchestrator/src/client/components/AnimatedNumber.tsx
+++ b/orchestrator/src/client/components/AnimatedNumber.tsx
@@ -5,6 +5,7 @@ import {
   MotionConfig,
   motion,
   type Transition,
+  useReducedMotion,
 } from "framer-motion";
 import React from "react";
 
@@ -17,7 +18,6 @@ const MASK_IMAGE = `linear-gradient(to right, transparent 0, #000 ${MASK_WIDTH},
 
 const MASK_SIZE = `100% calc(100% - ${MASK_HEIGHT} * 2),calc(100% - ${MASK_WIDTH} * 2) 100%,${MASK_WIDTH} ${MASK_HEIGHT},${MASK_WIDTH} ${MASK_HEIGHT},${MASK_WIDTH} ${MASK_HEIGHT},${MASK_WIDTH} ${MASK_HEIGHT}`;
 
-const DigitWidthMap = new WeakMap<HTMLElement, string>();
 const JustifyContext = React.createContext<{ justify: "left" | "right" }>({
   justify: "left",
 });
@@ -34,11 +34,6 @@ function useIsFirstRender() {
   return isFirst.current;
 }
 
-function calculateEmWidth(element: HTMLElement) {
-  const { width, fontSize } = getComputedStyle(element);
-  return `${parseFloat(width) / parseFloat(fontSize)}em`;
-}
-
 function safeModulo(n: number, m: number) {
   return ((n % m) + m) % m;
 }
@@ -52,8 +47,11 @@ function NumberMask({ children }: { children: React.ReactNode }) {
         margin: `0 calc(-1 * ${MASK_WIDTH})`,
         padding: `calc(${MASK_HEIGHT} / 2) ${MASK_WIDTH}`,
         position: "relative",
-        zIndex: -1,
+        zIndex: 0,
         overflow: "clip",
+        lineHeight: 1,
+        verticalAlign: "middle",
+        contain: "layout paint",
         WebkitMaskImage: MASK_IMAGE,
         WebkitMaskSize: MASK_SIZE,
         WebkitMaskPosition:
@@ -78,8 +76,7 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
   ref,
 ) {
   const { transition } = React.useContext(MotionContext);
-  const initialRef = React.useRef(initialValue).current;
-  const isFirstRender = useIsFirstRender();
+  const shouldReduceMotion = useReducedMotion();
   const containerRef = React.useRef<HTMLSpanElement>(null);
   const elementRef = React.useRef<HTMLSpanElement>(null);
 
@@ -89,24 +86,19 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
     [],
   );
 
-  const digitRefs = React.useRef<(HTMLSpanElement | null)[]>(
-    new Array(10).fill(null),
-  );
   const isPresent = true; // Fallback context flag derived from standard layout states
   const targetValue = isPresent ? value : 0;
-
-  React.useLayoutEffect(() => {
-    const digitEl = digitRefs.current[initialRef];
-    if (containerRef.current && digitEl) {
-      containerRef.current.style.width = calculateEmWidth(digitEl);
-    }
-  }, [initialRef]);
 
   const previousValueRef = React.useRef(initialValue);
 
   React.useLayoutEffect(() => {
     if (!containerRef.current || targetValue === previousValueRef.current)
       return;
+
+    if (shouldReduceMotion) {
+      previousValueRef.current = targetValue;
+      return;
+    }
 
     const containerRect = containerRef.current.getBoundingClientRect();
     const elementRect = elementRef.current?.getBoundingClientRect();
@@ -137,52 +129,19 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
       },
     );
 
-    // Also animate the width of containerRef from the previous digit's width to the new digit's width
-    const prevDigitEl = digitRefs.current[prev];
-    const targetDigitEl = digitRefs.current[targetValue];
-    if (prevDigitEl && targetDigitEl) {
-      const prevWidth =
-        (elementRef.current && DigitWidthMap.get(elementRef.current)) ||
-        calculateEmWidth(prevDigitEl);
-      const nextWidth = calculateEmWidth(targetDigitEl);
-
-      animate(
-        containerRef.current,
-        { width: [prevWidth, nextWidth] },
-        {
-          type: "spring",
-          duration: 0.6,
-          bounce: 0,
-          ...transition,
-        },
-      );
-    }
-
     return () => {
       controls.stop();
       previousValueRef.current = targetValue;
     };
-  }, [targetValue, trend, transition]);
-
-  React.useEffect(() => {
-    const digitEl = digitRefs.current[targetValue];
-    if ((isFirstRender && initialRef === targetValue) || !digitEl) return;
-
-    const emWidth = calculateEmWidth(digitEl);
-    if (elementRef.current) {
-      DigitWidthMap.set(elementRef.current, emWidth);
-    }
-  }, [targetValue, isFirstRender, initialRef]);
+  }, [targetValue, trend, transition, shouldReduceMotion]);
 
   const renderDigitSpan = (num: number) => (
     <span
       key={num}
       style={{
         display: "inline-block",
-        padding: `calc(${MASK_HEIGHT} / 2) 0`,
-      }}
-      ref={(el) => {
-        digitRefs.current[num] = el;
+        height: "1em",
+        lineHeight: 1,
       }}
     >
       {num}
@@ -202,7 +161,19 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
       {...props}
       ref={elementRef}
       data-state={isPresent ? undefined : "exiting"}
-      style={{ display: "inline-flex", justifyContent: "center" }}
+      data-animated-number-digit
+      style={{
+        display: "inline-flex",
+        justifyContent: "center",
+        flex: "0 0 1ch",
+        width: "1ch",
+        minWidth: "1ch",
+        maxWidth: "1ch",
+        lineHeight: 1,
+        fontVariantNumeric: "tabular-nums",
+        fontFeatureSettings: '"tnum" 1',
+        overflow: "visible",
+      }}
     >
       <span
         ref={containerRef}
@@ -212,6 +183,11 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
           flexDirection: "column",
           alignItems: "center",
           position: "relative",
+          flex: "0 0 1ch",
+          width: "1ch",
+          height: "1em",
+          lineHeight: 1,
+          overflow: "visible",
         }}
       >
         {upperDigits.length > 0 && (


### PR DESCRIPTION
## Summary
- Stabilizes AnimatedNumber digit layout with fixed tabular slots instead of measured width animation.
- Adds regression coverage for digit updates and digit-count changes.
- Adds a Ladle playground for manually stepping and auto-cycling values every 3 seconds.

## Validation
- ./orchestrator/node_modules/.bin/biome ci .
- npm run check:types:shared
- npm --workspace orchestrator run check:types
- npm --workspace gradcracker-extractor run check:types
- npm --workspace ukvisajobs-extractor run check:types
- npm --workspace orchestrator run build:client
- npm --workspace orchestrator run test:run

Closes #567