### PR TITLE
Gradcracker extractor rework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,6 +154,11 @@ RUN --mount=type=cache,target=/root/.npm \
     npm install --workspaces --include-workspace-root --omit=dev \
     --no-audit --no-fund --progress=false
 
+# Browser fallbacks and the Cloudflare solver run through Node Playwright.
+# Python Playwright uses a different browser revision, so install the Node
+# Firefox binary explicitly into PLAYWRIGHT_BROWSERS_PATH.
+RUN ./node_modules/.bin/playwright install firefox
+
 FROM runtime-base AS tectonic
 
 ARG TARGETARCH

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,8 @@ RUN --mount=type=cache,target=/root/.npm \
     npm install --workspaces --include-workspace-root --include=dev \
     --no-audit --no-fund --progress=false
 
-# Fetch Camoufox binaries before copying source to keep the download cached.
+# Fetch Camoufox binaries and GeoLite data before copying source to keep the
+# downloads cached and avoid runtime GitHub calls during browser launch.
 RUN --mount=type=secret,id=github_token,required=false \
     sh -c 'GITHUB_TOKEN="$([ -f /run/secrets/github_token ] && cat /run/secrets/github_token || true)" node ./scripts/camoufox-fetch.mjs'
 

--- a/docs-site/docs/extractors/gradcracker.md
+++ b/docs-site/docs/extractors/gradcracker.md
@@ -47,7 +47,8 @@ Implementation flow:
 3. Fetch detail pages for new jobs only.
 4. Extract `.body-content` description text.
 5. Decode Gradcracker `/out/...` apply URLs from the `u` query parameter.
-6. Fall back to Playwright/Crawlee only when the HTTP path cannot proceed.
+6. Reuse saved Cloudflare clearance cookies from the headed solve flow on the HTTP retry.
+7. Fall back to Playwright/Crawlee only when the HTTP path cannot proceed.
 
 ## Common problems
 
@@ -60,6 +61,7 @@ Implementation flow:
 ### The HTTP scraper is blocked
 
 - Leave browser fallback enabled so the extractor can use the existing Playwright/Crawlee challenge handling.
+- When the app opens a challenge browser, complete the challenge and wait for the solver to save a `cf_clearance` cookie. The next HTTP retry uses that saved cookie and the same browser user agent.
 - Set `GRADCRACKER_FORCE_BROWSER=1` when you specifically need to debug the legacy browser flow.
 
 ### Apply links stay on Gradcracker

--- a/docs-site/docs/extractors/gradcracker.md
+++ b/docs-site/docs/extractors/gradcracker.md
@@ -34,7 +34,8 @@ Defaults and controls:
 - Search terms are converted to Gradcracker role slugs, such as `software systems` to `software-systems`.
 - Defaults include `web-development` and `software-systems`.
 - `GRADCRACKER_MAX_JOBS_PER_TERM` controls the per-term cap.
-- `GRADCRACKER_HTTP_DETAIL_CONCURRENCY` controls concurrent detail-page fetches. The default is `6`.
+- `GRADCRACKER_HTTP_DETAIL_CONCURRENCY` controls concurrent detail-page fetches. The default is `2`.
+- `GRADCRACKER_HTTP_REQUEST_DELAY_MS` controls the minimum delay between HTTP request starts. The default is `1000`.
 - `JOBOPS_SKIP_APPLY_FOR_EXISTING=1` and `JOBOPS_EXISTING_JOB_URLS_FILE` are still honored by the browser fallback.
 - `GRADCRACKER_FORCE_BROWSER=1` forces the legacy Playwright/Crawlee path.
 - `GRADCRACKER_DISABLE_BROWSER_FALLBACK=1` returns the HTTP scraper result directly if the fast path is blocked.

--- a/docs-site/docs/extractors/gradcracker.md
+++ b/docs-site/docs/extractors/gradcracker.md
@@ -9,40 +9,65 @@ A plain-English walkthrough of the Gradcracker extractor in `extractors/gradcrac
 
 Original website: [gradcracker.com](https://www.gradcracker.com)
 
-## Big picture
+## What it is
 
-The crawler builds search URLs, scrapes listing pages, then opens job details for descriptions and apply URLs.
+The Gradcracker extractor finds UK graduate roles from [gradcracker.com](https://www.gradcracker.com).
 
-## 1) Build search URLs
+It now uses a fast HTTP-first scraper for normal runs. The scraper fetches Gradcracker list and detail HTML with a browser-like HTTP fingerprint, parses job cards locally, and decodes Gradcracker apply links without opening a browser. The older Playwright/Crawlee flow remains as a fallback when the HTTP path is blocked.
 
-- Combines UK regions with role terms.
-- Defaults include roles such as `web-development` and `software-systems`.
-- `GRADCRACKER_SEARCH_TERMS` overrides defaults.
+## Why it exists
 
-## 2) Crawl list pages
+Gradcracker is useful for UK graduate and early-career STEM roles that broad aggregators often miss.
 
-- Waits for job cards (`article[wire:key]`).
-- Extracts title, employer, discipline, deadline, salary, location, degree, start date.
-- Queues job detail pages.
+The HTTP-first implementation keeps the same normalized job output while avoiding the startup cost of launching a browser for every successful run.
 
-Controls:
+## How to use it
 
-- `GRADCRACKER_MAX_JOBS_PER_TERM`
-- `JOBOPS_SKIP_APPLY_FOR_EXISTING=1`
-- `JOBOPS_EXISTING_JOB_URLS` / `JOBOPS_EXISTING_JOB_URLS_FILE`
+1. Open **Run jobs** and choose **Automatic**.
+2. Select **United Kingdom** as the country.
+3. Leave **Gradcracker** enabled in **Sources** or toggle it on.
+4. Set your usual search terms and run budget.
+5. Start the run and monitor progress in the pipeline progress card.
 
-## 3) Crawl detail pages
+Defaults and controls:
 
-- Waits for `.body-content`
-- Captures full description text
-- Clicks apply button to resolve final application URL
-- Handles popup and same-tab redirects
+- Search terms are converted to Gradcracker role slugs, such as `software systems` to `software-systems`.
+- Defaults include `web-development` and `software-systems`.
+- `GRADCRACKER_MAX_JOBS_PER_TERM` controls the per-term cap.
+- `GRADCRACKER_HTTP_DETAIL_CONCURRENCY` controls concurrent detail-page fetches. The default is `6`.
+- `JOBOPS_SKIP_APPLY_FOR_EXISTING=1` and `JOBOPS_EXISTING_JOB_URLS_FILE` are still honored by the browser fallback.
+- `GRADCRACKER_FORCE_BROWSER=1` forces the legacy Playwright/Crawlee path.
+- `GRADCRACKER_DISABLE_BROWSER_FALLBACK=1` returns the HTTP scraper result directly if the fast path is blocked.
 
-## 4) Progress reporting
+Implementation flow:
 
-Set `JOBOPS_EMIT_PROGRESS=1` for structured progress lines consumable by orchestrator UI.
+1. Build search URLs from UK regions and role terms.
+2. Fetch list pages and parse `article[wire:key]` job cards.
+3. Fetch detail pages for new jobs only.
+4. Extract `.body-content` description text.
+5. Decode Gradcracker `/out/...` apply URLs from the `u` query parameter.
+6. Fall back to Playwright/Crawlee only when the HTTP path cannot proceed.
 
-## Notes
+## Common problems
 
-- Uses Playwright + Crawlee via Camoufox.
-- Low concurrency and longer timeouts for stability.
+### Gradcracker does not return jobs
+
+- Confirm the selected country is **United Kingdom**.
+- Try Gradcracker-specific terms such as `software systems`, `web development`, or `data science`.
+- Lower the run budget if a term is too broad and you only need the newest listings.
+
+### The HTTP scraper is blocked
+
+- Leave browser fallback enabled so the extractor can use the existing Playwright/Crawlee challenge handling.
+- Set `GRADCRACKER_FORCE_BROWSER=1` when you specifically need to debug the legacy browser flow.
+
+### Apply links stay on Gradcracker
+
+- Some listings may not expose a decodable `/out/...` target.
+- The extractor still stores the Gradcracker job URL, so those postings remain usable even when the final application URL is unavailable.
+
+## Related pages
+
+- [Extractors Overview](/docs/next/extractors/overview)
+- [Pipeline Run](/docs/next/features/pipeline-run)
+- [Add an Extractor](/docs/next/workflows/add-an-extractor)

--- a/extractors/browser-utils/package.json
+++ b/extractors/browser-utils/package.json
@@ -10,7 +10,8 @@
     "./*": "./src/*"
   },
   "dependencies": {
-    "camoufox-js": "^0.9.2"
+    "camoufox-js": "^0.9.2",
+    "tough-cookie": "^6.0.1"
   },
   "peerDependencies": {
     "playwright": "*"

--- a/extractors/browser-utils/src/cookies.ts
+++ b/extractors/browser-utils/src/cookies.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import type { BrowserContext, Cookie } from "playwright";
+import type { BrowserContext, Cookie as PlaywrightCookie } from "playwright";
+import { CookieJar as ToughCookieJar } from "tough-cookie";
 
 /**
  * Cookies worth persisting — CF clearance and common session cookies.
@@ -20,13 +21,24 @@ const DATA_DIR_COOKIE_STORAGE_DIRNAME = "cloudflare-cookies";
 interface PersistedCookieJar {
   extractorId: string;
   savedAt: string;
-  cookies: Cookie[];
+  cookies: PlaywrightCookie[];
   userAgent?: string;
 }
 
 export interface CookieJarInfo {
   hasCookies: boolean;
+  hasClearanceCookie: boolean;
+  cookieCount: number;
   userAgent?: string;
+}
+
+export interface FetchCookieJar {
+  setCookie: (cookie: string, url: string) => Promise<void> | void;
+  getCookieString: (url: string) => Promise<string> | string;
+}
+
+export interface PersistedFetchCookieJarInfo extends CookieJarInfo {
+  cookieJar: FetchCookieJar;
 }
 
 export function getCloudflareCookieStorageDir(storageDir?: string): string {
@@ -42,11 +54,60 @@ function cookiePath(storageDir: string, extractorId: string): string {
   return join(storageDir, `${extractorId}-cookies.json`);
 }
 
-function isExpired(cookie: Cookie): boolean {
+function isExpired(cookie: PlaywrightCookie): boolean {
   // expires = -1 means session cookie (no expiry) — keep it, it's still valid
   // for the current process lifetime
-  if (cookie.expires === -1) return false;
+  if (typeof cookie.expires !== "number" || cookie.expires === -1) {
+    return false;
+  }
   return cookie.expires < Date.now() / 1000;
+}
+
+function hasClearanceCookie(cookies: PlaywrightCookie[]): boolean {
+  return cookies.some((cookie) => cookie.name === "cf_clearance");
+}
+
+async function readPersistedCookieJar(
+  extractorId: string,
+  storageDir?: string,
+): Promise<PersistedCookieJar | null> {
+  const path = cookiePath(
+    getCloudflareCookieStorageDir(storageDir),
+    extractorId,
+  );
+
+  try {
+    const data = await readFile(path, "utf-8");
+    return JSON.parse(data) as PersistedCookieJar;
+  } catch {
+    return null;
+  }
+}
+
+function getValidCookies(jar: PersistedCookieJar): PlaywrightCookie[] {
+  return Array.isArray(jar.cookies)
+    ? jar.cookies.filter((cookie) => !isExpired(cookie))
+    : [];
+}
+
+function cookieOriginUrl(cookie: PlaywrightCookie): string {
+  const protocol = cookie.secure ? "https" : "http";
+  const domain = cookie.domain.replace(/^\./, "") || "localhost";
+  const path = cookie.path?.startsWith("/") ? cookie.path : "/";
+  return `${protocol}://${domain}${path}`;
+}
+
+function toSetCookieHeader(cookie: PlaywrightCookie): string {
+  const parts = [`${cookie.name}=${cookie.value}`];
+  if (cookie.domain) parts.push(`Domain=${cookie.domain}`);
+  if (cookie.path) parts.push(`Path=${cookie.path}`);
+  if (typeof cookie.expires === "number" && cookie.expires !== -1) {
+    parts.push(`Expires=${new Date(cookie.expires * 1000).toUTCString()}`);
+  }
+  if (cookie.httpOnly) parts.push("HttpOnly");
+  if (cookie.secure) parts.push("Secure");
+  if (cookie.sameSite) parts.push(`SameSite=${cookie.sameSite}`);
+  return parts.join("; ");
 }
 
 /**
@@ -61,7 +122,7 @@ export async function saveCookies(
   context: BrowserContext,
   extractorId: string,
   storageDir?: string,
-): Promise<void> {
+): Promise<number> {
   const resolvedStorageDir = getCloudflareCookieStorageDir(storageDir);
   const allCookies = await context.cookies();
 
@@ -73,7 +134,7 @@ export async function saveCookies(
       c.name.toLowerCase().includes("auth"),
   );
 
-  if (relevant.length === 0) return;
+  if (relevant.length === 0) return 0;
 
   // Auto-capture the browser's User-Agent so headless retries can reuse it.
   // CF ties cf_clearance to the UA + TLS fingerprint — without matching UA
@@ -95,6 +156,7 @@ export async function saveCookies(
   const path = cookiePath(resolvedStorageDir, extractorId);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(path, JSON.stringify(jar, null, 2));
+  return relevant.length;
 }
 
 /**
@@ -144,21 +206,56 @@ export async function readCookieJar(
   extractorId: string,
   storageDir?: string,
 ): Promise<CookieJarInfo> {
-  const path = cookiePath(
-    getCloudflareCookieStorageDir(storageDir),
-    extractorId,
-  );
+  const jar = await readPersistedCookieJar(extractorId, storageDir);
 
-  let jar: PersistedCookieJar;
-  try {
-    const data = await readFile(path, "utf-8");
-    jar = JSON.parse(data) as PersistedCookieJar;
-  } catch {
-    return { hasCookies: false };
+  if (!jar) {
+    return { hasCookies: false, hasClearanceCookie: false, cookieCount: 0 };
   }
 
-  const hasValid = jar.cookies.some((c) => !isExpired(c));
-  return { hasCookies: hasValid, userAgent: jar.userAgent };
+  const valid = getValidCookies(jar);
+  return {
+    hasCookies: valid.length > 0,
+    hasClearanceCookie: hasClearanceCookie(valid),
+    cookieCount: valid.length,
+    userAgent: jar.userAgent,
+  };
+}
+
+/**
+ * Creates a Fetch-compatible cookie jar from cookies saved by Playwright.
+ * HTTP extractors can pass this to clients such as `impit` so the headed
+ * challenge solve and the fast HTTP retry share the same Cloudflare session.
+ */
+export async function createPersistedFetchCookieJar(
+  extractorId: string,
+  storageDir?: string,
+): Promise<PersistedFetchCookieJarInfo> {
+  const toughJar = new ToughCookieJar();
+  const persistedJar = await readPersistedCookieJar(extractorId, storageDir);
+  const validCookies = persistedJar ? getValidCookies(persistedJar) : [];
+
+  for (const cookie of validCookies) {
+    await toughJar.setCookie(
+      toSetCookieHeader(cookie),
+      cookieOriginUrl(cookie),
+      {
+        ignoreError: true,
+      },
+    );
+  }
+
+  return {
+    hasCookies: validCookies.length > 0,
+    hasClearanceCookie: hasClearanceCookie(validCookies),
+    cookieCount: validCookies.length,
+    userAgent: persistedJar?.userAgent,
+    cookieJar: {
+      setCookie: async (cookie, url) => {
+        await toughJar.setCookie(cookie, url, { ignoreError: true });
+      },
+      getCookieString: (url) => toughJar.getCookieString(url),
+    },
+  };
 }
 
 /**

--- a/extractors/browser-utils/src/index.ts
+++ b/extractors/browser-utils/src/index.ts
@@ -5,9 +5,8 @@
  * needs to handle Cloudflare WAF challenges, retry transient failures, or
  * persist cookies between runs.
  *
- * NOT for: HTTP-only extractors (adzuna, startupjobs) or Python-based
- * extractors (jobspy). Those don't use Playwright and can't benefit from
- * browser-level anti-detection.
+ * HTTP extractors can also reuse the persisted cookie-jar helpers when a
+ * headed challenge solve needs to carry over to a fetch-based retry.
  */
 
 export {
@@ -19,9 +18,12 @@ export {
 } from "./challenge.js";
 export {
   type CookieJarInfo,
+  createPersistedFetchCookieJar,
+  type FetchCookieJar,
   getCloudflareCookieStorageDir,
   invalidateCookies,
   loadCookies,
+  type PersistedFetchCookieJarInfo,
   readCookieJar,
   saveCookies,
 } from "./cookies.js";

--- a/extractors/browser-utils/src/solver.ts
+++ b/extractors/browser-utils/src/solver.ts
@@ -1,12 +1,32 @@
 import type { BrowserContext } from "playwright";
 import { isChallengePage } from "./challenge.js";
-import { saveCookies } from "./cookies.js";
+import { readCookieJar, saveCookies } from "./cookies.js";
 import { createLaunchOptions } from "./launch.js";
 
 export type SolverResult =
-  | { status: "solved" }
+  | { status: "solved"; cookiesSaved: number }
   | { status: "timeout" }
   | { status: "error"; message: string };
+
+function noReusableCookiesError(): SolverResult {
+  return {
+    status: "error",
+    message:
+      "Challenge appeared solved, but no reusable Cloudflare clearance cookie was saved.",
+  };
+}
+
+async function saveReusableCookies(
+  context: BrowserContext,
+  extractorId: string,
+  storageDir: string,
+): Promise<number | null> {
+  const cookiesSaved = await saveCookies(context, extractorId, storageDir);
+  if (cookiesSaved === 0) return null;
+
+  const jar = await readCookieJar(extractorId, storageDir);
+  return jar.hasClearanceCookie ? cookiesSaved : null;
+}
 
 const SOLVED_PAGE = `data:text/html,${encodeURIComponent(`<!DOCTYPE html>
 <html><head><style>
@@ -63,9 +83,14 @@ export async function solveChallenge(
     // If there's no challenge, we're done — save cookies anyway since the
     // browser session established a valid cf_clearance
     if (!(await isChallengePage(page))) {
-      await saveCookies(context, extractorId, storageDir);
+      const cookiesSaved = await saveReusableCookies(
+        context,
+        extractorId,
+        storageDir,
+      );
+      if (cookiesSaved === null) return noReusableCookiesError();
       await showSolvedPage(page);
-      return { status: "solved" };
+      return { status: "solved", cookiesSaved };
     }
 
     // Poll until the challenge is resolved or timeout
@@ -76,9 +101,14 @@ export async function solveChallenge(
       await page.waitForTimeout(pollInterval);
 
       if (!(await isChallengePage(page))) {
-        await saveCookies(context, extractorId, storageDir);
+        const cookiesSaved = await saveReusableCookies(
+          context,
+          extractorId,
+          storageDir,
+        );
+        if (cookiesSaved === null) return noReusableCookiesError();
         await showSolvedPage(page);
-        return { status: "solved" };
+        return { status: "solved", cookiesSaved };
       }
     }
 

--- a/extractors/browser-utils/tests/cookies.test.ts
+++ b/extractors/browser-utils/tests/cookies.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  createPersistedFetchCookieJar,
   getCloudflareCookieStorageDir,
   invalidateCookies,
   readCookieJar,
@@ -80,7 +81,11 @@ describe("cookies", () => {
     it("returns hasCookies false when no file exists", async () => {
       const dir = storageDir();
       const result = await readCookieJar("nonexistent", dir);
-      expect(result).toEqual({ hasCookies: false });
+      expect(result).toEqual({
+        hasCookies: false,
+        hasClearanceCookie: false,
+        cookieCount: 0,
+      });
     });
 
     it("returns saved userAgent and hasCookies true", async () => {
@@ -91,6 +96,8 @@ describe("cookies", () => {
 
       const result = await readCookieJar("hiringcafe", dir);
       expect(result.hasCookies).toBe(true);
+      expect(result.hasClearanceCookie).toBe(true);
+      expect(result.cookieCount).toBe(1);
       expect(result.userAgent).toBe("Mozilla/5.0 SolverUA");
     });
 
@@ -114,6 +121,8 @@ describe("cookies", () => {
 
       const result = await readCookieJar("hiringcafe", dir);
       expect(result.hasCookies).toBe(false);
+      expect(result.hasClearanceCookie).toBe(false);
+      expect(result.cookieCount).toBe(0);
       // UA is still returned — caller decides whether to use it
       expect(result.userAgent).toBe("Mozilla/5.0 StaleUA");
     });
@@ -124,6 +133,7 @@ describe("cookies", () => {
 
       const result = await readCookieJar("gradcracker", dir);
       expect(result.hasCookies).toBe(true);
+      expect(result.hasClearanceCookie).toBe(true);
       expect(result.userAgent).toBeUndefined();
     });
   });
@@ -160,7 +170,7 @@ describe("cookies", () => {
         "Mozilla/5.0 Camoufox/123",
       );
 
-      await saveCookies(ctx, "test-extractor", dir);
+      await expect(saveCookies(ctx, "test-extractor", dir)).resolves.toBe(1);
 
       const jar = await readCookieJar("test-extractor", dir);
       expect(jar.hasCookies).toBe(true);
@@ -185,7 +195,7 @@ describe("cookies", () => {
         pages: () => [],
       } as unknown as import("playwright").BrowserContext;
 
-      await saveCookies(ctx, "no-pages", dir);
+      await expect(saveCookies(ctx, "no-pages", dir)).resolves.toBe(1);
 
       const jar = await readCookieJar("no-pages", dir);
       expect(jar.hasCookies).toBe(true);
@@ -196,10 +206,47 @@ describe("cookies", () => {
       const dir = storageDir();
       const ctx = mockContext([{ name: "irrelevant_cookie" }]);
 
-      await saveCookies(ctx, "empty", dir);
+      await expect(saveCookies(ctx, "empty", dir)).resolves.toBe(0);
 
       const jar = await readCookieJar("empty", dir);
       expect(jar.hasCookies).toBe(false);
+    });
+  });
+
+  describe("createPersistedFetchCookieJar", () => {
+    it("replays saved Playwright cookies through a Fetch-compatible jar", async () => {
+      const dir = storageDir();
+      writeCookieJar(dir, "gradcracker", {
+        userAgent: "Mozilla/5.0 SolverUA",
+      });
+
+      const result = await createPersistedFetchCookieJar("gradcracker", dir);
+
+      expect(result.hasCookies).toBe(true);
+      expect(result.hasClearanceCookie).toBe(true);
+      expect(result.cookieCount).toBe(1);
+      expect(result.userAgent).toBe("Mozilla/5.0 SolverUA");
+      await expect(
+        result.cookieJar.getCookieString("https://www.example.com/jobs"),
+      ).resolves.toBe("cf_clearance=fake");
+      await expect(
+        result.cookieJar.getCookieString("http://www.example.com/jobs"),
+      ).resolves.toBe("");
+    });
+
+    it("keeps response cookies in memory for later HTTP requests", async () => {
+      const dir = storageDir();
+      writeCookieJar(dir, "gradcracker");
+
+      const result = await createPersistedFetchCookieJar("gradcracker", dir);
+      await result.cookieJar.setCookie(
+        "session_id=abc; Domain=.example.com; Path=/; Secure",
+        "https://www.example.com/jobs",
+      );
+
+      await expect(
+        result.cookieJar.getCookieString("https://www.example.com/jobs"),
+      ).resolves.toBe("cf_clearance=fake; session_id=abc");
     });
   });
 

--- a/extractors/gradcracker/manifest.ts
+++ b/extractors/gradcracker/manifest.ts
@@ -25,6 +25,7 @@ export const manifest: ExtractorManifest = {
       existingJobUrls,
       searchTerms: context.searchTerms,
       maxJobsPerTerm,
+      shouldCancel: context.shouldCancel,
       onProgress: (progress) => {
         if (context.shouldCancel?.()) return;
 

--- a/extractors/gradcracker/manifest.ts
+++ b/extractors/gradcracker/manifest.ts
@@ -38,6 +38,7 @@ export const manifest: ExtractorManifest = {
           jobPagesEnqueued: progress.jobPagesEnqueued,
           jobPagesSkipped: progress.jobPagesSkipped,
           jobPagesProcessed: progress.jobPagesProcessed,
+          detail: progress.detail,
         });
       },
     });

--- a/extractors/gradcracker/manifest.ts
+++ b/extractors/gradcracker/manifest.ts
@@ -52,9 +52,22 @@ export const manifest: ExtractorManifest = {
       };
     }
 
+    // Gradcracker is a UK-only board. Its location strings are UK region names
+    // (e.g. "London and South East", "North West") which don't contain "United
+    // Kingdom" / "UK", so the orchestrator's country filter would drop every job
+    // without an explicit country key. Stamp it here so the matcher knows.
+    const jobs = result.jobs.map((job) => ({
+      ...job,
+      locationEvidence: {
+        country: "united kingdom",
+        location: job.location ?? null,
+        source: "gradcracker",
+      },
+    }));
+
     return {
       success: true,
-      jobs: result.jobs,
+      jobs,
     };
   },
 };

--- a/extractors/gradcracker/package.json
+++ b/extractors/gradcracker/package.json
@@ -6,7 +6,9 @@
   "dependencies": {
     "browser-utils": "^0.0.1",
     "camoufox-js": "^0.9.2",
+    "cheerio": "^1.0.0",
     "crawlee": "^3.0.0",
+    "impit": "^0.11.0",
     "playwright": "*",
     "tsx": "^4.4.0"
   },
@@ -16,9 +18,6 @@
     "@types/node": "^24.0.0",
     "fs-extra": "^11.3.0",
     "typescript": "~5.9.0"
-  },
-  "optionalDependencies": {
-    "impit-linux-x64-gnu": "^0.1.0"
   },
   "scripts": {
     "start": "tsx src/main.ts",

--- a/extractors/gradcracker/src/run.ts
+++ b/extractors/gradcracker/src/run.ts
@@ -3,6 +3,9 @@ import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
+import * as cheerio from "cheerio";
+import type { Element } from "domhandler";
+import { Impit } from "impit";
 
 type CreateJobInput = {
   source: "gradcracker";
@@ -25,6 +28,29 @@ const EXTRACTOR_DIR = join(srcDir, "..");
 const STORAGE_DIR = join(EXTRACTOR_DIR, "storage/datasets/default");
 const JOBOPS_STORAGE_DIR = join(EXTRACTOR_DIR, "storage/jobops");
 const JOBOPS_PROGRESS_PREFIX = "JOBOPS_PROGRESS ";
+const GRADCRACKER_BASE_URL = "https://www.gradcracker.com";
+const DEFAULT_DETAIL_CONCURRENCY = 6;
+
+const LOCATIONS = [
+  "london-and-south-east",
+  "north-west",
+  "yorkshire",
+  "east-midlands",
+  "west-midlands",
+  "south-west",
+] as const;
+
+const DEFAULT_ROLES = ["web-development", "software-systems"] as const;
+
+const CF_CHALLENGE_MARKERS = [
+  "cf-challenge-running",
+  "cf-turnstile",
+  "Checking your browser",
+  "challenges.cloudflare.com",
+  "Just a moment...",
+  "cf-please-wait",
+  "cf_chl_opt",
+] as const;
 
 export interface CrawlerResult {
   success: boolean;
@@ -37,8 +63,12 @@ export interface CrawlerResult {
 export interface RunCrawlerOptions {
   existingJobUrls?: string[];
   onProgress?: (update: JobExtractorProgress) => void;
+  shouldCancel?: () => boolean;
   searchTerms?: string[];
   maxJobsPerTerm?: number;
+  fetchImpl?: FetchLike;
+  browserFallback?: boolean;
+  detailConcurrency?: number;
 }
 
 interface JobExtractorProgress {
@@ -53,6 +83,533 @@ interface JobExtractorProgress {
   ts?: string;
 }
 
+export interface GradcrackerJobSummary {
+  title: string;
+  jobUrl: string;
+  employer: string;
+  employerUrl?: string;
+  disciplines?: string;
+  deadline?: string;
+  salary?: string;
+  location?: string;
+  degreeRequired?: string;
+  starting?: string;
+  role: string;
+}
+
+interface GradcrackerJobDetail {
+  applicationLink?: string;
+  jobDescription?: string;
+}
+
+type FetchResponseLike = {
+  ok: boolean;
+  status: number;
+  statusText?: string;
+  url?: string;
+  headers?: Headers;
+  text: () => Promise<string>;
+};
+
+type FetchLike = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<FetchResponseLike>;
+
+class ChallengeRequiredError extends Error {
+  constructor(readonly url: string) {
+    super(`Cloudflare challenge required for ${url}`);
+  }
+}
+
+function toPositiveIntOrFallback(
+  value: number | string | undefined,
+  fallback: number,
+): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseInt(value, 10)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.floor(parsed));
+}
+
+function normalizeSearchRole(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function resolveRoles(searchTerms: string[] | undefined): string[] {
+  if (!searchTerms || searchTerms.length === 0) return [...DEFAULT_ROLES];
+
+  const roles = searchTerms.map(normalizeSearchRole).filter(Boolean);
+  return roles.length > 0 ? roles : [...DEFAULT_ROLES];
+}
+
+function buildSearchUrl(location: string, role: string): string {
+  return `${GRADCRACKER_BASE_URL}/search/computing-technology/${role}-graduate-jobs-in-${location}?order=dateAdded`;
+}
+
+function normalizeUrl(
+  raw: string | null | undefined,
+  baseUrl = GRADCRACKER_BASE_URL,
+): string | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw, baseUrl);
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch {
+    return raw.replace(/\/$/, "");
+  }
+}
+
+function toAbsoluteUrl(
+  raw: string | null | undefined,
+  baseUrl: string,
+): string {
+  if (!raw) return "";
+  try {
+    return new URL(raw, baseUrl).href;
+  } catch {
+    return raw;
+  }
+}
+
+function cleanInlineText(value: string | null | undefined): string | undefined {
+  const cleaned = value?.replace(/\s+/g, " ").trim();
+  return cleaned || undefined;
+}
+
+function cleanMultilineText(
+  value: string | null | undefined,
+): string | undefined {
+  const cleaned = value
+    ?.replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .filter(Boolean)
+    .join("\n");
+
+  return cleaned || undefined;
+}
+
+function hasChallengeMarkers(html: string): boolean {
+  return CF_CHALLENGE_MARKERS.some((marker) => html.includes(marker));
+}
+
+function isChallengeResponse(
+  response: FetchResponseLike,
+  html: string,
+): boolean {
+  const mitigated = response.headers?.get("cf-mitigated")?.toLowerCase();
+  if (mitigated === "challenge") return true;
+  if (
+    (response.status === 403 || response.status === 503) &&
+    hasChallengeMarkers(html)
+  ) {
+    return true;
+  }
+  return hasChallengeMarkers(html);
+}
+
+function getDdText(
+  $: cheerio.CheerioAPI,
+  article: cheerio.Cheerio<Element>,
+  label: string,
+): string | undefined {
+  const dt = article
+    .find("dt")
+    .filter((_, element) => cleanInlineText($(element).text()) === label)
+    .first();
+  if (dt.length === 0) return undefined;
+  return cleanInlineText(dt.next("dd").text());
+}
+
+function extractDeadline(
+  $: cheerio.CheerioAPI,
+  article: cheerio.Cheerio<Element>,
+): string | undefined {
+  const deadlineText = article
+    .find("div")
+    .map((_, element) => cleanInlineText($(element).text()) ?? "")
+    .get()
+    .find((text) => text.startsWith("Deadline:"));
+
+  return deadlineText?.replace(/^Deadline:\s*/i, "").trim() || undefined;
+}
+
+export function parseGradcrackerListPage(
+  html: string,
+  pageUrl: string,
+  role = "",
+): GradcrackerJobSummary[] {
+  const $ = cheerio.load(html);
+
+  return $("article[wire\\:key]")
+    .map((_, element) => {
+      const article = $(element);
+      const titleAnchor = article.find("h2 a").first();
+      const title = cleanInlineText(titleAnchor.text());
+      const jobUrl = normalizeUrl(titleAnchor.attr("href"), pageUrl);
+      if (!title || !jobUrl) return null;
+
+      const employer =
+        cleanInlineText(article.find("figure img").first().attr("alt")) ??
+        "Unknown Employer";
+      const employerUrl = normalizeUrl(
+        article.find("figure a").first().attr("href"),
+        pageUrl,
+      );
+
+      return {
+        title,
+        jobUrl,
+        employer,
+        ...(employerUrl ? { employerUrl } : {}),
+        ...(cleanInlineText(article.find("h3").first().text())
+          ? { disciplines: cleanInlineText(article.find("h3").first().text()) }
+          : {}),
+        ...(extractDeadline($, article)
+          ? { deadline: extractDeadline($, article) }
+          : {}),
+        ...(getDdText($, article, "Salary")
+          ? { salary: getDdText($, article, "Salary") }
+          : {}),
+        ...(getDdText($, article, "Location")
+          ? { location: getDdText($, article, "Location") }
+          : {}),
+        ...(getDdText($, article, "Degree required")
+          ? { degreeRequired: getDdText($, article, "Degree required") }
+          : {}),
+        ...(getDdText($, article, "Starting")
+          ? { starting: getDdText($, article, "Starting") }
+          : {}),
+        role,
+      };
+    })
+    .get()
+    .filter((job): job is GradcrackerJobSummary => job !== null);
+}
+
+function decodeRepeatedly(value: string): string {
+  let decoded = value;
+  for (let i = 0; i < 3; i += 1) {
+    try {
+      const next = decodeURIComponent(decoded);
+      if (next === decoded) break;
+      decoded = next;
+    } catch {
+      break;
+    }
+  }
+  return decoded;
+}
+
+export function decodeGradcrackerOutUrl(value: string): string | undefined {
+  try {
+    const url = new URL(value, GRADCRACKER_BASE_URL);
+    if (
+      url.hostname !== "www.gradcracker.com" ||
+      (url.pathname !== "/out" && !url.pathname.startsWith("/out/"))
+    ) {
+      return url.href;
+    }
+
+    const target = url.searchParams.get("u");
+    if (!target) return url.href;
+
+    return decodeRepeatedly(target);
+  } catch {
+    return undefined;
+  }
+}
+
+export function parseGradcrackerDetailPage(
+  html: string,
+  pageUrl: string,
+): GradcrackerJobDetail {
+  const $ = cheerio.load(html);
+  const jobDescription = cleanMultilineText($(".body-content").first().text());
+  const applyHref =
+    $("a[dusk='apply-button']").first().attr("href") ??
+    $("a[href*='/out/']").first().attr("href") ??
+    $("a")
+      .filter((_, element) =>
+        /apply/i.test(cleanInlineText($(element).text()) ?? ""),
+      )
+      .first()
+      .attr("href");
+
+  const applicationLink = applyHref
+    ? decodeGradcrackerOutUrl(toAbsoluteUrl(applyHref, pageUrl))
+    : undefined;
+
+  return {
+    ...(applicationLink ? { applicationLink } : {}),
+    ...(jobDescription ? { jobDescription } : {}),
+  };
+}
+
+function createImpitFetch(): FetchLike {
+  const impit = new Impit({
+    browser: "firefox",
+    timeout: 30_000,
+  });
+
+  return (input, init) =>
+    impit.fetch(input, init as Parameters<Impit["fetch"]>[1]);
+}
+
+async function fetchHtml(args: {
+  fetchImpl: FetchLike;
+  url: string;
+}): Promise<string> {
+  const response = await args.fetchImpl(args.url, {
+    headers: {
+      accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "accept-language": "en-GB,en;q=0.9",
+    },
+  });
+  const html = await response.text();
+
+  if (isChallengeResponse(response, html)) {
+    throw new ChallengeRequiredError(args.url);
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      `Gradcracker request failed with ${response.status} ${response.statusText ?? ""}`.trim(),
+    );
+  }
+
+  return html;
+}
+
+function createProgressTracker(args: {
+  listPagesTotal: number;
+  onProgress?: (update: JobExtractorProgress) => void;
+}) {
+  const state: Required<
+    Pick<
+      JobExtractorProgress,
+      | "listPagesProcessed"
+      | "jobCardsFound"
+      | "jobPagesEnqueued"
+      | "jobPagesSkipped"
+      | "jobPagesProcessed"
+    >
+  > &
+    Pick<JobExtractorProgress, "phase" | "currentUrl" | "listPagesTotal"> = {
+    phase: "list",
+    listPagesProcessed: 0,
+    listPagesTotal: args.listPagesTotal,
+    jobCardsFound: 0,
+    jobPagesEnqueued: 0,
+    jobPagesSkipped: 0,
+    jobPagesProcessed: 0,
+  };
+
+  const emit = () => {
+    args.onProgress?.({
+      ...state,
+      ts: new Date().toISOString(),
+    });
+  };
+
+  return {
+    init() {
+      emit();
+    },
+    markListPageDone(params: {
+      currentUrl: string;
+      jobCardsFound: number;
+      jobPagesEnqueued: number;
+      jobPagesSkipped: number;
+    }) {
+      state.phase = "list";
+      state.currentUrl = params.currentUrl;
+      state.listPagesProcessed += 1;
+      state.jobCardsFound += params.jobCardsFound;
+      state.jobPagesEnqueued += params.jobPagesEnqueued;
+      state.jobPagesSkipped += params.jobPagesSkipped;
+      emit();
+    },
+    markJobPageDone(currentUrl: string) {
+      state.phase = "job";
+      state.currentUrl = currentUrl;
+      state.jobPagesProcessed += 1;
+      emit();
+    },
+  };
+}
+
+async function mapWithConcurrency<T, R>(
+  values: T[],
+  concurrency: number,
+  callback: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < values.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await callback(values[currentIndex]);
+    }
+  }
+
+  const workers = Array.from(
+    { length: Math.min(concurrency, values.length) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+export async function runHttpCrawler(
+  options: RunCrawlerOptions = {},
+): Promise<CrawlerResult> {
+  const fetchImpl = options.fetchImpl ?? createImpitFetch();
+  const roles = resolveRoles(options.searchTerms);
+  const maxJobsPerTerm = toPositiveIntOrFallback(options.maxJobsPerTerm, 50);
+  const existingJobUrls = new Set(
+    (options.existingJobUrls ?? [])
+      .map((url) => normalizeUrl(url))
+      .filter((url): url is string => Boolean(url)),
+  );
+  const detailConcurrency = toPositiveIntOrFallback(
+    options.detailConcurrency ??
+      process.env.GRADCRACKER_HTTP_DETAIL_CONCURRENCY,
+    DEFAULT_DETAIL_CONCURRENCY,
+  );
+  const startUrls = LOCATIONS.flatMap((location) =>
+    roles.map((role) => ({
+      role,
+      url: buildSearchUrl(location, role),
+    })),
+  );
+  const progress = createProgressTracker({
+    listPagesTotal: startUrls.length,
+    onProgress: options.onProgress,
+  });
+
+  progress.init();
+
+  try {
+    const seen = new Set<string>();
+    const termCounts = new Map<string, number>();
+    const pendingDetails: GradcrackerJobSummary[] = [];
+
+    for (const startUrl of startUrls) {
+      if (options.shouldCancel?.()) {
+        return { success: true, jobs: [] };
+      }
+
+      const currentTermCount = termCounts.get(startUrl.role) ?? 0;
+      if (currentTermCount >= maxJobsPerTerm) {
+        progress.markListPageDone({
+          currentUrl: startUrl.url,
+          jobCardsFound: 0,
+          jobPagesEnqueued: 0,
+          jobPagesSkipped: 0,
+        });
+        continue;
+      }
+
+      const html = await fetchHtml({ fetchImpl, url: startUrl.url });
+      const summaries = parseGradcrackerListPage(
+        html,
+        startUrl.url,
+        startUrl.role,
+      );
+      let enqueued = 0;
+      let skippedKnown = 0;
+
+      for (const summary of summaries) {
+        if ((termCounts.get(startUrl.role) ?? 0) >= maxJobsPerTerm) {
+          break;
+        }
+
+        const normalizedJobUrl = normalizeUrl(summary.jobUrl);
+        if (!normalizedJobUrl) continue;
+
+        if (existingJobUrls.has(normalizedJobUrl)) {
+          skippedKnown += 1;
+          continue;
+        }
+
+        if (seen.has(normalizedJobUrl)) continue;
+        seen.add(normalizedJobUrl);
+        pendingDetails.push(summary);
+        enqueued += 1;
+        termCounts.set(startUrl.role, (termCounts.get(startUrl.role) ?? 0) + 1);
+      }
+
+      progress.markListPageDone({
+        currentUrl: startUrl.url,
+        jobCardsFound: summaries.length,
+        jobPagesEnqueued: enqueued,
+        jobPagesSkipped: skippedKnown,
+      });
+    }
+
+    const jobs = await mapWithConcurrency(
+      pendingDetails,
+      detailConcurrency,
+      async (summary) => {
+        if (options.shouldCancel?.()) {
+          return null;
+        }
+
+        const html = await fetchHtml({ fetchImpl, url: summary.jobUrl });
+        const detail = parseGradcrackerDetailPage(html, summary.jobUrl);
+        progress.markJobPageDone(summary.jobUrl);
+
+        const job: CreateJobInput = {
+          source: "gradcracker",
+          title: summary.title,
+          employer: summary.employer,
+          jobUrl: summary.jobUrl,
+        };
+        if (summary.employerUrl) job.employerUrl = summary.employerUrl;
+        if (detail.applicationLink)
+          job.applicationLink = detail.applicationLink;
+        if (summary.disciplines) job.disciplines = summary.disciplines;
+        if (summary.deadline) job.deadline = summary.deadline;
+        if (summary.salary) job.salary = summary.salary;
+        if (summary.location) job.location = summary.location;
+        if (summary.degreeRequired) job.degreeRequired = summary.degreeRequired;
+        if (summary.starting) job.starting = summary.starting;
+        if (detail.jobDescription) job.jobDescription = detail.jobDescription;
+        return job;
+      },
+    );
+
+    return {
+      success: true,
+      jobs: jobs.filter((job): job is CreateJobInput => job !== null),
+    };
+  } catch (error) {
+    if (error instanceof ChallengeRequiredError) {
+      return { success: false, jobs: [], challengeRequired: error.url };
+    }
+
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Unexpected error while running Gradcracker HTTP scraper.";
+
+    return { success: false, jobs: [], error: message };
+  }
+}
+
 async function writeExistingJobUrlsFile(
   existingJobUrls: string[] | undefined,
 ): Promise<string | null> {
@@ -63,7 +620,7 @@ async function writeExistingJobUrlsFile(
   return filePath;
 }
 
-export async function runCrawler(
+async function runBrowserCrawler(
   options: RunCrawlerOptions = {},
 ): Promise<CrawlerResult> {
   let challengeRequired: string | undefined;
@@ -149,6 +706,29 @@ export async function runCrawler(
     const message = error instanceof Error ? error.message : "Unknown error";
     return { success: false, jobs: [], error: message, challengeRequired };
   }
+}
+
+export async function runCrawler(
+  options: RunCrawlerOptions = {},
+): Promise<CrawlerResult> {
+  if (process.env.GRADCRACKER_FORCE_BROWSER === "1") {
+    return runBrowserCrawler(options);
+  }
+
+  const httpResult = await runHttpCrawler(options);
+  const shouldFallback =
+    options.browserFallback !== false &&
+    !options.fetchImpl &&
+    !httpResult.success &&
+    process.env.GRADCRACKER_DISABLE_BROWSER_FALLBACK !== "1";
+
+  if (!shouldFallback) return httpResult;
+
+  const browserResult = await runBrowserCrawler(options);
+  if (browserResult.success) return browserResult;
+  return browserResult.error || browserResult.challengeRequired
+    ? browserResult
+    : httpResult;
 }
 
 async function readCrawledJobs(): Promise<CreateJobInput[]> {

--- a/extractors/gradcracker/src/run.ts
+++ b/extractors/gradcracker/src/run.ts
@@ -29,7 +29,8 @@ const STORAGE_DIR = join(EXTRACTOR_DIR, "storage/datasets/default");
 const JOBOPS_STORAGE_DIR = join(EXTRACTOR_DIR, "storage/jobops");
 const JOBOPS_PROGRESS_PREFIX = "JOBOPS_PROGRESS ";
 const GRADCRACKER_BASE_URL = "https://www.gradcracker.com";
-const DEFAULT_DETAIL_CONCURRENCY = 6;
+const DEFAULT_DETAIL_CONCURRENCY = 2;
+const DEFAULT_REQUEST_DELAY_MS = 1_000;
 
 const LOCATIONS = [
   "london-and-south-east",
@@ -69,6 +70,7 @@ export interface RunCrawlerOptions {
   fetchImpl?: FetchLike;
   browserFallback?: boolean;
   detailConcurrency?: number;
+  requestDelayMs?: number;
 }
 
 interface JobExtractorProgress {
@@ -80,8 +82,15 @@ interface JobExtractorProgress {
   jobPagesEnqueued?: number;
   jobPagesSkipped?: number;
   jobPagesProcessed?: number;
+  detail?: string;
   ts?: string;
 }
+
+type GradcrackerChildProgressEvent =
+  | { type: "challenge_required"; url: string }
+  | { type: "progress"; progress: JobExtractorProgress };
+
+const CHILD_OUTPUT_HISTORY_LIMIT = 40;
 
 export interface GradcrackerJobSummary {
   title: string;
@@ -122,6 +131,75 @@ class ChallengeRequiredError extends Error {
   }
 }
 
+export function parseGradcrackerProgressLine(
+  line: string,
+): GradcrackerChildProgressEvent | null {
+  if (!line.startsWith(JOBOPS_PROGRESS_PREFIX)) return null;
+
+  const raw = line.slice(JOBOPS_PROGRESS_PREFIX.length).trim();
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  if (
+    parsed.event === "challenge_required" &&
+    typeof parsed.url === "string" &&
+    parsed.url.length > 0
+  ) {
+    return { type: "challenge_required", url: parsed.url };
+  }
+
+  return {
+    type: "progress",
+    progress: parsed as JobExtractorProgress,
+  };
+}
+
+function rememberChildOutputLine(lines: string[], line: string): void {
+  const cleaned = line.replace(/\s+/g, " ").trim();
+  if (!cleaned) return;
+  lines.push(cleaned);
+  if (lines.length > CHILD_OUTPUT_HISTORY_LIMIT) {
+    lines.splice(0, lines.length - CHILD_OUTPUT_HISTORY_LIMIT);
+  }
+}
+
+export function summarizeGradcrackerBrowserFailure(
+  lines: string[],
+  fallbackMessage: string,
+): string {
+  const combined = lines.join("\n");
+  const missingExecutable = /Executable doesn't exist at ([^\n]+)/.exec(
+    combined,
+  );
+  const failedLaunch = /Failed to launch browser/i.test(combined);
+
+  if (missingExecutable || failedLaunch) {
+    const path = missingExecutable?.[1]?.trim();
+    return [
+      "Gradcracker browser fallback could not launch Playwright Firefox.",
+      path ? `Missing executable: ${path}.` : undefined,
+      "Rebuild the Docker image so the Node Playwright browser binary is installed, or run `npx playwright install firefox` in the runtime image.",
+    ]
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  const meaningfulLine = [...lines]
+    .reverse()
+    .find(
+      (line) =>
+        !line.startsWith("INFO  PlaywrightCrawler") && !line.startsWith("> "),
+    );
+
+  return meaningfulLine
+    ? `Gradcracker browser fallback failed: ${meaningfulLine}`
+    : fallbackMessage;
+}
+
 function toPositiveIntOrFallback(
   value: number | string | undefined,
   fallback: number,
@@ -135,6 +213,63 @@ function toPositiveIntOrFallback(
 
   if (!Number.isFinite(parsed)) return fallback;
   return Math.max(1, Math.floor(parsed));
+}
+
+function toNonNegativeIntOrFallback(
+  value: number | string | undefined,
+  fallback: number,
+): number {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string"
+        ? Number.parseInt(value, 10)
+        : Number.NaN;
+
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(0, Math.floor(parsed));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function createRequestStartLimiter(minIntervalMs: number): () => Promise<void> {
+  if (minIntervalMs <= 0) return async () => {};
+
+  let nextStartAt = 0;
+  let queue = Promise.resolve();
+
+  return async () => {
+    const previous = queue;
+    let releaseQueue!: () => void;
+    queue = new Promise<void>((resolve) => {
+      releaseQueue = resolve;
+    });
+
+    await previous;
+    try {
+      const waitMs = Math.max(0, nextStartAt - Date.now());
+      if (waitMs > 0) {
+        await sleep(waitMs);
+      }
+      nextStartAt = Date.now() + minIntervalMs;
+    } finally {
+      releaseQueue();
+    }
+  };
+}
+
+function createPacedFetch(
+  fetchImpl: FetchLike,
+  requestDelayMs: number,
+): FetchLike {
+  const waitForRequestTurn = createRequestStartLimiter(requestDelayMs);
+
+  return async (input, init) => {
+    await waitForRequestTurn();
+    return fetchImpl(input, init);
+  };
 }
 
 function normalizeSearchRole(value: string): string {
@@ -476,7 +611,14 @@ async function mapWithConcurrency<T, R>(
 export async function runHttpCrawler(
   options: RunCrawlerOptions = {},
 ): Promise<CrawlerResult> {
-  const fetchImpl = options.fetchImpl ?? createImpitFetch();
+  const rawFetchImpl = options.fetchImpl ?? createImpitFetch();
+  const requestDelayMs = toNonNegativeIntOrFallback(
+    options.requestDelayMs ??
+      process.env.GRADCRACKER_HTTP_REQUEST_DELAY_MS ??
+      (options.fetchImpl ? 0 : DEFAULT_REQUEST_DELAY_MS),
+    DEFAULT_REQUEST_DELAY_MS,
+  );
+  const fetchImpl = createPacedFetch(rawFetchImpl, requestDelayMs);
   const roles = resolveRoles(options.searchTerms);
   const maxJobsPerTerm = toPositiveIntOrFallback(options.maxJobsPerTerm, 50);
   const existingJobUrls = new Set(
@@ -624,6 +766,7 @@ async function runBrowserCrawler(
   options: RunCrawlerOptions = {},
 ): Promise<CrawlerResult> {
   let challengeRequired: string | undefined;
+  const childOutputLines: string[] = [];
 
   try {
     await clearStorageDataset();
@@ -652,25 +795,35 @@ async function runBrowserCrawler(
         },
       });
 
+      let settled = false;
+      const failForChallenge = (url: string) => {
+        if (settled) return;
+        settled = true;
+        challengeRequired = url;
+        options.onProgress?.({
+          currentUrl: url,
+          detail: `Gradcracker hit a Cloudflare challenge: ${url}`,
+          ts: new Date().toISOString(),
+        });
+        child.kill("SIGTERM");
+        reject(new ChallengeRequiredError(url));
+      };
+
       const handleLine = (line: string, stream: NodeJS.WriteStream) => {
-        if (line.startsWith(JOBOPS_PROGRESS_PREFIX)) {
-          const raw = line.slice(JOBOPS_PROGRESS_PREFIX.length).trim();
-          try {
-            const parsed = JSON.parse(raw) as Record<string, unknown>;
-            // Detect challenge_required signal from the child process
-            if (
-              parsed.event === "challenge_required" &&
-              typeof parsed.url === "string"
-            ) {
-              challengeRequired = parsed.url;
-              return;
-            }
-            options.onProgress?.(parsed as unknown as JobExtractorProgress);
-          } catch {
-            // ignore malformed progress lines
+        if (settled) return;
+
+        const progressEvent = parseGradcrackerProgressLine(line);
+        if (progressEvent) {
+          if (progressEvent.type === "challenge_required") {
+            failForChallenge(progressEvent.url);
+            return;
           }
+          options.onProgress?.(progressEvent.progress);
           return;
         }
+
+        if (line.startsWith(JOBOPS_PROGRESS_PREFIX)) return;
+        rememberChildOutputLine(childOutputLines, line);
         stream.write(`${line}\n`);
       };
 
@@ -687,14 +840,27 @@ async function runBrowserCrawler(
       child.on("close", (code) => {
         stdoutRl?.close();
         stderrRl?.close();
+        if (settled) return;
+        settled = true;
         if (code === 0) {
           resolve();
         } else {
-          reject(new Error(`Crawler exited with code ${code}`));
+          reject(
+            new Error(
+              summarizeGradcrackerBrowserFailure(
+                childOutputLines,
+                `Gradcracker browser crawler exited with code ${code}`,
+              ),
+            ),
+          );
         }
       });
 
-      child.on("error", reject);
+      child.on("error", (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      });
     });
 
     const jobs = await readCrawledJobs();
@@ -726,6 +892,16 @@ export async function runCrawler(
 
   const browserResult = await runBrowserCrawler(options);
   if (browserResult.success) return browserResult;
+
+  if (httpResult.challengeRequired && browserResult.error) {
+    return {
+      ...httpResult,
+      error: httpResult.error
+        ? `${httpResult.error}; ${browserResult.error}`
+        : browserResult.error,
+    };
+  }
+
   return browserResult.error || browserResult.challengeRequired
     ? browserResult
     : httpResult;

--- a/extractors/gradcracker/src/run.ts
+++ b/extractors/gradcracker/src/run.ts
@@ -3,6 +3,10 @@ import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
+import {
+  createPersistedFetchCookieJar,
+  getCloudflareCookieStorageDir,
+} from "browser-utils";
 import * as cheerio from "cheerio";
 import type { Element } from "domhandler";
 import { Impit } from "impit";
@@ -28,6 +32,7 @@ const EXTRACTOR_DIR = join(srcDir, "..");
 const STORAGE_DIR = join(EXTRACTOR_DIR, "storage/datasets/default");
 const JOBOPS_STORAGE_DIR = join(EXTRACTOR_DIR, "storage/jobops");
 const JOBOPS_PROGRESS_PREFIX = "JOBOPS_PROGRESS ";
+const EXTRACTOR_ID = "gradcracker";
 const GRADCRACKER_BASE_URL = "https://www.gradcracker.com";
 const DEFAULT_DETAIL_CONCURRENCY = 2;
 const DEFAULT_REQUEST_DELAY_MS = 1_000;
@@ -491,10 +496,19 @@ export function parseGradcrackerDetailPage(
   };
 }
 
-function createImpitFetch(): FetchLike {
+async function createImpitFetch(): Promise<FetchLike> {
+  const persistedCookies = await createPersistedFetchCookieJar(
+    EXTRACTOR_ID,
+    getCloudflareCookieStorageDir(),
+  );
+  const headers = persistedCookies.userAgent
+    ? { "user-agent": persistedCookies.userAgent }
+    : undefined;
   const impit = new Impit({
     browser: "firefox",
     timeout: 30_000,
+    cookieJar: persistedCookies.cookieJar,
+    ...(headers ? { headers } : {}),
   });
 
   return (input, init) =>
@@ -611,7 +625,7 @@ async function mapWithConcurrency<T, R>(
 export async function runHttpCrawler(
   options: RunCrawlerOptions = {},
 ): Promise<CrawlerResult> {
-  const rawFetchImpl = options.fetchImpl ?? createImpitFetch();
+  const rawFetchImpl = options.fetchImpl ?? (await createImpitFetch());
   const requestDelayMs = toNonNegativeIntOrFallback(
     options.requestDelayMs ??
       process.env.GRADCRACKER_HTTP_REQUEST_DELAY_MS ??

--- a/extractors/gradcracker/tests/run.test.ts
+++ b/extractors/gradcracker/tests/run.test.ts
@@ -3,7 +3,9 @@ import {
   decodeGradcrackerOutUrl,
   parseGradcrackerDetailPage,
   parseGradcrackerListPage,
+  parseGradcrackerProgressLine,
   runHttpCrawler,
+  summarizeGradcrackerBrowserFailure,
 } from "../src/run";
 
 function createResponse(
@@ -157,6 +159,45 @@ describe("Gradcracker HTTP scraper", () => {
     expect(fetchMock).toHaveBeenCalledTimes(6);
   });
 
+  it("paces HTTP request starts when a delay is configured", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+
+    try {
+      const requestStartedAt: number[] = [];
+      const fetchMock = vi.fn(async (input: string | URL) => {
+        requestStartedAt.push(Date.now());
+        const url = String(input);
+        if (url.includes("/graduate-job/81268/")) {
+          return createResponse(DETAIL_HTML, { url });
+        }
+        return createResponse(LIST_HTML, { url });
+      });
+
+      const resultPromise = runHttpCrawler({
+        searchTerms: ["software systems"],
+        maxJobsPerTerm: 1,
+        fetchImpl: fetchMock,
+        requestDelayMs: 100,
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(requestStartedAt).toEqual([0]);
+
+      await vi.advanceTimersByTimeAsync(99);
+      expect(requestStartedAt).toEqual([0]);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(resultPromise).resolves.toMatchObject({
+        success: true,
+        jobs: [expect.objectContaining({ employer: "WSP" })],
+      });
+      expect(requestStartedAt).toEqual([0, 100]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports Cloudflare challenges from the HTTP path", async () => {
     const fetchMock = vi.fn(async (input: string | URL) =>
       createResponse("<title>Just a moment...</title>", {
@@ -176,6 +217,46 @@ describe("Gradcracker HTTP scraper", () => {
     expect(result.success).toBe(false);
     expect(result.challengeRequired).toContain(
       "software-systems-graduate-jobs-in-london-and-south-east",
+    );
+  });
+
+  it("detects child-process Cloudflare progress signals", () => {
+    expect(
+      parseGradcrackerProgressLine(
+        'JOBOPS_PROGRESS {"event":"challenge_required","url":"https://www.gradcracker.com/challenge"}',
+      ),
+    ).toEqual({
+      type: "challenge_required",
+      url: "https://www.gradcracker.com/challenge",
+    });
+
+    expect(
+      parseGradcrackerProgressLine(
+        'JOBOPS_PROGRESS {"phase":"list","listPagesProcessed":1,"jobCardsFound":12}',
+      ),
+    ).toEqual({
+      type: "progress",
+      progress: {
+        phase: "list",
+        listPagesProcessed: 1,
+        jobCardsFound: 12,
+      },
+    });
+  });
+
+  it("summarizes missing Playwright browser fallback failures", () => {
+    expect(
+      summarizeGradcrackerBrowserFailure(
+        [
+          "Failed to launch browser. Please check the following:",
+          "browserType.launchPersistentContext: Executable doesn't exist at /ms-playwright/firefox-1511/firefox/firefox",
+          "Please run the following command to download new browsers:",
+          "npx playwright install",
+        ],
+        "Crawler exited with code 1",
+      ),
+    ).toBe(
+      "Gradcracker browser fallback could not launch Playwright Firefox. Missing executable: /ms-playwright/firefox-1511/firefox/firefox. Rebuild the Docker image so the Node Playwright browser binary is installed, or run `npx playwright install firefox` in the runtime image.",
     );
   });
 });

--- a/extractors/gradcracker/tests/run.test.ts
+++ b/extractors/gradcracker/tests/run.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  decodeGradcrackerOutUrl,
+  parseGradcrackerDetailPage,
+  parseGradcrackerListPage,
+  runHttpCrawler,
+} from "../src/run";
+
+function createResponse(
+  payload: string,
+  init: Partial<Response> = {},
+): Response {
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: init.statusText ?? "OK",
+    url: init.url ?? "",
+    headers: init.headers ?? new Headers(),
+    text: async () => payload,
+  } as Response;
+}
+
+const LIST_HTML = `
+  <article wire:key="job-81268">
+    <figure>
+      <a href="/hub/408/wsp">
+        <img alt="WSP" />
+      </a>
+    </figure>
+    <h2>
+      <a href="/hub/408/wsp/graduate-job/81268/graduate-professional-rail-modelling-and-simulation-analyst">
+        Graduate/Professional Rail Modelling and Simulation Analyst
+      </a>
+    </h2>
+    <h3>Mechanical, Maths, Computer Science, Software, Analytics.</h3>
+    <div>Deadline: Ongoing</div>
+    <dl>
+      <div><dt>Salary</dt><dd>Competitive</dd></div>
+      <div><dt>Location</dt><dd>London</dd></div>
+      <div><dt>Degree required</dt><dd>Bachelor's</dd></div>
+      <div><dt>Starting</dt><dd>September 2026</dd></div>
+    </dl>
+  </article>
+`;
+
+const DETAIL_HTML = `
+  <main>
+    <div class="body-content">
+      <p>Build transport modelling tools.</p>
+      <p>Work with Python, data, and simulation platforms.</p>
+    </div>
+    <a href="/out/408?jobID=81268&u=https%253A%252F%252Fexample.com%252Fapply%253Fjob%253D81268&signature=abc">
+      Apply online now
+    </a>
+  </main>
+`;
+
+describe("Gradcracker HTTP scraper", () => {
+  it("parses list cards with the fields used by the pipeline", () => {
+    const [job] = parseGradcrackerListPage(
+      LIST_HTML,
+      "https://www.gradcracker.com/search/computing-technology/software-systems-graduate-jobs-in-london-and-south-east?order=dateAdded",
+      "software-systems",
+    );
+
+    expect(job).toEqual({
+      title: "Graduate/Professional Rail Modelling and Simulation Analyst",
+      jobUrl:
+        "https://www.gradcracker.com/hub/408/wsp/graduate-job/81268/graduate-professional-rail-modelling-and-simulation-analyst",
+      employer: "WSP",
+      employerUrl: "https://www.gradcracker.com/hub/408/wsp",
+      disciplines: "Mechanical, Maths, Computer Science, Software, Analytics.",
+      deadline: "Ongoing",
+      salary: "Competitive",
+      location: "London",
+      degreeRequired: "Bachelor's",
+      starting: "September 2026",
+      role: "software-systems",
+    });
+  });
+
+  it("decodes Gradcracker out links without opening a browser", () => {
+    expect(
+      decodeGradcrackerOutUrl(
+        "https://www.gradcracker.com/out/408?jobID=81268&u=https%253A%252F%252Fexample.com%252Fapply%253Fjob%253D81268&signature=abc",
+      ),
+    ).toBe("https://example.com/apply?job=81268");
+
+    expect(
+      parseGradcrackerDetailPage(
+        DETAIL_HTML,
+        "https://www.gradcracker.com/hub/408/wsp/graduate-job/81268/example",
+      ),
+    ).toEqual({
+      applicationLink: "https://example.com/apply?job=81268",
+      jobDescription:
+        "Build transport modelling tools.\nWork with Python, data, and simulation platforms.",
+    });
+  });
+
+  it("fetches list and detail pages with per-term caps", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes("/graduate-job/81268/")) {
+        return createResponse(DETAIL_HTML, { url });
+      }
+      return createResponse(LIST_HTML, { url });
+    });
+
+    const progress = vi.fn();
+    const result = await runHttpCrawler({
+      searchTerms: ["software systems"],
+      maxJobsPerTerm: 1,
+      fetchImpl: fetchMock,
+      onProgress: progress,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.jobs).toHaveLength(1);
+    expect(result.jobs[0]).toEqual(
+      expect.objectContaining({
+        source: "gradcracker",
+        employer: "WSP",
+        applicationLink: "https://example.com/apply?job=81268",
+      }),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(progress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        listPagesProcessed: 6,
+        listPagesTotal: 6,
+        jobPagesEnqueued: 1,
+        jobPagesProcessed: 0,
+      }),
+    );
+  });
+
+  it("skips known job URLs before fetching detail pages", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) => {
+      const url = String(input);
+      if (url.includes("/graduate-job/81268/")) {
+        throw new Error("known jobs should not fetch details");
+      }
+      return createResponse(LIST_HTML, { url });
+    });
+
+    const result = await runHttpCrawler({
+      searchTerms: ["software systems"],
+      existingJobUrls: [
+        "https://www.gradcracker.com/hub/408/wsp/graduate-job/81268/graduate-professional-rail-modelling-and-simulation-analyst",
+      ],
+      maxJobsPerTerm: 1,
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ success: true, jobs: [] });
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  it("reports Cloudflare challenges from the HTTP path", async () => {
+    const fetchMock = vi.fn(async (input: string | URL) =>
+      createResponse("<title>Just a moment...</title>", {
+        ok: false,
+        status: 403,
+        statusText: "Forbidden",
+        url: String(input),
+        headers: new Headers({ "cf-mitigated": "challenge" }),
+      }),
+    );
+
+    const result = await runHttpCrawler({
+      searchTerms: ["software systems"],
+      fetchImpl: fetchMock,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.challengeRequired).toContain(
+      "software-systems-graduate-jobs-in-london-and-south-east",
+    );
+  });
+});

--- a/orchestrator/src/client/api/client.pipeline.test.ts
+++ b/orchestrator/src/client/api/client.pipeline.test.ts
@@ -156,6 +156,7 @@ describe("pipeline client helpers", () => {
           status: "solved",
           extractorId: "gradcracker",
           challengesRemaining: 0,
+          cookiesSaved: 1,
         },
         meta: { requestId: "req-solve" },
       }),
@@ -165,6 +166,7 @@ describe("pipeline client helpers", () => {
       status: "solved",
       extractorId: "gradcracker",
       challengesRemaining: 0,
+      cookiesSaved: 1,
     });
     expect(fetchSpy).toHaveBeenCalledWith(
       "/api/pipeline/solve-challenge",

--- a/orchestrator/src/client/api/pipeline.ts
+++ b/orchestrator/src/client/api/pipeline.ts
@@ -43,11 +43,13 @@ export async function solvePipelineChallenge(extractorId: string): Promise<{
   status: "solved";
   extractorId: string;
   challengesRemaining: number;
+  cookiesSaved: number;
 }> {
   return fetchApi<{
     status: "solved";
     extractorId: string;
     challengesRemaining: number;
+    cookiesSaved: number;
   }>("/pipeline/solve-challenge", {
     method: "POST",
     body: JSON.stringify({ extractorId }),

--- a/orchestrator/src/client/components/AnimatedNumber.stories.tsx
+++ b/orchestrator/src/client/components/AnimatedNumber.stories.tsx
@@ -1,0 +1,122 @@
+import type { Story } from "@ladle/react";
+import { Minus, Pause, Play, Plus, RotateCcw } from "lucide-react";
+import React from "react";
+import { AnimatedNumber } from "./AnimatedNumber";
+
+const CYCLE_VALUES = [92, 93, 99, 100, 8, 0, 42, 78, 122, 5, 87, 90];
+
+const buttonClassName =
+  "inline-flex h-9 items-center justify-center gap-1.5 rounded-md border border-border/70 bg-background px-3 text-xs font-medium text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+
+const clampValue = (value: number) => Math.max(-999, Math.min(9999, value));
+
+export const Playground: Story = () => {
+  const [value, setValue] = React.useState(92);
+  const [isCycling, setIsCycling] = React.useState(true);
+  const cycleIndexRef = React.useRef(0);
+
+  React.useEffect(() => {
+    if (!isCycling) return;
+
+    const intervalId = window.setInterval(() => {
+      cycleIndexRef.current = (cycleIndexRef.current + 1) % CYCLE_VALUES.length;
+      setValue(CYCLE_VALUES[cycleIndexRef.current]);
+    }, 3000);
+
+    return () => window.clearInterval(intervalId);
+  }, [isCycling]);
+
+  const setManualValue = (nextValue: number) => {
+    setIsCycling(false);
+    setValue(clampValue(nextValue));
+  };
+
+  const reset = () => {
+    cycleIndexRef.current = 0;
+    setValue(CYCLE_VALUES[0]);
+  };
+
+  return (
+    <main className="min-h-[420px] bg-background p-6 text-foreground">
+      <section className="mx-auto flex max-w-2xl flex-col gap-6 rounded-lg border border-border bg-card p-6 shadow-sm">
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            AnimatedNumber
+          </p>
+          <div className="flex items-end justify-between gap-4">
+            <div className="text-7xl font-semibold leading-none tabular-nums">
+              <AnimatedNumber>{value}</AnimatedNumber>
+            </div>
+            <button
+              type="button"
+              className={buttonClassName}
+              onClick={() => setIsCycling((current) => !current)}
+            >
+              {isCycling ? (
+                <Pause className="h-4 w-4" />
+              ) : (
+                <Play className="h-4 w-4" />
+              )}
+              {isCycling ? "Pause" : "Play"}
+            </button>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setManualValue(value - 10)}
+          >
+            <Minus className="h-4 w-4" />
+            10
+          </button>
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setManualValue(value - 1)}
+          >
+            <Minus className="h-4 w-4" />1
+          </button>
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setManualValue(value + 1)}
+          >
+            <Plus className="h-4 w-4" />1
+          </button>
+          <button
+            type="button"
+            className={buttonClassName}
+            onClick={() => setManualValue(value + 10)}
+          >
+            <Plus className="h-4 w-4" />
+            10
+          </button>
+          <button type="button" className={buttonClassName} onClick={reset}>
+            <RotateCcw className="h-4 w-4" />
+            Reset
+          </button>
+        </div>
+
+        <div className="grid gap-2 sm:grid-cols-2">
+          {CYCLE_VALUES.map((candidate) => (
+            <button
+              type="button"
+              key={candidate}
+              className={`${buttonClassName} justify-between`}
+              onClick={() => setManualValue(candidate)}
+            >
+              <span>{candidate}</span>
+              {candidate === value ? (
+                <span className="text-muted-foreground">active</span>
+              ) : null}
+            </button>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+};
+
+Playground.storyName = "Playground";

--- a/orchestrator/src/client/components/AnimatedNumber.test.tsx
+++ b/orchestrator/src/client/components/AnimatedNumber.test.tsx
@@ -31,4 +31,40 @@ describe("AnimatedNumber", () => {
     const element = screen.getByRole("img");
     expect(element.getAttribute("aria-label")).toMatch(/1\.234,56/);
   });
+
+  it("keeps digit columns in stable tabular slots while values update", () => {
+    const { container, rerender } = render(
+      <AnimatedNumber>{92}</AnimatedNumber>,
+    );
+
+    rerender(<AnimatedNumber>{93}</AnimatedNumber>);
+
+    expect(screen.getByRole("img", { name: "93" })).toBeInTheDocument();
+
+    const digitSlots = Array.from(
+      container.querySelectorAll<HTMLElement>("[data-animated-number-digit]"),
+    );
+
+    expect(digitSlots).toHaveLength(2);
+    for (const slot of digitSlots) {
+      expect(slot.style.width).toBe("1ch");
+      expect(slot.style.minWidth).toBe("1ch");
+      expect(slot.style.maxWidth).toBe("1ch");
+      expect(slot.style.flex).toBe("0 0 1ch");
+      expect(slot.style.fontVariantNumeric).toBe("tabular-nums");
+    }
+  });
+
+  it("keeps digit slots aligned when the number gains a digit", () => {
+    const { container, rerender } = render(
+      <AnimatedNumber>{99}</AnimatedNumber>,
+    );
+
+    rerender(<AnimatedNumber>{100}</AnimatedNumber>);
+
+    expect(screen.getByRole("img", { name: "100" })).toBeInTheDocument();
+    expect(
+      container.querySelectorAll("[data-animated-number-digit]"),
+    ).toHaveLength(3);
+  });
 });

--- a/orchestrator/src/client/components/AnimatedNumber.tsx
+++ b/orchestrator/src/client/components/AnimatedNumber.tsx
@@ -5,6 +5,7 @@ import {
   MotionConfig,
   motion,
   type Transition,
+  useReducedMotion,
 } from "framer-motion";
 import React from "react";
 
@@ -17,7 +18,6 @@ const MASK_IMAGE = `linear-gradient(to right, transparent 0, #000 ${MASK_WIDTH},
 
 const MASK_SIZE = `100% calc(100% - ${MASK_HEIGHT} * 2),calc(100% - ${MASK_WIDTH} * 2) 100%,${MASK_WIDTH} ${MASK_HEIGHT},${MASK_WIDTH} ${MASK_HEIGHT},${MASK_WIDTH} ${MASK_HEIGHT},${MASK_WIDTH} ${MASK_HEIGHT}`;
 
-const DigitWidthMap = new WeakMap<HTMLElement, string>();
 const JustifyContext = React.createContext<{ justify: "left" | "right" }>({
   justify: "left",
 });
@@ -34,11 +34,6 @@ function useIsFirstRender() {
   return isFirst.current;
 }
 
-function calculateEmWidth(element: HTMLElement) {
-  const { width, fontSize } = getComputedStyle(element);
-  return `${parseFloat(width) / parseFloat(fontSize)}em`;
-}
-
 function safeModulo(n: number, m: number) {
   return ((n % m) + m) % m;
 }
@@ -52,8 +47,11 @@ function NumberMask({ children }: { children: React.ReactNode }) {
         margin: `0 calc(-1 * ${MASK_WIDTH})`,
         padding: `calc(${MASK_HEIGHT} / 2) ${MASK_WIDTH}`,
         position: "relative",
-        zIndex: -1,
+        zIndex: 0,
         overflow: "clip",
+        lineHeight: 1,
+        verticalAlign: "middle",
+        contain: "layout paint",
         WebkitMaskImage: MASK_IMAGE,
         WebkitMaskSize: MASK_SIZE,
         WebkitMaskPosition:
@@ -78,8 +76,7 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
   ref,
 ) {
   const { transition } = React.useContext(MotionContext);
-  const initialRef = React.useRef(initialValue).current;
-  const isFirstRender = useIsFirstRender();
+  const shouldReduceMotion = useReducedMotion();
   const containerRef = React.useRef<HTMLSpanElement>(null);
   const elementRef = React.useRef<HTMLSpanElement>(null);
 
@@ -89,24 +86,19 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
     [],
   );
 
-  const digitRefs = React.useRef<(HTMLSpanElement | null)[]>(
-    new Array(10).fill(null),
-  );
   const isPresent = true; // Fallback context flag derived from standard layout states
   const targetValue = isPresent ? value : 0;
-
-  React.useLayoutEffect(() => {
-    const digitEl = digitRefs.current[initialRef];
-    if (containerRef.current && digitEl) {
-      containerRef.current.style.width = calculateEmWidth(digitEl);
-    }
-  }, [initialRef]);
 
   const previousValueRef = React.useRef(initialValue);
 
   React.useLayoutEffect(() => {
     if (!containerRef.current || targetValue === previousValueRef.current)
       return;
+
+    if (shouldReduceMotion) {
+      previousValueRef.current = targetValue;
+      return;
+    }
 
     const containerRect = containerRef.current.getBoundingClientRect();
     const elementRect = elementRef.current?.getBoundingClientRect();
@@ -137,52 +129,19 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
       },
     );
 
-    // Also animate the width of containerRef from the previous digit's width to the new digit's width
-    const prevDigitEl = digitRefs.current[prev];
-    const targetDigitEl = digitRefs.current[targetValue];
-    if (prevDigitEl && targetDigitEl) {
-      const prevWidth =
-        (elementRef.current && DigitWidthMap.get(elementRef.current)) ||
-        calculateEmWidth(prevDigitEl);
-      const nextWidth = calculateEmWidth(targetDigitEl);
-
-      animate(
-        containerRef.current,
-        { width: [prevWidth, nextWidth] },
-        {
-          type: "spring",
-          duration: 0.6,
-          bounce: 0,
-          ...transition,
-        },
-      );
-    }
-
     return () => {
       controls.stop();
       previousValueRef.current = targetValue;
     };
-  }, [targetValue, trend, transition]);
-
-  React.useEffect(() => {
-    const digitEl = digitRefs.current[targetValue];
-    if ((isFirstRender && initialRef === targetValue) || !digitEl) return;
-
-    const emWidth = calculateEmWidth(digitEl);
-    if (elementRef.current) {
-      DigitWidthMap.set(elementRef.current, emWidth);
-    }
-  }, [targetValue, isFirstRender, initialRef]);
+  }, [targetValue, trend, transition, shouldReduceMotion]);
 
   const renderDigitSpan = (num: number) => (
     <span
       key={num}
       style={{
         display: "inline-block",
-        padding: `calc(${MASK_HEIGHT} / 2) 0`,
-      }}
-      ref={(el) => {
-        digitRefs.current[num] = el;
+        height: "1em",
+        lineHeight: 1,
       }}
     >
       {num}
@@ -202,7 +161,19 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
       {...props}
       ref={elementRef}
       data-state={isPresent ? undefined : "exiting"}
-      style={{ display: "inline-flex", justifyContent: "center" }}
+      data-animated-number-digit
+      style={{
+        display: "inline-flex",
+        justifyContent: "center",
+        flex: "0 0 1ch",
+        width: "1ch",
+        minWidth: "1ch",
+        maxWidth: "1ch",
+        lineHeight: 1,
+        fontVariantNumeric: "tabular-nums",
+        fontFeatureSettings: '"tnum" 1',
+        overflow: "visible",
+      }}
     >
       <span
         ref={containerRef}
@@ -212,6 +183,11 @@ const Digit = React.forwardRef<HTMLSpanElement, DigitProps>(function Digit(
           flexDirection: "column",
           alignItems: "center",
           position: "relative",
+          flex: "0 0 1ch",
+          width: "1ch",
+          height: "1em",
+          lineHeight: 1,
+          overflow: "visible",
         }}
       >
         {upperDigits.length > 0 && (

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -16,6 +16,7 @@ import type { PipelineProgressState } from "@shared/types";
 import { Loader2, ShieldAlert } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { showErrorToast } from "@/client/lib/error-toast";
 import { subscribeToEventSource } from "@/client/lib/sse";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -105,7 +106,7 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
       await solvePipelineChallenge(extractorId);
     } catch (err) {
       viewerWindow?.close();
-      console.error("Solve challenge request failed:", err);
+      showErrorToast(err, "Failed to solve challenge");
     } finally {
       setSolvingExtractor(null);
     }

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -695,12 +695,14 @@ pipelineRouter.post("/solve-challenge", async (req: Request, res: Response) => {
         route: "/api/pipeline/solve-challenge",
         extractorId: body.extractorId,
         challengesRemaining: remaining,
+        cookiesSaved: result.cookiesSaved,
       });
 
       ok(res, {
         status: "solved",
         extractorId: body.extractorId,
         challengesRemaining: remaining,
+        cookiesSaved: result.cookiesSaved,
       });
     } else {
       logger.warn("Challenge solver did not succeed", {

--- a/orchestrator/src/server/extractors/deployment.test.ts
+++ b/orchestrator/src/server/extractors/deployment.test.ts
@@ -53,6 +53,16 @@ describe("extractor deployment config", () => {
     );
   });
 
+  it("installs the Node Playwright Firefox binary for browser fallbacks", async () => {
+    const dockerfile = await readFile(resolve(process.cwd(), "../Dockerfile"), {
+      encoding: "utf8",
+    });
+
+    expect(dockerfile).toContain(
+      "./node_modules/.bin/playwright install firefox",
+    );
+  });
+
   it("syncs the Naukri extractor in compose development mode", async () => {
     const composeFile = await readFile(
       resolve(process.cwd(), "../docker-compose.yml"),

--- a/orchestrator/src/server/extractors/deployment.test.ts
+++ b/orchestrator/src/server/extractors/deployment.test.ts
@@ -63,6 +63,22 @@ describe("extractor deployment config", () => {
     );
   });
 
+  it("bakes Camoufox GeoLite data during Docker builds", async () => {
+    const dockerfile = await readFile(resolve(process.cwd(), "../Dockerfile"), {
+      encoding: "utf8",
+    });
+    const fetchScript = await readFile(
+      resolve(process.cwd(), "../scripts/camoufox-fetch.mjs"),
+      { encoding: "utf8" },
+    );
+
+    expect(dockerfile).toContain("node ./scripts/camoufox-fetch.mjs");
+    expect(fetchScript).toContain(
+      'import { downloadMMDB } from "camoufox-js/dist/locale.js";',
+    );
+    expect(fetchScript).toContain("await downloadMMDB();");
+  });
+
   it("syncs the Naukri extractor in compose development mode", async () => {
     const composeFile = await readFile(
       resolve(process.cwd(), "../docker-compose.yml"),

--- a/orchestrator/src/server/pipeline/cancellation.test.ts
+++ b/orchestrator/src/server/pipeline/cancellation.test.ts
@@ -5,16 +5,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const stepState = vi.hoisted(() => {
   let resolveDiscover:
-    | ((value: { discoveredJobs: []; sourceErrors: [] }) => void)
+    | ((value: {
+        discoveredJobs: [];
+        sourceErrors: [];
+        pendingChallenges: [];
+      }) => void)
     | null = null;
   return {
     setResolver: (
-      fn: (value: { discoveredJobs: []; sourceErrors: [] }) => void,
+      fn: (value: {
+        discoveredJobs: [];
+        sourceErrors: [];
+        pendingChallenges: [];
+      }) => void,
     ) => {
       resolveDiscover = fn;
     },
     resolveDiscover: () =>
-      resolveDiscover?.({ discoveredJobs: [], sourceErrors: [] }),
+      resolveDiscover?.({
+        discoveredJobs: [],
+        sourceErrors: [],
+        pendingChallenges: [],
+      }),
   };
 });
 
@@ -35,7 +47,11 @@ vi.mock("./steps", () => ({
   loadProfileStep: vi.fn(async () => ({})),
   discoverJobsStep: vi.fn(
     () =>
-      new Promise<{ discoveredJobs: []; sourceErrors: [] }>((resolve) => {
+      new Promise<{
+        discoveredJobs: [];
+        sourceErrors: [];
+        pendingChallenges: [];
+      }>((resolve) => {
         stepState.setResolver(resolve);
       }),
   ),

--- a/orchestrator/src/server/pipeline/challenges.test.ts
+++ b/orchestrator/src/server/pipeline/challenges.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const challenge = {
+  extractorId: "gradcracker",
+  extractorName: "Gradcracker",
+  url: "https://www.gradcracker.com/search/computing-technology/software-developer-graduate-jobs-in-london-and-south-east?order=dateAdded",
+  sources: ["gradcracker"],
+};
+
+vi.mock("../repositories/pipeline", () => ({
+  createPipelineRun: vi.fn(async () => ({
+    id: "run-challenge-1",
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+    status: "running",
+    jobsDiscovered: 0,
+    jobsProcessed: 0,
+    errorMessage: null,
+  })),
+  updatePipelineRun: vi.fn(async () => undefined),
+}));
+
+vi.mock("./steps", () => ({
+  loadProfileStep: vi.fn(async () => ({})),
+  discoverJobsStep: vi.fn(async () => ({
+    discoveredJobs: [],
+    sourceErrors: [
+      "Gradcracker: Cloudflare challenge required for https://www.gradcracker.com/search/computing-technology/software-developer-graduate-jobs-in-london-and-south-east?order=dateAdded (sources: gradcracker)",
+    ],
+    pendingChallenges: [challenge],
+  })),
+  importJobsStep: vi.fn(async () => ({ created: 0, skipped: 0 })),
+  scoreJobsStep: vi.fn(async () => ({ unprocessedJobs: [], scoredJobs: [] })),
+  selectJobsStep: vi.fn(() => []),
+  processJobsStep: vi.fn(async () => ({ processedCount: 0 })),
+  notifyPipelineWebhookStep: vi.fn(async () => undefined),
+}));
+
+describe.sequential("pipeline challenge handling", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-pipeline-challenge-"));
+    process.env.DATA_DIR = tempDir;
+    process.env.NODE_ENV = "test";
+
+    await import("../db/migrate");
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import("../db/index");
+    closeDb();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("fails loudly when a solved challenge immediately reappears with no jobs", async () => {
+    const pipeline = await import("./orchestrator");
+    const pipelineRepo = await import("../repositories/pipeline");
+    const steps = await import("./steps");
+
+    const runPromise = pipeline.runPipeline({
+      sources: ["gradcracker"],
+      locationIntent: {
+        selectedCountry: "united kingdom",
+        country: "united kingdom",
+        cityLocations: [],
+        workplaceTypes: [],
+        geoScope: "selected_only",
+        searchScope: "selected_only",
+        matchStrictness: "flexible",
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(pipeline.getPendingChallenges()).toHaveLength(1);
+    });
+
+    expect(pipeline.resolvePipelineChallenge("gradcracker")).toEqual({
+      resolved: true,
+      remaining: 0,
+    });
+
+    const result = await runPromise;
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        success: false,
+        jobsDiscovered: 0,
+        jobsProcessed: 0,
+        error: expect.stringContaining(
+          "still returned a Cloudflare challenge after the solve step",
+        ),
+      }),
+    );
+    expect(vi.mocked(steps.discoverJobsStep)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(steps.importJobsStep)).not.toHaveBeenCalled();
+    expect(vi.mocked(pipelineRepo.updatePipelineRun)).toHaveBeenCalledWith(
+      "run-challenge-1",
+      expect.objectContaining({
+        status: "failed",
+        errorMessage: expect.stringContaining(
+          "still returned a Cloudflare challenge after the solve step",
+        ),
+      }),
+    );
+  });
+});

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -208,6 +208,23 @@ function ensureNotCancelled(tenantId = getActiveTenantId()): void {
   }
 }
 
+function buildRepeatedChallengeMessage(args: {
+  challenges: PendingChallenge[];
+  sourceErrors: string[];
+}): string {
+  const extractorNames =
+    args.challenges
+      .map((challenge) => challenge.extractorName || challenge.extractorId)
+      .filter(Boolean)
+      .join(", ") || "One or more extractors";
+  const sourceDetails =
+    args.sourceErrors.length > 0
+      ? ` Details: ${args.sourceErrors.join("; ")}`
+      : "";
+
+  return `${extractorNames} still returned a Cloudflare challenge after the solve step, so the pipeline stopped instead of completing with zero jobs.${sourceDetails}`;
+}
+
 /**
  * Run the full job discovery and processing pipeline.
  */
@@ -342,19 +359,26 @@ export async function runPipeline(
         sourceErrors = [...sourceErrors, ...retryResult.sourceErrors];
         pendingChallenges = retryResult.pendingChallenges;
 
-        // If the retry itself hits challenges again (e.g. cookie expired
-        // between solve and retry), we don't loop — just continue with whatever
-        // the first run discovered.  The user will see partial results and can
-        // re-run the pipeline.
+        // If the retry itself hits challenges again (e.g. no reusable cookie was
+        // persisted, or the cookie was rejected), keep partial results only when
+        // something useful was discovered. Otherwise stop loudly instead of
+        // presenting a successful zero-job run.
         if (retryResult.pendingChallenges.length > 0) {
-          pipelineLogger.warn(
-            "Retry after challenge still has challenges — continuing with partial results",
-            {
-              retryPendingChallenges: retryResult.pendingChallenges.map(
-                (c) => c.extractorId,
-              ),
-            },
-          );
+          const message = buildRepeatedChallengeMessage({
+            challenges: retryResult.pendingChallenges,
+            sourceErrors: retryResult.sourceErrors,
+          });
+
+          if (discoveredJobs.length === 0) {
+            throw new Error(message);
+          }
+
+          pipelineLogger.warn(message, {
+            retryPendingChallenges: retryResult.pendingChallenges.map(
+              (c) => c.extractorId,
+            ),
+            retrySourceErrors: retryResult.sourceErrors,
+          });
         }
 
         progressHelpers.crawlingComplete(discoveredJobs.length);

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -385,12 +385,12 @@ export async function runPipeline(
       }
 
       ensureNotCancelled(tenantId);
-      const { created } = await importJobsStep({ discoveredJobs });
-      jobsDiscovered = created;
+      jobsDiscovered = discoveredJobs.length;
+      const { created, skipped } = await importJobsStep({ discoveredJobs });
 
       await persistResultSummary({ stage: "import" });
       await pipelineRepo.updatePipelineRun(pipelineRun.id, {
-        jobsDiscovered: created,
+        jobsDiscovered,
       });
 
       let unprocessedJobs: import("@shared/types").Job[] = [];
@@ -474,22 +474,24 @@ export async function runPipeline(
         resultSummary,
       });
 
-      progressHelpers.complete(created, processedCount);
+      progressHelpers.complete(jobsDiscovered, processedCount);
       pipelineLogger.info("Pipeline run completed", {
-        jobsDiscovered: created,
+        jobsDiscovered,
+        jobsImported: created,
+        jobsSkipped: skipped,
         jobsProcessed: processedCount,
       });
 
       await notifyPipelineWebhookStep("pipeline.completed", {
         pipelineRunId: pipelineRun.id,
-        jobsDiscovered: created,
+        jobsDiscovered,
         jobsScored: unprocessedJobs.length,
         jobsProcessed: processedCount,
       });
 
       return {
         success: true,
-        jobsDiscovered: created,
+        jobsDiscovered,
         jobsProcessed: processedCount,
       };
     } catch (error) {

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -1,6 +1,7 @@
 import type { PipelineConfig } from "@shared/types";
+import type { ExtractorRuntimeContext } from "@shared/types/extractors";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getProgress, resetProgress } from "../progress";
+import { getProgress, resetProgress, subscribeToProgress } from "../progress";
 import { discoverJobsStep } from "./discover-jobs";
 
 vi.mock("@server/repositories/settings", () => ({
@@ -98,6 +99,59 @@ describe("discoverJobsStep", () => {
     expect(jobspyManifest.run).toHaveBeenCalledWith(
       expect.objectContaining({ selectedSources: ["indeed", "linkedin"] }),
     );
+  });
+
+  it("streams extractor progress detail while discovery is still running", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+
+    const gradcrackerManifest = {
+      id: "gradcracker",
+      displayName: "Gradcracker",
+      providesSources: ["gradcracker"],
+      run: vi.fn(async (context: ExtractorRuntimeContext) => {
+        context.onProgress?.({
+          currentUrl: "https://www.gradcracker.com/challenge",
+          detail:
+            "Gradcracker hit a Cloudflare challenge: https://www.gradcracker.com/challenge",
+        });
+
+        return { success: true, jobs: [] };
+      }),
+    };
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["software developer"]),
+      jobspyCountryIndeed: "united kingdom",
+    } as any);
+
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map([["gradcracker", gradcrackerManifest as any]]),
+      manifestBySource: new Map([["gradcracker", gradcrackerManifest as any]]),
+      availableSources: ["gradcracker"],
+    } as any);
+
+    const updates: Array<{ step: string; detail?: string }> = [];
+    const unsubscribe = subscribeToProgress((progress) => {
+      updates.push({ step: progress.step, detail: progress.detail });
+    });
+
+    try {
+      await discoverJobsStep({
+        mergedConfig: {
+          ...baseConfig,
+          sources: ["gradcracker"],
+        },
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(updates).toContainEqual({
+      step: "crawling",
+      detail:
+        "Gradcracker hit a Cloudflare challenge: https://www.gradcracker.com/challenge",
+    });
   });
 
   it("throws when all enabled sources fail", async () => {

--- a/orchestrator/src/server/pipeline/steps/import-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/import-jobs.ts
@@ -6,9 +6,15 @@ import { progressHelpers } from "../progress";
 export async function importJobsStep(args: {
   discoveredJobs: CreateJobInput[];
 }): Promise<{ created: number; skipped: number }> {
-  logger.info("Importing discovered jobs");
+  logger.info("Importing discovered jobs", {
+    discovered: args.discoveredJobs.length,
+  });
   const { created, skipped } = await jobsRepo.createJobs(args.discoveredJobs);
-  logger.info("Import step complete", { created, skipped });
+  logger.info("Import step complete", {
+    discovered: args.discoveredJobs.length,
+    created,
+    skipped,
+  });
 
   progressHelpers.importComplete(created, skipped);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -257,7 +257,9 @@
       "dependencies": {
         "browser-utils": "^0.0.1",
         "camoufox-js": "^0.9.2",
+        "cheerio": "^1.0.0",
         "crawlee": "^3.0.0",
+        "impit": "^0.11.0",
         "playwright": "*",
         "tsx": "^4.4.0"
       },
@@ -267,9 +269,6 @@
         "@types/node": "^24.0.0",
         "fs-extra": "^11.3.0",
         "typescript": "~5.9.0"
-      },
-      "optionalDependencies": {
-        "impit-linux-x64-gnu": "^0.1.0"
       }
     },
     "extractors/gradcracker/node_modules/@apify/tsconfig": {
@@ -300,6 +299,62 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "extractors/gradcracker/node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "extractors/gradcracker/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "extractors/gradcracker/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "extractors/gradcracker/node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,8 @@
       "version": "0.0.1",
       "license": "SEE LICENSE IN ../../LICENSE",
       "dependencies": {
-        "camoufox-js": "^0.9.2"
+        "camoufox-js": "^0.9.2",
+        "tough-cookie": "^6.0.1"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",

--- a/scripts/camoufox-fetch.mjs
+++ b/scripts/camoufox-fetch.mjs
@@ -1,3 +1,4 @@
+import { downloadMMDB } from "camoufox-js/dist/locale.js";
 import { CamoufoxFetcher } from "camoufox-js/dist/pkgman.js";
 
 const githubToken = process.env.GITHUB_TOKEN?.trim() || "";
@@ -50,3 +51,4 @@ if (githubToken) {
 }
 
 await new CamoufoxFetcher().install();
+await downloadMMDB();


### PR DESCRIPTION
## Summary
- Reuse solved Cloudflare cookies and browser user agent in the fast Gradcracker HTTP scraper so retries can recover after a captcha solve
- Tighten challenge handling so the pipeline stops loudly if the retry still returns no usable jobs
- Keep browser fallback, deployment, and docs aligned with the new recovery path

## Testing
- Biome formatting and lint checks passed
- Type checks passed for shared, orchestrator, Gradcracker, and UK Visa Jobs workspaces
- Client build passed
- Orchestrator test suite passed