### PR TITLE
Include saved Watchlist jobs in pipeline discovery

### DIFF
--- a/orchestrator/src/server/api/routes/watchlist.ts
+++ b/orchestrator/src/server/api/routes/watchlist.ts
@@ -1,31 +1,20 @@
-import {
-  badRequest,
-  notFound,
-  toAppError,
-  unprocessableEntity,
-} from "@infra/errors";
+import { badRequest, toAppError, unprocessableEntity } from "@infra/errors";
 import { asyncRoute, fail, ok } from "@infra/http";
 import { listCareerBoardSources } from "@server/config/career-boards";
-import * as jobsRepo from "@server/repositories/jobs";
 import * as watchlistRepo from "@server/repositories/watchlist";
+import { getWatchlistSourceAdapter } from "@server/watchlist/adapters";
 import {
-  getWatchlistSourceAdapter,
-  listWatchlistSourceAdapters,
-} from "@server/watchlist/adapters";
-import type {
-  JobListItem,
-  WatchlistCheckResponse,
-  WatchlistJobResult,
-  WatchlistResultsResponse,
-  WatchlistSelectedSource,
-  WatchlistSourceResult,
-} from "@shared/types";
+  getCurrentWatchlistResults,
+  getWatchlistSelectedSourceById,
+  getWatchlistSourceTypeDescriptors,
+  hydrateWatchlistSelectedSources,
+  withWatchlistSourceTimeout,
+} from "@server/watchlist/results";
+import type { WatchlistResultsResponse } from "@shared/types";
 import { type Request, type Response, Router } from "express";
 import { z } from "zod";
 
 export const watchlistRouter = Router();
-
-const WATCHLIST_SOURCE_TIMEOUT_MS = 30000;
 
 const watchlistStateParamsSchema = z.object({
   source: z.string().trim().min(1).max(120),
@@ -73,25 +62,6 @@ const watchlistSourceBrandingSchema = z.object({
   careersUrl: z.string().trim().url().max(2000),
 });
 
-function getSourceTypeDescriptors() {
-  return listWatchlistSourceAdapters().map((adapter) => adapter.descriptor);
-}
-
-function hydrateSelectedSource(
-  source: WatchlistSelectedSource,
-): WatchlistSelectedSource {
-  const adapter = getWatchlistSourceAdapter(source.sourceType);
-  return adapter?.hydrateSelectedSource(source) ?? source;
-}
-
-function hydrateSelectedSources(
-  selectedSources: Awaited<
-    ReturnType<typeof watchlistRepo.listWatchlistSelectedSources>
-  >,
-) {
-  return selectedSources.map(hydrateSelectedSource);
-}
-
 function getWatchlistSourcesPayload(
   catalogSources: Awaited<ReturnType<typeof listCareerBoardSources>>,
   selectedSources: Awaited<
@@ -100,8 +70,8 @@ function getWatchlistSourcesPayload(
 ) {
   return {
     catalogSources,
-    selectedSources: hydrateSelectedSources(selectedSources),
-    availableSourceTypes: getSourceTypeDescriptors(),
+    selectedSources: hydrateWatchlistSelectedSources(selectedSources),
+    availableSourceTypes: getWatchlistSourceTypeDescriptors(),
   };
 }
 
@@ -127,57 +97,10 @@ watchlistRouter.get(
 watchlistRouter.post(
   "/results",
   asyncRoute(async (_req: Request, res: Response) => {
-    const selectedSources = hydrateSelectedSources(
-      await watchlistRepo.listWatchlistSelectedSources(),
+    ok(
+      res,
+      (await getCurrentWatchlistResults()) satisfies WatchlistResultsResponse,
     );
-
-    if (selectedSources.length === 0) {
-      return ok(res, {
-        checkedAt: null,
-        previousLastCheckedAt: null,
-        sources: [],
-      } satisfies WatchlistResultsResponse);
-    }
-
-    const fetchedSources = await Promise.all(
-      selectedSources.map((source) => fetchWatchlistSource(source)),
-    );
-    const successfulSources = fetchedSources.filter(
-      (item): item is Extract<WatchlistSourceResult, { status: "success" }> =>
-        item.status === "success",
-    );
-    const checksBySource = new Map<string, Set<string>>();
-
-    for (const item of successfulSources) {
-      for (const job of item.jobs) {
-        const sourceJobIds =
-          checksBySource.get(job.source) ?? new Set<string>();
-        sourceJobIds.add(job.sourceJobId);
-        checksBySource.set(job.source, sourceJobIds);
-      }
-    }
-
-    const check = await watchlistRepo.recordWatchlistCheck({
-      checks: Array.from(checksBySource, ([source, sourceJobIds]) => ({
-        source,
-        sourceJobIds: Array.from(sourceJobIds),
-      })),
-    });
-    const [states, workspaceJobs] = await Promise.all([
-      watchlistRepo.listWatchlistJobStates(),
-      jobsRepo.getJobListItems(),
-    ]);
-
-    ok(res, {
-      checkedAt: check.checkedAt,
-      previousLastCheckedAt: check.previousLastCheckedAt,
-      sources: annotateSourceResults({
-        sourceResults: fetchedSources,
-        check,
-        states,
-        workspaceJobs,
-      }),
-    } satisfies WatchlistResultsResponse);
   }),
 );
 
@@ -196,7 +119,7 @@ watchlistRouter.post(
     }
 
     try {
-      const source = await getSelectedSourceById(
+      const source = await getWatchlistSelectedSourceById(
         parsedBody.data.selectedSourceId,
       );
       const adapter = getWatchlistSourceAdapter(source.sourceType);
@@ -210,7 +133,7 @@ watchlistRouter.post(
       }
       ok(
         res,
-        await withSourceTimeout((signal) =>
+        await withWatchlistSourceTimeout((signal) =>
           adapter.fetchJobDetails({
             source,
             jobRef: parsedBody.data.jobRef,
@@ -239,7 +162,7 @@ watchlistRouter.post(
     }
 
     try {
-      const source = await getSelectedSourceById(
+      const source = await getWatchlistSelectedSourceById(
         parsedBody.data.selectedSourceId,
       );
       const adapter = getWatchlistSourceAdapter(source.sourceType);
@@ -251,7 +174,7 @@ watchlistRouter.post(
           }),
         );
       }
-      const result = await withSourceTimeout((signal) =>
+      const result = await withWatchlistSourceTimeout((signal) =>
         adapter.prepareImportDraft({
           source,
           jobRef: parsedBody.data.jobRef,
@@ -287,7 +210,7 @@ watchlistRouter.post(
 
     try {
       const selectedSource = parsedBody.data.selectedSourceId
-        ? await getSelectedSourceById(parsedBody.data.selectedSourceId)
+        ? await getWatchlistSelectedSourceById(parsedBody.data.selectedSourceId)
         : null;
       const source = selectedSource ?? {
         sourceType: parsedBody.data.sourceType,
@@ -306,7 +229,7 @@ watchlistRouter.post(
 
       ok(
         res,
-        await withSourceTimeout((signal) =>
+        await withWatchlistSourceTimeout((signal) =>
           fetchBranding({
             source,
             signal,
@@ -501,126 +424,3 @@ watchlistRouter.delete(
     ok(res, { cleared: true });
   }),
 );
-
-async function getSelectedSourceById(
-  selectedSourceId: string,
-): Promise<WatchlistSelectedSource> {
-  const selectedSources = hydrateSelectedSources(
-    await watchlistRepo.listWatchlistSelectedSources(),
-  );
-  const source = selectedSources.find((item) => item.id === selectedSourceId);
-  if (!source) {
-    throw notFound("Watchlist source was not found");
-  }
-  return source;
-}
-
-async function fetchWatchlistSource(
-  source: WatchlistSelectedSource,
-): Promise<WatchlistSourceResult> {
-  const adapter = getWatchlistSourceAdapter(source.sourceType);
-  if (!adapter) {
-    return {
-      status: "error",
-      source,
-      error: `Unsupported watchlist source type: ${source.sourceType}`,
-    };
-  }
-
-  try {
-    const result = await withSourceTimeout((signal) =>
-      adapter.fetchJobs({ source, signal }),
-    );
-    return {
-      status: "success",
-      source,
-      jobs: result.jobs.map((job) => ({
-        ...job,
-        rowState: "new",
-        isNewSinceLastCheck: false,
-        workspaceJob: null,
-      })),
-      total: result.total,
-      fetched: result.fetched,
-    };
-  } catch (error) {
-    return {
-      status: "error",
-      source,
-      error: error instanceof Error ? error.message : String(error),
-    };
-  }
-}
-
-function annotateSourceResults(input: {
-  sourceResults: WatchlistSourceResult[];
-  check: WatchlistCheckResponse;
-  states: Awaited<ReturnType<typeof watchlistRepo.listWatchlistJobStates>>;
-  workspaceJobs: JobListItem[];
-}): WatchlistSourceResult[] {
-  const ignoredKeys = new Set(
-    input.states
-      .filter((state) => state.state === "ignored")
-      .map((state) => getJobKey(state.source, state.sourceJobId)),
-  );
-  const newJobKeys = new Set(
-    input.check.jobs
-      .filter((job) => job.isNewSinceLastCheck)
-      .map((job) => getJobKey(String(job.source), job.sourceJobId)),
-  );
-  const importedByKey = new Map<string, JobListItem>();
-  const importedByUrl = new Map<string, JobListItem>();
-  for (const job of input.workspaceJobs) {
-    if (job.sourceJobId) {
-      importedByKey.set(getJobKey(String(job.source), job.sourceJobId), job);
-    }
-    importedByUrl.set(job.jobUrl, job);
-  }
-
-  return input.sourceResults.map((result) => {
-    if (result.status === "error") return result;
-
-    return {
-      ...result,
-      jobs: result.jobs.map((job): WatchlistJobResult => {
-        const jobKey = getJobKey(String(job.source), job.sourceJobId);
-        const workspaceJob =
-          importedByKey.get(jobKey) ?? importedByUrl.get(job.jobUrl) ?? null;
-        const rowState = workspaceJob
-          ? "moved_to_workspace"
-          : ignoredKeys.has(jobKey)
-            ? "ignored"
-            : "new";
-
-        return {
-          ...job,
-          rowState,
-          isNewSinceLastCheck: rowState === "new" && newJobKeys.has(jobKey),
-          workspaceJob: workspaceJob
-            ? { id: workspaceJob.id, status: workspaceJob.status }
-            : null,
-        };
-      }),
-    };
-  });
-}
-
-async function withSourceTimeout<T>(
-  callback: (signal: AbortSignal) => Promise<T>,
-): Promise<T> {
-  const controller = new AbortController();
-  const timeout = setTimeout(
-    () => controller.abort(),
-    WATCHLIST_SOURCE_TIMEOUT_MS,
-  );
-
-  try {
-    return await callback(controller.signal);
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-
-function getJobKey(source: string, sourceJobId: string): string {
-  return `${source}:${sourceJobId}`;
-}

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -351,6 +351,7 @@ export async function runPipeline(
         const retryConfig = { ...mergedConfig, sources: challengedSources };
         const retryResult = await discoverJobsStep({
           mergedConfig: retryConfig,
+          includeWatchlist: false,
           shouldCancel: () =>
             getPipelineState(tenantId).cancelRequestedAt !== null,
         });

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -1,3 +1,4 @@
+import { runWithRequestContext } from "@infra/request-context";
 import type { PipelineConfig } from "@shared/types";
 import type { ExtractorRuntimeContext } from "@shared/types/extractors";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -14,6 +15,19 @@ vi.mock("@server/repositories/jobs", () => ({
 
 vi.mock("@server/extractors/registry", () => ({
   getExtractorRegistry: vi.fn(),
+}));
+
+vi.mock("@server/watchlist/results", () => ({
+  listHydratedWatchlistSelectedSources: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("./watchlist-jobs", () => ({
+  discoverWatchlistJobsForPipeline: vi.fn().mockResolvedValue({
+    discoveredJobs: [],
+    sourceErrors: [],
+    selectedSourceCount: 0,
+    failedSourceCount: 0,
+  }),
 }));
 
 const baseConfig: PipelineConfig = {
@@ -288,6 +302,202 @@ describe("discoverJobsStep", () => {
 
     expect(result.discoveredJobs).toEqual([]);
     expect(result.sourceErrors).toEqual([]);
+  });
+
+  it("adds watchlist jobs to normal extractor discovery for the active user", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+    const watchlistResults = await import("@server/watchlist/results");
+    const watchlistStep = await import("./watchlist-jobs");
+
+    const selectedWatchlistSource = {
+      id: "watchlist-source",
+      catalogSourceId: "acme",
+      label: "Acme",
+      careersUrl: "https://acme.wd1.myworkdayjobs.com/acme",
+      cxsJobsUrl: null,
+      sourceType: "workday",
+      isCustom: false,
+      sortOrder: 0,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    const jobspyManifest = {
+      id: "jobspy",
+      displayName: "JobSpy",
+      providesSources: ["linkedin"],
+      run: vi.fn().mockResolvedValue({
+        success: true,
+        jobs: [
+          {
+            source: "linkedin",
+            title: "Extractor Engineer",
+            employer: "Extractor Co",
+            jobUrl: "https://example.com/extractor",
+            location: "London, United Kingdom",
+          },
+        ],
+      }),
+    };
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["engineer"]),
+      jobspyCountryIndeed: "united kingdom",
+    } as any);
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map([["jobspy", jobspyManifest as any]]),
+      manifestBySource: new Map([["linkedin", jobspyManifest as any]]),
+      availableSources: ["linkedin"],
+    } as any);
+    vi.mocked(
+      watchlistResults.listHydratedWatchlistSelectedSources,
+    ).mockResolvedValue([selectedWatchlistSource as any]);
+    vi.mocked(watchlistStep.discoverWatchlistJobsForPipeline).mockResolvedValue(
+      {
+        discoveredJobs: [
+          {
+            source: "workday:acme",
+            sourceJobId: "watchlist-job",
+            title: "Watchlist Engineer",
+            employer: "Acme",
+            jobUrl: "https://example.com/watchlist",
+            applicationLink: "https://example.com/watchlist",
+            location: "London, United Kingdom",
+            jobDescription: "Build product systems.",
+          },
+        ],
+        sourceErrors: [],
+        selectedSourceCount: 1,
+        failedSourceCount: 0,
+      },
+    );
+
+    const result = await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverJobsStep({
+          mergedConfig: {
+            ...baseConfig,
+            sources: ["linkedin"],
+          },
+        }),
+    );
+
+    expect(result.discoveredJobs.map((job) => job.title)).toEqual([
+      "Extractor Engineer",
+      "Watchlist Engineer",
+    ]);
+    expect(watchlistStep.discoverWatchlistJobsForPipeline).toHaveBeenCalledWith(
+      {
+        selectedSources: [selectedWatchlistSource],
+        shouldCancel: undefined,
+      },
+    );
+  });
+
+  it("does not touch watchlist discovery when no user context exists", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+    const watchlistResults = await import("@server/watchlist/results");
+    const watchlistStep = await import("./watchlist-jobs");
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["engineer"]),
+    } as any);
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map(),
+      manifestBySource: new Map(),
+      availableSources: [],
+    } as any);
+
+    await discoverJobsStep({
+      mergedConfig: {
+        ...baseConfig,
+        sources: [],
+      },
+    });
+
+    expect(
+      watchlistResults.listHydratedWatchlistSelectedSources,
+    ).not.toHaveBeenCalled();
+    expect(
+      watchlistStep.discoverWatchlistJobsForPipeline,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("keeps watchlist source failures non-fatal when extractors succeed", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+    const watchlistResults = await import("@server/watchlist/results");
+    const watchlistStep = await import("./watchlist-jobs");
+
+    const selectedWatchlistSource = {
+      id: "watchlist-source",
+      catalogSourceId: null,
+      label: "Acme",
+      careersUrl: "https://acme.wd1.myworkdayjobs.com/acme",
+      cxsJobsUrl: null,
+      sourceType: "workday",
+      isCustom: true,
+      sortOrder: 0,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const linkedinManifest = {
+      id: "jobspy",
+      displayName: "JobSpy",
+      providesSources: ["linkedin"],
+      run: vi.fn().mockResolvedValue({
+        success: true,
+        jobs: [
+          {
+            source: "linkedin",
+            title: "Engineer",
+            employer: "Contoso",
+            jobUrl: "https://example.com/job",
+            location: "London, United Kingdom",
+          },
+        ],
+      }),
+    };
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["engineer"]),
+      jobspyCountryIndeed: "united kingdom",
+    } as any);
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map([["jobspy", linkedinManifest as any]]),
+      manifestBySource: new Map([["linkedin", linkedinManifest as any]]),
+      availableSources: ["linkedin"],
+    } as any);
+    vi.mocked(
+      watchlistResults.listHydratedWatchlistSelectedSources,
+    ).mockResolvedValue([selectedWatchlistSource as any]);
+    vi.mocked(watchlistStep.discoverWatchlistJobsForPipeline).mockResolvedValue(
+      {
+        discoveredJobs: [],
+        sourceErrors: ["Watchlist Acme: failed to fetch jobs"],
+        selectedSourceCount: 1,
+        failedSourceCount: 1,
+      },
+    );
+
+    const result = await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverJobsStep({
+          mergedConfig: {
+            ...baseConfig,
+            sources: ["linkedin"],
+          },
+        }),
+    );
+
+    expect(result.discoveredJobs).toHaveLength(1);
+    expect(result.sourceErrors).toContain(
+      "Watchlist Acme: failed to fetch jobs",
+    );
   });
 
   it("drops discovered jobs when employer matches blocked company keywords", async () => {

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -429,6 +429,41 @@ describe("discoverJobsStep", () => {
     ).not.toHaveBeenCalled();
   });
 
+  it("skips watchlist discovery when disabled for a retry pass", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+    const watchlistResults = await import("@server/watchlist/results");
+    const watchlistStep = await import("./watchlist-jobs");
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["engineer"]),
+    } as any);
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map(),
+      manifestBySource: new Map(),
+      availableSources: [],
+    } as any);
+
+    await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverJobsStep({
+          mergedConfig: {
+            ...baseConfig,
+            sources: [],
+          },
+          includeWatchlist: false,
+        }),
+    );
+
+    expect(
+      watchlistResults.listHydratedWatchlistSelectedSources,
+    ).not.toHaveBeenCalled();
+    expect(
+      watchlistStep.discoverWatchlistJobsForPipeline,
+    ).not.toHaveBeenCalled();
+  });
+
   it("keeps watchlist source failures non-fatal when extractors succeed", async () => {
     const settingsRepo = await import("@server/repositories/settings");
     const registryModule = await import("@server/extractors/registry");

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -27,6 +27,7 @@ vi.mock("./watchlist-jobs", () => ({
     sourceErrors: [],
     selectedSourceCount: 0,
     failedSourceCount: 0,
+    searchFilteredCount: 0,
   }),
 }));
 
@@ -370,6 +371,7 @@ describe("discoverJobsStep", () => {
         sourceErrors: [],
         selectedSourceCount: 1,
         failedSourceCount: 0,
+        searchFilteredCount: 0,
       },
     );
 
@@ -391,6 +393,7 @@ describe("discoverJobsStep", () => {
     expect(watchlistStep.discoverWatchlistJobsForPipeline).toHaveBeenCalledWith(
       {
         selectedSources: [selectedWatchlistSource],
+        searchTerms: ["engineer"],
         shouldCancel: undefined,
       },
     );
@@ -480,6 +483,7 @@ describe("discoverJobsStep", () => {
         sourceErrors: ["Watchlist Acme: failed to fetch jobs"],
         selectedSourceCount: 1,
         failedSourceCount: 1,
+        searchFilteredCount: 0,
       },
     );
 

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -121,6 +121,7 @@ function buildLocationEvidence(args: {
 
 export async function discoverJobsStep(args: {
   mergedConfig: PipelineConfig;
+  includeWatchlist?: boolean;
   shouldCancel?: () => boolean;
 }): Promise<{
   discoveredJobs: CreateJobInput[];
@@ -131,6 +132,7 @@ export async function discoverJobsStep(args: {
 
   const discoveredJobs: CreateJobInput[] = [];
   const sourceErrors: string[] = [];
+  const includeWatchlist = args.includeWatchlist !== false;
 
   const settings = await settingsRepo.getAllSettings();
   const registry = await getExtractorRegistry();
@@ -312,7 +314,7 @@ export async function discoverJobsStep(args: {
   let watchlistSelectedSources: Awaited<
     ReturnType<typeof listHydratedWatchlistSelectedSources>
   > = [];
-  if (getUserId()) {
+  if (includeWatchlist && getUserId()) {
     try {
       watchlistSelectedSources = await listHydratedWatchlistSelectedSources();
     } catch (error) {

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -391,6 +391,7 @@ export async function discoverJobsStep(args: {
     });
     const watchlistResult = await discoverWatchlistJobsForPipeline({
       selectedSources: watchlistSelectedSources,
+      searchTerms,
       shouldCancel: args.shouldCancel,
     });
     completedSources += 1;

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -1,9 +1,11 @@
 import { logger } from "@infra/logger";
 import { sanitizeUnknown } from "@infra/sanitize";
 import { getExtractorRegistry } from "@server/extractors/registry";
+import { getUserId } from "@server/infra/request-context";
 import { getAllJobUrls } from "@server/repositories/jobs";
 import * as settingsRepo from "@server/repositories/settings";
 import { asyncPool } from "@server/utils/async-pool";
+import { listHydratedWatchlistSelectedSources } from "@server/watchlist/results";
 import type { ExtractorSourceId } from "@shared/extractors";
 import { matchJobLocationIntent } from "@shared/job-matching.js";
 import {
@@ -21,6 +23,7 @@ import {
   progressHelpers,
   updateProgress,
 } from "../progress";
+import { discoverWatchlistJobsForPipeline } from "./watchlist-jobs";
 
 const DISCOVERY_CONCURRENCY = 3;
 
@@ -306,7 +309,23 @@ export async function discoverJobsStep(args: {
     });
   }
 
-  const totalSources = sourceTasks.length;
+  let watchlistSelectedSources: Awaited<
+    ReturnType<typeof listHydratedWatchlistSelectedSources>
+  > = [];
+  if (getUserId()) {
+    try {
+      watchlistSelectedSources = await listHydratedWatchlistSelectedSources();
+    } catch (error) {
+      logger.warn("Failed to load Watchlist sources for pipeline discovery", {
+        step: "discover-jobs",
+        error: sanitizeUnknown(error),
+      });
+      sourceErrors.push("Watchlist: failed to load selected sources");
+    }
+  }
+
+  const totalSources =
+    sourceTasks.length + (watchlistSelectedSources.length > 0 ? 1 : 0);
   let completedSources = 0;
 
   progressHelpers.startCrawling(totalSources);
@@ -363,6 +382,29 @@ export async function discoverJobsStep(args: {
     sourceErrors.push(...sourceResult.sourceErrors);
     if (sourceResult.challenge) {
       pendingChallenges.push(sourceResult.challenge);
+    }
+  }
+
+  if (watchlistSelectedSources.length > 0 && !args.shouldCancel?.()) {
+    progressHelpers.startSource("watchlist", completedSources, totalSources, {
+      detail: "Watchlist: fetching saved sources...",
+    });
+    const watchlistResult = await discoverWatchlistJobsForPipeline({
+      selectedSources: watchlistSelectedSources,
+      shouldCancel: args.shouldCancel,
+    });
+    completedSources += 1;
+    progressHelpers.completeSource(completedSources, totalSources);
+
+    discoveredJobs.push(...watchlistResult.discoveredJobs);
+    sourceErrors.push(...watchlistResult.sourceErrors);
+
+    if (
+      sourceTasks.length === 0 &&
+      watchlistResult.selectedSourceCount > 0 &&
+      watchlistResult.failedSourceCount === watchlistResult.selectedSourceCount
+    ) {
+      throw new Error(`All sources failed: ${sourceErrors.join("; ")}`);
     }
   }
 

--- a/orchestrator/src/server/pipeline/steps/watchlist-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/watchlist-jobs.test.ts
@@ -158,7 +158,131 @@ describe("discoverWatchlistJobsForPipeline", () => {
       jobDescription: "Build reliable systems.",
       datePosted: "2026-01-02",
     });
+    expect(result.searchFilteredCount).toBe(0);
     expect(withWatchlistSourceTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it("imports watchlist jobs when the title matches a search term", async () => {
+    vi.mocked(getWatchlistResultsForSources).mockResolvedValue({
+      checkedAt: "2026-01-03T00:00:00.000Z",
+      previousLastCheckedAt: null,
+      sources: [
+        {
+          status: "success",
+          source: workdaySource,
+          jobs: [watchlistJob({ title: "Senior Platform Engineer" })],
+          total: 1,
+          fetched: 1,
+        },
+      ],
+    });
+
+    const result = await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverWatchlistJobsForPipeline({
+          selectedSources: [workdaySource],
+          searchTerms: ["platform engineer"],
+        }),
+    );
+
+    expect(result.discoveredJobs).toHaveLength(1);
+    expect(result.discoveredJobs[0]?.title).toBe("Platform Engineer");
+    expect(result.searchFilteredCount).toBe(0);
+  });
+
+  it("imports watchlist jobs when the description matches a search term", async () => {
+    const adapters = await import("@server/watchlist/adapters");
+    vi.mocked(adapters.getWatchlistSourceAdapter).mockReturnValue({
+      prepareImportDraft: vi.fn().mockResolvedValue({
+        draft: {
+          source: "workday:acme",
+          sourceJobId: "job-1",
+          title: "Product Engineer",
+          employer: "Acme",
+          jobUrl: "https://example.com/job",
+          applicationLink: "https://example.com/apply",
+          location: "London, United Kingdom",
+          jobDescription: "Build backend services for customer workflows.",
+        },
+        source: "workday:acme",
+        sourceHost: "example.com",
+      }),
+    } as any);
+    vi.mocked(getWatchlistResultsForSources).mockResolvedValue({
+      checkedAt: "2026-01-03T00:00:00.000Z",
+      previousLastCheckedAt: null,
+      sources: [
+        {
+          status: "success",
+          source: workdaySource,
+          jobs: [watchlistJob({ title: "Product Engineer" })],
+          total: 1,
+          fetched: 1,
+        },
+      ],
+    });
+
+    const result = await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverWatchlistJobsForPipeline({
+          selectedSources: [workdaySource],
+          searchTerms: ["backend services"],
+        }),
+    );
+
+    expect(result.discoveredJobs).toHaveLength(1);
+    expect(result.discoveredJobs[0]?.jobDescription).toContain(
+      "backend services",
+    );
+    expect(result.searchFilteredCount).toBe(0);
+  });
+
+  it("skips watchlist jobs that do not match any search term", async () => {
+    const adapters = await import("@server/watchlist/adapters");
+    vi.mocked(adapters.getWatchlistSourceAdapter).mockReturnValue({
+      prepareImportDraft: vi.fn().mockResolvedValue({
+        draft: {
+          source: "workday:acme",
+          sourceJobId: "job-1",
+          title: "Payroll Analyst",
+          employer: "Acme",
+          jobUrl: "https://example.com/job",
+          applicationLink: "https://example.com/apply",
+          location: "London, United Kingdom",
+          jobDescription: "Prepare monthly payroll reports.",
+        },
+        source: "workday:acme",
+        sourceHost: "example.com",
+      }),
+    } as any);
+    vi.mocked(getWatchlistResultsForSources).mockResolvedValue({
+      checkedAt: "2026-01-03T00:00:00.000Z",
+      previousLastCheckedAt: null,
+      sources: [
+        {
+          status: "success",
+          source: workdaySource,
+          jobs: [watchlistJob({ title: "Payroll Analyst" })],
+          total: 1,
+          fetched: 1,
+        },
+      ],
+    });
+
+    const result = await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverWatchlistJobsForPipeline({
+          selectedSources: [workdaySource],
+          searchTerms: ["platform engineer"],
+        }),
+    );
+
+    expect(result.discoveredJobs).toEqual([]);
+    expect(result.searchFilteredCount).toBe(1);
+    expect(result.sourceErrors).toEqual([]);
   });
 
   it("skips ignored and already-imported watchlist jobs", async () => {
@@ -239,6 +363,7 @@ describe("discoverWatchlistJobsForPipeline", () => {
       sourceErrors: [],
       selectedSourceCount: 0,
       failedSourceCount: 0,
+      searchFilteredCount: 0,
     });
     expect(listHydratedWatchlistSelectedSources).not.toHaveBeenCalled();
   });

--- a/orchestrator/src/server/pipeline/steps/watchlist-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/watchlist-jobs.test.ts
@@ -1,0 +1,245 @@
+import { runWithRequestContext } from "@infra/request-context";
+import {
+  getWatchlistResultsForSources,
+  listHydratedWatchlistSelectedSources,
+  withWatchlistSourceTimeout,
+} from "@server/watchlist/results";
+import type {
+  WatchlistJobResult,
+  WatchlistSelectedSource,
+} from "@shared/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { discoverWatchlistJobsForPipeline } from "./watchlist-jobs";
+
+vi.mock("@server/watchlist/results", () => ({
+  getWatchlistResultsForSources: vi.fn(),
+  listHydratedWatchlistSelectedSources: vi.fn(),
+  withWatchlistSourceTimeout: vi.fn((callback) =>
+    callback(new AbortController().signal),
+  ),
+}));
+
+vi.mock("@server/watchlist/adapters", () => ({
+  getWatchlistSourceAdapter: vi.fn(),
+}));
+
+const workdaySource: WatchlistSelectedSource = {
+  id: "source-workday",
+  catalogSourceId: "acme",
+  label: "Acme",
+  careersUrl: "https://acme.wd1.myworkdayjobs.com/acme",
+  cxsJobsUrl: "https://acme.wd1.myworkdayjobs.com/wday/cxs/acme/acme/jobs",
+  sourceType: "workday",
+  isCustom: false,
+  sortOrder: 0,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const bamboohrSource: WatchlistSelectedSource = {
+  id: "source-bamboohr",
+  catalogSourceId: null,
+  label: "Beta",
+  careersUrl: "https://beta.bamboohr.com/careers",
+  cxsJobsUrl: null,
+  sourceType: "bamboohr",
+  isCustom: true,
+  sortOrder: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+function watchlistJob(overrides: Partial<WatchlistJobResult>) {
+  return {
+    jobRef: "https://example.com/job",
+    source: "workday:acme",
+    sourceJobId: "job-1",
+    sourceType: "workday",
+    title: "Platform Engineer",
+    employer: "Acme",
+    jobUrl: "https://example.com/job",
+    applicationLink: "https://example.com/job",
+    location: "London, United Kingdom",
+    postedAt: "2026-01-02",
+    rowState: "new",
+    isNewSinceLastCheck: true,
+    workspaceJob: null,
+    ...overrides,
+  } satisfies WatchlistJobResult;
+}
+
+describe("discoverWatchlistJobsForPipeline", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(listHydratedWatchlistSelectedSources).mockResolvedValue([]);
+    vi.mocked(getWatchlistResultsForSources).mockResolvedValue({
+      checkedAt: "2026-01-03T00:00:00.000Z",
+      previousLastCheckedAt: null,
+      sources: [],
+    });
+
+    const adapters = await import("@server/watchlist/adapters");
+    vi.mocked(adapters.getWatchlistSourceAdapter).mockReturnValue({
+      sourceType: "workday",
+      descriptor: {} as any,
+      catalogSchema: {} as any,
+      parseCatalogSources: vi.fn(),
+      hydrateSelectedSource: vi.fn(),
+      normalizeCustomSelection: vi.fn(),
+      fetchJobs: vi.fn(),
+      fetchJobDetails: vi.fn(),
+      prepareImportDraft: vi.fn().mockResolvedValue({
+        draft: {
+          source: "workday:acme",
+          sourceJobId: "job-1",
+          title: "Platform Engineer",
+          employer: "Acme",
+          jobUrl: "https://example.com/job",
+          applicationLink: "https://example.com/apply",
+          location: "London, United Kingdom",
+          jobDescription: "Build reliable systems.",
+          jobType: "Full time",
+        },
+        source: "workday:acme",
+        sourceHost: "example.com",
+      }),
+    } as any);
+  });
+
+  it("fetches details and converts Workday and BambooHR watchlist jobs", async () => {
+    vi.mocked(getWatchlistResultsForSources).mockResolvedValue({
+      checkedAt: "2026-01-03T00:00:00.000Z",
+      previousLastCheckedAt: null,
+      sources: [
+        {
+          status: "success",
+          source: workdaySource,
+          jobs: [watchlistJob({})],
+          total: 1,
+          fetched: 1,
+        },
+        {
+          status: "success",
+          source: bamboohrSource,
+          jobs: [
+            watchlistJob({
+              jobRef: "https://beta.bamboohr.com/careers/2",
+              source: "bamboohr:beta",
+              sourceJobId: "job-2",
+              sourceType: "bamboohr",
+              title: "Backend Engineer",
+              employer: "Beta",
+              jobUrl: "https://beta.bamboohr.com/careers/2",
+              applicationLink: "https://beta.bamboohr.com/careers/2",
+            }),
+          ],
+          total: 1,
+          fetched: 1,
+        },
+      ],
+    });
+
+    const result = await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverWatchlistJobsForPipeline({
+          selectedSources: [workdaySource, bamboohrSource],
+        }),
+    );
+
+    expect(result.discoveredJobs).toHaveLength(2);
+    expect(result.discoveredJobs[0]).toMatchObject({
+      source: "workday:acme",
+      sourceJobId: "job-1",
+      title: "Platform Engineer",
+      employer: "Acme",
+      jobUrl: "https://example.com/job",
+      applicationLink: "https://example.com/apply",
+      jobDescription: "Build reliable systems.",
+      datePosted: "2026-01-02",
+    });
+    expect(withWatchlistSourceTimeout).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips ignored and already-imported watchlist jobs", async () => {
+    vi.mocked(getWatchlistResultsForSources).mockResolvedValue({
+      checkedAt: "2026-01-03T00:00:00.000Z",
+      previousLastCheckedAt: null,
+      sources: [
+        {
+          status: "success",
+          source: workdaySource,
+          jobs: [
+            watchlistJob({ rowState: "ignored" }),
+            watchlistJob({
+              rowState: "moved_to_workspace",
+              sourceJobId: "job-2",
+              workspaceJob: { id: "workspace-job", status: "discovered" },
+            }),
+          ],
+          total: 2,
+          fetched: 2,
+        },
+      ],
+    });
+
+    const result = await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverWatchlistJobsForPipeline({
+          selectedSources: [workdaySource],
+        }),
+    );
+
+    expect(result.discoveredJobs).toEqual([]);
+    expect(withWatchlistSourceTimeout).not.toHaveBeenCalled();
+  });
+
+  it("reports detail failures without returning raw upstream bodies", async () => {
+    const adapters = await import("@server/watchlist/adapters");
+    vi.mocked(adapters.getWatchlistSourceAdapter).mockReturnValue({
+      prepareImportDraft: vi
+        .fn()
+        .mockRejectedValue(new Error("raw upstream body with secret token")),
+    } as any);
+    vi.mocked(getWatchlistResultsForSources).mockResolvedValue({
+      checkedAt: "2026-01-03T00:00:00.000Z",
+      previousLastCheckedAt: null,
+      sources: [
+        {
+          status: "success",
+          source: workdaySource,
+          jobs: [watchlistJob({})],
+          total: 1,
+          fetched: 1,
+        },
+      ],
+    });
+
+    const result = await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverWatchlistJobsForPipeline({
+          selectedSources: [workdaySource],
+        }),
+    );
+
+    expect(result.discoveredJobs).toEqual([]);
+    expect(result.sourceErrors).toEqual([
+      "Watchlist Acme: failed to fetch details for job-1",
+    ]);
+    expect(result.sourceErrors.join(" ")).not.toContain("secret token");
+  });
+
+  it("does nothing when no user context is active", async () => {
+    const result = await discoverWatchlistJobsForPipeline();
+
+    expect(result).toEqual({
+      discoveredJobs: [],
+      sourceErrors: [],
+      selectedSourceCount: 0,
+      failedSourceCount: 0,
+    });
+    expect(listHydratedWatchlistSelectedSources).not.toHaveBeenCalled();
+  });
+});

--- a/orchestrator/src/server/pipeline/steps/watchlist-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/watchlist-jobs.ts
@@ -1,0 +1,186 @@
+import { logger } from "@infra/logger";
+import { sanitizeUnknown } from "@infra/sanitize";
+import { getUserId } from "@server/infra/request-context";
+import { asyncPool } from "@server/utils/async-pool";
+import { getWatchlistSourceAdapter } from "@server/watchlist/adapters";
+import {
+  getWatchlistResultsForSources,
+  listHydratedWatchlistSelectedSources,
+  withWatchlistSourceTimeout,
+} from "@server/watchlist/results";
+import type {
+  CreateJobInput,
+  ManualJobDraft,
+  WatchlistJobResult,
+  WatchlistSelectedSource,
+} from "@shared/types";
+
+const WATCHLIST_DETAIL_CONCURRENCY = 3;
+
+export type PipelineWatchlistDiscoveryResult = {
+  discoveredJobs: CreateJobInput[];
+  sourceErrors: string[];
+  selectedSourceCount: number;
+  failedSourceCount: number;
+};
+
+function optionalString(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function buildWatchlistSourceError(
+  source: Pick<WatchlistSelectedSource, "label" | "sourceType">,
+  reason: string,
+): string {
+  const label = source.label.trim() || source.sourceType;
+  return `Watchlist ${label}: ${reason}`;
+}
+
+function createJobInputFromWatchlistJob(
+  job: WatchlistJobResult,
+  draft: ManualJobDraft,
+): CreateJobInput {
+  return {
+    source: draft.source ?? job.source,
+    sourceJobId: draft.sourceJobId ?? job.sourceJobId,
+    title: draft.title ?? job.title,
+    employer: draft.employer ?? job.employer,
+    jobUrl: draft.jobUrl ?? job.jobUrl,
+    applicationLink: optionalString(
+      draft.applicationLink ?? job.applicationLink,
+    ),
+    location: optionalString(draft.location ?? job.location),
+    datePosted: optionalString(job.postedAt),
+    jobDescription: optionalString(draft.jobDescription),
+    jobType: optionalString(draft.jobType),
+    jobLevel: optionalString(draft.jobLevel),
+    jobFunction: optionalString(draft.jobFunction),
+    disciplines: optionalString(draft.disciplines),
+    degreeRequired: optionalString(draft.degreeRequired),
+    starting: optionalString(draft.starting),
+    deadline: optionalString(draft.deadline),
+    salary: optionalString(draft.salary),
+  };
+}
+
+export async function discoverWatchlistJobsForPipeline(
+  args: {
+    selectedSources?: WatchlistSelectedSource[];
+    shouldCancel?: () => boolean;
+  } = {},
+): Promise<PipelineWatchlistDiscoveryResult> {
+  if (!getUserId()) {
+    logger.info("Skipping Watchlist pipeline discovery without user context", {
+      step: "discover-watchlist-jobs",
+    });
+    return {
+      discoveredJobs: [],
+      sourceErrors: [],
+      selectedSourceCount: 0,
+      failedSourceCount: 0,
+    };
+  }
+
+  const selectedSources =
+    args.selectedSources ?? (await listHydratedWatchlistSelectedSources());
+  if (selectedSources.length === 0 || args.shouldCancel?.()) {
+    return {
+      discoveredJobs: [],
+      sourceErrors: [],
+      selectedSourceCount: selectedSources.length,
+      failedSourceCount: 0,
+    };
+  }
+
+  logger.info("Fetching Watchlist jobs for pipeline discovery", {
+    step: "discover-watchlist-jobs",
+    selectedSourceCount: selectedSources.length,
+  });
+
+  const results = await getWatchlistResultsForSources(selectedSources);
+  const discoveredJobs: CreateJobInput[] = [];
+  const sourceErrors: string[] = [];
+  let failedSourceCount = 0;
+
+  for (const result of results.sources) {
+    if (result.status === "error") {
+      failedSourceCount += 1;
+      sourceErrors.push(
+        buildWatchlistSourceError(result.source, "failed to fetch jobs"),
+      );
+      logger.warn("Watchlist source failed during pipeline discovery", {
+        step: "discover-watchlist-jobs",
+        selectedSourceId: result.source.id,
+        sourceType: result.source.sourceType,
+        error: result.error,
+      });
+      continue;
+    }
+
+    const adapter = getWatchlistSourceAdapter(result.source.sourceType);
+    if (!adapter) {
+      failedSourceCount += 1;
+      sourceErrors.push(
+        buildWatchlistSourceError(result.source, "unsupported source type"),
+      );
+      continue;
+    }
+
+    const jobsToImport = result.jobs.filter((job) => job.rowState === "new");
+    const detailResults = await asyncPool({
+      items: jobsToImport,
+      concurrency: WATCHLIST_DETAIL_CONCURRENCY,
+      shouldStop: args.shouldCancel,
+      task: async (job) => {
+        if (args.shouldCancel?.()) return null;
+
+        try {
+          const importDraft = await withWatchlistSourceTimeout((signal) =>
+            adapter.prepareImportDraft({
+              source: result.source,
+              jobRef: job.jobRef,
+              signal,
+            }),
+          );
+          return createJobInputFromWatchlistJob(job, importDraft.draft);
+        } catch (error) {
+          logger.warn("Watchlist job detail fetch failed during discovery", {
+            step: "discover-watchlist-jobs",
+            selectedSourceId: result.source.id,
+            sourceType: result.source.sourceType,
+            source: job.source,
+            sourceJobId: job.sourceJobId,
+            error: sanitizeUnknown(error),
+          });
+          sourceErrors.push(
+            buildWatchlistSourceError(
+              result.source,
+              `failed to fetch details for ${job.sourceJobId}`,
+            ),
+          );
+          return null;
+        }
+      },
+    });
+
+    for (const job of detailResults) {
+      if (job) discoveredJobs.push(job);
+    }
+  }
+
+  logger.info("Watchlist pipeline discovery complete", {
+    step: "discover-watchlist-jobs",
+    selectedSourceCount: selectedSources.length,
+    failedSourceCount,
+    discovered: discoveredJobs.length,
+    sourceErrorCount: sourceErrors.length,
+  });
+
+  return {
+    discoveredJobs,
+    sourceErrors,
+    selectedSourceCount: selectedSources.length,
+    failedSourceCount,
+  };
+}

--- a/orchestrator/src/server/pipeline/steps/watchlist-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/watchlist-jobs.ts
@@ -8,12 +8,14 @@ import {
   listHydratedWatchlistSelectedSources,
   withWatchlistSourceTimeout,
 } from "@server/watchlist/results";
+import { normalizeJobTitle } from "@shared/job-matching.js";
 import type {
   CreateJobInput,
   ManualJobDraft,
   WatchlistJobResult,
   WatchlistSelectedSource,
 } from "@shared/types";
+import { normalizeSearchTerms } from "@shared/utils/search-terms";
 
 const WATCHLIST_DETAIL_CONCURRENCY = 3;
 
@@ -22,6 +24,7 @@ export type PipelineWatchlistDiscoveryResult = {
   sourceErrors: string[];
   selectedSourceCount: number;
   failedSourceCount: number;
+  searchFilteredCount: number;
 };
 
 function optionalString(value: string | null | undefined): string | undefined {
@@ -64,9 +67,40 @@ function createJobInputFromWatchlistJob(
   };
 }
 
+function getWatchlistSearchText(job: CreateJobInput): string {
+  return normalizeJobTitle(
+    [
+      job.title,
+      job.jobDescription,
+      job.jobFunction,
+      job.jobType,
+      job.disciplines,
+      job.skills,
+    ]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join(" "),
+  );
+}
+
+function matchesWatchlistSearchTerms(
+  job: CreateJobInput,
+  searchTerms: readonly string[],
+): boolean {
+  const normalizedTerms = normalizeSearchTerms([...searchTerms])
+    .map((term) => normalizeJobTitle(term))
+    .filter(Boolean);
+  if (normalizedTerms.length === 0) return true;
+
+  const searchableText = getWatchlistSearchText(job);
+  if (!searchableText) return false;
+
+  return normalizedTerms.some((term) => searchableText.includes(term));
+}
+
 export async function discoverWatchlistJobsForPipeline(
   args: {
     selectedSources?: WatchlistSelectedSource[];
+    searchTerms?: string[];
     shouldCancel?: () => boolean;
   } = {},
 ): Promise<PipelineWatchlistDiscoveryResult> {
@@ -79,29 +113,34 @@ export async function discoverWatchlistJobsForPipeline(
       sourceErrors: [],
       selectedSourceCount: 0,
       failedSourceCount: 0,
+      searchFilteredCount: 0,
     };
   }
 
   const selectedSources =
     args.selectedSources ?? (await listHydratedWatchlistSelectedSources());
+  const searchTerms = normalizeSearchTerms(args.searchTerms ?? []);
   if (selectedSources.length === 0 || args.shouldCancel?.()) {
     return {
       discoveredJobs: [],
       sourceErrors: [],
       selectedSourceCount: selectedSources.length,
       failedSourceCount: 0,
+      searchFilteredCount: 0,
     };
   }
 
   logger.info("Fetching Watchlist jobs for pipeline discovery", {
     step: "discover-watchlist-jobs",
     selectedSourceCount: selectedSources.length,
+    searchTermCount: searchTerms.length,
   });
 
   const results = await getWatchlistResultsForSources(selectedSources);
   const discoveredJobs: CreateJobInput[] = [];
   const sourceErrors: string[] = [];
   let failedSourceCount = 0;
+  let searchFilteredCount = 0;
 
   for (const result of results.sources) {
     if (result.status === "error") {
@@ -165,7 +204,12 @@ export async function discoverWatchlistJobsForPipeline(
     });
 
     for (const job of detailResults) {
-      if (job) discoveredJobs.push(job);
+      if (!job) continue;
+      if (matchesWatchlistSearchTerms(job, searchTerms)) {
+        discoveredJobs.push(job);
+      } else {
+        searchFilteredCount += 1;
+      }
     }
   }
 
@@ -173,7 +217,9 @@ export async function discoverWatchlistJobsForPipeline(
     step: "discover-watchlist-jobs",
     selectedSourceCount: selectedSources.length,
     failedSourceCount,
-    discovered: discoveredJobs.length,
+    matchedCount: discoveredJobs.length,
+    searchFilteredCount,
+    searchTermCount: searchTerms.length,
     sourceErrorCount: sourceErrors.length,
   });
 
@@ -182,5 +228,6 @@ export async function discoverWatchlistJobsForPipeline(
     sourceErrors,
     selectedSourceCount: selectedSources.length,
     failedSourceCount,
+    searchFilteredCount,
   };
 }

--- a/orchestrator/src/server/watchlist/results.test.ts
+++ b/orchestrator/src/server/watchlist/results.test.ts
@@ -1,0 +1,207 @@
+import * as jobsRepo from "@server/repositories/jobs";
+import * as watchlistRepo from "@server/repositories/watchlist";
+import { getWatchlistSourceAdapter } from "@server/watchlist/adapters";
+import type { WatchlistSelectedSource } from "@shared/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getWatchlistResultsForSources,
+  hydrateWatchlistSelectedSources,
+} from "./results";
+
+vi.mock("@server/repositories/watchlist", () => ({
+  listWatchlistSelectedSources: vi.fn(),
+  listWatchlistJobStates: vi.fn(),
+  recordWatchlistCheck: vi.fn(),
+}));
+
+vi.mock("@server/repositories/jobs", () => ({
+  getJobListItems: vi.fn(),
+}));
+
+vi.mock("@server/watchlist/adapters", () => ({
+  getWatchlistSourceAdapter: vi.fn(),
+  listWatchlistSourceAdapters: vi.fn(() => []),
+}));
+
+const workdaySource: WatchlistSelectedSource = {
+  id: "workday-source",
+  catalogSourceId: "acme",
+  label: "Acme",
+  careersUrl: "https://acme.wd1.myworkdayjobs.com/acme",
+  cxsJobsUrl: null,
+  sourceType: "workday",
+  isCustom: false,
+  sortOrder: 0,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+const bamboohrSource: WatchlistSelectedSource = {
+  id: "bamboohr-source",
+  catalogSourceId: null,
+  label: "Beta",
+  careersUrl: "https://beta.bamboohr.com/careers",
+  cxsJobsUrl: null,
+  sourceType: "bamboohr",
+  isCustom: true,
+  sortOrder: 1,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("watchlist results service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(watchlistRepo.recordWatchlistCheck).mockResolvedValue({
+      previousLastCheckedAt: "2026-01-01T00:00:00.000Z",
+      checkedAt: "2026-01-02T00:00:00.000Z",
+      jobs: [
+        {
+          source: "workday:acme",
+          sourceJobId: "new-job",
+          isNewSinceLastCheck: true,
+          firstSeenAt: "2026-01-02T00:00:00.000Z",
+          lastSeenAt: "2026-01-02T00:00:00.000Z",
+        },
+      ],
+    });
+    vi.mocked(watchlistRepo.listWatchlistJobStates).mockResolvedValue([
+      {
+        source: "workday:acme",
+        sourceJobId: "ignored-job",
+        state: "ignored",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+    vi.mocked(jobsRepo.getJobListItems).mockResolvedValue([
+      {
+        id: "workspace-job",
+        source: "bamboohr:beta",
+        sourceJobId: "imported-job",
+        title: "Imported",
+        employer: "Beta",
+        jobUrl: "https://beta.bamboohr.com/careers/2",
+        applicationLink: "https://beta.bamboohr.com/careers/2",
+        datePosted: null,
+        deadline: null,
+        salary: null,
+        location: null,
+        status: "discovered",
+        outcome: null,
+        closedAt: null,
+        suitabilityScore: null,
+        sponsorMatchScore: null,
+        pdfRegenerating: false,
+        pdfFreshness: "missing",
+        salaryMinAmount: null,
+        salaryMaxAmount: null,
+        salaryCurrency: null,
+        discoveredAt: "2026-01-01T00:00:00.000Z",
+        readyAt: null,
+        appliedAt: null,
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      } as any,
+    ]);
+    vi.mocked(getWatchlistSourceAdapter).mockImplementation((sourceType) => {
+      if (sourceType === "workday") {
+        return {
+          hydrateSelectedSource: (source: WatchlistSelectedSource) => ({
+            ...source,
+            label: "Hydrated Acme",
+          }),
+          fetchJobs: vi.fn().mockResolvedValue({
+            total: 2,
+            fetched: 2,
+            jobs: [
+              {
+                jobRef: "https://example.com/new",
+                source: "workday:acme",
+                sourceJobId: "new-job",
+                sourceType: "workday",
+                title: "New Engineer",
+                employer: "Acme",
+                jobUrl: "https://example.com/new",
+                applicationLink: "https://example.com/new",
+                location: "London",
+                postedAt: "2026-01-02",
+              },
+              {
+                jobRef: "https://example.com/ignored",
+                source: "workday:acme",
+                sourceJobId: "ignored-job",
+                sourceType: "workday",
+                title: "Ignored Engineer",
+                employer: "Acme",
+                jobUrl: "https://example.com/ignored",
+                applicationLink: "https://example.com/ignored",
+                location: "London",
+                postedAt: "2026-01-02",
+              },
+            ],
+          }),
+        } as any;
+      }
+
+      return {
+        hydrateSelectedSource: (source: WatchlistSelectedSource) => source,
+        fetchJobs: vi.fn().mockResolvedValue({
+          total: 1,
+          fetched: 1,
+          jobs: [
+            {
+              jobRef: "https://beta.bamboohr.com/careers/2",
+              source: "bamboohr:beta",
+              sourceJobId: "imported-job",
+              sourceType: "bamboohr",
+              title: "Imported",
+              employer: "Beta",
+              jobUrl: "https://beta.bamboohr.com/careers/2",
+              applicationLink: "https://beta.bamboohr.com/careers/2",
+              location: "Remote",
+              postedAt: null,
+            },
+          ],
+        }),
+      } as any;
+    });
+  });
+
+  it("hydrates selected sources through their adapters", () => {
+    expect(hydrateWatchlistSelectedSources([workdaySource])).toMatchObject([
+      {
+        id: "workday-source",
+        label: "Hydrated Acme",
+      },
+    ]);
+  });
+
+  it("fetches sources, records checks, and annotates ignored/imported jobs", async () => {
+    const result = await getWatchlistResultsForSources([
+      workdaySource,
+      bamboohrSource,
+    ]);
+
+    expect(watchlistRepo.recordWatchlistCheck).toHaveBeenCalledWith({
+      checks: [
+        { source: "workday:acme", sourceJobIds: ["new-job", "ignored-job"] },
+        { source: "bamboohr:beta", sourceJobIds: ["imported-job"] },
+      ],
+    });
+    expect(result.checkedAt).toBe("2026-01-02T00:00:00.000Z");
+    expect(result.sources).toHaveLength(2);
+
+    const workdayJobs =
+      result.sources[0]?.status === "success" ? result.sources[0].jobs : [];
+    expect(workdayJobs.map((job) => job.rowState)).toEqual(["new", "ignored"]);
+    expect(workdayJobs[0]?.isNewSinceLastCheck).toBe(true);
+
+    const bamboohrJobs =
+      result.sources[1]?.status === "success" ? result.sources[1].jobs : [];
+    expect(bamboohrJobs[0]?.rowState).toBe("moved_to_workspace");
+    expect(bamboohrJobs[0]?.workspaceJob).toEqual({
+      id: "workspace-job",
+      status: "discovered",
+    });
+  });
+});

--- a/orchestrator/src/server/watchlist/results.ts
+++ b/orchestrator/src/server/watchlist/results.ts
@@ -1,0 +1,227 @@
+import { notFound } from "@infra/errors";
+import * as jobsRepo from "@server/repositories/jobs";
+import * as watchlistRepo from "@server/repositories/watchlist";
+import {
+  getWatchlistSourceAdapter,
+  listWatchlistSourceAdapters,
+} from "@server/watchlist/adapters";
+import type {
+  JobListItem,
+  WatchlistCheckResponse,
+  WatchlistJobResult,
+  WatchlistResultsResponse,
+  WatchlistSelectedSource,
+  WatchlistSourceResult,
+} from "@shared/types";
+
+export const WATCHLIST_SOURCE_TIMEOUT_MS = 30000;
+
+export function getWatchlistSourceTypeDescriptors() {
+  return listWatchlistSourceAdapters().map((adapter) => adapter.descriptor);
+}
+
+export function hydrateWatchlistSelectedSource(
+  source: WatchlistSelectedSource,
+): WatchlistSelectedSource {
+  const adapter = getWatchlistSourceAdapter(source.sourceType);
+  return adapter?.hydrateSelectedSource(source) ?? source;
+}
+
+export function hydrateWatchlistSelectedSources(
+  selectedSources: WatchlistSelectedSource[],
+): WatchlistSelectedSource[] {
+  return selectedSources.map(hydrateWatchlistSelectedSource);
+}
+
+export async function listHydratedWatchlistSelectedSources(): Promise<
+  WatchlistSelectedSource[]
+> {
+  return hydrateWatchlistSelectedSources(
+    await watchlistRepo.listWatchlistSelectedSources(),
+  );
+}
+
+export async function getWatchlistResultsForSources(
+  selectedSources: WatchlistSelectedSource[],
+): Promise<WatchlistResultsResponse> {
+  if (selectedSources.length === 0) {
+    return {
+      checkedAt: null,
+      previousLastCheckedAt: null,
+      sources: [],
+    };
+  }
+
+  const fetchedSources = await Promise.all(
+    selectedSources.map((source) => fetchWatchlistSource(source)),
+  );
+  const successfulSources = fetchedSources.filter(
+    (item): item is Extract<WatchlistSourceResult, { status: "success" }> =>
+      item.status === "success",
+  );
+  const checksBySource = new Map<string, Set<string>>();
+
+  for (const item of successfulSources) {
+    for (const job of item.jobs) {
+      const sourceJobIds = checksBySource.get(job.source) ?? new Set<string>();
+      sourceJobIds.add(job.sourceJobId);
+      checksBySource.set(job.source, sourceJobIds);
+    }
+  }
+
+  const check = await watchlistRepo.recordWatchlistCheck({
+    checks: Array.from(checksBySource, ([source, sourceJobIds]) => ({
+      source,
+      sourceJobIds: Array.from(sourceJobIds),
+    })),
+  });
+  const [states, workspaceJobs] = await Promise.all([
+    watchlistRepo.listWatchlistJobStates(),
+    jobsRepo.getJobListItems(),
+  ]);
+
+  return {
+    checkedAt: check.checkedAt,
+    previousLastCheckedAt: check.previousLastCheckedAt,
+    sources: annotateWatchlistSourceResults({
+      sourceResults: fetchedSources,
+      check,
+      states,
+      workspaceJobs,
+    }),
+  };
+}
+
+export async function getCurrentWatchlistResults(): Promise<WatchlistResultsResponse> {
+  return getWatchlistResultsForSources(
+    await listHydratedWatchlistSelectedSources(),
+  );
+}
+
+export async function getWatchlistSelectedSourceById(
+  selectedSourceId: string,
+): Promise<WatchlistSelectedSource> {
+  const source = (await listHydratedWatchlistSelectedSources()).find(
+    (item) => item.id === selectedSourceId,
+  );
+  if (!source) {
+    throw notFound("Watchlist source was not found");
+  }
+  return source;
+}
+
+export async function fetchWatchlistSource(
+  source: WatchlistSelectedSource,
+): Promise<WatchlistSourceResult> {
+  const adapter = getWatchlistSourceAdapter(source.sourceType);
+  if (!adapter) {
+    return {
+      status: "error",
+      source,
+      error: `Unsupported watchlist source type: ${source.sourceType}`,
+    };
+  }
+
+  try {
+    const result = await withWatchlistSourceTimeout((signal) =>
+      adapter.fetchJobs({ source, signal }),
+    );
+    return {
+      status: "success",
+      source,
+      jobs: result.jobs.map((job) => ({
+        ...job,
+        rowState: "new",
+        isNewSinceLastCheck: false,
+        workspaceJob: null,
+      })),
+      total: result.total,
+      fetched: result.fetched,
+    };
+  } catch (error) {
+    return {
+      status: "error",
+      source,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function annotateWatchlistSourceResults(input: {
+  sourceResults: WatchlistSourceResult[];
+  check: WatchlistCheckResponse;
+  states: Awaited<ReturnType<typeof watchlistRepo.listWatchlistJobStates>>;
+  workspaceJobs: JobListItem[];
+}): WatchlistSourceResult[] {
+  const ignoredKeys = new Set(
+    input.states
+      .filter((state) => state.state === "ignored")
+      .map((state) => getWatchlistJobKey(state.source, state.sourceJobId)),
+  );
+  const newJobKeys = new Set(
+    input.check.jobs
+      .filter((job) => job.isNewSinceLastCheck)
+      .map((job) => getWatchlistJobKey(String(job.source), job.sourceJobId)),
+  );
+  const importedByKey = new Map<string, JobListItem>();
+  const importedByUrl = new Map<string, JobListItem>();
+  for (const job of input.workspaceJobs) {
+    if (job.sourceJobId) {
+      importedByKey.set(
+        getWatchlistJobKey(String(job.source), job.sourceJobId),
+        job,
+      );
+    }
+    importedByUrl.set(job.jobUrl, job);
+  }
+
+  return input.sourceResults.map((result) => {
+    if (result.status === "error") return result;
+
+    return {
+      ...result,
+      jobs: result.jobs.map((job): WatchlistJobResult => {
+        const jobKey = getWatchlistJobKey(String(job.source), job.sourceJobId);
+        const workspaceJob =
+          importedByKey.get(jobKey) ?? importedByUrl.get(job.jobUrl) ?? null;
+        const rowState = workspaceJob
+          ? "moved_to_workspace"
+          : ignoredKeys.has(jobKey)
+            ? "ignored"
+            : "new";
+
+        return {
+          ...job,
+          rowState,
+          isNewSinceLastCheck: rowState === "new" && newJobKeys.has(jobKey),
+          workspaceJob: workspaceJob
+            ? { id: workspaceJob.id, status: workspaceJob.status }
+            : null,
+        };
+      }),
+    };
+  });
+}
+
+export async function withWatchlistSourceTimeout<T>(
+  callback: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    WATCHLIST_SOURCE_TIMEOUT_MS,
+  );
+
+  try {
+    return await callback(controller.signal);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function getWatchlistJobKey(
+  source: string,
+  sourceJobId: string,
+): string {
+  return `${source}:${sourceJobId}`;
+}


### PR DESCRIPTION
**Summary**
- Automatically include the active user’s saved Watchlist sources in pipeline discovery.
- Extract shared Watchlist result handling into a reusable server service and reuse it from the existing Watchlist API route.
- Enrich Watchlist jobs with full import drafts before handing them to the normal import, dedupe, scoring, and processing flow.
- Keep Watchlist scoped to the current tenant/user and preserve existing route contracts.

**Testing**
- Added unit coverage for the shared Watchlist results service and the pipeline Watchlist ingestion step.
- Extended discovery tests to cover mixed extractor + Watchlist runs, user scoping, no-op behavior when no Watchlist sources exist, and non-fatal Watchlist source failures.
- Full validation passed: formatting, type checks, client build, and the orchestrator test suite.