### PR TITLE
Add hosted signup and platform LLM gating

### DIFF
--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -42,6 +42,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 
 ![Model settings section](/img/features/settings-model-section.png)
 
+- In hosted deployments with platform-managed LLM enabled, this section is hidden because provider, API key, and model selection are managed by the hosted platform.
 - Choose provider (`openrouter`, `lmstudio`, `ollama`, `openai`, `glm`, `gemini`, `gemini_cli`, `codex`)
 - Set provider-specific base URL/API key when required
 - Configure the default model/runtime, plus purpose-specific overrides for:

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -79,7 +79,7 @@ JOBOPS_HOSTED_QUOTAS_ENABLED=false
 
 These flags only affect hosted mode. Leaving `JOBOPS_APP_MODE` unset keeps the current first-run setup, private-workspace user creation, settings, and local behavior unchanged.
 
-When hosted mode is active, first-run setup is disabled. Hosted users must be created through hosted signup when `JOBOPS_HOSTED_SIGNUPS_ENABLED=true`, or by a later tenant-owner/admin user-management flow.
+When hosted mode is active, first-run setup is disabled. Hosted users must be created through hosted signup when `JOBOPS_HOSTED_SIGNUPS_ENABLED=true`, or by a later tenant-owner/admin user-management flow. Hosted signup appears on `/sign-in` as a **Create account** tab only when hosted mode and hosted signups are both enabled.
 
 ## Codex sign-in
 

--- a/orchestrator/src/client/lib/queryKeys.ts
+++ b/orchestrator/src/client/lib/queryKeys.ts
@@ -1,6 +1,10 @@
 import type { JobStatus, PostApplicationProvider } from "@shared/types";
 
 export const queryKeys = {
+  app: {
+    all: ["app"] as const,
+    status: () => [...queryKeys.app.all, "status"] as const,
+  },
   designResume: {
     all: ["design-resume"] as const,
     current: () => [...queryKeys.designResume.all, "current"] as const,

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -11,6 +11,7 @@ import { renderWithQueryClient } from "../test/renderWithQueryClient";
 import { OnboardingPage } from "./OnboardingPage";
 
 vi.mock("@client/api", () => ({
+  getAppStatus: vi.fn(),
   getAuthBootstrapStatus: vi.fn(async () => ({ setupRequired: false })),
   hasAuthenticatedSession: vi.fn(() => true),
   importDesignResumeFromFile: vi.fn(),
@@ -124,6 +125,28 @@ const authUser = {
   updatedAt: "2026-06-01T00:00:00.000Z",
 };
 
+const localAppStatus = {
+  appMode: "local" as const,
+  capabilities: {
+    hostedSignups: false,
+    platformLlm: false,
+    quotas: false,
+    userEditableLlmSettings: true,
+  },
+  hostedTenantConfigured: false,
+};
+
+const hostedPlatformLlmStatus = {
+  appMode: "hosted" as const,
+  capabilities: {
+    hostedSignups: true,
+    platformLlm: true,
+    quotas: true,
+    userEditableLlmSettings: false,
+  },
+  hostedTenantConfigured: true,
+};
+
 const analyticsTrack = vi.fn();
 
 function getTrackedEvent(name: string) {
@@ -186,6 +209,9 @@ async function renderPage() {
   );
   await waitFor(() => {
     expect(api.getAuthBootstrapStatus).toHaveBeenCalled();
+  });
+  await waitFor(() => {
+    expect(screen.queryAllByText("Loading launch console...")).toHaveLength(0);
   });
   return rendered;
 }
@@ -263,6 +289,7 @@ describe("OnboardingPage", () => {
         },
       } as any;
     });
+    vi.mocked(api.getAppStatus).mockResolvedValue(localAppStatus);
   });
 
   it("shows one active server requirement and collapses completed checks", async () => {
@@ -286,6 +313,48 @@ describe("OnboardingPage", () => {
     expect(screen.getByText("2/4")).toBeInTheDocument();
     expect(screen.getByText("Model connected")).toBeInTheDocument();
     expect(screen.getAllByText("Load your resume").length).toBeGreaterThan(0);
+  });
+
+  it("hides account and model launch steps in hosted platform LLM mode", async () => {
+    const hostedResumeStatus: OnboardingStatusResponse = {
+      complete: false,
+      nextRequirementId: "resume",
+      requirements: [
+        {
+          id: "resume",
+          status: "needs_action",
+          title: "Load your resume",
+          message:
+            "Upload a resume file, or connect Reactive Resume and choose a template.",
+          primaryAction: "upload_resume",
+        },
+      ],
+    };
+    vi.mocked(api.getAppStatus).mockResolvedValue(hostedPlatformLlmStatus);
+    vi.mocked(useOnboardingStatus).mockReturnValue({
+      status: hostedResumeStatus,
+      complete: false,
+      nextRequirementId: "resume",
+      requirements: hostedResumeStatus.requirements,
+      checking: false,
+      error: null,
+      refetch: vi.fn(),
+    } as any);
+
+    await renderPage();
+
+    expect(await screen.findByText("content:resume")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /account workspace/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /model connection/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Step 1 of 2")).toBeInTheDocument();
+    expect(screen.getByText("0/2")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Workspace account created"),
+    ).not.toBeInTheDocument();
   });
 
   it("calls the focused model action from the active requirement", async () => {

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -46,6 +46,7 @@ vi.mock("./onboarding/components/OnboardingCoach", () => ({
 
 vi.mock("./onboarding/components/OnboardingStepContent", () => ({
   OnboardingStepContent: (props: {
+    allowReactiveResume?: boolean;
     currentStep: string;
     onCodexAuthStatusChange?: (status: {
       authenticated: boolean;
@@ -56,6 +57,10 @@ vi.mock("./onboarding/components/OnboardingStepContent", () => ({
   }) => (
     <div>
       <div>content:{props.currentStep}</div>
+      <div>
+        reactive-resume:
+        {props.allowReactiveResume === false ? "off" : "on"}
+      </div>
       <button
         type="button"
         onClick={() =>
@@ -344,6 +349,7 @@ describe("OnboardingPage", () => {
     await renderPage();
 
     expect(await screen.findByText("content:resume")).toBeInTheDocument();
+    expect(screen.getByText("reactive-resume:off")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /account workspace/i }),
     ).not.toBeInTheDocument();
@@ -352,6 +358,9 @@ describe("OnboardingPage", () => {
     ).not.toBeInTheDocument();
     expect(screen.getByText("Step 1 of 2")).toBeInTheDocument();
     expect(screen.getByText("0/2")).toBeInTheDocument();
+    expect(
+      screen.getByText("Upload your existing resume, PDF or DOCX"),
+    ).toBeInTheDocument();
     expect(
       screen.queryByText("Workspace account created"),
     ).not.toBeInTheDocument();

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -719,9 +719,11 @@ const LaunchOnboardingPage: React.FC = () => {
     new Set<"provider" | "endpoint" | "api_key" | "model">(),
   );
   const isAppStatusLoading = appStatusQuery.isLoading && !appStatusQuery.data;
-  const showAccountStep = appStatusQuery.data?.appMode !== "hosted";
+  const isHostedMode = appStatusQuery.data?.appMode === "hosted";
+  const showAccountStep = !isHostedMode;
   const showModelStep =
     appStatusQuery.data?.capabilities.userEditableLlmSettings ?? true;
+  const allowReactiveResumeSetup = !isHostedMode;
   const visiblePanels = useMemo(
     () =>
       DEFAULT_ONBOARDING_PANELS.filter((panel) => {
@@ -970,6 +972,10 @@ const LaunchOnboardingPage: React.FC = () => {
     (showAccountStep ? 1 : 0) +
     (onboarding.complete ? 1 : 0);
   const totalSteps = visiblePanels.length;
+  const activePrimaryAction =
+    isHostedMode && activePanel === "resume"
+      ? "upload_resume"
+      : (activeRequirement?.primaryAction ?? "none");
 
   const submitActivePanel = async () => {
     if (activePanel === "account") {
@@ -986,7 +992,7 @@ const LaunchOnboardingPage: React.FC = () => {
       return;
     }
     if (activePanel === "resume") {
-      if (flow.resumeSetupMode === "rxresume") {
+      if (allowReactiveResumeSetup && flow.resumeSetupMode === "rxresume") {
         const status = await flow.handleSaveRxresume();
         if (status?.complete) setActivePanel("first-run");
         return;
@@ -1026,6 +1032,7 @@ const LaunchOnboardingPage: React.FC = () => {
       <PageMain className="space-y-4">
         <OnboardingCoach
           activePanel={activePanel}
+          allowReactiveResume={allowReactiveResumeSetup}
           onPanelChange={(panel) => {
             if (visiblePanels.includes(panel)) setActivePanel(panel);
           }}
@@ -1111,7 +1118,9 @@ const LaunchOnboardingPage: React.FC = () => {
                         ? "Workspace account created"
                         : activePanel === "first-run"
                           ? "Ready for the first run"
-                          : activeRequirement?.title}
+                          : isHostedMode && activePanel === "resume"
+                            ? "Upload your existing resume, PDF or DOCX"
+                            : activeRequirement?.title}
                     </CardTitle>
                     <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
                       {activePanel === "account"
@@ -1120,9 +1129,11 @@ const LaunchOnboardingPage: React.FC = () => {
                           ? showModelStep
                             ? "Your model and resume are loaded. Job Ops can start turning job leads into ranked, actionable work."
                             : "Your resume is loaded. Job Ops can start turning job leads into ranked, actionable work."
-                          : activeRequirement?.status === "ready"
-                            ? activeRequirement.message
-                            : "Complete this setup check to unlock the next part of your job-search workflow."}
+                          : isHostedMode && activePanel === "resume"
+                            ? "Upload your existing resume as a PDF or DOCX. Job Ops will use it as the baseline for matching, fit assessment, search terms, and application workflows."
+                            : activeRequirement?.status === "ready"
+                              ? activeRequirement.message
+                              : "Complete this setup check to unlock the next part of your job-search workflow."}
                     </p>
                   </div>
                 </CardHeader>
@@ -1174,6 +1185,7 @@ const LaunchOnboardingPage: React.FC = () => {
                     </div>
                   ) : activePanel === "model" || activePanel === "resume" ? (
                     <OnboardingStepContent
+                      allowReactiveResume={allowReactiveResumeSetup}
                       baseResumeValidation={baseResumeValidation}
                       baseResumeValue={flow.watch("rxresumeBaseResumeId")}
                       currentStep={activePanel as StepId}
@@ -1315,9 +1327,7 @@ const LaunchOnboardingPage: React.FC = () => {
                         ? flow.isGeneratingSearchTerms
                           ? "Preparing search terms..."
                           : "Open ready queue"
-                        : getActionLabel(
-                            activeRequirement?.primaryAction ?? "none",
-                          )}
+                        : getActionLabel(activePrimaryAction)}
                     <ArrowRight className="h-4 w-4" />
                   </Button>
                 </div>

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -4,6 +4,7 @@ import type {
   OnboardingRequirement,
   OnboardingRequirementPrimaryAction,
 } from "@shared/types";
+import { useQuery } from "@tanstack/react-query";
 import {
   ArrowRight,
   CheckCircle2,
@@ -23,10 +24,12 @@ import { Navigate, useNavigate } from "react-router-dom";
 import {
   type AuthUser,
   type CodexAuthStatusResponse,
+  getAppStatus,
   getAuthBootstrapStatus,
   hasAuthenticatedSession,
   setupFirstAdmin,
 } from "@/client/api";
+import { queryKeys } from "@/client/lib/queryKeys";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -54,6 +57,12 @@ import type {
 import { useOnboardingFlow } from "./onboarding/useOnboardingFlow";
 
 const TOTAL_ONBOARDING_STEPS = 4;
+const DEFAULT_ONBOARDING_PANELS: OnboardingPanelId[] = [
+  "account",
+  "model",
+  "resume",
+  "first-run",
+];
 const ACCOUNT_PREVIEW_RAIL_ITEMS: Array<{
   id: OnboardingPanelId;
   label: string;
@@ -103,17 +112,12 @@ function getActionLabel(action: OnboardingRequirementPrimaryAction): string {
   }
 }
 
-function getPanelStepLabel(panel: OnboardingPanelId): string {
-  switch (panel) {
-    case "account":
-      return "Step 1 of 4";
-    case "model":
-      return "Step 2 of 4";
-    case "resume":
-      return "Step 3 of 4";
-    case "first-run":
-      return "Step 4 of 4";
-  }
+function getPanelStepLabel(
+  panel: OnboardingPanelId,
+  panels = DEFAULT_ONBOARDING_PANELS,
+): string {
+  const stepIndex = panels.indexOf(panel);
+  return `Step ${Math.max(stepIndex, 0) + 1} of ${panels.length}`;
 }
 
 function useOnboardingDropoffAnalytics(args: {
@@ -701,6 +705,10 @@ const AccountSetupOnboarding: React.FC<{
 const LaunchOnboardingPage: React.FC = () => {
   const flow = useOnboardingFlow();
   const onboarding = useOnboardingStatus();
+  const appStatusQuery = useQuery({
+    queryKey: queryKeys.app.status(),
+    queryFn: getAppStatus,
+  });
   const navigate = useNavigate();
   const [activePanel, setActivePanel] = useState<OnboardingPanelId>("model");
   const [coachReplayNonce, setCoachReplayNonce] = useState(0);
@@ -710,14 +718,44 @@ const LaunchOnboardingPage: React.FC = () => {
   const trackedModelConfigFieldsRef = useRef(
     new Set<"provider" | "endpoint" | "api_key" | "model">(),
   );
+  const isAppStatusLoading = appStatusQuery.isLoading && !appStatusQuery.data;
+  const showAccountStep = appStatusQuery.data?.appMode !== "hosted";
+  const showModelStep =
+    appStatusQuery.data?.capabilities.userEditableLlmSettings ?? true;
+  const visiblePanels = useMemo(
+    () =>
+      DEFAULT_ONBOARDING_PANELS.filter((panel) => {
+        if (panel === "account") return showAccountStep;
+        if (panel === "model") return showModelStep;
+        return true;
+      }),
+    [showAccountStep, showModelStep],
+  );
+  const visibleRequirements = useMemo(
+    () =>
+      onboarding.requirements.filter(
+        (requirement) => requirement.id !== "model" || showModelStep,
+      ),
+    [onboarding.requirements, showModelStep],
+  );
+  const fallbackPanel = useMemo<OnboardingPanelId>(() => {
+    if (
+      onboarding.nextRequirementId &&
+      visiblePanels.includes(onboarding.nextRequirementId)
+    ) {
+      return onboarding.nextRequirementId;
+    }
+    if (onboarding.complete) return "first-run";
+    return visiblePanels.includes("model") ? "model" : "resume";
+  }, [onboarding.complete, onboarding.nextRequirementId, visiblePanels]);
 
   const modelRequirement = useMemo(
-    () => getRequirement(onboarding.requirements, "model"),
-    [onboarding.requirements],
+    () => getRequirement(visibleRequirements, "model"),
+    [visibleRequirements],
   );
   const resumeRequirement = useMemo(
-    () => getRequirement(onboarding.requirements, "resume"),
-    [onboarding.requirements],
+    () => getRequirement(visibleRequirements, "resume"),
+    [visibleRequirements],
   );
   const activeRequirement =
     activePanel === "account" || activePanel === "first-run"
@@ -743,15 +781,16 @@ const LaunchOnboardingPage: React.FC = () => {
   });
 
   useEffect(() => {
+    if (isAppStatusLoading) return;
     trackProductEvent("onboarding_step_viewed", {
       step: toAnalyticsStep(activePanel),
       step_index: getStepIndex(activePanel),
       requirement_status: getActiveRequirementStatus(),
     });
-  }, [activePanel, getActiveRequirementStatus]);
+  }, [activePanel, getActiveRequirementStatus, isAppStatusLoading]);
 
   useEffect(() => {
-    if (!onboarding.status || onboarding.checking) return;
+    if (!onboarding.status || onboarding.checking || isAppStatusLoading) return;
     trackProductEvent("onboarding_status_checked", {
       complete: onboarding.complete,
       next_step: getNextStep(onboarding.nextRequirementId, onboarding.complete),
@@ -760,6 +799,7 @@ const LaunchOnboardingPage: React.FC = () => {
     });
   }, [
     modelRequirement,
+    isAppStatusLoading,
     onboarding.checking,
     onboarding.complete,
     onboarding.nextRequirementId,
@@ -811,14 +851,29 @@ const LaunchOnboardingPage: React.FC = () => {
   );
 
   useEffect(() => {
-    if (onboarding.nextRequirementId) {
+    if (isAppStatusLoading) return;
+    if (!visiblePanels.includes(activePanel)) {
+      setActivePanel(fallbackPanel);
+      return;
+    }
+    if (
+      onboarding.nextRequirementId &&
+      visiblePanels.includes(onboarding.nextRequirementId)
+    ) {
       setActivePanel(onboarding.nextRequirementId);
       return;
     }
     if (onboarding.complete) {
       setActivePanel("first-run");
     }
-  }, [onboarding.complete, onboarding.nextRequirementId]);
+  }, [
+    activePanel,
+    fallbackPanel,
+    isAppStatusLoading,
+    onboarding.complete,
+    onboarding.nextRequirementId,
+    visiblePanels,
+  ]);
 
   useEffect(() => {
     if (
@@ -881,6 +936,25 @@ const LaunchOnboardingPage: React.FC = () => {
     return <Navigate to="/jobs/ready" replace />;
   }
 
+  if (isAppStatusLoading) {
+    return (
+      <>
+        <PageHeader
+          icon={Sparkles}
+          title="Launch Console"
+          subtitle="Loading the launch checks Job Ops needs before it can work your search."
+        />
+        <PageMain>
+          <Card className="border-border/60 bg-card shadow-none">
+            <CardContent className="flex min-h-[24rem] items-center justify-center text-sm text-muted-foreground">
+              Loading launch console...
+            </CardContent>
+          </Card>
+        </PageMain>
+      </>
+    );
+  }
+
   const llmValidation = toValidationState(modelRequirement);
   const baseResumeValidation = toValidationState(resumeRequirement);
   const rxresumeValidation: ValidationState = {
@@ -891,18 +965,22 @@ const LaunchOnboardingPage: React.FC = () => {
       baseResumeValidation.valid,
   };
   const completedCount =
-    onboarding.requirements.filter(
-      (requirement) => requirement.status === "ready",
-    ).length +
-    1 +
+    visibleRequirements.filter((requirement) => requirement.status === "ready")
+      .length +
+    (showAccountStep ? 1 : 0) +
     (onboarding.complete ? 1 : 0);
+  const totalSteps = visiblePanels.length;
 
   const submitActivePanel = async () => {
     if (activePanel === "account") {
-      setActivePanel(onboarding.nextRequirementId ?? "model");
+      setActivePanel(fallbackPanel);
       return;
     }
     if (activePanel === "model") {
+      if (!showModelStep) {
+        setActivePanel(fallbackPanel);
+        return;
+      }
       const status = await flow.handleSaveModel();
       if (status?.complete) setActivePanel("first-run");
       return;
@@ -938,14 +1016,22 @@ const LaunchOnboardingPage: React.FC = () => {
       <PageHeader
         icon={Sparkles}
         title="Launch Console"
-        subtitle="Load the LLM and resume Job Ops needs before it can work your search."
+        subtitle={
+          showModelStep
+            ? "Load the LLM and resume Job Ops needs before it can work your search."
+            : "Load the resume Job Ops needs before it can work your search."
+        }
       />
 
       <PageMain className="space-y-4">
         <OnboardingCoach
           activePanel={activePanel}
-          onPanelChange={setActivePanel}
+          onPanelChange={(panel) => {
+            if (visiblePanels.includes(panel)) setActivePanel(panel);
+          }}
           replayNonce={coachReplayNonce}
+          showAccount={showAccountStep}
+          showModel={showModelStep}
           status={onboarding.status}
         />
 
@@ -955,7 +1041,7 @@ const LaunchOnboardingPage: React.FC = () => {
               <div className="flex items-center justify-between gap-3">
                 <CardTitle className="text-base">Launch checks</CardTitle>
                 <span className="text-xs text-muted-foreground">
-                  {completedCount}/{TOTAL_ONBOARDING_STEPS}
+                  {completedCount}/{totalSteps}
                 </span>
               </div>
               <p className="text-xs leading-5 text-muted-foreground">
@@ -969,7 +1055,9 @@ const LaunchOnboardingPage: React.FC = () => {
                 complete={onboarding.complete}
                 nextRequirementId={onboarding.nextRequirementId}
                 onPanelSelect={setActivePanel}
-                requirements={onboarding.requirements}
+                requirements={visibleRequirements}
+                showAccount={showAccountStep}
+                showModel={showModelStep}
               />
               <Button
                 type="button"
@@ -992,7 +1080,9 @@ const LaunchOnboardingPage: React.FC = () => {
           </Card>
 
           <Card className="border-border/60 bg-card shadow-none">
-            {onboarding.checking || flow.settingsLoading ? (
+            {onboarding.checking ||
+            flow.settingsLoading ||
+            isAppStatusLoading ? (
               <CardContent className="flex min-h-[24rem] items-center justify-center text-sm text-muted-foreground">
                 Loading launch console...
               </CardContent>
@@ -1006,7 +1096,7 @@ const LaunchOnboardingPage: React.FC = () => {
               >
                 <CardHeader className="space-y-3 border-b border-border/60 px-6 py-5">
                   <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-                    <span>{getPanelStepLabel(activePanel)}</span>
+                    <span>{getPanelStepLabel(activePanel, visiblePanels)}</span>
                     {activePanel === "account" ||
                     activeRequirement?.status === "ready" ? (
                       <span className="inline-flex items-center gap-1.5 text-emerald-600">
@@ -1027,7 +1117,9 @@ const LaunchOnboardingPage: React.FC = () => {
                       {activePanel === "account"
                         ? "Your private workspace is ready. Finish the model and resume checks so Job Ops can work from the right account context."
                         : activePanel === "first-run"
-                          ? "Your model and resume are loaded. Job Ops can start turning job leads into ranked, actionable work."
+                          ? showModelStep
+                            ? "Your model and resume are loaded. Job Ops can start turning job leads into ranked, actionable work."
+                            : "Your resume is loaded. Job Ops can start turning job leads into ranked, actionable work."
                           : activeRequirement?.status === "ready"
                             ? activeRequirement.message
                             : "Complete this setup check to unlock the next part of your job-search workflow."}
@@ -1036,14 +1128,17 @@ const LaunchOnboardingPage: React.FC = () => {
                 </CardHeader>
 
                 <CardContent className="flex flex-1 flex-col gap-5 px-6 pt-5">
-                  {activePanel !== "account" && activePanel !== "first-run" ? (
+                  {showAccountStep &&
+                  activePanel !== "account" &&
+                  activePanel !== "first-run" ? (
                     <div className="flex items-center gap-2 text-sm text-emerald-600">
                       <CheckCircle2 className="h-4 w-4" />
                       <span>Workspace account created</span>
                     </div>
                   ) : null}
 
-                  {modelRequirement?.status === "ready" &&
+                  {showModelStep &&
+                  modelRequirement?.status === "ready" &&
                   activePanel !== "model" &&
                   activePanel !== "first-run" ? (
                     <div className="flex items-center gap-2 text-sm text-emerald-600">

--- a/orchestrator/src/client/pages/SettingsPage.test.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.test.tsx
@@ -15,6 +15,7 @@ const render = (ui: Parameters<typeof renderWithQueryClient>[0]) =>
   renderWithQueryClient(ui);
 
 vi.mock("../api", () => ({
+  getAppStatus: vi.fn(),
   getSettings: vi.fn(),
   getLlmModels: vi.fn().mockResolvedValue([]),
   getCodexAuthStatus: vi.fn().mockResolvedValue({
@@ -98,6 +99,28 @@ const baseSettings = createAppSettings({
   ],
 });
 
+const localAppStatus = {
+  appMode: "local" as const,
+  capabilities: {
+    hostedSignups: false,
+    platformLlm: false,
+    quotas: false,
+    userEditableLlmSettings: true,
+  },
+  hostedTenantConfigured: false,
+};
+
+const hostedPlatformLlmStatus = {
+  appMode: "hosted" as const,
+  capabilities: {
+    hostedSignups: true,
+    platformLlm: true,
+    quotas: true,
+    userEditableLlmSettings: false,
+  },
+  hostedTenantConfigured: true,
+};
+
 const renderPage = () => {
   return render(
     <MemoryRouter initialEntries={["/settings"]}>
@@ -169,6 +192,7 @@ describe("SettingsPage", () => {
       value: vi.fn(),
     });
     _resetTracerReadinessCache();
+    vi.mocked(api.getAppStatus).mockResolvedValue(localAppStatus);
     vi.mocked(api.getTracerReadiness).mockResolvedValue({
       status: "ready",
       isPubliclyAvailable: true,
@@ -573,6 +597,24 @@ describe("SettingsPage", () => {
 
     const saveButton = getSaveButton();
     await waitFor(() => expect(saveButton).toBeDisabled());
+  });
+
+  it("hides model settings and defaults to writing style for hosted platform LLM", async () => {
+    vi.mocked(api.getAppStatus).mockResolvedValue(hostedPlatformLlmStatus);
+    vi.mocked(api.getSettings).mockResolvedValue(baseSettings);
+
+    render(
+      <MemoryRouter initialEntries={["/settings#model"]}>
+        <SettingsPage />
+      </MemoryRouter>,
+    );
+
+    await openNavGroup(/^ai$/i);
+
+    expect(screen.queryByRole("button", { name: /models/i })).toBeNull();
+    expect(
+      await screen.findByRole("heading", { name: /writing style/i }),
+    ).toBeInTheDocument();
   });
 
   it("does not mark Reactive Resume settings dirty when project catalog hydration finishes", async () => {

--- a/orchestrator/src/client/pages/SettingsPage.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.tsx
@@ -444,6 +444,23 @@ const NULL_SETTINGS_PAYLOAD: UpdateSettingsInput = {
   scoringPromptTemplate: null,
 };
 
+function getResetSettingsPayload(
+  canEditLlmSettings: boolean,
+): Partial<UpdateSettingsInput> {
+  if (canEditLlmSettings) return NULL_SETTINGS_PAYLOAD;
+  const payload: Partial<UpdateSettingsInput> = { ...NULL_SETTINGS_PAYLOAD };
+  delete payload.model;
+  delete payload.modelScorer;
+  delete payload.modelTailoring;
+  delete payload.modelProjectSelection;
+  delete payload.llmProvider;
+  delete payload.llmBaseUrl;
+  delete payload.llmApiKey;
+  delete payload.llmPurposeOverrides;
+  delete payload.llmPurposeApiKeys;
+  return payload;
+}
+
 const mapSettingsToForm = (data: AppSettings): UpdateSettingsInput => ({
   model: data.model.override ?? "",
   modelScorer: data.modelScorer.override ?? "",
@@ -758,24 +775,6 @@ export const SettingsPage: React.FC = () => {
     useState<SettingsSectionId>("model");
   const [openGroups, setOpenGroups] = useState<SettingsGroupId[]>([]);
 
-  useEffect(() => {
-    const hash = location.hash.replace(/^#/, "");
-    const allSectionIds = SETTINGS_NAV_GROUPS.flatMap((g) =>
-      g.items.map((i) => i.id),
-    );
-    if (hash && allSectionIds.includes(hash as SettingsSectionId)) {
-      setActiveSection(hash as SettingsSectionId);
-      const parentGroup = SETTINGS_NAV_GROUPS.find((g) =>
-        g.items.some((i) => i.id === hash),
-      );
-      if (parentGroup) {
-        setOpenGroups((prev) =>
-          prev.includes(parentGroup.id) ? prev : [...prev, parentGroup.id],
-        );
-      }
-    }
-  }, [location.hash]);
-
   const [settingsSearch, setSettingsSearch] = useState("");
   const [isSaving, setIsSaving] = useState(false);
   const [rxresumeValidationStatus, setRxresumeValidationStatus] =
@@ -829,6 +828,10 @@ export const SettingsPage: React.FC = () => {
     queryKey: queryKeys.settings.current(),
     queryFn: api.getSettings,
   });
+  const appStatusQuery = useQuery({
+    queryKey: queryKeys.app.status(),
+    queryFn: api.getAppStatus,
+  });
   const backupsQuery = useQuery({
     queryKey: queryKeys.backups.list(),
     queryFn: api.getBackups,
@@ -838,6 +841,9 @@ export const SettingsPage: React.FC = () => {
   const backups = backupsQuery.data?.backups ?? [];
   const nextScheduled = backupsQuery.data?.nextScheduled ?? null;
   const isLoadingBackups = backupsQuery.isLoading;
+  const canEditLlmSettings =
+    appStatusQuery.data?.capabilities.userEditableLlmSettings ?? true;
+  useQueryErrorToast(appStatusQuery.error, "Failed to load app status");
   useQueryErrorToast(backupsQuery.error, "Failed to load backups");
 
   const resumeProjectsValue = useWatch({
@@ -1100,15 +1106,15 @@ export const SettingsPage: React.FC = () => {
         envPayload.adzunaAppId = normalizeString(data.adzunaAppId);
       }
 
-      if (dirtyFields.llmProvider) {
+      if (canEditLlmSettings && dirtyFields.llmProvider) {
         envPayload.llmProvider = data.llmProvider ?? null;
       }
 
-      if (dirtyFields.llmBaseUrl) {
+      if (canEditLlmSettings && dirtyFields.llmBaseUrl) {
         envPayload.llmBaseUrl = normalizeString(data.llmBaseUrl);
       }
 
-      if (dirtyFields.llmApiKey) {
+      if (canEditLlmSettings && dirtyFields.llmApiKey) {
         const value = normalizePrivateInput(data.llmApiKey);
         if (value !== undefined) envPayload.llmApiKey = value;
       }
@@ -1133,40 +1139,46 @@ export const SettingsPage: React.FC = () => {
         if (value !== undefined) envPayload.webhookSecret = value;
       }
 
+      const llmPayload: Partial<UpdateSettingsInput> = canEditLlmSettings
+        ? {
+            model: dirtyFields.llmProvider
+              ? dirtyFields.model
+                ? normalizeString(data.model)
+                : null
+              : normalizeString(data.model),
+            ...(dirtyFields.llmProvider
+              ? {
+                  modelScorer: null,
+                  modelTailoring: null,
+                  modelProjectSelection: null,
+                  llmPurposeOverrides: normalizePurposeOverrides(
+                    data.llmPurposeOverrides,
+                    { dropInheritedProviderOverrides: true },
+                  ),
+                }
+              : {}),
+            ...(dirtyFields.llmPurposeOverrides
+              ? {
+                  llmPurposeOverrides: normalizePurposeOverrides(
+                    data.llmPurposeOverrides,
+                  ),
+                  modelScorer: null,
+                  modelTailoring: null,
+                  modelProjectSelection: null,
+                }
+              : {}),
+            ...(dirtyFields.llmPurposeApiKeys
+              ? {
+                  llmPurposeApiKeys: normalizePurposeApiKeys(
+                    data.llmPurposeApiKeys,
+                  ),
+                }
+              : {}),
+          }
+        : {};
+
       const payload: Partial<UpdateSettingsInput> = {
-        model: dirtyFields.llmProvider
-          ? dirtyFields.model
-            ? normalizeString(data.model)
-            : null
-          : normalizeString(data.model),
-        ...(dirtyFields.llmProvider
-          ? {
-              modelScorer: null,
-              modelTailoring: null,
-              modelProjectSelection: null,
-              llmPurposeOverrides: normalizePurposeOverrides(
-                data.llmPurposeOverrides,
-                { dropInheritedProviderOverrides: true },
-              ),
-            }
-          : {}),
-        ...(dirtyFields.llmPurposeOverrides
-          ? {
-              llmPurposeOverrides: normalizePurposeOverrides(
-                data.llmPurposeOverrides,
-              ),
-              modelScorer: null,
-              modelTailoring: null,
-              modelProjectSelection: null,
-            }
-          : {}),
-        ...(dirtyFields.llmPurposeApiKeys
-          ? {
-              llmPurposeApiKeys: normalizePurposeApiKeys(
-                data.llmPurposeApiKeys,
-              ),
-            }
-          : {}),
+        ...llmPayload,
         pipelineWebhookUrl: normalizeString(data.pipelineWebhookUrl),
         jobCompleteWebhookUrl: normalizeString(data.jobCompleteWebhookUrl),
         resumeProjects: resumeProjectsOverride,
@@ -1399,7 +1411,7 @@ export const SettingsPage: React.FC = () => {
     try {
       setIsSaving(true);
       const updated = await updateSettingsMutation.mutateAsync(
-        NULL_SETTINGS_PAYLOAD,
+        getResetSettingsPayload(canEditLlmSettings),
       );
       setSettings(updated);
       reset(mapSettingsToForm(updated));
@@ -1417,16 +1429,47 @@ export const SettingsPage: React.FC = () => {
     toast.success("Discarded unsaved changes");
   };
 
-  const filteredNavGroups = useMemo(
+  const visibleNavGroups = useMemo(
     () =>
       SETTINGS_NAV_GROUPS.map((group) => ({
         ...group,
-        items: group.items.filter((item) =>
-          matchesSettingsSearch(settingsSearch, item),
+        items: group.items.filter(
+          (item) => canEditLlmSettings || item.id !== "model",
         ),
       })).filter((group) => group.items.length > 0),
-    [settingsSearch],
+    [canEditLlmSettings],
   );
+
+  const filteredNavGroups = useMemo(
+    () =>
+      visibleNavGroups
+        .map((group) => ({
+          ...group,
+          items: group.items.filter((item) =>
+            matchesSettingsSearch(settingsSearch, item),
+          ),
+        }))
+        .filter((group) => group.items.length > 0),
+    [settingsSearch, visibleNavGroups],
+  );
+
+  useEffect(() => {
+    const hash = location.hash.replace(/^#/, "");
+    const allSectionIds = visibleNavGroups.flatMap((g) =>
+      g.items.map((i) => i.id),
+    );
+    if (hash && allSectionIds.includes(hash as SettingsSectionId)) {
+      setActiveSection(hash as SettingsSectionId);
+      const parentGroup = visibleNavGroups.find((g) =>
+        g.items.some((i) => i.id === hash),
+      );
+      if (parentGroup) {
+        setOpenGroups((prev) =>
+          prev.includes(parentGroup.id) ? prev : [...prev, parentGroup.id],
+        );
+      }
+    }
+  }, [location.hash, visibleNavGroups]);
 
   const visibleSectionIds = useMemo(
     () =>
@@ -1441,14 +1484,16 @@ export const SettingsPage: React.FC = () => {
     }
   }, [activeSection, visibleSectionIds]);
 
+  const firstVisibleGroup = visibleNavGroups[0] ?? SETTINGS_NAV_GROUPS[0];
+  const firstVisibleSection = firstVisibleGroup.items[0];
   const activeSectionMeta =
-    SETTINGS_NAV_GROUPS.flatMap((group) => group.items).find(
-      (item) => item.id === activeSection,
-    ) ?? SETTINGS_NAV_GROUPS[0].items[0];
+    visibleNavGroups
+      .flatMap((group) => group.items)
+      .find((item) => item.id === activeSection) ?? firstVisibleSection;
   const activeGroup =
-    SETTINGS_NAV_GROUPS.find((group) =>
+    visibleNavGroups.find((group) =>
       group.items.some((item) => item.id === activeSection),
-    ) ?? SETTINGS_NAV_GROUPS[0];
+    ) ?? firstVisibleGroup;
 
   const sectionHasDirtyState = (sectionId: SettingsSectionId) =>
     SECTION_FIELD_MAP[sectionId].some((field) => Boolean(dirtyFields[field]));
@@ -1523,9 +1568,9 @@ export const SettingsPage: React.FC = () => {
   };
 
   const selectedSectionBadge = getSectionBadge(activeSection);
-  const dirtySectionCount = SETTINGS_NAV_GROUPS.flatMap(
-    (group) => group.items,
-  ).filter((item) => sectionHasDirtyState(item.id)).length;
+  const dirtySectionCount = visibleNavGroups
+    .flatMap((group) => group.items)
+    .filter((item) => sectionHasDirtyState(item.id)).length;
   const activeSectionIsDirty = sectionHasDirtyState(activeSection);
 
   let activeSectionContent: React.ReactNode;

--- a/orchestrator/src/client/pages/SignInPage.test.tsx
+++ b/orchestrator/src/client/pages/SignInPage.test.tsx
@@ -4,12 +4,22 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SignInPage } from "./SignInPage";
 
 vi.mock("@client/api", () => ({
+  getAppStatus: vi.fn(async () => ({
+    appMode: "local",
+    capabilities: {
+      hostedSignups: false,
+      platformLlm: false,
+      quotas: false,
+      userEditableLlmSettings: true,
+    },
+    hostedTenantConfigured: false,
+  })),
   getAuthBootstrapStatus: vi.fn(async () => ({
     setupRequired: false,
   })),
   hasAuthenticatedSession: vi.fn(() => false),
   restoreAuthSessionFromLegacyCredentials: vi.fn(async () => false),
-  setupFirstAdmin: vi.fn(async () => ({
+  signupWithCredentials: vi.fn(async () => ({
     id: "user-1",
     username: "admin",
     displayName: null,
@@ -24,17 +34,49 @@ vi.mock("@client/api", () => ({
 }));
 
 import {
+  getAppStatus,
   getAuthBootstrapStatus,
   hasAuthenticatedSession,
   restoreAuthSessionFromLegacyCredentials,
-  setupFirstAdmin,
   signInWithCredentials,
+  signupWithCredentials,
 } from "@client/api";
+
+const localAppStatus = {
+  appMode: "local" as const,
+  capabilities: {
+    hostedSignups: false,
+    platformLlm: false,
+    quotas: false,
+    userEditableLlmSettings: true,
+  },
+  hostedTenantConfigured: false,
+};
+
+const hostedSignupAppStatus = {
+  appMode: "hosted" as const,
+  capabilities: {
+    hostedSignups: true,
+    platformLlm: false,
+    quotas: false,
+    userEditableLlmSettings: true,
+  },
+  hostedTenantConfigured: true,
+};
+
+const hostedSignupDisabledAppStatus = {
+  ...hostedSignupAppStatus,
+  capabilities: {
+    ...hostedSignupAppStatus.capabilities,
+    hostedSignups: false,
+  },
+};
 
 describe("SignInPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    vi.mocked(getAppStatus).mockResolvedValue(localAppStatus);
     vi.mocked(getAuthBootstrapStatus).mockResolvedValue({
       setupRequired: false,
     });
@@ -51,7 +93,7 @@ describe("SignInPage", () => {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
-    vi.mocked(setupFirstAdmin).mockResolvedValue(authUser);
+    vi.mocked(signupWithCredentials).mockResolvedValue(authUser);
     vi.mocked(signInWithCredentials).mockResolvedValue(undefined);
   });
 
@@ -133,6 +175,97 @@ describe("SignInPage", () => {
     );
 
     expect(await screen.findByText("onboarding")).toBeInTheDocument();
-    expect(setupFirstAdmin).not.toHaveBeenCalled();
+    expect(signupWithCredentials).not.toHaveBeenCalled();
+  });
+
+  it("shows hosted signup tabs only when enabled by app status", async () => {
+    vi.mocked(getAppStatus).mockResolvedValueOnce(hostedSignupAppStatus);
+
+    render(
+      <MemoryRouter initialEntries={["/sign-in"]}>
+        <Routes>
+          <Route path="/sign-in" element={<SignInPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByRole("tab", { name: "Create account" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Sign in" })).toBeInTheDocument();
+  });
+
+  it("hides hosted signup when hosted signups are disabled", async () => {
+    vi.mocked(getAppStatus).mockResolvedValueOnce(
+      hostedSignupDisabledAppStatus,
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/sign-in"]}>
+        <Routes>
+          <Route path="/sign-in" element={<SignInPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(restoreAuthSessionFromLegacyCredentials).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.queryByRole("tab", { name: "Create account" })).toBeNull();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+  });
+
+  it("creates a hosted signup account and returns to the requested next route", async () => {
+    vi.mocked(getAppStatus).mockResolvedValueOnce(hostedSignupAppStatus);
+    vi.mocked(signupWithCredentials).mockResolvedValueOnce({
+      id: "user-2",
+      username: "new-user",
+      displayName: "New User",
+      isSystemAdmin: false,
+      isDisabled: false,
+      workspaceId: "tenant_hosted",
+      workspaceName: "JobOps",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    render(
+      <MemoryRouter initialEntries={["/sign-in?next=%2Fjobs%2Fall"]}>
+        <Routes>
+          <Route path="/sign-in" element={<SignInPage />} />
+          <Route path="/jobs/all" element={<div>all-jobs-page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const signupTab = await screen.findByRole("tab", {
+      name: "Create account",
+    });
+    fireEvent.pointerDown(signupTab);
+    fireEvent.click(signupTab);
+    await screen.findByLabelText("Name");
+    fireEvent.change(screen.getByLabelText("Name"), {
+      target: { value: "New User" },
+    });
+    fireEvent.change(screen.getByLabelText("Username"), {
+      target: { value: " new-user " },
+    });
+    fireEvent.change(screen.getByLabelText("Password"), {
+      target: { value: "super-secret" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create account" }));
+
+    await waitFor(() => {
+      expect(signupWithCredentials).toHaveBeenCalledWith({
+        username: "new-user",
+        password: "super-secret",
+        displayName: "New User",
+      });
+      expect(screen.getByText("all-jobs-page")).toBeInTheDocument();
+    });
+    expect(localStorage.getItem("jobops.rememberedAuthUsers")).toContain(
+      "new-user",
+    );
   });
 });

--- a/orchestrator/src/client/pages/SignInPage.tsx
+++ b/orchestrator/src/client/pages/SignInPage.tsx
@@ -1,9 +1,10 @@
 import {
+  getAppStatus,
   getAuthBootstrapStatus,
   hasAuthenticatedSession,
   restoreAuthSessionFromLegacyCredentials,
-  setupFirstAdmin,
   signInWithCredentials,
+  signupWithCredentials,
 } from "@client/api";
 import type { FormEvent } from "react";
 import { useEffect, useMemo, useState } from "react";
@@ -17,10 +18,13 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   loadRememberedAuthUsers,
   rememberAuthUser,
 } from "../lib/remembered-auth-users";
+
+type AuthMode = "sign-in" | "signup";
 
 function resolveNextPath(rawNext: string | null): string {
   if (!rawNext || !rawNext.startsWith("/")) return "/jobs/ready";
@@ -33,10 +37,11 @@ function resolveNextPath(rawNext: string | null): string {
 export function SignInPage() {
   const location = useLocation();
   const navigate = useNavigate();
+  const [authMode, setAuthMode] = useState<AuthMode>("sign-in");
   const [username, setUsername] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [password, setPassword] = useState("");
-  const [setupRequired, setSetupRequired] = useState(false);
+  const [hostedSignupEnabled, setHostedSignupEnabled] = useState(false);
   const [isBusy, setIsBusy] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [rememberedUsers, setRememberedUsers] = useState(() =>
@@ -62,9 +67,15 @@ export function SignInPage() {
 
     void (async () => {
       try {
+        const appStatus = await getAppStatus();
+        if (cancelled) return;
+        const canSignup =
+          appStatus.appMode === "hosted" &&
+          appStatus.capabilities.hostedSignups;
+        setHostedSignupEnabled(canSignup);
+
         const bootstrap = await getAuthBootstrapStatus();
         if (cancelled) return;
-        setSetupRequired(bootstrap.setupRequired);
         if (bootstrap.setupRequired) {
           navigate("/onboarding", { replace: true });
           return;
@@ -75,6 +86,14 @@ export function SignInPage() {
         if (restored || hasAuthenticatedSession()) {
           navigate(nextPath, { replace: true });
           return;
+        }
+      } catch (error) {
+        if (!cancelled) {
+          setErrorMessage(
+            error instanceof Error
+              ? error.message
+              : "Unable to load sign-in status.",
+          );
         }
       } finally {
         if (!cancelled) {
@@ -95,13 +114,17 @@ export function SignInPage() {
       setErrorMessage("Enter both username and password.");
       return;
     }
+    if (authMode === "signup" && password.length < 8) {
+      setErrorMessage("Password must be at least 8 characters.");
+      return;
+    }
 
     setIsBusy(true);
     setErrorMessage(null);
 
     try {
-      if (setupRequired) {
-        const user = await setupFirstAdmin({
+      if (authMode === "signup") {
+        const user = await signupWithCredentials({
           username: normalizedUsername,
           password,
           displayName: displayName.trim() || normalizedUsername,
@@ -129,20 +152,50 @@ export function SignInPage() {
     }
   };
 
+  const resetFormFeedback = (nextMode: AuthMode) => {
+    setAuthMode(nextMode);
+    setErrorMessage(null);
+    setPassword("");
+  };
+
+  const title = authMode === "signup" ? "Create account" : "Sign in";
+  const description =
+    authMode === "signup"
+      ? "Create your JobOps account for this hosted workspace."
+      : "Enter your JobOps username and password.";
+
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(120,119,198,0.08),_transparent_45%),linear-gradient(180deg,_rgba(15,23,42,0.02),_transparent_30%)] px-4 py-16">
       <div className="mx-auto flex min-h-[70vh] max-w-md items-center">
         <Card className="w-full border-border/60 bg-background/95 shadow-xl">
           <CardHeader className="space-y-2">
-            <CardTitle className="text-2xl tracking-tight">Sign in</CardTitle>
-            <CardDescription>
-              {setupRequired
-                ? "Create the first system admin for this JobOps instance."
-                : "Enter your JobOps username and password."}
-            </CardDescription>
+            <CardTitle className="text-2xl tracking-tight">{title}</CardTitle>
+            <CardDescription>{description}</CardDescription>
           </CardHeader>
           <CardContent>
-            {!setupRequired && rememberedUsers.length > 0 ? (
+            {hostedSignupEnabled ? (
+              <Tabs
+                value={authMode}
+                onValueChange={(value) => resetFormFeedback(value as AuthMode)}
+                className="mb-5"
+              >
+                <TabsList className="grid w-full grid-cols-2">
+                  <TabsTrigger
+                    value="sign-in"
+                    onClick={() => resetFormFeedback("sign-in")}
+                  >
+                    Sign in
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="signup"
+                    onClick={() => resetFormFeedback("signup")}
+                  >
+                    Create account
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
+            ) : null}
+            {authMode === "sign-in" && rememberedUsers.length > 0 ? (
               <div className="mb-5 space-y-2">
                 <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
                   Remembered on this browser
@@ -175,7 +228,7 @@ export function SignInPage() {
               </div>
             ) : null}
             <form className="space-y-4" onSubmit={handleSubmit}>
-              {setupRequired ? (
+              {authMode === "signup" ? (
                 <div className="space-y-2">
                   <label
                     className="text-sm font-medium"
@@ -215,7 +268,9 @@ export function SignInPage() {
                 <Input
                   id="auth-password"
                   type="password"
-                  autoComplete="current-password"
+                  autoComplete={
+                    authMode === "signup" ? "new-password" : "current-password"
+                  }
                   value={password}
                   onChange={(event) => setPassword(event.currentTarget.value)}
                   placeholder="Enter password"
@@ -229,11 +284,11 @@ export function SignInPage() {
               ) : null}
               <Button className="w-full" type="submit" disabled={isBusy}>
                 {isBusy
-                  ? setupRequired
+                  ? authMode === "signup"
                     ? "Creating account..."
                     : "Signing in..."
-                  : setupRequired
-                    ? "Create workspace"
+                  : authMode === "signup"
+                    ? "Create account"
                     : "Sign in"}
               </Button>
             </form>

--- a/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.test.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.test.tsx
@@ -109,4 +109,19 @@ describe("BaseResumeStep", () => {
       ),
     ).toBeInTheDocument();
   });
+
+  it("shows only document upload copy when Reactive Resume is disabled", () => {
+    render(<BaseResumeStep {...defaultProps} allowReactiveResume={false} />);
+
+    expect(
+      screen.getByText("Upload your existing resume, PDF or DOCX"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Supported formats: PDF and DOCX."),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("radio", { name: /use reactive resume/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/Reactive Resume JSON/i)).not.toBeInTheDocument();
+  });
 });

--- a/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.tsx
@@ -111,6 +111,7 @@ function ResumeImportProgress({
 }
 
 export const BaseResumeStep: React.FC<{
+  allowReactiveResume?: boolean;
   baseResumeValidation: ValidationState;
   baseResumeValue: string | null;
   hasRxResumeAccess: boolean;
@@ -132,6 +133,7 @@ export const BaseResumeStep: React.FC<{
   onRxresumeUrlChange: (value: string) => void;
   onTemplateResumeChange: (value: string | null) => void;
 }> = ({
+  allowReactiveResume = true,
   baseResumeValidation,
   baseResumeValue,
   hasRxResumeAccess,
@@ -154,6 +156,18 @@ export const BaseResumeStep: React.FC<{
   onTemplateResumeChange,
 }) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const effectiveResumeSetupMode = allowReactiveResume
+    ? resumeSetupMode
+    : "upload";
+  const uploadTitle = allowReactiveResume
+    ? "Upload a resume file"
+    : "Upload your existing resume, PDF or DOCX";
+  const uploadDescription = allowReactiveResume
+    ? "Job Ops imports Reactive Resume JSON directly. PDF and DOCX files are sent to your configured AI model and stored as a local Design Resume. That resume drives job matching, fit assessment, search terms, and application workflows."
+    : "Upload your existing resume as a PDF or DOCX. Job Ops will import it and use it as the baseline for matching, fit assessment, search terms, and application workflows.";
+  const supportedFormats = allowReactiveResume
+    ? "Supported formats: PDF, DOCX, and Reactive Resume JSON."
+    : "Supported formats: PDF and DOCX.";
 
   return (
     <div className="space-y-6" data-onboarding-target="resume-options">
@@ -171,59 +185,63 @@ export const BaseResumeStep: React.FC<{
         }}
       />
 
-      <RadioGroup
-        value={resumeSetupMode}
-        onValueChange={(value) =>
-          onResumeSetupModeChange(value === "rxresume" ? "rxresume" : "upload")
-        }
-        className="grid gap-4 lg:grid-cols-2"
-      >
-        {[
-          {
-            value: "upload",
-            title: "Upload a file",
-            description:
-              "Turn a PDF, DOCX, or Reactive Resume JSON into the baseline Job Ops uses for matching and tailoring.",
-          },
-          {
-            value: "rxresume",
-            title: "Use Reactive Resume",
-            description:
-              "Connect an existing Reactive Resume so Job Ops can assess fit and build applications from it.",
-          },
-        ].map((option) => {
-          const checked = resumeSetupMode === option.value;
-          const radioId = `resume-setup-${option.value}`;
-          return (
-            <label
-              key={option.value}
-              htmlFor={radioId}
-              className={cn(
-                "flex cursor-pointer items-start gap-4 rounded-xl border p-4 transition-colors",
-                checked
-                  ? "border-primary bg-muted/40"
-                  : "border-border/60 hover:bg-muted/20",
-              )}
-            >
-              <RadioGroupItem
-                id={radioId}
-                value={option.value}
-                className="mt-1"
-              />
-              <div className="space-y-1">
-                <div className="text-base font-medium text-foreground">
-                  {option.title}
+      {allowReactiveResume ? (
+        <RadioGroup
+          value={resumeSetupMode}
+          onValueChange={(value) =>
+            onResumeSetupModeChange(
+              value === "rxresume" ? "rxresume" : "upload",
+            )
+          }
+          className="grid gap-4 lg:grid-cols-2"
+        >
+          {[
+            {
+              value: "upload",
+              title: "Upload a file",
+              description:
+                "Turn a PDF, DOCX, or Reactive Resume JSON into the baseline Job Ops uses for matching and tailoring.",
+            },
+            {
+              value: "rxresume",
+              title: "Use Reactive Resume",
+              description:
+                "Connect an existing Reactive Resume so Job Ops can assess fit and build applications from it.",
+            },
+          ].map((option) => {
+            const checked = resumeSetupMode === option.value;
+            const radioId = `resume-setup-${option.value}`;
+            return (
+              <label
+                key={option.value}
+                htmlFor={radioId}
+                className={cn(
+                  "flex cursor-pointer items-start gap-4 rounded-xl border p-4 transition-colors",
+                  checked
+                    ? "border-primary bg-muted/40"
+                    : "border-border/60 hover:bg-muted/20",
+                )}
+              >
+                <RadioGroupItem
+                  id={radioId}
+                  value={option.value}
+                  className="mt-1"
+                />
+                <div className="space-y-1">
+                  <div className="text-base font-medium text-foreground">
+                    {option.title}
+                  </div>
+                  <div className="text-sm leading-6 text-muted-foreground">
+                    {option.description}
+                  </div>
                 </div>
-                <div className="text-sm leading-6 text-muted-foreground">
-                  {option.description}
-                </div>
-              </div>
-            </label>
-          );
-        })}
-      </RadioGroup>
+              </label>
+            );
+          })}
+        </RadioGroup>
+      ) : null}
 
-      {resumeSetupMode === "upload" ? (
+      {effectiveResumeSetupMode === "upload" ? (
         <>
           {isImportingResume ? (
             <ResumeImportProgress
@@ -233,12 +251,9 @@ export const BaseResumeStep: React.FC<{
           ) : (
             <div className="rounded-lg border border-border/60 bg-muted/10 p-5">
               <div className="space-y-2">
-                <div className="text-sm font-medium">Upload a resume file</div>
+                <div className="text-sm font-medium">{uploadTitle}</div>
                 <p className="text-sm text-muted-foreground">
-                  Job Ops imports Reactive Resume JSON directly. PDF and DOCX
-                  files are sent to your configured AI model and stored as a
-                  local Design Resume. That resume drives job matching, fit
-                  assessment, search terms, and application workflows.
+                  {uploadDescription}
                 </p>
               </div>
 
@@ -252,7 +267,7 @@ export const BaseResumeStep: React.FC<{
                   Upload resume file
                 </Button>
                 <div className="text-xs text-muted-foreground">
-                  Supported formats: PDF, DOCX, and Reactive Resume JSON.
+                  {supportedFormats}
                 </div>
               </div>
             </div>

--- a/orchestrator/src/client/pages/onboarding/components/OnboardingCoach.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/OnboardingCoach.tsx
@@ -84,12 +84,16 @@ export const OnboardingCoach: React.FC<{
   activePanel: OnboardingPanelId;
   onPanelChange: (panel: OnboardingPanelId) => void;
   replayNonce: number;
+  showAccount?: boolean;
+  showModel?: boolean;
   scope?: "account" | "launch";
   status: OnboardingStatusResponse | null;
 }> = ({
   activePanel,
   onPanelChange,
   replayNonce,
+  showAccount = true,
+  showModel = true,
   scope = "launch",
   status,
 }) => {
@@ -113,11 +117,20 @@ export const OnboardingCoach: React.FC<{
   useEffect(() => () => removeJoyridePortal(), []);
 
   const steps = useMemo<CoachStep[]>(() => {
+    const introContent =
+      showAccount && showModel
+        ? "Complete the setup checks that let Job Ops work for you: a workspace account, an LLM for reasoning, and a resume for matching."
+        : showModel
+          ? "Complete the setup checks that let Job Ops work for you: an LLM for reasoning and a resume for matching."
+          : "Complete the resume setup check that lets Job Ops match jobs and prepare your search.";
+    const primaryPanel =
+      status?.nextRequirementId === "model" && !showModel
+        ? activePanel
+        : (status?.nextRequirementId ?? activePanel);
     const introStep: CoachStep = {
       target: '[data-onboarding-target="launch-rail"]',
       title: "Load the command centre",
-      content:
-        "Complete the setup checks that let Job Ops work for you: a workspace account, an LLM for reasoning, and a resume for matching.",
+      content: introContent,
       data: { panel: activePanel },
     };
 
@@ -128,7 +141,7 @@ export const OnboardingCoach: React.FC<{
         activePanel === "account"
           ? "Use this button to create the workspace account and continue to the next steps."
           : "Use this button to verify the current setup check. When both checks pass, it opens the ready queue.",
-      data: { panel: status?.nextRequirementId ?? activePanel },
+      data: { panel: primaryPanel },
     };
 
     if (scope === "account") {
@@ -166,23 +179,25 @@ export const OnboardingCoach: React.FC<{
       ];
     }
 
-    const launchSteps: CoachStep[] = [
-      introStep,
-      {
+    const launchSteps: CoachStep[] = [introStep];
+
+    if (showModel) {
+      launchSteps.push({
         target: '[data-onboarding-target="model-form"]',
         title: "LLM engine",
         content:
           "This model powers scoring, tailoring, ghostwriting, and email classification. Verify it once so Job Ops can read opportunities for you.",
         data: { panel: "model" },
-      },
-      {
-        target: '[data-onboarding-target="resume-options"]',
-        title: "Resume baseline",
-        content:
-          "Your resume becomes the baseline for job matching, fit assessment, and application workflows. Upload a file or connect Reactive Resume.",
-        data: { panel: "resume" },
-      },
-    ];
+      });
+    }
+
+    launchSteps.push({
+      target: '[data-onboarding-target="resume-options"]',
+      title: "Resume baseline",
+      content:
+        "Your resume becomes the baseline for job matching, fit assessment, and application workflows. Upload a file or connect Reactive Resume.",
+      data: { panel: "resume" },
+    });
 
     if (status?.complete) {
       launchSteps.push({
@@ -195,7 +210,14 @@ export const OnboardingCoach: React.FC<{
     }
 
     return launchSteps;
-  }, [activePanel, scope, status?.complete, status?.nextRequirementId]);
+  }, [
+    activePanel,
+    scope,
+    showAccount,
+    showModel,
+    status?.complete,
+    status?.nextRequirementId,
+  ]);
 
   useEffect(() => {
     if ((scope === "launch" && !status) || readDismissed(storageKey)) return;

--- a/orchestrator/src/client/pages/onboarding/components/OnboardingCoach.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/OnboardingCoach.tsx
@@ -82,6 +82,7 @@ function CoachTooltip({
 
 export const OnboardingCoach: React.FC<{
   activePanel: OnboardingPanelId;
+  allowReactiveResume?: boolean;
   onPanelChange: (panel: OnboardingPanelId) => void;
   replayNonce: number;
   showAccount?: boolean;
@@ -90,6 +91,7 @@ export const OnboardingCoach: React.FC<{
   status: OnboardingStatusResponse | null;
 }> = ({
   activePanel,
+  allowReactiveResume = true,
   onPanelChange,
   replayNonce,
   showAccount = true,
@@ -127,6 +129,9 @@ export const OnboardingCoach: React.FC<{
       status?.nextRequirementId === "model" && !showModel
         ? activePanel
         : (status?.nextRequirementId ?? activePanel);
+    const resumeContent = allowReactiveResume
+      ? "Your resume becomes the baseline for job matching, fit assessment, and application workflows. Upload a file or connect Reactive Resume."
+      : "Upload your existing resume as a PDF or DOCX. Job Ops uses it as the baseline for matching, fit assessment, and application workflows.";
     const introStep: CoachStep = {
       target: '[data-onboarding-target="launch-rail"]',
       title: "Load the command centre",
@@ -194,8 +199,7 @@ export const OnboardingCoach: React.FC<{
     launchSteps.push({
       target: '[data-onboarding-target="resume-options"]',
       title: "Resume baseline",
-      content:
-        "Your resume becomes the baseline for job matching, fit assessment, and application workflows. Upload a file or connect Reactive Resume.",
+      content: resumeContent,
       data: { panel: "resume" },
     });
 
@@ -212,6 +216,7 @@ export const OnboardingCoach: React.FC<{
     return launchSteps;
   }, [
     activePanel,
+    allowReactiveResume,
     scope,
     showAccount,
     showModel,

--- a/orchestrator/src/client/pages/onboarding/components/OnboardingStepContent.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/OnboardingStepContent.tsx
@@ -6,6 +6,7 @@ import { BaseResumeStep } from "./BaseResumeStep";
 import { LlmConnectionStep } from "./LlmConnectionStep";
 
 export const OnboardingStepContent: React.FC<{
+  allowReactiveResume?: boolean;
   baseResumeValidation: ValidationState;
   baseResumeValue: string | null;
   currentStep: StepId;
@@ -73,6 +74,7 @@ export const OnboardingStepContent: React.FC<{
 
     return (
       <BaseResumeStep
+        allowReactiveResume={props.allowReactiveResume}
         baseResumeValidation={props.baseResumeValidation}
         baseResumeValue={props.baseResumeValue}
         hasRxResumeAccess={hasRxResumeAccess}

--- a/orchestrator/src/client/pages/onboarding/components/OnboardingStepRail.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/OnboardingStepRail.tsx
@@ -30,8 +30,6 @@ const RAIL_ITEMS: Array<{
     subtitle: "Launch",
   },
 ];
-const TOTAL_ONBOARDING_STEPS = RAIL_ITEMS.length;
-
 function getRequirement(
   requirements: OnboardingRequirement[],
   id: OnboardingRequirement["id"],
@@ -70,20 +68,32 @@ export const OnboardingStepRail: React.FC<{
   nextRequirementId: OnboardingRequirement["id"] | null;
   onPanelSelect: (panel: OnboardingPanelId) => void;
   requirements: OnboardingRequirement[];
+  showAccount?: boolean;
+  showModel?: boolean;
 }> = ({
   activePanel,
   complete,
   nextRequirementId,
   onPanelSelect,
   requirements,
+  showAccount = true,
+  showModel = true,
 }) => {
+  const railItems = RAIL_ITEMS.filter((item) => {
+    if (item.id === "account") return showAccount;
+    if (item.id === "model") return showModel;
+    return true;
+  });
+  const visibleRequirements = requirements.filter(
+    (requirement) => requirement.id !== "model" || showModel,
+  );
   const completedCount =
-    requirements.filter((requirement) => requirement.status === "ready")
+    visibleRequirements.filter((requirement) => requirement.status === "ready")
       .length +
-    1 +
+    (showAccount ? 1 : 0) +
     (complete ? 1 : 0);
   const progressValue = Math.round(
-    (completedCount / Math.max(TOTAL_ONBOARDING_STEPS, 1)) * 100,
+    (completedCount / Math.max(railItems.length, 1)) * 100,
   );
 
   return (
@@ -94,7 +104,7 @@ export const OnboardingStepRail: React.FC<{
       </div>
 
       <div className="space-y-1">
-        {RAIL_ITEMS.map((item) => {
+        {railItems.map((item) => {
           const requirement =
             item.id === "account" || item.id === "first-run"
               ? undefined

--- a/orchestrator/src/server/api/routes/auth.test.ts
+++ b/orchestrator/src/server/api/routes/auth.test.ts
@@ -474,6 +474,24 @@ describe.sequential("Auth routes", () => {
         "First-run setup is disabled in hosted mode",
       );
     });
+
+    it("does not report first-run setup as required in hosted mode", async () => {
+      await stopServer({ server, closeDb, tempDir });
+      ({ server, baseUrl, closeDb, tempDir } = await startServer({
+        env: {
+          JOBOPS_TEST_AUTH_BYPASS: "0",
+          JOBOPS_APP_MODE: "hosted",
+          JOBOPS_HOSTED_TENANT_ID: "tenant_default",
+        },
+      }));
+
+      const res = await fetch(`${baseUrl}/api/auth/bootstrap-status`);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.ok).toBe(true);
+      expect(body.data.setupRequired).toBe(false);
+    });
   });
 
   describe("public demo auth behavior", () => {

--- a/orchestrator/src/server/api/routes/auth.ts
+++ b/orchestrator/src/server/api/routes/auth.ts
@@ -188,7 +188,7 @@ authRouter.post(
 authRouter.get(
   "/bootstrap-status",
   asyncRoute(async (_req: Request, res: Response) => {
-    if (isDemoMode()) {
+    if (isDemoMode() || getJobOpsAppConfig().appMode === "hosted") {
       ok(res, { setupRequired: false });
       return;
     }

--- a/orchestrator/src/server/services/onboarding-status.test.ts
+++ b/orchestrator/src/server/services/onboarding-status.test.ts
@@ -4,12 +4,17 @@ const mocks = vi.hoisted(() => ({
   applySettingsUpdates: vi.fn(),
   getConfiguredRxResumeBaseResumeId: vi.fn(),
   getDesignResumeStatus: vi.fn(),
+  getJobOpsAppStatus: vi.fn(),
   getResume: vi.fn(),
   getSetting: vi.fn(),
   isDemoMode: vi.fn(),
   validateLlmCredentials: vi.fn(),
   validateResumeSchema: vi.fn(),
   validateRxResumeCredentials: vi.fn(),
+}));
+
+vi.mock("@server/config/app-mode", () => ({
+  getJobOpsAppStatus: mocks.getJobOpsAppStatus,
 }));
 
 vi.mock("@server/config/demo", () => ({
@@ -85,6 +90,16 @@ import {
 describe("onboarding status engine", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getJobOpsAppStatus.mockReturnValue({
+      appMode: "local",
+      capabilities: {
+        hostedSignups: false,
+        platformLlm: false,
+        quotas: false,
+        userEditableLlmSettings: true,
+      },
+      hostedTenantConfigured: false,
+    });
     mocks.isDemoMode.mockReturnValue(false);
     mocks.getSetting.mockImplementation(async (key: string) => {
       const values: Record<string, string | null> = {
@@ -157,6 +172,35 @@ describe("onboarding status engine", () => {
     expect(status).toMatchObject({
       complete: true,
       nextRequirementId: null,
+    });
+  });
+
+  it("omits model onboarding when hosted platform LLM manages model settings", async () => {
+    mocks.getJobOpsAppStatus.mockReturnValue({
+      appMode: "hosted",
+      capabilities: {
+        hostedSignups: true,
+        platformLlm: true,
+        quotas: true,
+        userEditableLlmSettings: false,
+      },
+      hostedTenantConfigured: true,
+    });
+    mocks.getDesignResumeStatus.mockResolvedValue({ exists: false });
+    mocks.validateLlmCredentials.mockResolvedValue({
+      valid: false,
+      message: "LLM API key is missing.",
+    });
+
+    const status = await getOnboardingStatus();
+
+    expect(mocks.validateLlmCredentials).not.toHaveBeenCalled();
+    expect(status.complete).toBe(false);
+    expect(status.nextRequirementId).toBe("resume");
+    expect(status.requirements).toHaveLength(1);
+    expect(status.requirements[0]).toMatchObject({
+      id: "resume",
+      status: "needs_action",
     });
   });
 

--- a/orchestrator/src/server/services/onboarding-status.test.ts
+++ b/orchestrator/src/server/services/onboarding-status.test.ts
@@ -195,12 +195,14 @@ describe("onboarding status engine", () => {
     const status = await getOnboardingStatus();
 
     expect(mocks.validateLlmCredentials).not.toHaveBeenCalled();
+    expect(mocks.validateRxResumeCredentials).not.toHaveBeenCalled();
     expect(status.complete).toBe(false);
     expect(status.nextRequirementId).toBe("resume");
     expect(status.requirements).toHaveLength(1);
     expect(status.requirements[0]).toMatchObject({
       id: "resume",
       status: "needs_action",
+      title: "Upload your existing resume, PDF or DOCX",
     });
   });
 

--- a/orchestrator/src/server/services/onboarding-status.ts
+++ b/orchestrator/src/server/services/onboarding-status.ts
@@ -433,10 +433,40 @@ async function buildResumeRequirement(): Promise<OnboardingRequirement> {
   });
 }
 
+async function buildHostedResumeRequirement(): Promise<OnboardingRequirement> {
+  const localStatus = await getDesignResumeStatus();
+  if (localStatus.exists) {
+    return buildRequirement({
+      id: "resume",
+      status: "ready",
+      title: "Resume loaded",
+      message:
+        "Your resume is ready to drive job matching, fit assessment, search terms, and application workflows.",
+      primaryAction: "none",
+      details: {
+        source: "local",
+        documentId: localStatus.documentId ?? null,
+        updatedAt: localStatus.updatedAt ?? null,
+      },
+    });
+  }
+
+  return buildRequirement({
+    id: "resume",
+    status: "needs_action",
+    title: "Upload your existing resume, PDF or DOCX",
+    message:
+      "Upload your existing resume as a PDF or DOCX. Job Ops will use it as the baseline for matching, fit assessment, search terms, and application workflows.",
+    primaryAction: "upload_resume",
+    details: { source: "upload" },
+  });
+}
+
 export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {
   const appStatus = getJobOpsAppStatus();
   const userEditableLlmSettings =
     appStatus.capabilities.userEditableLlmSettings;
+  const hostedMode = appStatus.appMode === "hosted";
 
   if (isDemoMode()) {
     const requirements: OnboardingRequirement[] = [
@@ -463,8 +493,17 @@ export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {
   }
 
   const requirements = userEditableLlmSettings
-    ? [await buildModelRequirement(), await buildResumeRequirement()]
-    : [await buildResumeRequirement()];
+    ? [
+        await buildModelRequirement(),
+        hostedMode
+          ? await buildHostedResumeRequirement()
+          : await buildResumeRequirement(),
+      ]
+    : [
+        hostedMode
+          ? await buildHostedResumeRequirement()
+          : await buildResumeRequirement(),
+      ];
   const nextRequirement = requirements.find(
     (requirement) => requirement.status !== "ready",
   );

--- a/orchestrator/src/server/services/onboarding-status.ts
+++ b/orchestrator/src/server/services/onboarding-status.ts
@@ -1,6 +1,7 @@
 import { unprocessableEntity } from "@infra/errors";
 import { logger } from "@infra/logger";
 import { getRequestId } from "@infra/request-context";
+import { getJobOpsAppStatus } from "@server/config/app-mode";
 import { isDemoMode } from "@server/config/demo";
 import { getSetting } from "@server/repositories/settings";
 import { enqueueAutoPdfRegenerationForSettingsChanges } from "@server/services/auto-pdf-regeneration";
@@ -433,15 +434,23 @@ async function buildResumeRequirement(): Promise<OnboardingRequirement> {
 }
 
 export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {
+  const appStatus = getJobOpsAppStatus();
+  const userEditableLlmSettings =
+    appStatus.capabilities.userEditableLlmSettings;
+
   if (isDemoMode()) {
     const requirements: OnboardingRequirement[] = [
-      buildRequirement({
-        id: "model",
-        status: "ready",
-        title: "Model connected",
-        message: "Demo mode simulates the model connection.",
-        primaryAction: "none",
-      }),
+      ...(userEditableLlmSettings
+        ? [
+            buildRequirement({
+              id: "model",
+              status: "ready",
+              title: "Model connected",
+              message: "Demo mode simulates the model connection.",
+              primaryAction: "none",
+            }),
+          ]
+        : []),
       buildRequirement({
         id: "resume",
         status: "ready",
@@ -453,9 +462,9 @@ export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {
     return { complete: true, nextRequirementId: null, requirements };
   }
 
-  const model = await buildModelRequirement();
-  const resume = await buildResumeRequirement();
-  const requirements = [model, resume];
+  const requirements = userEditableLlmSettings
+    ? [await buildModelRequirement(), await buildResumeRequirement()]
+    : [await buildResumeRequirement()];
   const nextRequirement = requirements.find(
     (requirement) => requirement.status !== "ready",
   );


### PR DESCRIPTION
## Summary
- Add hosted signup flow on `/sign-in` when hosted signups are enabled, while preserving local sign-in behavior
- Hide model settings when platform-managed LLM settings are not user-editable and avoid submitting those fields in resets/saves
- Treat hosted mode as non-bootstrap in auth status and document the new hosted UX
- Add unit coverage for sign-in, settings visibility, and hosted bootstrap status

## Testing
- Unit tests added/updated for hosted signup, settings navigation, and auth bootstrap behavior
- Not run (not requested)