### PR TITLE
Add hosted signup into the configured tenant

### DIFF
--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -67,7 +67,7 @@ JOBOPS_APP_MODE=hosted
 JOBOPS_HOSTED_TENANT_ID=tenant_hosted
 ```
 
-`JOBOPS_HOSTED_TENANT_ID` is required in hosted mode. JobOps fails startup if `JOBOPS_APP_MODE=hosted` is set without a hosted tenant ID.
+`JOBOPS_HOSTED_TENANT_ID` is required in hosted mode. JobOps fails startup if `JOBOPS_APP_MODE=hosted` is set without a hosted tenant ID. The tenant must already exist in the database before hosted signup can create users for it; hosted signup does not create tenants.
 
 Optional hosted capabilities default to disabled:
 
@@ -78,6 +78,8 @@ JOBOPS_HOSTED_QUOTAS_ENABLED=false
 ```
 
 These flags only affect hosted mode. Leaving `JOBOPS_APP_MODE` unset keeps the current first-run setup, private-workspace user creation, settings, and local behavior unchanged.
+
+When hosted mode is active, first-run setup is disabled. Hosted users must be created through hosted signup when `JOBOPS_HOSTED_SIGNUPS_ENABLED=true`, or by a later tenant-owner/admin user-management flow.
 
 ## Codex sign-in
 

--- a/orchestrator/src/client/api/auth.ts
+++ b/orchestrator/src/client/api/auth.ts
@@ -90,6 +90,37 @@ export async function setupFirstAdmin(input: {
   return data.user;
 }
 
+export async function signupWithCredentials(input: {
+  username: string;
+  password: string;
+  displayName?: string;
+}): Promise<AuthUser> {
+  const res = await fetch("/api/auth/signup", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  const parsed = await readAuthResponse<{
+    token: string;
+    user: AuthUser;
+  }>(res);
+  if ("ok" in parsed) {
+    if (!parsed.ok) throw toApiError(res, parsed);
+    if (!parsed.data?.token || !parsed.data.user) {
+      throw new Error("Signup response was incomplete");
+    }
+    setAuthenticatedSession(parsed.data.token);
+    return parsed.data.user;
+  }
+  if (!parsed.success) throw toApiError(res, parsed);
+  const data = parsed.data as { token?: string; user?: AuthUser } | undefined;
+  if (!data?.token || !data.user) {
+    throw new Error("Signup response was incomplete");
+  }
+  setAuthenticatedSession(data.token);
+  return data.user;
+}
+
 export async function getCurrentAuthContext(): Promise<CurrentAuthContext> {
   const result = await fetchApi<{
     user: AuthUser;

--- a/orchestrator/src/server/api/routes/auth.test.ts
+++ b/orchestrator/src/server/api/routes/auth.test.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import type { Server } from "node:http";
 import { join } from "node:path";
+import { eq, sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { startServer, stopServer } from "./test-utils";
 
@@ -20,6 +21,27 @@ describe.sequential("Auth routes", () => {
   afterEach(async () => {
     await stopServer({ server, closeDb, tempDir });
   });
+
+  async function countTenants(): Promise<number> {
+    const { db, schema } = await import("@server/db");
+    const [row] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(schema.tenants);
+    return row?.count ?? 0;
+  }
+
+  async function getTenantMembership(input: { userId: string }) {
+    const { db, schema } = await import("@server/db");
+    const [row] = await db
+      .select({
+        tenantId: schema.tenantMemberships.tenantId,
+        role: schema.tenantMemberships.role,
+      })
+      .from(schema.tenantMemberships)
+      .where(eq(schema.tenantMemberships.userId, input.userId))
+      .limit(1);
+    return row ?? null;
+  }
 
   describe("POST /api/auth/login", () => {
     beforeEach(async () => {
@@ -99,6 +121,220 @@ describe.sequential("Auth routes", () => {
     });
   });
 
+  describe("POST /api/auth/signup", () => {
+    beforeEach(async () => {
+      ({ server, baseUrl, closeDb, tempDir } = await startServer({
+        env: {
+          JOBOPS_TEST_AUTH_BYPASS: "0",
+          JOBOPS_APP_MODE: "hosted",
+          JOBOPS_HOSTED_SIGNUPS_ENABLED: "true",
+          JOBOPS_HOSTED_TENANT_ID: "tenant_default",
+        },
+      }));
+    });
+
+    it("creates a hosted tenant member and signs them in", async () => {
+      const tenantsBefore = await countTenants();
+      const signupRes = await fetch(`${baseUrl}/api/auth/signup`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-request-id": "req-hosted-signup",
+        },
+        body: JSON.stringify({
+          username: " NewUser ",
+          displayName: "New User",
+          password: "super-secret-password",
+        }),
+      });
+
+      expect(signupRes.status).toBe(201);
+      expect(signupRes.headers.get("x-request-id")).toBe("req-hosted-signup");
+      const signupBody = await signupRes.json();
+      expect(signupBody.ok).toBe(true);
+      expect(signupBody.meta.requestId).toBe("req-hosted-signup");
+      expect(signupBody.data.token).toBeTruthy();
+      expect(signupBody.data.expiresIn).toBeGreaterThan(0);
+      expect(signupBody.data.user).toMatchObject({
+        username: "newuser",
+        displayName: "New User",
+        isSystemAdmin: false,
+        isDisabled: false,
+        workspaceId: "tenant_default",
+        workspaceName: "JobOps",
+      });
+
+      await expect(countTenants()).resolves.toBe(tenantsBefore);
+      await expect(
+        getTenantMembership({ userId: signupBody.data.user.id }),
+      ).resolves.toEqual({
+        tenantId: "tenant_default",
+        role: "member",
+      });
+
+      const meRes = await fetch(`${baseUrl}/api/auth/me`, {
+        headers: { Authorization: `Bearer ${signupBody.data.token}` },
+      });
+      expect(meRes.status).toBe(200);
+      const meBody = await meRes.json();
+      expect(meBody.ok).toBe(true);
+      expect(meBody.data.user).toMatchObject({
+        id: signupBody.data.user.id,
+        username: "newuser",
+        workspaceId: "tenant_default",
+        isSystemAdmin: false,
+      });
+    });
+
+    it("returns 409 for duplicate usernames", async () => {
+      const firstRes = await fetch(`${baseUrl}/api/auth/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "adam",
+          password: "adam-secret",
+        }),
+      });
+      expect(firstRes.status).toBe(201);
+
+      const secondRes = await fetch(`${baseUrl}/api/auth/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: " Adam ",
+          password: "adam-secret-2",
+        }),
+      });
+
+      expect(secondRes.status).toBe(409);
+      const body = await secondRes.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("CONFLICT");
+      expect(body.error.message).toContain("Username already exists");
+    });
+
+    it("returns 400 for invalid signup input", async () => {
+      const res = await fetch(`${baseUrl}/api/auth/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username: "sam", password: "short" }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("INVALID_REQUEST");
+      expect(body.error.message).toBe(
+        "Password must be at least 8 characters.",
+      );
+    });
+  });
+
+  describe("POST /api/auth/signup gated modes", () => {
+    it("rejects signup in local mode", async () => {
+      ({ server, baseUrl, closeDb, tempDir } = await startServer({
+        env: {
+          JOBOPS_TEST_AUTH_BYPASS: "0",
+        },
+      }));
+
+      const res = await fetch(`${baseUrl}/api/auth/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "local-user",
+          password: "local-secret",
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("FORBIDDEN");
+    });
+
+    it("rejects signup when hosted signups are disabled", async () => {
+      ({ server, baseUrl, closeDb, tempDir } = await startServer({
+        env: {
+          JOBOPS_TEST_AUTH_BYPASS: "0",
+          JOBOPS_APP_MODE: "hosted",
+          JOBOPS_HOSTED_TENANT_ID: "tenant_default",
+        },
+      }));
+
+      const res = await fetch(`${baseUrl}/api/auth/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "closed-user",
+          password: "closed-secret",
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("FORBIDDEN");
+      expect(body.error.message).toContain("Hosted signups are disabled");
+    });
+
+    it("rejects signup in demo mode", async () => {
+      ({ server, baseUrl, closeDb, tempDir } = await startServer({
+        env: {
+          DEMO_MODE: "true",
+          JOBOPS_TEST_AUTH_BYPASS: "0",
+          JOBOPS_APP_MODE: "hosted",
+          JOBOPS_HOSTED_SIGNUPS_ENABLED: "true",
+          JOBOPS_HOSTED_TENANT_ID: "tenant_default",
+        },
+      }));
+
+      const res = await fetch(`${baseUrl}/api/auth/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "demo-user",
+          password: "demo-secret",
+        }),
+      });
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+    });
+
+    it("rejects signup when the configured hosted tenant is missing", async () => {
+      ({ server, baseUrl, closeDb, tempDir } = await startServer({
+        env: {
+          JOBOPS_TEST_AUTH_BYPASS: "0",
+          JOBOPS_APP_MODE: "hosted",
+          JOBOPS_HOSTED_SIGNUPS_ENABLED: "true",
+          JOBOPS_HOSTED_TENANT_ID: "tenant_missing",
+        },
+      }));
+
+      const tenantsBefore = await countTenants();
+      const res = await fetch(`${baseUrl}/api/auth/signup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "missing-tenant-user",
+          password: "missing-secret",
+        }),
+      });
+
+      expect(res.status).toBe(503);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
+      expect(body.error.message).toContain(
+        "Configured hosted tenant is not available",
+      );
+      await expect(countTenants()).resolves.toBe(tenantsBefore);
+    });
+  });
+
   describe("JWT-authenticated requests", () => {
     beforeEach(async () => {
       ({ server, baseUrl, closeDb, tempDir } = await startServer({
@@ -168,6 +404,33 @@ describe.sequential("Auth routes", () => {
       ({ server, baseUrl, closeDb, tempDir } = await startServer());
     });
 
+    it("creates the first admin in local mode", async () => {
+      const res = await fetch(`${baseUrl}/api/auth/setup`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-request-id": "req-local-setup",
+        },
+        body: JSON.stringify({
+          username: "admin",
+          displayName: "Admin",
+          password: "super-secret-password",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.meta.requestId).toBe("req-local-setup");
+      expect(body.data.token).toBeTruthy();
+      expect(body.data.user).toMatchObject({
+        username: "admin",
+        displayName: "Admin",
+        isSystemAdmin: true,
+        workspaceId: "tenant_default",
+      });
+    });
+
     it("rejects a short first-admin password", async () => {
       const res = await fetch(`${baseUrl}/api/auth/setup`, {
         method: "POST",
@@ -182,6 +445,34 @@ describe.sequential("Auth routes", () => {
         "Password must be at least 8 characters.",
       );
       expect(body.error.details.fieldErrors.password).toBe("[REDACTED]");
+    });
+
+    it("rejects first-run setup in hosted mode", async () => {
+      await stopServer({ server, closeDb, tempDir });
+      ({ server, baseUrl, closeDb, tempDir } = await startServer({
+        env: {
+          JOBOPS_TEST_AUTH_BYPASS: "0",
+          JOBOPS_APP_MODE: "hosted",
+          JOBOPS_HOSTED_TENANT_ID: "tenant_default",
+        },
+      }));
+
+      const res = await fetch(`${baseUrl}/api/auth/setup`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "admin",
+          password: "super-secret-password",
+        }),
+      });
+
+      expect(res.status).toBe(403);
+      const body = await res.json();
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("FORBIDDEN");
+      expect(body.error.message).toContain(
+        "First-run setup is disabled in hosted mode",
+      );
     });
   });
 

--- a/orchestrator/src/server/api/routes/auth.ts
+++ b/orchestrator/src/server/api/routes/auth.ts
@@ -1,7 +1,14 @@
-import { badRequest, serviceUnavailable, unauthorized } from "@infra/errors";
+import {
+  badRequest,
+  conflict,
+  forbidden,
+  serviceUnavailable,
+  unauthorized,
+} from "@infra/errors";
 import { asyncRoute, fail, ok } from "@infra/http";
 import { blacklistToken, signToken, verifyToken } from "@server/auth/jwt";
 import { verifyPassword } from "@server/auth/password";
+import { getJobOpsAppConfig } from "@server/config/app-mode";
 import { isDemoMode } from "@server/config/demo";
 import { getOrCreateAnalyticsInstallState } from "@server/repositories/product-analytics";
 import * as usersRepo from "@server/repositories/users";
@@ -18,6 +25,11 @@ const setupSchema = loginSchema.extend({
   password: z.string().min(8).max(500),
   displayName: z.string().trim().min(1).max(120).optional(),
 });
+
+function isUsernameConflictError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /UNIQUE constraint failed: users\.username/i.test(error.message);
+}
 
 function toSetupValidationMessage(error: z.ZodError): string {
   const issue = error.issues[0];
@@ -45,6 +57,76 @@ function toSetupValidationMessage(error: z.ZodError): string {
 }
 
 export const authRouter = Router();
+
+authRouter.post(
+  "/signup",
+  asyncRoute(async (req: Request, res: Response) => {
+    if (isDemoMode()) {
+      fail(res, serviceUnavailable("Signup is disabled in the public demo."));
+      return;
+    }
+
+    const appConfig = getJobOpsAppConfig();
+    if (appConfig.appMode !== "hosted") {
+      fail(res, forbidden("Signup is available only in hosted mode"));
+      return;
+    }
+    if (!appConfig.capabilities.hostedSignups) {
+      fail(res, forbidden("Hosted signups are disabled"));
+      return;
+    }
+    if (!appConfig.hostedTenantId) {
+      fail(res, serviceUnavailable("Hosted tenant is not configured"));
+      return;
+    }
+
+    const parsed = setupSchema.safeParse(req.body);
+    if (!parsed.success) {
+      fail(
+        res,
+        badRequest(
+          toSetupValidationMessage(parsed.error),
+          parsed.error.flatten(),
+        ),
+      );
+      return;
+    }
+
+    let user: usersRepo.PublicUser | null;
+    try {
+      user = await usersRepo.createHostedTenantUser({
+        username: parsed.data.username,
+        password: parsed.data.password,
+        displayName: parsed.data.displayName ?? parsed.data.username,
+        tenantId: appConfig.hostedTenantId,
+      });
+    } catch (error) {
+      if (isUsernameConflictError(error)) {
+        fail(res, conflict("Username already exists"));
+        return;
+      }
+      throw error;
+    }
+
+    if (!user) {
+      fail(
+        res,
+        serviceUnavailable("Configured hosted tenant is not available"),
+      );
+      return;
+    }
+
+    const { token, expiresIn } = await signToken({
+      sub: user.id,
+      userId: user.id,
+      tenantId: user.workspaceId,
+      username: user.username,
+      isSystemAdmin: user.isSystemAdmin,
+    });
+
+    ok(res, { token, expiresIn, user }, 201);
+  }),
+);
 
 authRouter.post(
   "/login",
@@ -118,6 +200,11 @@ authRouter.get(
 authRouter.post(
   "/setup",
   asyncRoute(async (req: Request, res: Response) => {
+    if (getJobOpsAppConfig().appMode === "hosted") {
+      fail(res, forbidden("First-run setup is disabled in hosted mode"));
+      return;
+    }
+
     if (isDemoMode()) {
       fail(
         res,

--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -212,6 +212,7 @@ export function createAuthGuard() {
       normalizedMethod === "POST" &&
       (normalizedPath === "/api/auth/login" ||
         normalizedPath === "/api/auth/logout" ||
+        normalizedPath === "/api/auth/signup" ||
         normalizedPath === "/api/auth/setup")
     )
       return true;

--- a/orchestrator/src/server/repositories/users.ts
+++ b/orchestrator/src/server/repositories/users.ts
@@ -212,6 +212,59 @@ export async function createPrivateWorkspaceUser(input: {
   return user;
 }
 
+export async function createHostedTenantUser(input: {
+  username: string;
+  password: string;
+  tenantId: string;
+  displayName?: string | null;
+}): Promise<PublicUser | null> {
+  const now = new Date().toISOString();
+  const username = normalizeUsername(input.username);
+  const userId = randomUUID();
+  const { passwordHash, passwordSalt } = await hashPassword(input.password);
+
+  const created = db.transaction((tx) => {
+    const tenant = tx
+      .select({ id: tenants.id })
+      .from(tenants)
+      .where(eq(tenants.id, input.tenantId))
+      .get();
+    if (!tenant) return false;
+
+    tx.insert(users)
+      .values({
+        id: userId,
+        username,
+        displayName: input.displayName?.trim() || null,
+        passwordHash,
+        passwordSalt,
+        isSystemAdmin: false,
+        isDisabled: false,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    tx.insert(tenantMemberships)
+      .values({
+        id: randomUUID(),
+        userId,
+        tenantId: input.tenantId,
+        role: "member",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+
+    return true;
+  });
+
+  if (!created) return null;
+  const user = await getUserById(userId);
+  if (!user) throw new Error("Failed to load created user");
+  return user;
+}
+
 export async function createInitialSystemAdmin(input: {
   username: string;
   password: string;


### PR DESCRIPTION
## Summary
- Add `POST /api/auth/signup` for hosted mode and sign users into the configured tenant.
- Keep signup gated behind hosted mode and hosted signup flags, with duplicate usernames rejected cleanly.
- Block first-run setup in hosted mode so the local bootstrap flow stays local-only.
- Add a client signup helper, repository support for hosted user creation, and docs updates for the hosted flow.

## Testing
- Added auth route coverage for successful hosted signup, duplicate usernames, invalid input, local-mode rejection, demo-mode rejection, missing tenant rejection, and hosted setup blocking.
- Verified the returned token works on protected auth routes and that hosted signup does not create a new tenant.