### PR TITLE
feat: fuzzy dedup for job import pipeline (closes #585)

### DIFF
--- a/orchestrator/src/server/pipeline/cancellation.test.ts
+++ b/orchestrator/src/server/pipeline/cancellation.test.ts
@@ -55,7 +55,11 @@ vi.mock("./steps", () => ({
         stepState.setResolver(resolve);
       }),
   ),
-  importJobsStep: vi.fn(async () => ({ created: 0, skipped: 0 })),
+  importJobsStep: vi.fn(async () => ({
+    created: 0,
+    skipped: 0,
+    fuzzyMerged: 0,
+  })),
   scoreJobsStep: vi.fn(async () => ({ unprocessedJobs: [], scoredJobs: [] })),
   selectJobsStep: vi.fn(() => []),
   processJobsStep: vi.fn(async () => ({ processedCount: 0 })),

--- a/orchestrator/src/server/pipeline/challenges.test.ts
+++ b/orchestrator/src/server/pipeline/challenges.test.ts
@@ -32,7 +32,11 @@ vi.mock("./steps", () => ({
     ],
     pendingChallenges: [challenge],
   })),
-  importJobsStep: vi.fn(async () => ({ created: 0, skipped: 0 })),
+  importJobsStep: vi.fn(async () => ({
+    created: 0,
+    skipped: 0,
+    fuzzyMerged: 0,
+  })),
   scoreJobsStep: vi.fn(async () => ({ unprocessedJobs: [], scoredJobs: [] })),
   selectJobsStep: vi.fn(() => []),
   processJobsStep: vi.fn(async () => ({ processedCount: 0 })),

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -386,7 +386,9 @@ export async function runPipeline(
 
       ensureNotCancelled(tenantId);
       jobsDiscovered = discoveredJobs.length;
-      const { created, skipped } = await importJobsStep({ discoveredJobs });
+      const { created, skipped, fuzzyMerged } = await importJobsStep({
+        discoveredJobs,
+      });
 
       await persistResultSummary({ stage: "import" });
       await pipelineRepo.updatePipelineRun(pipelineRun.id, {
@@ -477,6 +479,7 @@ export async function runPipeline(
       progressHelpers.complete(jobsDiscovered, processedCount);
       pipelineLogger.info("Pipeline run completed", {
         jobsDiscovered,
+        jobsFuzzyMerged: fuzzyMerged,
         jobsImported: created,
         jobsSkipped: skipped,
         jobsProcessed: processedCount,

--- a/orchestrator/src/server/pipeline/steps/import-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/import-jobs.ts
@@ -1,22 +1,36 @@
 import { logger } from "@infra/logger";
 import * as jobsRepo from "@server/repositories/jobs";
+import { deduplicateJobsByTitleAndEmployer } from "@shared/job-matching.js";
 import type { CreateJobInput } from "@shared/types";
 import { progressHelpers } from "../progress";
 
 export async function importJobsStep(args: {
   discoveredJobs: CreateJobInput[];
-}): Promise<{ created: number; skipped: number }> {
+}): Promise<{ created: number; skipped: number; fuzzyMerged: number }> {
   logger.info("Importing discovered jobs", {
     discovered: args.discoveredJobs.length,
   });
-  const { created, skipped } = await jobsRepo.createJobs(args.discoveredJobs);
+
+  const dedupedJobs = deduplicateJobsByTitleAndEmployer(args.discoveredJobs);
+  const fuzzyMerged = args.discoveredJobs.length - dedupedJobs.length;
+
+  if (fuzzyMerged > 0) {
+    logger.info("Fuzzy-deduped discovered jobs before import", {
+      original: args.discoveredJobs.length,
+      dedupedCount: dedupedJobs.length,
+      fuzzyMerged,
+    });
+  }
+
+  const { created, skipped } = await jobsRepo.createJobs(dedupedJobs);
   logger.info("Import step complete", {
     discovered: args.discoveredJobs.length,
+    fuzzyMerged,
     created,
     skipped,
   });
 
-  progressHelpers.importComplete(created, skipped);
+  progressHelpers.importComplete(created, skipped + fuzzyMerged);
 
-  return { created, skipped };
+  return { created, skipped, fuzzyMerged };
 }

--- a/shared/src/job-matching.test.ts
+++ b/shared/src/job-matching.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { deduplicateJobsByTitleAndEmployer } from "./job-matching";
+
+function makeJob(
+  overrides: Partial<{
+    source: string;
+    title: string;
+    employer: string;
+    jobUrl: string;
+    location: string | undefined;
+    salary: string | undefined;
+    jobDescription: string | undefined;
+    sourceJobId: string | undefined;
+  }>,
+) {
+  return {
+    source: "indeed" as const,
+    title: "Software Engineer",
+    employer: "Acme Corp",
+    jobUrl: `https://example.com/${Math.random()}`,
+    ...overrides,
+  };
+}
+
+describe("deduplicateJobsByTitleAndEmployer", () => {
+  it("returns an empty list unchanged", () => {
+    expect(deduplicateJobsByTitleAndEmployer([])).toEqual([]);
+  });
+
+  it("returns a single job unchanged", () => {
+    const job = makeJob({ title: "Frontend Engineer", employer: "Globex" });
+    const result = deduplicateJobsByTitleAndEmployer([job]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(job);
+  });
+
+  it("merges exact title + employer duplicates into one entry", () => {
+    const first = makeJob({
+      title: "Backend Engineer",
+      employer: "NRT Technology Corp",
+      jobUrl: "https://board-a.com/job/1",
+    });
+    const second = makeJob({
+      title: "Backend Engineer",
+      employer: "NRT Technology Corp",
+      jobUrl: "https://board-b.com/job/2",
+    });
+
+    const result = deduplicateJobsByTitleAndEmployer([first, second]);
+    expect(result).toHaveLength(1);
+    // First-seen URL is canonical
+    expect(result[0].jobUrl).toBe("https://board-a.com/job/1");
+  });
+
+  it("merges employer punctuation variants (dot, pipe)", () => {
+    const first = makeJob({
+      title: "Backend Engineer",
+      employer: "NRT Technology Corp | Las Vegas, NV, US",
+      jobUrl: "https://board-a.com/job/1",
+    });
+    const second = makeJob({
+      title: "Backend Engineer",
+      employer: "NRT Technology Corp. | Las Vegas, NV",
+      jobUrl: "https://board-b.com/job/2",
+    });
+
+    const result = deduplicateJobsByTitleAndEmployer([first, second]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("merges employer suffix variants (Ltd vs Limited)", () => {
+    const first = makeJob({
+      title: "Platform Engineer",
+      employer: "Acme Ltd",
+      jobUrl: "https://board-a.com/job/1",
+    });
+    const second = makeJob({
+      title: "Platform Engineer",
+      employer: "Acme Limited",
+      jobUrl: "https://board-b.com/job/2",
+    });
+
+    const result = deduplicateJobsByTitleAndEmployer([first, second]);
+    expect(result).toHaveLength(1);
+  });
+
+  it("keeps both jobs when employers differ significantly", () => {
+    const first = makeJob({ title: "Backend Engineer", employer: "Acme Labs" });
+    const second = makeJob({
+      title: "Backend Engineer",
+      employer: "Globex Inc",
+    });
+
+    const result = deduplicateJobsByTitleAndEmployer([first, second]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("keeps both jobs when titles differ significantly", () => {
+    const first = makeJob({ title: "Backend Engineer", employer: "Acme Labs" });
+    const second = makeJob({
+      title: "Product Designer",
+      employer: "Acme Labs",
+    });
+
+    const result = deduplicateJobsByTitleAndEmployer([first, second]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("merges location from first and salary from second into one entry", () => {
+    const first = makeJob({
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      jobUrl: "https://board-a.com/job/1",
+      location: "Las Vegas, NV",
+      salary: undefined,
+    });
+    const second = makeJob({
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      jobUrl: "https://board-b.com/job/2",
+      location: undefined,
+      salary: "$120,000",
+    });
+
+    const result = deduplicateJobsByTitleAndEmployer([first, second]);
+    expect(result).toHaveLength(1);
+    expect(result[0].location).toBe("Las Vegas, NV");
+    expect(result[0].salary).toBe("$120,000");
+  });
+
+  it("retains jobDescription when only one duplicate has it", () => {
+    const withDesc = makeJob({
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      jobUrl: "https://board-a.com/job/1",
+      jobDescription: "A great role building APIs.",
+    });
+    const withoutDesc = makeJob({
+      title: "Backend Engineer",
+      employer: "Acme Labs",
+      jobUrl: "https://board-b.com/job/2",
+      jobDescription: undefined,
+    });
+
+    // First listing has description
+    const result1 = deduplicateJobsByTitleAndEmployer([withDesc, withoutDesc]);
+    expect(result1[0].jobDescription).toBe("A great role building APIs.");
+
+    // Second listing has description — should still be merged in
+    const result2 = deduplicateJobsByTitleAndEmployer([withoutDesc, withDesc]);
+    expect(result2[0].jobDescription).toBe("A great role building APIs.");
+  });
+
+  it("merges sourceJobId from second when first lacks it", () => {
+    const first = makeJob({
+      title: "Data Engineer",
+      employer: "Acme Labs",
+      jobUrl: "https://board-a.com/job/1",
+      sourceJobId: undefined,
+    });
+    const second = makeJob({
+      title: "Data Engineer",
+      employer: "Acme Labs",
+      jobUrl: "https://board-b.com/job/2",
+      sourceJobId: "ext-42",
+    });
+
+    const result = deduplicateJobsByTitleAndEmployer([first, second]);
+    expect(result).toHaveLength(1);
+    expect(result[0].sourceJobId).toBe("ext-42");
+  });
+
+  it("handles three-way duplicates, merging all into one entry", () => {
+    const jobs = [
+      makeJob({
+        title: "SRE Engineer",
+        employer: "Acme Labs",
+        jobUrl: "https://board-a.com/job/1",
+        location: "Remote",
+      }),
+      makeJob({
+        title: "SRE Engineer",
+        employer: "Acme Labs",
+        jobUrl: "https://board-b.com/job/2",
+        salary: "$150k",
+      }),
+      makeJob({
+        title: "SRE Engineer",
+        employer: "Acme Labs",
+        jobUrl: "https://board-c.com/job/3",
+        jobDescription: "Maintain infrastructure.",
+      }),
+    ];
+
+    const result = deduplicateJobsByTitleAndEmployer(jobs);
+    expect(result).toHaveLength(1);
+    expect(result[0].location).toBe("Remote");
+    expect(result[0].salary).toBe("$150k");
+    expect(result[0].jobDescription).toBe("Maintain infrastructure.");
+  });
+
+  it("respects custom threshold overrides", () => {
+    // With a very high threshold (100) nothing except exact matches should collapse
+    const first = makeJob({ title: "Senior Engineer", employer: "Acme Ltd" });
+    const second = makeJob({
+      title: "Senior Engineer",
+      employer: "Acme Limited",
+    });
+
+    // Default thresholds → merged
+    expect(deduplicateJobsByTitleAndEmployer([first, second])).toHaveLength(1);
+
+    // employerThreshold=100 → not merged (Ltd vs Limited doesn't hit 100)
+    expect(
+      deduplicateJobsByTitleAndEmployer([first, second], {
+        employerThreshold: 100,
+      }),
+    ).toHaveLength(2);
+  });
+});

--- a/shared/src/job-matching.ts
+++ b/shared/src/job-matching.ts
@@ -3,6 +3,7 @@ import {
   matchesRequestedCountry,
   shouldApplyStrictCityFilter,
 } from "./search-cities.js";
+import type { CreateJobInput } from "./types/jobs.js";
 import type { LocationIntent } from "./types/location";
 import { normalizeWhitespace } from "./utils/string";
 
@@ -186,4 +187,132 @@ export function matchJobLocationIntent(
   }
 
   return { matched: false, reasonCode: "no_match", priority: 0 };
+}
+
+const FUZZY_DEDUP_TITLE_THRESHOLD = 90;
+const FUZZY_DEDUP_EMPLOYER_THRESHOLD = 85;
+
+/**
+ * Merge two CreateJobInput objects, preferring the first non-null/non-undefined
+ * value for each optional field. Required fields (source, title, employer,
+ * jobUrl) are taken from `base`.
+ */
+function mergeJobInputs(
+  base: CreateJobInput,
+  incoming: CreateJobInput,
+): CreateJobInput {
+  return {
+    // Required — always from base
+    source: base.source,
+    title: base.title,
+    employer: base.employer,
+    jobUrl: base.jobUrl,
+    // Optional — first non-null wins
+    employerUrl: base.employerUrl ?? incoming.employerUrl,
+    applicationLink: base.applicationLink ?? incoming.applicationLink,
+    disciplines: base.disciplines ?? incoming.disciplines,
+    deadline: base.deadline ?? incoming.deadline,
+    salary: base.salary ?? incoming.salary,
+    location: base.location ?? incoming.location,
+    locationEvidence: base.locationEvidence ?? incoming.locationEvidence,
+    degreeRequired: base.degreeRequired ?? incoming.degreeRequired,
+    starting: base.starting ?? incoming.starting,
+    jobDescription: base.jobDescription ?? incoming.jobDescription,
+    sourceJobId: base.sourceJobId ?? incoming.sourceJobId,
+    jobUrlDirect: base.jobUrlDirect ?? incoming.jobUrlDirect,
+    datePosted: base.datePosted ?? incoming.datePosted,
+    jobType: base.jobType ?? incoming.jobType,
+    salarySource: base.salarySource ?? incoming.salarySource,
+    salaryInterval: base.salaryInterval ?? incoming.salaryInterval,
+    salaryMinAmount: base.salaryMinAmount ?? incoming.salaryMinAmount,
+    salaryMaxAmount: base.salaryMaxAmount ?? incoming.salaryMaxAmount,
+    salaryCurrency: base.salaryCurrency ?? incoming.salaryCurrency,
+    isRemote: base.isRemote ?? incoming.isRemote,
+    jobLevel: base.jobLevel ?? incoming.jobLevel,
+    jobFunction: base.jobFunction ?? incoming.jobFunction,
+    listingType: base.listingType ?? incoming.listingType,
+    emails: base.emails ?? incoming.emails,
+    companyIndustry: base.companyIndustry ?? incoming.companyIndustry,
+    companyLogo: base.companyLogo ?? incoming.companyLogo,
+    companyUrlDirect: base.companyUrlDirect ?? incoming.companyUrlDirect,
+    companyAddresses: base.companyAddresses ?? incoming.companyAddresses,
+    companyNumEmployees:
+      base.companyNumEmployees ?? incoming.companyNumEmployees,
+    companyRevenue: base.companyRevenue ?? incoming.companyRevenue,
+    companyDescription: base.companyDescription ?? incoming.companyDescription,
+    skills: base.skills ?? incoming.skills,
+    experienceRange: base.experienceRange ?? incoming.experienceRange,
+    companyRating: base.companyRating ?? incoming.companyRating,
+    companyReviewsCount:
+      base.companyReviewsCount ?? incoming.companyReviewsCount,
+    vacancyCount: base.vacancyCount ?? incoming.vacancyCount,
+    workFromHomeType: base.workFromHomeType ?? incoming.workFromHomeType,
+  };
+}
+
+/**
+ * Deduplicate a batch of discovered job listings by fuzzy-matching job title
+ * and employer name. Near-duplicate entries (same role at the same company
+ * scraped from different boards) are **merged** into a single enriched listing:
+ * for each optional field, the first non-null value across all duplicates is
+ * kept, so one listing's `location` and another's `salary` both survive.
+ *
+ * Reuses the existing `normalizeJobTitle`, `normalizeCompanyName`, and
+ * `calculateSimilarity` helpers — no new normalization logic.
+ *
+ * @param jobs - Freshly discovered job inputs from the current scrape run.
+ * @param opts - Optional threshold overrides.
+ * @returns Deduplicated (and field-merged) list.
+ */
+export function deduplicateJobsByTitleAndEmployer(
+  jobs: CreateJobInput[],
+  opts?: {
+    titleThreshold?: number;
+    employerThreshold?: number;
+  },
+): CreateJobInput[] {
+  const titleThreshold = opts?.titleThreshold ?? FUZZY_DEDUP_TITLE_THRESHOLD;
+  const employerThreshold =
+    opts?.employerThreshold ?? FUZZY_DEDUP_EMPLOYER_THRESHOLD;
+
+  type PreparedEntry = {
+    job: CreateJobInput;
+    normalizedTitle: string;
+    normalizedEmployer: string;
+  };
+
+  const merged: PreparedEntry[] = [];
+
+  for (const incoming of jobs) {
+    const normalizedTitle = normalizeJobTitle(incoming.title);
+    const normalizedEmployer = normalizeCompanyName(incoming.employer);
+
+    if (!normalizedTitle || !normalizedEmployer) {
+      merged.push({ job: incoming, normalizedTitle, normalizedEmployer });
+      continue;
+    }
+
+    const match = merged.find((entry) => {
+      if (!entry.normalizedTitle || !entry.normalizedEmployer) return false;
+      const titleScore = calculateSimilarity(
+        normalizedTitle,
+        entry.normalizedTitle,
+      );
+      if (titleScore <= titleThreshold) return false;
+      const employerScore = calculateSimilarity(
+        normalizedEmployer,
+        entry.normalizedEmployer,
+      );
+      return employerScore > employerThreshold;
+    });
+
+    if (match) {
+      // Merge incoming fields into the existing entry (first non-null wins).
+      match.job = mergeJobInputs(match.job, incoming);
+    } else {
+      merged.push({ job: incoming, normalizedTitle, normalizedEmployer });
+    }
+  }
+
+  return merged.map((entry) => entry.job);
 }


### PR DESCRIPTION
Resolves #585

## What
Adds a pre-import fuzzy dedup pass that merges near-duplicate job listings (same role at the same company scraped from multiple boards) into a single enriched entry before they hit the database.

## How
- New `deduplicateJobsByTitleAndEmployer()` in `shared/job-matching.ts`, reusing existing `normalizeJobTitle`, `normalizeCompanyName`, and `calculateSimilarity` helpers
- **Thresholds**: title score > 90, employer score > 85
- **Merge strategy**: first non-null field wins per field — so one listing's `location` and another's `salary` both appear in the final entry
- **Scope**: batch-only (current scrape run); no DB-level fuzzy scan
- Plugged into `importJobsStep` before `jobsRepo.createJobs`; `fuzzyMerged` count logged and reflected in the progress counter

## Tests
10 new unit tests including the exact example from the issue (`NRT Technology Corp | Las Vegas, NV, US` vs `NRT Technology Corp. | Las Vegas, NV`).

All 247 test files pass. Biome and tsc clean.