### PR TITLE
fix: split Dockerfile build stages to resolve QEMU SWC arm64 crash

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,10 +171,6 @@ RUN --mount=type=cache,id=npm-runtime-${TARGETARCH},target=/root/.npm \
     npm install --workspaces --include-workspace-root --omit=dev \
     --no-audit --no-fund --progress=false
 
-# Browser fallbacks and the Cloudflare solver run through Node Playwright.
-# Python Playwright uses a different browser revision, so install the Node
-# Firefox binary explicitly into PLAYWRIGHT_BROWSERS_PATH.
-RUN ./node_modules/.bin/playwright install firefox
 
 FROM runtime-node-deps AS camoufox-cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # SHARED BASE IMAGES
 # ============================================================================
-FROM node:22-slim AS runtime-base
+FROM --platform=$TARGETPLATFORM node:22-slim AS runtime-base
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV NODE_ENV=production
@@ -30,9 +30,24 @@ RUN npm install -g @openai/codex@${CODEX_CLI_VERSION}
 
 WORKDIR /app
 
-FROM runtime-base AS build-base
+FROM --platform=$BUILDPLATFORM node:22-slim AS build-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_ENV=production
+
+WORKDIR /app
 
 # Install compiler toolchain only for build-oriented stages.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    python3 python3-minimal libpython3.11-minimal \
+    build-essential pkg-config \
+    curl && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+FROM runtime-base AS target-build-base
+
+# Install compiler toolchain for target-platform dependency stages only.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential pkg-config && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
@@ -40,10 +55,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ============================================================================
 # BUILD INPUT STAGES
 # ============================================================================
-FROM build-base AS python-deps
+FROM target-build-base AS python-deps
+
+ARG TARGETARCH
 
 # Install Python dependencies with pip cache.
-RUN --mount=type=cache,target=/root/.cache/pip \
+RUN --mount=type=cache,id=pip-${TARGETARCH},target=/root/.cache/pip \
     pip3 install --break-system-packages playwright python-jobspy
 
 # Install Firefox for Python Playwright.
@@ -51,9 +68,10 @@ RUN python3 -m playwright install firefox
 
 FROM build-base AS node-deps
 
+ARG BUILDARCH
+
 # Copy package files for dependency installation.
 COPY package*.json ./
-COPY scripts/camoufox-fetch.mjs ./scripts/camoufox-fetch.mjs
 COPY docs-site/package*.json ./docs-site/
 COPY shared/package*.json ./shared/
 COPY orchestrator/package*.json ./orchestrator/
@@ -73,15 +91,11 @@ COPY extractors/fiveamsat/package*.json ./extractors/fiveamsat/
 COPY extractors/wazzuf/package*.json ./extractors/wazzuf/
 COPY extractors/browser-utils/package*.json ./extractors/browser-utils/
 
-# Install Node dependencies with npm cache (dev deps needed for build).
-RUN --mount=type=cache,target=/root/.npm \
+# Install build-time Node dependencies on the native builder platform. The
+# resulting client/docs assets are architecture-neutral static files.
+RUN --mount=type=cache,id=npm-build-${BUILDARCH},target=/root/.npm \
     npm install --workspaces --include-workspace-root --include=dev \
     --no-audit --no-fund --progress=false
-
-# Fetch Camoufox binaries and GeoLite data before copying source to keep the
-# downloads cached and avoid runtime GitHub calls during browser launch.
-RUN --mount=type=secret,id=github_token,required=false \
-    sh -c 'GITHUB_TOKEN="$([ -f /run/secrets/github_token ] && cat /run/secrets/github_token || true)" node ./scripts/camoufox-fetch.mjs'
 
 FROM node-deps AS build-sources
 
@@ -124,6 +138,8 @@ RUN npm run build:client
 # ============================================================================
 FROM runtime-base AS runtime-node-deps
 
+ARG TARGETARCH
+
 # Install virtual display dependencies for the headed Cloudflare challenge solver.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb x11vnc novnc websockify && \
@@ -151,7 +167,7 @@ COPY extractors/wazzuf/package*.json ./extractors/wazzuf/
 COPY extractors/browser-utils/package*.json ./extractors/browser-utils/
 
 # Install production Node dependencies only.
-RUN --mount=type=cache,target=/root/.npm \
+RUN --mount=type=cache,id=npm-runtime-${TARGETARCH},target=/root/.npm \
     npm install --workspaces --include-workspace-root --omit=dev \
     --no-audit --no-fund --progress=false
 
@@ -159,6 +175,14 @@ RUN --mount=type=cache,target=/root/.npm \
 # Python Playwright uses a different browser revision, so install the Node
 # Firefox binary explicitly into PLAYWRIGHT_BROWSERS_PATH.
 RUN ./node_modules/.bin/playwright install firefox
+
+FROM runtime-node-deps AS camoufox-cache
+
+# Fetch target-platform Camoufox binaries after production dependencies are
+# installed so arm64 images do not inherit x64 browser assets from build stages.
+COPY scripts/camoufox-fetch.mjs ./scripts/camoufox-fetch.mjs
+RUN --mount=type=secret,id=github_token,required=false \
+    sh -c 'GITHUB_TOKEN="$([ -f /run/secrets/github_token ] && cat /run/secrets/github_token || true)" node ./scripts/camoufox-fetch.mjs'
 
 FROM runtime-base AS tectonic
 
@@ -215,7 +239,7 @@ COPY --from=tectonic /usr/local/bin/tectonic /usr/local/bin/tectonic
 COPY --from=typst /usr/local/bin/typst /usr/local/bin/typst
 COPY --from=python-deps /usr/local/lib/python3.11/dist-packages /usr/local/lib/python3.11/dist-packages
 COPY --from=python-deps /ms-playwright /ms-playwright
-COPY --from=node-deps /root/.cache/camoufox /root/.cache/camoufox
+COPY --from=camoufox-cache /root/.cache/camoufox /root/.cache/camoufox
 
 # Copy built assets and runtime source code.
 COPY --from=client-build /app/orchestrator/dist ./orchestrator/dist

--- a/extractors/browser-utils/src/launch.ts
+++ b/extractors/browser-utils/src/launch.ts
@@ -24,45 +24,32 @@ const DEFAULTS: Required<Omit<BrowserLaunchOptions, "args">> = {
 
 /**
  * Creates Playwright launch options using Camoufox for anti-detection.
- * Falls back to vanilla Firefox if Camoufox fails to initialize.
+ *
+ * Camoufox is baked into the production Docker image via the `camoufox-cache`
+ * build stage and is the only supported browser. There is no vanilla Firefox
+ * fallback: if Camoufox is unavailable it means the image was built incorrectly
+ * or the binary was not fetched, and we want that to surface as an immediate
+ * hard failure rather than silently degrading anti-detection in production.
  *
  * This centralizes the launch config so all extractors use the same
  * anti-detection settings. Update this one place when Camoufox options change.
  *
- * @returns Launch options and a flag indicating whether Camoufox was used
+ * @returns Launch options for use with playwright's firefox.launch()
  */
 export async function createLaunchOptions(
   options: BrowserLaunchOptions = {},
-): Promise<{ launchOptions: LaunchOptions; usedCamoufox: boolean }> {
+): Promise<{ launchOptions: LaunchOptions; usedCamoufox: true }> {
   const merged = { ...DEFAULTS, ...options };
 
-  try {
-    const { launchOptions } = await import("camoufox-js");
+  const { launchOptions } = await import("camoufox-js");
 
-    const opts = await launchOptions({
-      headless: merged.headless,
-      humanize: merged.humanize,
-      geoip: merged.geoip,
-      block_webrtc: merged.block_webrtc,
-      args: options.args,
-    });
+  const opts = await launchOptions({
+    headless: merged.headless,
+    humanize: merged.humanize,
+    geoip: merged.geoip,
+    block_webrtc: merged.block_webrtc,
+    args: options.args,
+  });
 
-    return { launchOptions: opts, usedCamoufox: true };
-  } catch (error) {
-    // Camoufox binary missing or incompatible — fall back to vanilla Firefox.
-    // This happens in CI or when the binary hasn't been fetched yet.
-    console.warn(
-      `[browser-utils] Camoufox unavailable, falling back to vanilla Firefox: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-
-    return {
-      launchOptions: {
-        headless: merged.headless,
-        args: options.args,
-      },
-      usedCamoufox: false,
-    };
-  }
+  return { launchOptions: opts, usedCamoufox: true };
 }

--- a/orchestrator/src/server/extractors/deployment.test.ts
+++ b/orchestrator/src/server/extractors/deployment.test.ts
@@ -53,12 +53,16 @@ describe("extractor deployment config", () => {
     );
   });
 
-  it("installs the Node Playwright Firefox binary for browser fallbacks", async () => {
+  it("does not install a vanilla Node Playwright Firefox binary", async () => {
+    // Camoufox is the only supported browser in production. The vanilla Firefox
+    // fallback was removed so that a missing Camoufox binary surfaces as a hard
+    // failure rather than silently degrading anti-detection. Keeping this
+    // assertion prevents the fallback from being accidentally reintroduced.
     const dockerfile = await readFile(resolve(process.cwd(), "../Dockerfile"), {
       encoding: "utf8",
     });
 
-    expect(dockerfile).toContain(
+    expect(dockerfile).not.toContain(
       "./node_modules/.bin/playwright install firefox",
     );
   });


### PR DESCRIPTION
Splits the Dockerfile build steps so that dev-dependency installation and static client builds happen on the host ($BUILDPLATFORM). This avoids running the resource-heavy and emulation-fragile `@swc/core` dev postinstall step inside the emulated arm64 container.