### PR TITLE
Enforce user-scoped isolation for private data and webhook triggers

### DIFF
--- a/orchestrator/src/client/api/settings-profile.ts
+++ b/orchestrator/src/client/api/settings-profile.ts
@@ -122,6 +122,12 @@ export async function deleteDesignResumePicture(input?: {
   });
 }
 
+export async function getDesignResumeAssetContentBlob(
+  assetUrl: string,
+): Promise<Blob> {
+  return fetchBlobApi(normalizeApiPath(assetUrl), { cache: "no-store" });
+}
+
 export async function exportDesignResume(): Promise<DesignResumeExportResponse> {
   return fetchApi<DesignResumeExportResponse>("/design-resume/export");
 }

--- a/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.test.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.test.tsx
@@ -1,6 +1,18 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { BasicsCustomFieldsSection } from "./DesignResumeInlineSections";
+
+const mocks = vi.hoisted(() => ({
+  getDesignResumeAssetContentBlob: vi.fn(),
+}));
+
+vi.mock("@client/api/settings-profile", () => ({
+  getDesignResumeAssetContentBlob: mocks.getDesignResumeAssetContentBlob,
+}));
+
+import {
+  BasicsCustomFieldsSection,
+  PictureSection,
+} from "./DesignResumeInlineSections";
 
 describe("BasicsCustomFieldsSection", () => {
   it("lets the custom fields section title be renamed", () => {
@@ -43,5 +55,44 @@ describe("BasicsCustomFieldsSection", () => {
     expect(onChange).toHaveBeenCalledWith([
       { id: "field-1", title: "Availability", icon: "", text: "", link: "" },
     ]);
+  });
+
+  it("loads JobOps asset picture previews through the authenticated blob API", async () => {
+    const createObjectUrl = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:preview");
+    const revokeObjectUrl = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {});
+    mocks.getDesignResumeAssetContentBlob.mockResolvedValue(
+      new Blob(["image"], { type: "image/png" }),
+    );
+
+    const { unmount } = render(
+      <PictureSection
+        picture={{ url: "/api/design-resume/assets/asset-1/content" }}
+        pictureUploading={false}
+        pictureEnabled={true}
+        onUploadPicture={vi.fn()}
+        onDeletePicture={vi.fn()}
+        onUpdatePicture={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByAltText("Resume Studio profile").getAttribute("src"),
+      ).toBe("blob:preview");
+    });
+
+    expect(mocks.getDesignResumeAssetContentBlob).toHaveBeenCalledWith(
+      "/api/design-resume/assets/asset-1/content",
+    );
+
+    unmount();
+    expect(revokeObjectUrl).toHaveBeenCalledWith("blob:preview");
+
+    createObjectUrl.mockRestore();
+    revokeObjectUrl.mockRestore();
   });
 });

--- a/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.tsx
@@ -1,5 +1,7 @@
+import { getDesignResumeAssetContentBlob } from "@client/api/settings-profile";
 import type { DesignResumeJson } from "@shared/types";
 import { FileImage, ImagePlus, Plus, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -92,6 +94,41 @@ export function PictureSection({
   onUpdatePicture,
 }: PictureSectionProps) {
   const editDisabled = !pictureEnabled;
+  const pictureUrl = toText(picture.url);
+  const [previewUrl, setPreviewUrl] = useState(pictureUrl);
+
+  useEffect(() => {
+    if (!pictureUrl) {
+      setPreviewUrl("");
+      return;
+    }
+
+    if (!pictureUrl.startsWith("/api/design-resume/assets/")) {
+      setPreviewUrl(pictureUrl);
+      return;
+    }
+
+    let objectUrl: string | null = null;
+    let cancelled = false;
+
+    getDesignResumeAssetContentBlob(pictureUrl)
+      .then((blob) => {
+        objectUrl = URL.createObjectURL(blob);
+        if (cancelled) {
+          URL.revokeObjectURL(objectUrl);
+          return;
+        }
+        setPreviewUrl(objectUrl);
+      })
+      .catch(() => {
+        if (!cancelled) setPreviewUrl(pictureUrl);
+      });
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [pictureUrl]);
 
   return (
     <div className="grid gap-3">
@@ -109,7 +146,7 @@ export function PictureSection({
           className={`${insetPanelClassName} flex items-center gap-3 border-dashed p-3`}
         >
           <img
-            src={toText(picture.url)}
+            src={previewUrl}
             alt="Resume Studio profile"
             className="h-16 w-16 rounded-lg border border-border/60 object-cover"
           />

--- a/orchestrator/src/server/api/routes/auth.test.ts
+++ b/orchestrator/src/server/api/routes/auth.test.ts
@@ -213,6 +213,46 @@ describe.sequential("Auth routes", () => {
       expect(body.error.message).toContain("Username already exists");
     });
 
+    it("scopes backend analytics identity by hosted user", async () => {
+      async function signup(username: string): Promise<string> {
+        const res = await fetch(`${baseUrl}/api/auth/signup`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            username,
+            password: `${username}-secret`,
+          }),
+        });
+        expect(res.status).toBe(201);
+        const body = await res.json();
+        expect(body.ok).toBe(true);
+        return body.data.token as string;
+      }
+
+      async function analyticsDistinctId(token: string): Promise<string> {
+        const res = await fetch(`${baseUrl}/api/auth/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        expect(res.status).toBe(200);
+        const body = await res.json();
+        expect(body.ok).toBe(true);
+        return body.data.analyticsDistinctId as string;
+      }
+
+      const aliceToken = await signup("analytics-alice");
+      const bobToken = await signup("analytics-bob");
+
+      const aliceFirst = await analyticsDistinctId(aliceToken);
+      const aliceSecond = await analyticsDistinctId(aliceToken);
+      const bob = await analyticsDistinctId(bobToken);
+
+      expect(aliceFirst).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
+      expect(aliceSecond).toBe(aliceFirst);
+      expect(bob).not.toBe(aliceFirst);
+    });
+
     it("returns 400 for invalid signup input", async () => {
       const res = await fetch(`${baseUrl}/api/auth/signup`, {
         method: "POST",

--- a/orchestrator/src/server/api/routes/design-resume.ts
+++ b/orchestrator/src/server/api/routes/design-resume.ts
@@ -1,6 +1,7 @@
 import { badRequest, conflict, notFound, toAppError } from "@infra/errors";
 import { asyncRoute, fail, ok } from "@infra/http";
 import { logger } from "@infra/logger";
+import { getJobOpsAppConfig } from "@server/config/app-mode";
 import { getRequestId } from "@server/infra/request-context";
 import { enqueueAutoPdfRegenerationForReadyJobs } from "@server/services/auto-pdf-regeneration";
 import {
@@ -421,7 +422,7 @@ designResumeRouter.get(
     }
 
     const { asset, content } = await readDesignResumeAssetContent(assetId, {
-      bypassTenantScope: true,
+      bypassTenantScope: getJobOpsAppConfig().appMode !== "hosted",
     });
     res.setHeader("Content-Type", asset.mimeType);
     res.setHeader("Cache-Control", "private, max-age=60");

--- a/orchestrator/src/server/api/routes/post-application-providers.ts
+++ b/orchestrator/src/server/api/routes/post-application-providers.ts
@@ -3,7 +3,7 @@ import { badRequest, serviceUnavailable, upstreamError } from "@infra/errors";
 import { asyncRoute, fail, ok } from "@infra/http";
 import { logger } from "@infra/logger";
 import { executePostApplicationProviderAction } from "@server/services/post-application/providers";
-import { getActiveTenantId } from "@server/tenancy/context";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import {
   POST_APPLICATION_PROVIDER_ACTIONS,
   POST_APPLICATION_PROVIDERS,
@@ -47,6 +47,7 @@ const oauthStateStore = new Map<
   {
     accountKey: string;
     tenantId: string;
+    userId: string | null;
     redirectUri: string;
     createdAt: number;
   }
@@ -102,6 +103,7 @@ function setOauthState(
   entry: {
     accountKey: string;
     tenantId: string;
+    userId: string | null;
     redirectUri: string;
     createdAt: number;
   },
@@ -236,10 +238,12 @@ postApplicationProvidersRouter.get(
       const accountKey = parsed.accountKey ?? "default";
       const oauth = resolveGmailOauthConfig(req);
       const state = randomUUID();
+      const scope = getPrivateDataScope();
 
       setOauthState(state, {
         accountKey,
-        tenantId: getActiveTenantId(),
+        tenantId: scope.tenantId,
+        userId: scope.enforceUserIsolation ? scope.userId : null,
         redirectUri: oauth.redirectUri,
         createdAt: Date.now(),
       });
@@ -289,8 +293,13 @@ postApplicationProvidersRouter.post(
         fail(res, badRequest("OAuth state/account mismatch."));
         return;
       }
-      if (oauthState.tenantId !== getActiveTenantId()) {
+      const scope = getPrivateDataScope();
+      if (oauthState.tenantId !== scope.tenantId) {
         fail(res, badRequest("OAuth state/workspace mismatch."));
+        return;
+      }
+      if (scope.enforceUserIsolation && oauthState.userId !== scope.userId) {
+        fail(res, badRequest("OAuth state/user mismatch."));
         return;
       }
 

--- a/orchestrator/src/server/api/routes/tenant-isolation.test.ts
+++ b/orchestrator/src/server/api/routes/tenant-isolation.test.ts
@@ -20,6 +20,17 @@ async function login(baseUrl: string, username: string, password: string) {
   return body.data.token as string;
 }
 
+async function signup(baseUrl: string, username: string, password: string) {
+  const res = await fetch(`${baseUrl}/api/auth/signup`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const body = await res.json();
+  expect(res.status).toBe(201);
+  return body.data.token as string;
+}
+
 function authHeaders(token: string) {
   return {
     Authorization: `Bearer ${token}`,
@@ -198,5 +209,149 @@ describe.sequential("Tenant isolation", () => {
       headers: { Authorization: `Bearer ${newToken}` },
     });
     expect(newSessionRes.status).toBe(200);
+  });
+});
+
+describe.sequential("Hosted current-user isolation", () => {
+  let server: Server;
+  let baseUrl: string;
+  let closeDb: () => void;
+  let tempDir: string;
+
+  beforeEach(async () => {
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: {
+        JOBOPS_TEST_AUTH_BYPASS: "0",
+        JOBOPS_APP_MODE: "hosted",
+        JOBOPS_HOSTED_SIGNUPS_ENABLED: "true",
+        JOBOPS_HOSTED_TENANT_ID: "tenant_default",
+      },
+    }));
+  });
+
+  afterEach(async () => {
+    await stopServer({ server, closeDb, tempDir });
+  });
+
+  it("isolates private data between two hosted users in the same tenant", async () => {
+    const aliceToken = await signup(baseUrl, "alice", "alice-secret");
+    const bobToken = await signup(baseUrl, "bob", "bob-secret");
+
+    const aliceJob = await importManualJob(baseUrl, aliceToken, "Alice Role");
+    const bobJob = await importManualJob(baseUrl, bobToken, "Bob Role");
+    expect(aliceJob.id).not.toBe(bobJob.id);
+
+    const aliceList = await fetch(`${baseUrl}/api/jobs`, {
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    }).then((res) => res.json());
+    expect(aliceList.data.jobs.map((job: { id: string }) => job.id)).toEqual([
+      aliceJob.id,
+    ]);
+
+    const bobList = await fetch(`${baseUrl}/api/jobs`, {
+      headers: { Authorization: `Bearer ${bobToken}` },
+    }).then((res) => res.json());
+    expect(bobList.data.jobs.map((job: { id: string }) => job.id)).toEqual([
+      bobJob.id,
+    ]);
+
+    const bobReadsAliceJob = await fetch(`${baseUrl}/api/jobs/${aliceJob.id}`, {
+      headers: { Authorization: `Bearer ${bobToken}` },
+    });
+    expect(bobReadsAliceJob.status).toBe(404);
+
+    const bobMutatesAliceJob = await fetch(
+      `${baseUrl}/api/jobs/${aliceJob.id}`,
+      {
+        method: "PATCH",
+        headers: authHeaders(bobToken),
+        body: JSON.stringify({ status: "ready" }),
+      },
+    );
+    expect(bobMutatesAliceJob.status).toBe(404);
+
+    const pdfBytes = Buffer.from("%PDF-1.4\n%EOF\n").toString("base64");
+    const uploadPdfRes = await fetch(`${baseUrl}/api/jobs/${aliceJob.id}/pdf`, {
+      method: "POST",
+      headers: authHeaders(aliceToken),
+      body: JSON.stringify({
+        fileName: "resume.pdf",
+        mediaType: "application/pdf",
+        dataBase64: pdfBytes,
+      }),
+    });
+    expect(uploadPdfRes.status).toBe(201);
+
+    const bobReadsAlicePdf = await fetch(
+      `${baseUrl}/api/jobs/${aliceJob.id}/pdf`,
+      { headers: { Authorization: `Bearer ${bobToken}` } },
+    );
+    expect(bobReadsAlicePdf.status).toBe(404);
+
+    const uploadDocumentRes = await fetch(
+      `${baseUrl}/api/jobs/${aliceJob.id}/documents`,
+      {
+        method: "POST",
+        headers: authHeaders(aliceToken),
+        body: JSON.stringify({
+          fileName: "note.txt",
+          mediaType: "text/plain",
+          dataBase64: Buffer.from("private note").toString("base64"),
+        }),
+      },
+    );
+    expect(uploadDocumentRes.status).toBe(201);
+
+    const bobListsAliceDocuments = await fetch(
+      `${baseUrl}/api/jobs/${aliceJob.id}/documents`,
+      { headers: { Authorization: `Bearer ${bobToken}` } },
+    );
+    expect(bobListsAliceDocuments.status).toBe(404);
+
+    const bobReadsAliceChat = await fetch(
+      `${baseUrl}/api/jobs/${aliceJob.id}/chat/messages`,
+      { headers: { Authorization: `Bearer ${bobToken}` } },
+    );
+    expect(bobReadsAliceChat.status).toBe(404);
+
+    const savedSearchConfig = {
+      searchTerms: ["backend engineer"],
+      sources: ["linkedin"],
+      country: "united kingdom",
+      cityLocations: ["London"],
+      workplaceTypes: ["remote"],
+      searchScope: "selected_only",
+      matchStrictness: "exact_only",
+      topN: 10,
+      minSuitabilityScore: 55,
+      runBudget: 250,
+      automaticPresetId: "custom",
+    };
+
+    for (const token of [aliceToken, bobToken]) {
+      const res = await fetch(`${baseUrl}/api/pipeline/search-presets`, {
+        method: "POST",
+        headers: authHeaders(token),
+        body: JSON.stringify({
+          name: "Same name",
+          config: savedSearchConfig,
+        }),
+      });
+      expect(res.status).toBe(201);
+    }
+
+    const aliceSearches = await fetch(
+      `${baseUrl}/api/pipeline/search-presets`,
+      { headers: { Authorization: `Bearer ${aliceToken}` } },
+    ).then((res) => res.json());
+    const bobSearches = await fetch(`${baseUrl}/api/pipeline/search-presets`, {
+      headers: { Authorization: `Bearer ${bobToken}` },
+    }).then((res) => res.json());
+
+    expect(aliceSearches.data.searches).toHaveLength(1);
+    expect(bobSearches.data.searches).toHaveLength(1);
+    expect(aliceSearches.data.searches[0].id).not.toBe(
+      bobSearches.data.searches[0].id,
+    );
   });
 });

--- a/orchestrator/src/server/api/routes/webhook.test.ts
+++ b/orchestrator/src/server/api/routes/webhook.test.ts
@@ -76,4 +76,29 @@ describe.sequential("Webhook API routes", () => {
       await stopServer(demoServer);
     }
   });
+
+  it("rejects secret-only pipeline triggers in hosted mode", async () => {
+    const hostedServer = await startServer({
+      env: {
+        JOBOPS_APP_MODE: "hosted",
+        JOBOPS_HOSTED_TENANT_ID: "tenant_default",
+        WEBHOOK_SECRET: "secret",
+      },
+    });
+
+    try {
+      const res = await fetch(`${hostedServer.baseUrl}/api/webhook/trigger`, {
+        method: "POST",
+        headers: { Authorization: "Bearer secret" },
+      });
+      const body = await res.json();
+
+      expect(res.status).toBe(403);
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe("FORBIDDEN");
+      expect(body.error.message).toContain("unavailable in hosted mode");
+    } finally {
+      await stopServer(hostedServer);
+    }
+  });
 });

--- a/orchestrator/src/server/api/routes/webhook.ts
+++ b/orchestrator/src/server/api/routes/webhook.ts
@@ -1,7 +1,8 @@
-import { toAppError, unauthorized } from "@infra/errors";
+import { forbidden, toAppError, unauthorized } from "@infra/errors";
 import { fail, ok, okWithMeta } from "@infra/http";
 import { logger } from "@infra/logger";
 import { runWithRequestContext } from "@infra/request-context";
+import { getJobOpsAppConfig } from "@server/config/app-mode";
 import { isDemoMode } from "@server/config/demo";
 import { runPipeline } from "@server/pipeline/index";
 import { simulatePipelineRun } from "@server/services/demo-simulator";
@@ -31,6 +32,13 @@ webhookRouter.post("/trigger", async (req: Request, res: Response) => {
           runId: simulated.runId,
         },
         { simulated: true },
+      );
+    }
+
+    if (getJobOpsAppConfig().appMode === "hosted") {
+      return fail(
+        res,
+        forbidden("Webhook pipeline trigger is unavailable in hosted mode."),
       );
     }
 

--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -225,7 +225,7 @@ export function createAuthGuard() {
       ["GET", "HEAD"].includes(normalizedMethod) &&
       /^\/api\/design-resume\/assets\/[^/]+\/content$/.test(normalizedPath)
     )
-      return true;
+      return getJobOpsAppConfig().appMode !== "hosted";
     if (
       ["GET", "HEAD"].includes(normalizedMethod) &&
       /^\/api\/[^/]+\/health$/.test(normalizedPath)

--- a/orchestrator/src/server/db/migrate.test.ts
+++ b/orchestrator/src/server/db/migrate.test.ts
@@ -191,7 +191,7 @@ describe.sequential("database migrations", () => {
 
       const migratedDb = new Database(dbPath, { readonly: true });
       const indexes = migratedDb.prepare("PRAGMA index_list(tracer_links)").all();
-      const uniqueIndex = indexes.find((index) => index.name === "idx_tracer_links_tenant_job_source_destination_unique");
+      const uniqueIndex = indexes.find((index) => index.name === "idx_tracer_links_tenant_user_job_source_destination_unique");
       if (!uniqueIndex || !uniqueIndex.unique) {
         throw new Error("tracer_links composite unique index missing after migration");
       }

--- a/orchestrator/src/server/db/migrate.test.ts
+++ b/orchestrator/src/server/db/migrate.test.ts
@@ -221,4 +221,56 @@ describe.sequential("database migrations", () => {
       },
     );
   });
+
+  it("enforces private unique indexes when user_id is null", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-migrate-"));
+    const script = `
+      import { join } from "node:path";
+      import { pathToFileURL } from "node:url";
+      import Database from "better-sqlite3";
+
+      const dbPath = join(process.env.DATA_DIR, "jobs.db");
+      await import(pathToFileURL(join(process.cwd(), "src/server/db/migrate.ts")).href);
+
+      const migratedDb = new Database(dbPath);
+      migratedDb.prepare("INSERT INTO jobs(id, tenant_id, user_id, title, employer, job_url) VALUES (?, ?, NULL, ?, ?, ?)").run(
+        "job-null-owner-1",
+        "tenant_default",
+        "Role",
+        "Acme",
+        "https://example.com/null-owner",
+      );
+
+      let duplicateFailed = false;
+      try {
+        migratedDb.prepare("INSERT INTO jobs(id, tenant_id, user_id, title, employer, job_url) VALUES (?, ?, NULL, ?, ?, ?)").run(
+          "job-null-owner-2",
+          "tenant_default",
+          "Role",
+          "Acme",
+          "https://example.com/null-owner",
+        );
+      } catch {
+        duplicateFailed = true;
+      }
+
+      if (!duplicateFailed) {
+        throw new Error("jobs unique index allowed duplicate NULL user_id rows");
+      }
+
+      migratedDb.close();
+    `;
+
+    execFileSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", script],
+      {
+        env: {
+          ...process.env,
+          DATA_DIR: tempDir,
+        },
+        stdio: "pipe",
+      },
+    );
+  });
 });

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -1395,7 +1395,7 @@ function ensureTracerLinksUniqueIndex(): void {
         SELECT
           id,
           first_value(id) OVER (
-            PARTITION BY tenant_id, user_id, job_id, source_path, destination_url_hash
+            PARTITION BY tenant_id, coalesce(user_id, ''), job_id, source_path, destination_url_hash
             ORDER BY created_at ASC, id ASC
           ) AS keep_id
         FROM tracer_links
@@ -1419,7 +1419,7 @@ function ensureTracerLinksUniqueIndex(): void {
       SELECT
         id,
         first_value(id) OVER (
-          PARTITION BY tenant_id, user_id, job_id, source_path, destination_url_hash
+          PARTITION BY tenant_id, coalesce(user_id, ''), job_id, source_path, destination_url_hash
           ORDER BY created_at ASC, id ASC
         ) AS keep_id
       FROM tracer_links
@@ -1436,7 +1436,10 @@ function ensureTracerLinksUniqueIndex(): void {
     "DROP INDEX IF EXISTS idx_tracer_links_tenant_job_source_destination_unique",
   );
   sqlite.exec(
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracer_links_tenant_user_job_source_destination_unique ON tracer_links(tenant_id, user_id, job_id, source_path, destination_url_hash)",
+    "DROP INDEX IF EXISTS idx_tracer_links_tenant_user_job_source_destination_unique",
+  );
+  sqlite.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracer_links_tenant_user_job_source_destination_unique ON tracer_links(tenant_id, coalesce(user_id, ''), job_id, source_path, destination_url_hash)",
   );
 }
 
@@ -1641,22 +1644,33 @@ rebuildPostApplicationPrivateTables();
 rebuildSettingsTable();
 ensureTracerLinksUniqueIndex();
 sqlite.exec("DROP INDEX IF EXISTS idx_settings_tenant_key_unique");
+sqlite.exec("DROP INDEX IF EXISTS idx_settings_tenant_user_key_unique");
 sqlite.exec(
-  "CREATE UNIQUE INDEX IF NOT EXISTS idx_settings_tenant_user_key_unique ON settings(tenant_id, user_id, key)",
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_settings_tenant_user_key_unique ON settings(tenant_id, coalesce(user_id, ''), key)",
 );
 sqlite.exec("DROP INDEX IF EXISTS idx_jobs_tenant_job_url_unique");
+sqlite.exec("DROP INDEX IF EXISTS idx_jobs_tenant_user_job_url_unique");
 sqlite.exec(
-  "CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_user_job_url_unique ON jobs(tenant_id, user_id, job_url)",
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_user_job_url_unique ON jobs(tenant_id, coalesce(user_id, ''), job_url)",
 );
 sqlite.exec("DROP INDEX IF EXISTS idx_jobs_tenant_status");
 sqlite.exec(
-  "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_app_integrations_tenant_user_provider_account_unique ON post_application_integrations(tenant_id, user_id, provider, account_key)",
+  "DROP INDEX IF EXISTS idx_post_app_integrations_tenant_user_provider_account_unique",
 );
 sqlite.exec(
-  "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_app_messages_tenant_user_provider_account_external_unique ON post_application_messages(tenant_id, user_id, provider, account_key, external_message_id)",
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_app_integrations_tenant_user_provider_account_unique ON post_application_integrations(tenant_id, coalesce(user_id, ''), provider, account_key)",
 );
 sqlite.exec(
-  "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracer_links_tenant_user_job_source_destination_unique ON tracer_links(tenant_id, user_id, job_id, source_path, destination_url_hash)",
+  "DROP INDEX IF EXISTS idx_post_app_messages_tenant_user_provider_account_external_unique",
+);
+sqlite.exec(
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_app_messages_tenant_user_provider_account_external_unique ON post_application_messages(tenant_id, coalesce(user_id, ''), provider, account_key, external_message_id)",
+);
+sqlite.exec(
+  "DROP INDEX IF EXISTS idx_tracer_links_tenant_user_job_source_destination_unique",
+);
+sqlite.exec(
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracer_links_tenant_user_job_source_destination_unique ON tracer_links(tenant_id, coalesce(user_id, ''), job_id, source_path, destination_url_hash)",
 );
 sqlite.exec(
   "CREATE INDEX IF NOT EXISTS idx_jobs_tenant_user_status ON jobs(tenant_id, user_id, status)",

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -1381,6 +1381,7 @@ function ensureTracerLinksUniqueIndex(): void {
 
   for (const columnName of [
     "tenant_id",
+    "user_id",
     "job_id",
     "source_path",
     "destination_url_hash",
@@ -1394,7 +1395,7 @@ function ensureTracerLinksUniqueIndex(): void {
         SELECT
           id,
           first_value(id) OVER (
-            PARTITION BY tenant_id, job_id, source_path, destination_url_hash
+            PARTITION BY tenant_id, user_id, job_id, source_path, destination_url_hash
             ORDER BY created_at ASC, id ASC
           ) AS keep_id
         FROM tracer_links
@@ -1418,7 +1419,7 @@ function ensureTracerLinksUniqueIndex(): void {
       SELECT
         id,
         first_value(id) OVER (
-          PARTITION BY tenant_id, job_id, source_path, destination_url_hash
+          PARTITION BY tenant_id, user_id, job_id, source_path, destination_url_hash
           ORDER BY created_at ASC, id ASC
         ) AS keep_id
       FROM tracer_links
@@ -1432,8 +1433,163 @@ function ensureTracerLinksUniqueIndex(): void {
   `);
 
   sqlite.exec(
-    "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracer_links_tenant_job_source_destination_unique ON tracer_links(tenant_id, job_id, source_path, destination_url_hash)",
+    "DROP INDEX IF EXISTS idx_tracer_links_tenant_job_source_destination_unique",
   );
+  sqlite.exec(
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracer_links_tenant_user_job_source_destination_unique ON tracer_links(tenant_id, user_id, job_id, source_path, destination_url_hash)",
+  );
+}
+
+function rebuildPostApplicationPrivateTables(): void {
+  if (
+    !tableExists("post_application_integrations") ||
+    !tableExists("post_application_messages") ||
+    !tableExists("tracer_links")
+  ) {
+    return;
+  }
+
+  for (const tableName of [
+    "post_application_integrations",
+    "post_application_messages",
+    "tracer_links",
+  ]) {
+    if (
+      !tableHasColumn(tableName, "tenant_id") ||
+      !tableHasColumn(tableName, "user_id")
+    ) {
+      return;
+    }
+  }
+
+  sqlite.exec("PRAGMA foreign_keys = OFF");
+  try {
+    sqlite.exec(`
+      DROP TABLE IF EXISTS post_application_integrations_new;
+      CREATE TABLE post_application_integrations_new (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'tenant_default',
+        user_id TEXT,
+        provider TEXT NOT NULL CHECK(provider IN ('gmail', 'imap')),
+        account_key TEXT NOT NULL DEFAULT 'default',
+        display_name TEXT,
+        status TEXT NOT NULL DEFAULT 'disconnected' CHECK(status IN ('disconnected', 'connected', 'error')),
+        credentials TEXT,
+        last_connected_at INTEGER,
+        last_synced_at INTEGER,
+        last_error TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        UNIQUE(tenant_id, user_id, provider, account_key)
+      );
+      INSERT OR IGNORE INTO post_application_integrations_new (
+        id, tenant_id, user_id, provider, account_key, display_name, status,
+        credentials, last_connected_at, last_synced_at, last_error, created_at, updated_at
+      )
+      SELECT
+        id, tenant_id, user_id, provider, account_key, display_name, status,
+        credentials, last_connected_at, last_synced_at, last_error, created_at, updated_at
+      FROM post_application_integrations
+      ORDER BY created_at ASC, id ASC;
+      DROP TABLE post_application_integrations;
+      ALTER TABLE post_application_integrations_new RENAME TO post_application_integrations;
+
+      DROP TABLE IF EXISTS post_application_messages_new;
+      CREATE TABLE post_application_messages_new (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'tenant_default',
+        user_id TEXT,
+        provider TEXT NOT NULL CHECK(provider IN ('gmail', 'imap')),
+        account_key TEXT NOT NULL DEFAULT 'default',
+        integration_id TEXT,
+        sync_run_id TEXT,
+        external_message_id TEXT NOT NULL,
+        external_thread_id TEXT,
+        from_address TEXT NOT NULL DEFAULT '',
+        from_domain TEXT,
+        sender_name TEXT,
+        subject TEXT NOT NULL DEFAULT '',
+        received_at INTEGER NOT NULL,
+        snippet TEXT NOT NULL DEFAULT '',
+        classification_label TEXT,
+        classification_confidence REAL,
+        classification_payload TEXT,
+        relevance_llm_score REAL,
+        relevance_decision TEXT NOT NULL DEFAULT 'needs_llm' CHECK(relevance_decision IN ('relevant', 'not_relevant', 'needs_llm')),
+        match_confidence INTEGER,
+        message_type TEXT NOT NULL DEFAULT 'other' CHECK(message_type IN ('interview', 'rejection', 'offer', 'update', 'other')),
+        stage_event_payload TEXT,
+        processing_status TEXT NOT NULL DEFAULT 'pending_user' CHECK(processing_status IN ('auto_linked', 'pending_user', 'manual_linked', 'ignored')),
+        matched_job_id TEXT,
+        decided_at INTEGER,
+        decided_by TEXT,
+        error_code TEXT,
+        error_message TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        FOREIGN KEY (integration_id) REFERENCES post_application_integrations(id) ON DELETE SET NULL,
+        FOREIGN KEY (sync_run_id) REFERENCES post_application_sync_runs(id) ON DELETE SET NULL,
+        FOREIGN KEY (matched_job_id) REFERENCES jobs(id) ON DELETE SET NULL,
+        UNIQUE(tenant_id, user_id, provider, account_key, external_message_id)
+      );
+      INSERT OR IGNORE INTO post_application_messages_new (
+        id, tenant_id, user_id, provider, account_key, integration_id, sync_run_id,
+        external_message_id, external_thread_id, from_address, from_domain, sender_name,
+        subject, received_at, snippet, classification_label, classification_confidence,
+        classification_payload, relevance_llm_score, relevance_decision, match_confidence,
+        message_type, stage_event_payload, processing_status, matched_job_id, decided_at,
+        decided_by, error_code, error_message, created_at, updated_at
+      )
+      SELECT
+        id, tenant_id, user_id, provider, account_key, integration_id, sync_run_id,
+        external_message_id, external_thread_id, from_address, from_domain, sender_name,
+        subject, received_at, snippet, classification_label, classification_confidence,
+        classification_payload, relevance_llm_score, relevance_decision, match_confidence,
+        message_type, stage_event_payload, processing_status, matched_job_id, decided_at,
+        decided_by, error_code, error_message, created_at, updated_at
+      FROM post_application_messages
+      ORDER BY created_at ASC, id ASC;
+      DROP TABLE post_application_messages;
+      ALTER TABLE post_application_messages_new RENAME TO post_application_messages;
+
+      DROP TABLE IF EXISTS tracer_links_new;
+      CREATE TABLE tracer_links_new (
+        id TEXT PRIMARY KEY,
+        tenant_id TEXT NOT NULL DEFAULT 'tenant_default',
+        user_id TEXT,
+        token TEXT NOT NULL UNIQUE,
+        job_id TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        source_label TEXT NOT NULL,
+        destination_url TEXT NOT NULL,
+        destination_url_hash TEXT NOT NULL,
+        is_active INTEGER NOT NULL DEFAULT 1,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        FOREIGN KEY (job_id) REFERENCES jobs(id) ON DELETE CASCADE,
+        UNIQUE(tenant_id, user_id, job_id, source_path, destination_url_hash)
+      );
+      INSERT OR IGNORE INTO tracer_links_new (
+        id, tenant_id, user_id, token, job_id, source_path, source_label,
+        destination_url, destination_url_hash, is_active, created_at, updated_at
+      )
+      SELECT
+        id, tenant_id, user_id, token, job_id, source_path, source_label,
+        destination_url, destination_url_hash, is_active, created_at, updated_at
+      FROM tracer_links
+      ORDER BY created_at ASC, id ASC;
+      DROP TABLE tracer_links;
+      ALTER TABLE tracer_links_new RENAME TO tracer_links;
+    `);
+  } finally {
+    sqlite.exec("PRAGMA foreign_keys = ON");
+  }
 }
 
 function seedLegacyOwnerFromBasicAuth(): void {
@@ -1481,6 +1637,7 @@ console.log("🔐 Applying tenancy compatibility migrations...");
 ensureTenantColumns();
 seedLegacyOwnerFromBasicAuth();
 ensurePrivateUserColumns();
+rebuildPostApplicationPrivateTables();
 rebuildSettingsTable();
 ensureTracerLinksUniqueIndex();
 sqlite.exec("DROP INDEX IF EXISTS idx_settings_tenant_key_unique");
@@ -1490,6 +1647,16 @@ sqlite.exec(
 sqlite.exec("DROP INDEX IF EXISTS idx_jobs_tenant_job_url_unique");
 sqlite.exec(
   "CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_user_job_url_unique ON jobs(tenant_id, user_id, job_url)",
+);
+sqlite.exec("DROP INDEX IF EXISTS idx_jobs_tenant_status");
+sqlite.exec(
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_app_integrations_tenant_user_provider_account_unique ON post_application_integrations(tenant_id, user_id, provider, account_key)",
+);
+sqlite.exec(
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_post_app_messages_tenant_user_provider_account_external_unique ON post_application_messages(tenant_id, user_id, provider, account_key, external_message_id)",
+);
+sqlite.exec(
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_tracer_links_tenant_user_job_source_destination_unique ON tracer_links(tenant_id, user_id, job_id, source_path, destination_url_hash)",
 );
 sqlite.exec(
   "CREATE INDEX IF NOT EXISTS idx_jobs_tenant_user_status ON jobs(tenant_id, user_id, status)",

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -49,6 +49,76 @@ function addTenantColumn(tableName: string): void {
   );
 }
 
+function addUserColumn(tableName: string): void {
+  if (!tableExists(tableName) || tableHasColumn(tableName, "user_id")) {
+    return;
+  }
+  sqlite.exec(`ALTER TABLE ${tableName} ADD COLUMN user_id TEXT`);
+}
+
+function tenantOwnerFor(tableName: string): string {
+  return `(SELECT tenant_memberships.user_id
+    FROM tenant_memberships
+    WHERE tenant_memberships.tenant_id = ${tableName}.tenant_id
+    ORDER BY CASE tenant_memberships.role WHEN 'owner' THEN 0 ELSE 1 END,
+      tenant_memberships.created_at ASC,
+      tenant_memberships.user_id ASC
+    LIMIT 1)`;
+}
+
+function backfillUserFromTenantOwner(tableName: string): void {
+  if (
+    !tableExists(tableName) ||
+    !tableHasColumn(tableName, "tenant_id") ||
+    !tableHasColumn(tableName, "user_id")
+  ) {
+    return;
+  }
+
+  sqlite.exec(`
+    UPDATE ${tableName}
+    SET user_id = COALESCE(user_id, ${tenantOwnerFor(tableName)})
+    WHERE user_id IS NULL
+  `);
+}
+
+function backfillUserFromParent(args: {
+  tableName: string;
+  parentTableName: string;
+  localColumnName: string;
+  parentColumnName: string;
+}): void {
+  if (
+    !tableExists(args.tableName) ||
+    !tableExists(args.parentTableName) ||
+    !tableHasColumn(args.tableName, "user_id") ||
+    !tableHasColumn(args.parentTableName, "user_id") ||
+    !tableHasColumn(args.tableName, args.localColumnName) ||
+    !tableHasColumn(args.parentTableName, args.parentColumnName)
+  ) {
+    return;
+  }
+
+  sqlite.exec(`
+    UPDATE ${args.tableName}
+    SET user_id = (
+      SELECT ${args.parentTableName}.user_id
+      FROM ${args.parentTableName}
+      WHERE ${args.parentTableName}.${args.parentColumnName} =
+        ${args.tableName}.${args.localColumnName}
+      LIMIT 1
+    )
+    WHERE user_id IS NULL
+      AND EXISTS (
+        SELECT 1
+        FROM ${args.parentTableName}
+        WHERE ${args.parentTableName}.${args.parentColumnName} =
+          ${args.tableName}.${args.localColumnName}
+          AND ${args.parentTableName}.user_id IS NOT NULL
+      )
+  `);
+}
+
 function hashPasswordSync(password: string): {
   passwordHash: string;
   passwordSalt: string;
@@ -1163,22 +1233,144 @@ function ensureTenantColumns(): void {
   }
 }
 
+function ensurePrivateUserColumns(): void {
+  for (const tableName of [
+    "jobs",
+    "stage_events",
+    "tasks",
+    "job_notes",
+    "interviews",
+    "pipeline_runs",
+    "settings",
+    "job_chat_threads",
+    "job_chat_messages",
+    "job_chat_runs",
+    "design_resume_documents",
+    "design_resume_assets",
+    "job_documents",
+    "post_application_integrations",
+    "post_application_sync_runs",
+    "post_application_messages",
+    "tracer_links",
+    "tracer_click_events",
+  ]) {
+    addUserColumn(tableName);
+  }
+
+  for (const tableName of [
+    "jobs",
+    "pipeline_runs",
+    "settings",
+    "design_resume_documents",
+    "post_application_integrations",
+    "post_application_sync_runs",
+  ]) {
+    backfillUserFromTenantOwner(tableName);
+  }
+
+  for (const tableName of [
+    "stage_events",
+    "tasks",
+    "job_notes",
+    "interviews",
+  ]) {
+    backfillUserFromParent({
+      tableName,
+      parentTableName: "jobs",
+      localColumnName: "application_id",
+      parentColumnName: "id",
+    });
+    backfillUserFromTenantOwner(tableName);
+  }
+
+  for (const tableName of ["job_documents", "tracer_links"]) {
+    backfillUserFromParent({
+      tableName,
+      parentTableName: "jobs",
+      localColumnName: "job_id",
+      parentColumnName: "id",
+    });
+    backfillUserFromTenantOwner(tableName);
+  }
+
+  for (const tableName of [
+    "job_chat_threads",
+    "job_chat_messages",
+    "job_chat_runs",
+  ]) {
+    backfillUserFromParent({
+      tableName,
+      parentTableName: "jobs",
+      localColumnName: "job_id",
+      parentColumnName: "id",
+    });
+    backfillUserFromTenantOwner(tableName);
+  }
+
+  backfillUserFromParent({
+    tableName: "design_resume_assets",
+    parentTableName: "design_resume_documents",
+    localColumnName: "document_id",
+    parentColumnName: "id",
+  });
+  backfillUserFromTenantOwner("design_resume_assets");
+
+  for (const tableName of ["post_application_messages"]) {
+    backfillUserFromParent({
+      tableName,
+      parentTableName: "post_application_integrations",
+      localColumnName: "integration_id",
+      parentColumnName: "id",
+    });
+    backfillUserFromParent({
+      tableName,
+      parentTableName: "jobs",
+      localColumnName: "matched_job_id",
+      parentColumnName: "id",
+    });
+    backfillUserFromTenantOwner(tableName);
+  }
+
+  backfillUserFromParent({
+    tableName: "tracer_click_events",
+    parentTableName: "tracer_links",
+    localColumnName: "tracer_link_id",
+    parentColumnName: "id",
+  });
+  backfillUserFromTenantOwner("tracer_click_events");
+}
+
 function rebuildSettingsTable(): void {
   if (!tableExists("settings")) return;
 
   sqlite.exec(`CREATE TABLE IF NOT EXISTS settings_new (
     tenant_id TEXT NOT NULL DEFAULT 'tenant_default',
+    user_id TEXT,
     key TEXT NOT NULL,
     value TEXT NOT NULL,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
-    UNIQUE(tenant_id, key),
+    UNIQUE(tenant_id, user_id, key),
     FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE
   )`);
 
   const hasTenantId = tableHasColumn("settings", "tenant_id");
-  sqlite.exec(`INSERT OR REPLACE INTO settings_new(tenant_id, key, value, created_at, updated_at)
-    SELECT ${hasTenantId ? `COALESCE(tenant_id, ${sqlString(DEFAULT_TENANT_ID)})` : sqlString(DEFAULT_TENANT_ID)}, key, value, created_at, updated_at
+  const hasUserId = tableHasColumn("settings", "user_id");
+  const tenantExpression = hasTenantId
+    ? `COALESCE(tenant_id, ${sqlString(DEFAULT_TENANT_ID)})`
+    : sqlString(DEFAULT_TENANT_ID);
+  const ownerExpression = `(SELECT tenant_memberships.user_id
+    FROM tenant_memberships
+    WHERE tenant_memberships.tenant_id = ${tenantExpression}
+    ORDER BY CASE tenant_memberships.role WHEN 'owner' THEN 0 ELSE 1 END,
+      tenant_memberships.created_at ASC,
+      tenant_memberships.user_id ASC
+    LIMIT 1)`;
+  const userExpression = hasUserId
+    ? `COALESCE(user_id, ${ownerExpression})`
+    : ownerExpression;
+  sqlite.exec(`INSERT OR REPLACE INTO settings_new(tenant_id, user_id, key, value, created_at, updated_at)
+    SELECT ${tenantExpression}, ${userExpression}, key, value, created_at, updated_at
     FROM settings`);
   sqlite.exec("DROP TABLE IF EXISTS settings");
   sqlite.exec("ALTER TABLE settings_new RENAME TO settings");
@@ -1287,18 +1479,24 @@ function seedLegacyOwnerFromBasicAuth(): void {
 
 console.log("🔐 Applying tenancy compatibility migrations...");
 ensureTenantColumns();
+seedLegacyOwnerFromBasicAuth();
+ensurePrivateUserColumns();
 rebuildSettingsTable();
 ensureTracerLinksUniqueIndex();
+sqlite.exec("DROP INDEX IF EXISTS idx_settings_tenant_key_unique");
 sqlite.exec(
-  "CREATE UNIQUE INDEX IF NOT EXISTS idx_settings_tenant_key_unique ON settings(tenant_id, key)",
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_settings_tenant_user_key_unique ON settings(tenant_id, user_id, key)",
+);
+sqlite.exec("DROP INDEX IF EXISTS idx_jobs_tenant_job_url_unique");
+sqlite.exec(
+  "CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_user_job_url_unique ON jobs(tenant_id, user_id, job_url)",
 );
 sqlite.exec(
-  "CREATE UNIQUE INDEX IF NOT EXISTS idx_jobs_tenant_job_url_unique ON jobs(tenant_id, job_url)",
+  "CREATE INDEX IF NOT EXISTS idx_jobs_tenant_user_status ON jobs(tenant_id, user_id, status)",
 );
 sqlite.exec(
   "CREATE INDEX IF NOT EXISTS idx_auth_sessions_user_id ON auth_sessions(user_id)",
 );
-seedLegacyOwnerFromBasicAuth();
 
 sqlite.close();
 console.log("🎉 Database migrations complete!");

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -91,6 +91,9 @@ export const jobs = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
 
     // From crawler
     source: text("source").notNull().default("gradcracker"),
@@ -184,10 +187,9 @@ export const jobs = sqliteTable(
     updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
   },
   (table) => ({
-    tenantJobUrlUnique: uniqueIndex("idx_jobs_tenant_job_url_unique").on(
-      table.tenantId,
-      table.jobUrl,
-    ),
+    tenantUserJobUrlUnique: uniqueIndex(
+      "idx_jobs_tenant_user_job_url_unique",
+    ).on(table.tenantId, table.userId, table.jobUrl),
     tenantStatusIndex: index("idx_jobs_tenant_status").on(
       table.tenantId,
       table.status,
@@ -205,6 +207,9 @@ export const stageEvents = sqliteTable("stage_events", {
     .notNull()
     .default("tenant_default")
     .references(() => tenants.id, { onDelete: "cascade" }),
+  userId: text("user_id").references(() => users.id, {
+    onDelete: "cascade",
+  }),
   applicationId: text("application_id")
     .notNull()
     .references(() => jobs.id, { onDelete: "cascade" }),
@@ -223,6 +228,9 @@ export const tasks = sqliteTable("tasks", {
     .notNull()
     .default("tenant_default")
     .references(() => tenants.id, { onDelete: "cascade" }),
+  userId: text("user_id").references(() => users.id, {
+    onDelete: "cascade",
+  }),
   applicationId: text("application_id")
     .notNull()
     .references(() => jobs.id, { onDelete: "cascade" }),
@@ -243,6 +251,9 @@ export const jobNotes = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     jobId: text("job_id")
       .notNull()
       .references(() => jobs.id, { onDelete: "cascade" }),
@@ -265,6 +276,9 @@ export const interviews = sqliteTable("interviews", {
     .notNull()
     .default("tenant_default")
     .references(() => tenants.id, { onDelete: "cascade" }),
+  userId: text("user_id").references(() => users.id, {
+    onDelete: "cascade",
+  }),
   applicationId: text("application_id")
     .notNull()
     .references(() => jobs.id, { onDelete: "cascade" }),
@@ -280,6 +294,9 @@ export const pipelineRuns = sqliteTable("pipeline_runs", {
     .notNull()
     .default("tenant_default")
     .references(() => tenants.id, { onDelete: "cascade" }),
+  userId: text("user_id").references(() => users.id, {
+    onDelete: "cascade",
+  }),
   startedAt: text("started_at").notNull().default(sql`(datetime('now'))`),
   completedAt: text("completed_at"),
   status: text("status", {
@@ -329,6 +346,9 @@ export const jobChatThreads = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     jobId: text("job_id")
       .notNull()
       .references(() => jobs.id, { onDelete: "cascade" }),
@@ -357,6 +377,9 @@ export const jobChatMessages = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     threadId: text("thread_id")
       .notNull()
       .references(() => jobChatThreads.id, { onDelete: "cascade" }),
@@ -394,6 +417,9 @@ export const jobChatRuns = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     threadId: text("thread_id")
       .notNull()
       .references(() => jobChatThreads.id, { onDelete: "cascade" }),
@@ -428,14 +454,18 @@ export const settings = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     key: text("key").notNull(),
     value: text("value").notNull(),
     createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
     updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
   },
   (table) => ({
-    tenantKeyUnique: uniqueIndex("idx_settings_tenant_key_unique").on(
+    tenantUserKeyUnique: uniqueIndex("idx_settings_tenant_user_key_unique").on(
       table.tenantId,
+      table.userId,
       table.key,
     ),
   }),
@@ -627,6 +657,7 @@ export const designResumeDocuments = sqliteTable("design_resume_documents", {
     .notNull()
     .default("tenant_default")
     .references(() => tenants.id, { onDelete: "cascade" }),
+  userId: text("user_id").references(() => users.id, { onDelete: "cascade" }),
   title: text("title").notNull(),
   resumeJson: text("resume_json", { mode: "json" }).notNull(),
   revision: integer("revision").notNull().default(1),
@@ -645,6 +676,9 @@ export const designResumeAssets = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     documentId: text("document_id")
       .notNull()
       .references(() => designResumeDocuments.id, { onDelete: "cascade" }),
@@ -673,6 +707,9 @@ export const jobDocuments = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     jobId: text("job_id")
       .notNull()
       .references(() => jobs.id, { onDelete: "cascade" }),
@@ -700,6 +737,9 @@ export const postApplicationIntegrations = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     provider: text("provider", { enum: POST_APPLICATION_PROVIDERS }).notNull(),
     accountKey: text("account_key").notNull().default("default"),
     displayName: text("display_name"),
@@ -715,8 +755,8 @@ export const postApplicationIntegrations = sqliteTable(
   },
   (table) => ({
     providerAccountUnique: uniqueIndex(
-      "idx_post_app_integrations_tenant_provider_account_unique",
-    ).on(table.tenantId, table.provider, table.accountKey),
+      "idx_post_app_integrations_tenant_user_provider_account_unique",
+    ).on(table.tenantId, table.userId, table.provider, table.accountKey),
   }),
 );
 
@@ -728,6 +768,9 @@ export const postApplicationSyncRuns = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     provider: text("provider", { enum: POST_APPLICATION_PROVIDERS }).notNull(),
     accountKey: text("account_key").notNull().default("default"),
     integrationId: text("integration_id").references(
@@ -766,6 +809,9 @@ export const postApplicationMessages = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     provider: text("provider", { enum: POST_APPLICATION_PROVIDERS }).notNull(),
     accountKey: text("account_key").notNull().default("default"),
     integrationId: text("integration_id").references(
@@ -819,9 +865,10 @@ export const postApplicationMessages = sqliteTable(
   },
   (table) => ({
     providerAccountExternalMessageUnique: uniqueIndex(
-      "idx_post_app_messages_tenant_provider_account_external_unique",
+      "idx_post_app_messages_tenant_user_provider_account_external_unique",
     ).on(
       table.tenantId,
+      table.userId,
       table.provider,
       table.accountKey,
       table.externalMessageId,
@@ -840,6 +887,9 @@ export const tracerLinks = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     token: text("token").notNull().unique(),
     jobId: text("job_id")
       .notNull()
@@ -854,9 +904,10 @@ export const tracerLinks = sqliteTable(
   },
   (table) => ({
     jobPathDestinationUnique: uniqueIndex(
-      "idx_tracer_links_tenant_job_source_destination_unique",
+      "idx_tracer_links_tenant_user_job_source_destination_unique",
     ).on(
       table.tenantId,
+      table.userId,
       table.jobId,
       table.sourcePath,
       table.destinationUrlHash,
@@ -873,6 +924,9 @@ export const tracerClickEvents = sqliteTable(
       .notNull()
       .default("tenant_default")
       .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id").references(() => users.id, {
+      onDelete: "cascade",
+    }),
     tracerLinkId: text("tracer_link_id")
       .notNull()
       .references(() => tracerLinks.id, { onDelete: "cascade" }),

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -189,7 +189,7 @@ export const jobs = sqliteTable(
   (table) => ({
     tenantUserJobUrlUnique: uniqueIndex(
       "idx_jobs_tenant_user_job_url_unique",
-    ).on(table.tenantId, table.userId, table.jobUrl),
+    ).on(table.tenantId, sql`coalesce(${table.userId}, '')`, table.jobUrl),
     tenantStatusIndex: index("idx_jobs_tenant_user_status").on(
       table.tenantId,
       table.userId,
@@ -466,7 +466,7 @@ export const settings = sqliteTable(
   (table) => ({
     tenantUserKeyUnique: uniqueIndex("idx_settings_tenant_user_key_unique").on(
       table.tenantId,
-      table.userId,
+      sql`coalesce(${table.userId}, '')`,
       table.key,
     ),
   }),
@@ -757,7 +757,12 @@ export const postApplicationIntegrations = sqliteTable(
   (table) => ({
     providerAccountUnique: uniqueIndex(
       "idx_post_app_integrations_tenant_user_provider_account_unique",
-    ).on(table.tenantId, table.userId, table.provider, table.accountKey),
+    ).on(
+      table.tenantId,
+      sql`coalesce(${table.userId}, '')`,
+      table.provider,
+      table.accountKey,
+    ),
   }),
 );
 
@@ -869,7 +874,7 @@ export const postApplicationMessages = sqliteTable(
       "idx_post_app_messages_tenant_user_provider_account_external_unique",
     ).on(
       table.tenantId,
-      table.userId,
+      sql`coalesce(${table.userId}, '')`,
       table.provider,
       table.accountKey,
       table.externalMessageId,
@@ -908,7 +913,7 @@ export const tracerLinks = sqliteTable(
       "idx_tracer_links_tenant_user_job_source_destination_unique",
     ).on(
       table.tenantId,
-      table.userId,
+      sql`coalesce(${table.userId}, '')`,
       table.jobId,
       table.sourcePath,
       table.destinationUrlHash,

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -190,8 +190,9 @@ export const jobs = sqliteTable(
     tenantUserJobUrlUnique: uniqueIndex(
       "idx_jobs_tenant_user_job_url_unique",
     ).on(table.tenantId, table.userId, table.jobUrl),
-    tenantStatusIndex: index("idx_jobs_tenant_status").on(
+    tenantStatusIndex: index("idx_jobs_tenant_user_status").on(
       table.tenantId,
+      table.userId,
       table.status,
     ),
     tenantDiscoveredAtIndex: index("idx_jobs_tenant_discovered_at").on(

--- a/orchestrator/src/server/infra/job-queue.ts
+++ b/orchestrator/src/server/infra/job-queue.ts
@@ -10,6 +10,7 @@ export type AutoPdfRegenerationReason =
 
 export interface AutoPdfRegenerationJobPayload {
   tenantId: string;
+  userId?: string | null;
   jobId: string;
   reason: AutoPdfRegenerationReason;
   requestedAt: string;

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -12,7 +12,7 @@ import type { AppErrorCode } from "@infra/errors";
 import { logger } from "@infra/logger";
 import { trackServerProductEvent } from "@infra/product-analytics";
 import { runWithRequestContext } from "@infra/request-context";
-import { getActiveTenantId } from "@server/tenancy/context";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import { createLocationIntentFromLegacyInputs } from "@shared/location-domain.js";
 import type {
   JobStatus,
@@ -87,8 +87,14 @@ type LlmConfigState = {
 
 const pipelineStateByTenant = new Map<string, TenantPipelineState>();
 
-function getPipelineState(tenantId = getActiveTenantId()): TenantPipelineState {
-  let state = pipelineStateByTenant.get(tenantId);
+function getPipelineScopeKey(): string {
+  return getPrivateDataScope().scopeKey;
+}
+
+function getPipelineState(
+  scopeKey = getPipelineScopeKey(),
+): TenantPipelineState {
+  let state = pipelineStateByTenant.get(scopeKey);
   if (!state) {
     state = {
       isRunning: false,
@@ -97,7 +103,7 @@ function getPipelineState(tenantId = getActiveTenantId()): TenantPipelineState {
       activeChallengeState: null,
       activeLlmConfigState: null,
     };
-    pipelineStateByTenant.set(tenantId, state);
+    pipelineStateByTenant.set(scopeKey, state);
   }
   return state;
 }
@@ -202,8 +208,8 @@ class PipelineCancelledError extends Error {
   }
 }
 
-function ensureNotCancelled(tenantId = getActiveTenantId()): void {
-  if (getPipelineState(tenantId).cancelRequestedAt) {
+function ensureNotCancelled(scopeKey = getPipelineScopeKey()): void {
+  if (getPipelineState(scopeKey).cancelRequestedAt) {
     throw new PipelineCancelledError();
   }
 }
@@ -236,8 +242,8 @@ export async function runPipeline(
   jobsProcessed: number;
   error?: string;
 }> {
-  const tenantId = getActiveTenantId();
-  const tenantState = getPipelineState(tenantId);
+  const scopeKey = getPipelineScopeKey();
+  const tenantState = getPipelineState(scopeKey);
   if (tenantState.isRunning) {
     return {
       success: false,
@@ -295,18 +301,18 @@ export async function runPipeline(
     });
 
     try {
-      ensureNotCancelled(tenantId);
+      ensureNotCancelled(scopeKey);
       await persistResultSummary({ stage: "started" });
       const profile = await loadProfileStep();
       await persistResultSummary({ stage: "profile_loaded" });
 
-      ensureNotCancelled(tenantId);
+      ensureNotCancelled(scopeKey);
       await persistResultSummary({ stage: "discovery" });
       let { discoveredJobs, sourceErrors, pendingChallenges } =
         await discoverJobsStep({
           mergedConfig,
           shouldCancel: () =>
-            getPipelineState(tenantId).cancelRequestedAt !== null,
+            getPipelineState(scopeKey).cancelRequestedAt !== null,
         });
       await persistResultSummary({
         stage: "discovery",
@@ -341,7 +347,7 @@ export async function runPipeline(
         });
         tenantState.activeChallengeState = null;
 
-        ensureNotCancelled(tenantId);
+        ensureNotCancelled(scopeKey);
 
         // Re-run only the extractors that had challenges
         pipelineLogger.info("Challenges resolved, re-running extractors", {
@@ -352,7 +358,7 @@ export async function runPipeline(
         const retryResult = await discoverJobsStep({
           mergedConfig: retryConfig,
           shouldCancel: () =>
-            getPipelineState(tenantId).cancelRequestedAt !== null,
+            getPipelineState(scopeKey).cancelRequestedAt !== null,
         });
 
         discoveredJobs = [...discoveredJobs, ...retryResult.discoveredJobs];
@@ -384,7 +390,7 @@ export async function runPipeline(
         progressHelpers.crawlingComplete(discoveredJobs.length);
       }
 
-      ensureNotCancelled(tenantId);
+      ensureNotCancelled(scopeKey);
       jobsDiscovered = discoveredJobs.length;
       const { created, skipped, fuzzyMerged } = await importJobsStep({
         discoveredJobs,
@@ -398,13 +404,13 @@ export async function runPipeline(
       let unprocessedJobs: import("@shared/types").Job[] = [];
       let scoredJobs: import("./steps/types").ScoredJob[] = [];
 
-      ensureNotCancelled(tenantId);
+      ensureNotCancelled(scopeKey);
       await persistResultSummary({ stage: "scoring" });
       try {
         ({ unprocessedJobs, scoredJobs } = await scoreJobsStep({
           profile,
           shouldCancel: () =>
-            getPipelineState(tenantId).cancelRequestedAt !== null,
+            getPipelineState(scopeKey).cancelRequestedAt !== null,
         }));
       } catch (error) {
         if (error instanceof LlmNotConfiguredError) {
@@ -417,14 +423,14 @@ export async function runPipeline(
           });
           tenantState.activeLlmConfigState = null;
 
-          ensureNotCancelled(tenantId);
+          ensureNotCancelled(scopeKey);
 
           pipelineLogger.info("LLM configured, resuming scoring");
 
           ({ unprocessedJobs, scoredJobs } = await scoreJobsStep({
             profile,
             shouldCancel: () =>
-              getPipelineState(tenantId).cancelRequestedAt !== null,
+              getPipelineState(scopeKey).cancelRequestedAt !== null,
           }));
         } else {
           throw error;
@@ -435,7 +441,7 @@ export async function runPipeline(
         jobsScored: scoredJobs.length,
       });
 
-      ensureNotCancelled(tenantId);
+      ensureNotCancelled(scopeKey);
       await persistResultSummary({ stage: "selection" });
       const jobsToProcess = await selectJobsStep({
         scoredJobs,
@@ -460,7 +466,7 @@ export async function runPipeline(
         jobsToProcess,
         processJob,
         shouldCancel: () =>
-          getPipelineState(tenantId).cancelRequestedAt !== null,
+          getPipelineState(scopeKey).cancelRequestedAt !== null,
       });
       jobsProcessed = processedCount;
 

--- a/orchestrator/src/server/pipeline/progress.ts
+++ b/orchestrator/src/server/pipeline/progress.ts
@@ -1,5 +1,5 @@
 import { logger } from "@infra/logger";
-import { getActiveTenantId } from "@server/tenancy/context";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import type {
   PipelinePendingChallenge,
   PipelineProgressState,
@@ -50,6 +50,10 @@ const currentSourceStatsByTenant = new Map<
   string,
   Map<CrawlSource, SourceCrawlingStats>
 >();
+
+function getProgressScopeKey(): string {
+  return getPrivateDataScope().scopeKey;
+}
 
 function getCurrentProgressForTenant(tenantId: string): PipelineProgress {
   const current = currentProgressByTenant.get(tenantId);
@@ -125,7 +129,7 @@ const emptySourceCrawlingStats = (): SourceCrawlingStats => ({
   jobPagesProcessed: 0,
 });
 
-function aggregateCrawlingStats(tenantId = getActiveTenantId()) {
+function aggregateCrawlingStats(tenantId = getProgressScopeKey()) {
   const crawlingStatsBySource = getCurrentSourceStatsForTenant(tenantId);
   let termsProcessed = 0;
   let termsTotal = 0;
@@ -163,7 +167,7 @@ function aggregateCrawlingStats(tenantId = getActiveTenantId()) {
  * Update the current progress and notify all listeners.
  */
 export function updateProgress(update: Partial<PipelineProgress>): void {
-  const tenantId = getActiveTenantId();
+  const tenantId = getProgressScopeKey();
   currentProgress = { ...getCurrentProgressForTenant(tenantId), ...update };
   currentProgressByTenant.set(tenantId, currentProgress);
 
@@ -181,14 +185,14 @@ export function updateProgress(update: Partial<PipelineProgress>): void {
  * Get the current progress state.
  */
 export function getProgress(): PipelineProgress {
-  return { ...getCurrentProgressForTenant(getActiveTenantId()) };
+  return { ...getCurrentProgressForTenant(getProgressScopeKey()) };
 }
 
 /**
  * Subscribe to progress updates.
  */
 export function subscribeToProgress(listener: ProgressListener): () => void {
-  const tenantId = getActiveTenantId();
+  const tenantId = getProgressScopeKey();
   const listeners = listenersByTenant.get(tenantId) ?? new Set();
   listenersByTenant.set(tenantId, listeners);
   listeners.add(listener);
@@ -206,7 +210,7 @@ export function subscribeToProgress(listener: ProgressListener): () => void {
  * Reset progress to idle state.
  */
 export function resetProgress(): void {
-  const tenantId = getActiveTenantId();
+  const tenantId = getProgressScopeKey();
   currentSourceStatsByTenant.set(tenantId, new Map());
   currentProgress = createIdleProgress();
   currentProgressByTenant.set(tenantId, currentProgress);
@@ -218,7 +222,7 @@ export function resetProgress(): void {
 export const progressHelpers = {
   startCrawling: (sourcesTotal = 0) =>
     (() => {
-      const tenantId = getActiveTenantId();
+      const tenantId = getProgressScopeKey();
       const crawlingStatsBySource = getCurrentSourceStatsForTenant(tenantId);
       crawlingStatsBySource.clear();
       updateProgress({
@@ -243,7 +247,7 @@ export const progressHelpers = {
     sourcesTotal: number,
     options?: { termsTotal?: number; detail?: string },
   ) => {
-    const tenantId = getActiveTenantId();
+    const tenantId = getProgressScopeKey();
     const crawlingStatsBySource = getCurrentSourceStatsForTenant(tenantId);
     const existing =
       crawlingStatsBySource.get(source) ?? emptySourceCrawlingStats();
@@ -294,7 +298,7 @@ export const progressHelpers = {
     phase?: "list" | "job";
     currentUrl?: string;
   }) => {
-    const tenantId = getActiveTenantId();
+    const tenantId = getProgressScopeKey();
     const crawlingStatsBySource = getCurrentSourceStatsForTenant(tenantId);
     const current = getProgress();
     if (update.source) {

--- a/orchestrator/src/server/repositories/design-resume.ts
+++ b/orchestrator/src/server/repositories/design-resume.ts
@@ -1,60 +1,54 @@
 import { and, desc, eq } from "drizzle-orm";
 import { db, schema } from "../db/index";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { designResumeAssets, designResumeDocuments } = schema;
 
+function documentsScopeFilter() {
+  return privateDataScopeFilter(designResumeDocuments);
+}
+
+function assetsScopeFilter() {
+  return privateDataScopeFilter(designResumeAssets);
+}
+
 export async function getLatestDesignResumeDocument() {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(designResumeDocuments)
-    .where(eq(designResumeDocuments.tenantId, tenantId))
+    .where(documentsScopeFilter())
     .orderBy(desc(designResumeDocuments.updatedAt))
     .limit(1);
   return row ?? null;
 }
 
 export async function getDesignResumeDocumentById(id: string) {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(designResumeDocuments)
-    .where(
-      and(
-        eq(designResumeDocuments.tenantId, tenantId),
-        eq(designResumeDocuments.id, id),
-      ),
-    )
+    .where(and(documentsScopeFilter(), eq(designResumeDocuments.id, id)))
     .limit(1);
   return row ?? null;
 }
 
 export async function listDesignResumeAssets(documentId: string) {
-  const tenantId = getActiveTenantId();
   return db
     .select()
     .from(designResumeAssets)
     .where(
-      and(
-        eq(designResumeAssets.tenantId, tenantId),
-        eq(designResumeAssets.documentId, documentId),
-      ),
+      and(assetsScopeFilter(), eq(designResumeAssets.documentId, documentId)),
     )
     .orderBy(desc(designResumeAssets.updatedAt));
 }
 
 export async function getDesignResumeAssetById(id: string) {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(designResumeAssets)
-    .where(
-      and(
-        eq(designResumeAssets.tenantId, tenantId),
-        eq(designResumeAssets.id, id),
-      ),
-    )
+    .where(and(assetsScopeFilter(), eq(designResumeAssets.id, id)))
     .limit(1);
   return row ?? null;
 }
@@ -79,7 +73,7 @@ export async function upsertDesignResumeDocument(input: {
   createdAt?: string;
   updatedAt: string;
 }) {
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
   const existing = await getDesignResumeDocumentById(input.id);
   if (existing) {
     await db
@@ -94,15 +88,13 @@ export async function upsertDesignResumeDocument(input: {
         updatedAt: input.updatedAt,
       })
       .where(
-        and(
-          eq(designResumeDocuments.tenantId, tenantId),
-          eq(designResumeDocuments.id, input.id),
-        ),
+        and(documentsScopeFilter(), eq(designResumeDocuments.id, input.id)),
       );
   } else {
     await db.insert(designResumeDocuments).values({
       id: input.id,
-      tenantId,
+      tenantId: scope.tenantId,
+      userId: scope.userId,
       title: input.title,
       resumeJson: input.resumeJson,
       revision: input.revision,
@@ -128,10 +120,11 @@ export async function insertDesignResumeAsset(input: {
   createdAt?: string;
   updatedAt: string;
 }) {
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
   await db.insert(designResumeAssets).values({
     id: input.id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     documentId: input.documentId,
     kind: input.kind,
     originalName: input.originalName,
@@ -146,53 +139,36 @@ export async function insertDesignResumeAsset(input: {
 }
 
 export async function deleteDesignResumeAsset(id: string) {
-  const tenantId = getActiveTenantId();
   await db
     .delete(designResumeAssets)
-    .where(
-      and(
-        eq(designResumeAssets.tenantId, tenantId),
-        eq(designResumeAssets.id, id),
-      ),
-    );
+    .where(and(assetsScopeFilter(), eq(designResumeAssets.id, id)));
 }
 
 export async function deleteDesignResumeAssetsForDocument(documentId: string) {
-  const tenantId = getActiveTenantId();
   await db
     .delete(designResumeAssets)
     .where(
-      and(
-        eq(designResumeAssets.tenantId, tenantId),
-        eq(designResumeAssets.documentId, documentId),
-      ),
+      and(assetsScopeFilter(), eq(designResumeAssets.documentId, documentId)),
     );
 }
 
 export async function deleteDesignResumeDocument(id: string) {
-  const tenantId = getActiveTenantId();
   await db
     .delete(designResumeDocuments)
-    .where(
-      and(
-        eq(designResumeDocuments.tenantId, tenantId),
-        eq(designResumeDocuments.id, id),
-      ),
-    );
+    .where(and(documentsScopeFilter(), eq(designResumeDocuments.id, id)));
 }
 
 export async function findDesignResumeAssetForDocument(args: {
   documentId: string;
   kind: "picture";
 }) {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(designResumeAssets)
     .where(
       and(
         eq(designResumeAssets.documentId, args.documentId),
-        eq(designResumeAssets.tenantId, tenantId),
+        assetsScopeFilter(),
         eq(designResumeAssets.kind, args.kind),
       ),
     )

--- a/orchestrator/src/server/repositories/ghostwriter.ts
+++ b/orchestrator/src/server/repositories/ghostwriter.ts
@@ -13,9 +13,24 @@ import type {
 } from "@shared/types";
 import { and, desc, eq } from "drizzle-orm";
 import { db, schema } from "../db";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { jobChatMessages, jobChatRuns, jobChatThreads } = schema;
+
+function threadsScopeFilter() {
+  return privateDataScopeFilter(jobChatThreads);
+}
+
+function messagesScopeFilter() {
+  return privateDataScopeFilter(jobChatMessages);
+}
+
+function runsScopeFilter() {
+  return privateDataScopeFilter(jobChatRuns);
+}
 
 function parseSelectedContextIds(
   value: string | null,
@@ -141,16 +156,10 @@ function mapRun(row: typeof jobChatRuns.$inferSelect): JobChatRun {
 export async function listThreadsForJob(
   jobId: string,
 ): Promise<JobChatThread[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(jobChatThreads)
-    .where(
-      and(
-        eq(jobChatThreads.tenantId, tenantId),
-        eq(jobChatThreads.jobId, jobId),
-      ),
-    )
+    .where(and(threadsScopeFilter(), eq(jobChatThreads.jobId, jobId)))
     .orderBy(desc(jobChatThreads.updatedAt));
 
   return rows.map(mapThread);
@@ -173,16 +182,10 @@ export async function getOrCreateThreadForJob(input: {
 export async function getThreadById(
   threadId: string,
 ): Promise<JobChatThread | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobChatThreads)
-    .where(
-      and(
-        eq(jobChatThreads.tenantId, tenantId),
-        eq(jobChatThreads.id, threadId),
-      ),
-    );
+    .where(and(threadsScopeFilter(), eq(jobChatThreads.id, threadId)));
   return row ? mapThread(row) : null;
 }
 
@@ -190,13 +193,12 @@ export async function getThreadForJob(
   jobId: string,
   threadId: string,
 ): Promise<JobChatThread | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobChatThreads)
     .where(
       and(
-        eq(jobChatThreads.tenantId, tenantId),
+        threadsScopeFilter(),
         eq(jobChatThreads.id, threadId),
         eq(jobChatThreads.jobId, jobId),
       ),
@@ -210,11 +212,12 @@ export async function createThread(input: {
 }): Promise<JobChatThread> {
   const id = randomUUID();
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   await db.insert(jobChatThreads).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     jobId: input.jobId,
     title: input.title ?? null,
     createdAt: now,
@@ -238,7 +241,6 @@ export async function updateThreadSelectedNoteIds(input: {
   selectedNoteIds: string[];
 }): Promise<JobChatThread | null> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
 
   await db
     .update(jobChatThreads)
@@ -250,7 +252,7 @@ export async function updateThreadSelectedNoteIds(input: {
     })
     .where(
       and(
-        eq(jobChatThreads.tenantId, tenantId),
+        threadsScopeFilter(),
         eq(jobChatThreads.id, input.threadId),
         eq(jobChatThreads.jobId, input.jobId),
       ),
@@ -267,7 +269,6 @@ export async function updateThreadContext(input: {
   selectedDocumentIds?: string[];
 }): Promise<JobChatThread | null> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
 
   await db
     .update(jobChatThreads)
@@ -299,7 +300,7 @@ export async function updateThreadContext(input: {
     })
     .where(
       and(
-        eq(jobChatThreads.tenantId, tenantId),
+        threadsScopeFilter(),
         eq(jobChatThreads.id, input.threadId),
         eq(jobChatThreads.jobId, input.jobId),
       ),
@@ -313,19 +314,13 @@ export async function touchThread(
   lastMessageAt?: string,
 ): Promise<void> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
   await db
     .update(jobChatThreads)
     .set({
       updatedAt: now,
       ...(lastMessageAt !== undefined ? { lastMessageAt } : {}),
     })
-    .where(
-      and(
-        eq(jobChatThreads.tenantId, tenantId),
-        eq(jobChatThreads.id, threadId),
-      ),
-    );
+    .where(and(threadsScopeFilter(), eq(jobChatThreads.id, threadId)));
 }
 
 export async function listMessagesForThread(
@@ -334,17 +329,11 @@ export async function listMessagesForThread(
 ): Promise<JobChatMessage[]> {
   const limit = options?.limit ?? 200;
   const offset = options?.offset ?? 0;
-  const tenantId = getActiveTenantId();
 
   const rows = await db
     .select()
     .from(jobChatMessages)
-    .where(
-      and(
-        eq(jobChatMessages.tenantId, tenantId),
-        eq(jobChatMessages.threadId, threadId),
-      ),
-    )
+    .where(and(messagesScopeFilter(), eq(jobChatMessages.threadId, threadId)))
     .orderBy(jobChatMessages.createdAt)
     .limit(limit)
     .offset(offset);
@@ -355,16 +344,10 @@ export async function listMessagesForThread(
 export async function getMessageById(
   messageId: string,
 ): Promise<JobChatMessage | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobChatMessages)
-    .where(
-      and(
-        eq(jobChatMessages.tenantId, tenantId),
-        eq(jobChatMessages.id, messageId),
-      ),
-    );
+    .where(and(messagesScopeFilter(), eq(jobChatMessages.id, messageId)));
   return row ? mapMessage(row) : null;
 }
 
@@ -383,11 +366,12 @@ export async function createMessage(input: {
 }): Promise<JobChatMessage> {
   const id = randomUUID();
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   await db.insert(jobChatMessages).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     threadId: input.threadId,
     jobId: input.jobId,
     role: input.role,
@@ -422,7 +406,6 @@ export async function updateMessage(
   },
 ): Promise<JobChatMessage | null> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
 
   await db
     .update(jobChatMessages)
@@ -433,12 +416,7 @@ export async function updateMessage(
       ...(input.tokensOut !== undefined ? { tokensOut: input.tokensOut } : {}),
       updatedAt: now,
     })
-    .where(
-      and(
-        eq(jobChatMessages.tenantId, tenantId),
-        eq(jobChatMessages.id, messageId),
-      ),
-    );
+    .where(and(messagesScopeFilter(), eq(jobChatMessages.id, messageId)));
 
   const message = await getMessageById(messageId);
   if (message) {
@@ -450,14 +428,13 @@ export async function updateMessage(
 export async function getLatestAssistantMessage(
   threadId: string,
 ): Promise<JobChatMessage | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobChatMessages)
     .where(
       and(
         eq(jobChatMessages.threadId, threadId),
-        eq(jobChatMessages.tenantId, tenantId),
+        messagesScopeFilter(),
         eq(jobChatMessages.role, "assistant"),
       ),
     )
@@ -477,11 +454,12 @@ export async function createRun(input: {
   const id = randomUUID();
   const startedAt = Date.now();
   const now = new Date(startedAt).toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   await db.insert(jobChatRuns).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     threadId: input.threadId,
     jobId: input.jobId,
     status: "running",
@@ -504,25 +482,23 @@ export async function createRun(input: {
 }
 
 export async function getRunById(runId: string): Promise<JobChatRun | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobChatRuns)
-    .where(and(eq(jobChatRuns.tenantId, tenantId), eq(jobChatRuns.id, runId)));
+    .where(and(runsScopeFilter(), eq(jobChatRuns.id, runId)));
   return row ? mapRun(row) : null;
 }
 
 export async function getActiveRunForThread(
   threadId: string,
 ): Promise<JobChatRun | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobChatRuns)
     .where(
       and(
         eq(jobChatRuns.threadId, threadId),
-        eq(jobChatRuns.tenantId, tenantId),
+        runsScopeFilter(),
         eq(jobChatRuns.status, "running"),
       ),
     )
@@ -542,7 +518,6 @@ export async function completeRun(
 ): Promise<JobChatRun | null> {
   const nowEpoch = Date.now();
   const nowIso = new Date(nowEpoch).toISOString();
-  const tenantId = getActiveTenantId();
 
   await db
     .update(jobChatRuns)
@@ -553,7 +528,7 @@ export async function completeRun(
       errorMessage: input.errorMessage ?? null,
       updatedAt: nowIso,
     })
-    .where(and(eq(jobChatRuns.tenantId, tenantId), eq(jobChatRuns.id, runId)));
+    .where(and(runsScopeFilter(), eq(jobChatRuns.id, runId)));
 
   return getRunById(runId);
 }
@@ -561,15 +536,9 @@ export async function completeRun(
 export async function deleteAllMessagesForThread(
   threadId: string,
 ): Promise<number> {
-  const tenantId = getActiveTenantId();
   const result = await db
     .delete(jobChatMessages)
-    .where(
-      and(
-        eq(jobChatMessages.tenantId, tenantId),
-        eq(jobChatMessages.threadId, threadId),
-      ),
-    );
+    .where(and(messagesScopeFilter(), eq(jobChatMessages.threadId, threadId)));
 
   return result.changes;
 }
@@ -577,15 +546,9 @@ export async function deleteAllMessagesForThread(
 export async function deleteAllRunsForThread(
   threadId: string,
 ): Promise<number> {
-  const tenantId = getActiveTenantId();
   const result = await db
     .delete(jobChatRuns)
-    .where(
-      and(
-        eq(jobChatRuns.tenantId, tenantId),
-        eq(jobChatRuns.threadId, threadId),
-      ),
-    );
+    .where(and(runsScopeFilter(), eq(jobChatRuns.threadId, threadId)));
 
   return result.changes;
 }
@@ -598,16 +561,10 @@ export async function setActiveRoot(
   messageId: string,
 ): Promise<void> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
   await db
     .update(jobChatThreads)
     .set({ activeRootMessageId: messageId, updatedAt: now })
-    .where(
-      and(
-        eq(jobChatThreads.tenantId, tenantId),
-        eq(jobChatThreads.id, threadId),
-      ),
-    );
+    .where(and(threadsScopeFilter(), eq(jobChatThreads.id, threadId)));
 }
 
 /**
@@ -618,16 +575,10 @@ export async function setActiveChild(
   activeChildId: string,
 ): Promise<void> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
   await db
     .update(jobChatMessages)
     .set({ activeChildId, updatedAt: now })
-    .where(
-      and(
-        eq(jobChatMessages.tenantId, tenantId),
-        eq(jobChatMessages.id, messageId),
-      ),
-    );
+    .where(and(messagesScopeFilter(), eq(jobChatMessages.id, messageId)));
 }
 
 /**
@@ -636,13 +587,12 @@ export async function setActiveChild(
 export async function getChildrenOfMessage(
   parentMessageId: string,
 ): Promise<JobChatMessage[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(jobChatMessages)
     .where(
       and(
-        eq(jobChatMessages.tenantId, tenantId),
+        messagesScopeFilter(),
         eq(jobChatMessages.parentMessageId, parentMessageId),
       ),
     )
@@ -668,6 +618,7 @@ export async function getSiblingsOf(
       .from(jobChatMessages)
       .where(
         and(
+          messagesScopeFilter(),
           eq(jobChatMessages.threadId, message.threadId),
           eq(jobChatMessages.role, message.role),
         ),
@@ -711,17 +662,11 @@ export async function getSiblingsOf(
 export async function getActivePathFromRoot(
   threadId: string,
 ): Promise<JobChatMessage[]> {
-  const tenantId = getActiveTenantId();
   // Load all messages for this thread into memory (fine for typical sizes)
   const allRows = await db
     .select()
     .from(jobChatMessages)
-    .where(
-      and(
-        eq(jobChatMessages.tenantId, tenantId),
-        eq(jobChatMessages.threadId, threadId),
-      ),
-    )
+    .where(and(messagesScopeFilter(), eq(jobChatMessages.threadId, threadId)))
     .orderBy(jobChatMessages.createdAt);
   const all = allRows.map(mapMessage);
 
@@ -806,7 +751,6 @@ export async function completeRunIfRunning(
 ): Promise<JobChatRun | null> {
   const nowEpoch = Date.now();
   const nowIso = new Date(nowEpoch).toISOString();
-  const tenantId = getActiveTenantId();
 
   await db
     .update(jobChatRuns)
@@ -819,7 +763,7 @@ export async function completeRunIfRunning(
     })
     .where(
       and(
-        eq(jobChatRuns.tenantId, tenantId),
+        runsScopeFilter(),
         eq(jobChatRuns.id, runId),
         eq(jobChatRuns.status, "running"),
       ),

--- a/orchestrator/src/server/repositories/job-documents.ts
+++ b/orchestrator/src/server/repositories/job-documents.ts
@@ -2,9 +2,16 @@ import { randomUUID } from "node:crypto";
 import type { JobDocument } from "@shared/types";
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { db, schema } from "../db/index";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { jobDocuments } = schema;
+
+function documentsScopeFilter() {
+  return privateDataScopeFilter(jobDocuments);
+}
 
 type CreateJobDocumentInput = {
   jobId: string;
@@ -34,13 +41,10 @@ function mapRowToJobDocument(
 }
 
 export async function listJobDocuments(jobId: string): Promise<JobDocument[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(jobDocuments)
-    .where(
-      and(eq(jobDocuments.tenantId, tenantId), eq(jobDocuments.jobId, jobId)),
-    )
+    .where(and(documentsScopeFilter(), eq(jobDocuments.jobId, jobId)))
     .orderBy(desc(jobDocuments.createdAt), desc(jobDocuments.id));
 
   return rows
@@ -51,13 +55,14 @@ export async function listJobDocuments(jobId: string): Promise<JobDocument[]> {
 export async function createJobDocument(
   input: CreateJobDocumentInput,
 ): Promise<JobDocument> {
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
   const now = new Date().toISOString();
   const id = randomUUID();
 
   await db.insert(jobDocuments).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     jobId: input.jobId,
     fileName: input.fileName,
     mediaType: input.mediaType,
@@ -79,13 +84,12 @@ export async function getJobDocumentForJob(
   jobId: string,
   documentId: string,
 ): Promise<JobDocumentWithStorage | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobDocuments)
     .where(
       and(
-        eq(jobDocuments.tenantId, tenantId),
+        documentsScopeFilter(),
         eq(jobDocuments.jobId, jobId),
         eq(jobDocuments.id, documentId),
       ),
@@ -100,13 +104,12 @@ export async function listJobDocumentsByIds(
 ): Promise<JobDocumentWithStorage[]> {
   if (documentIds.length === 0) return [];
 
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(jobDocuments)
     .where(
       and(
-        eq(jobDocuments.tenantId, tenantId),
+        documentsScopeFilter(),
         eq(jobDocuments.jobId, jobId),
         inArray(jobDocuments.id, [...documentIds]),
       ),
@@ -122,12 +125,11 @@ export async function deleteJobDocumentForJob(
   const document = await getJobDocumentForJob(jobId, documentId);
   if (!document) return null;
 
-  const tenantId = getActiveTenantId();
   await db
     .delete(jobDocuments)
     .where(
       and(
-        eq(jobDocuments.tenantId, tenantId),
+        documentsScopeFilter(),
         eq(jobDocuments.jobId, jobId),
         eq(jobDocuments.id, documentId),
       ),

--- a/orchestrator/src/server/repositories/jobs.ts
+++ b/orchestrator/src/server/repositories/jobs.ts
@@ -532,7 +532,7 @@ async function insertJob(input: CreateJobInput): Promise<Job> {
 
 function isJobUrlUniqueViolation(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  return /UNIQUE constraint failed: (jobs\.job_url|jobs\.tenant_id, jobs\.job_url|jobs\.tenant_id, jobs\.user_id, jobs\.job_url)/i.test(
+  return /UNIQUE constraint failed: (jobs\.job_url|jobs\.tenant_id, jobs\.job_url|jobs\.tenant_id, jobs\.user_id, jobs\.job_url|index ['"]idx_jobs_tenant_user_job_url_unique['"])/i.test(
     error.message,
   );
 }

--- a/orchestrator/src/server/repositories/jobs.ts
+++ b/orchestrator/src/server/repositories/jobs.ts
@@ -34,9 +34,20 @@ import {
   sql,
 } from "drizzle-orm";
 import { db, schema } from "../db/index";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { jobNotes, jobs } = schema;
+
+function jobsScopeFilter() {
+  return privateDataScopeFilter(jobs);
+}
+
+function jobNotesScopeFilter() {
+  return privateDataScopeFilter(jobNotes);
+}
 
 type AppliedDuplicateMatchCandidate = {
   id: string;
@@ -98,20 +109,17 @@ function serializeLocationEvidence(
  * Get all jobs, optionally filtered by status.
  */
 export async function getAllJobs(statuses?: JobStatus[]): Promise<Job[]> {
-  const tenantId = getActiveTenantId();
   const query =
     statuses && statuses.length > 0
       ? db
           .select()
           .from(jobs)
-          .where(
-            and(eq(jobs.tenantId, tenantId), inArray(jobs.status, statuses)),
-          )
+          .where(and(jobsScopeFilter(), inArray(jobs.status, statuses)))
           .orderBy(desc(jobs.discoveredAt))
       : db
           .select()
           .from(jobs)
-          .where(eq(jobs.tenantId, tenantId))
+          .where(jobsScopeFilter())
           .orderBy(desc(jobs.discoveredAt));
 
   const rows = await query;
@@ -124,7 +132,6 @@ export async function getAllJobs(statuses?: JobStatus[]): Promise<Job[]> {
 export async function getJobListItems(
   statuses?: JobStatus[],
 ): Promise<JobListItemWithPdfFreshnessInput[]> {
-  const tenantId = getActiveTenantId();
   const selection = {
     id: jobs.id,
     source: jobs.source,
@@ -169,14 +176,12 @@ export async function getJobListItems(
       ? db
           .select(selection)
           .from(jobs)
-          .where(
-            and(eq(jobs.tenantId, tenantId), inArray(jobs.status, statuses)),
-          )
+          .where(and(jobsScopeFilter(), inArray(jobs.status, statuses)))
           .orderBy(desc(jobs.discoveredAt))
       : db
           .select(selection)
           .from(jobs)
-          .where(eq(jobs.tenantId, tenantId))
+          .where(jobsScopeFilter())
           .orderBy(desc(jobs.discoveredAt));
 
   const rows = await query;
@@ -202,7 +207,6 @@ export async function getJobListItems(
 export async function getAppliedDuplicateMatchCandidates(): Promise<
   AppliedDuplicateMatchCandidate[]
 > {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select({
       id: jobs.id,
@@ -216,7 +220,7 @@ export async function getAppliedDuplicateMatchCandidates(): Promise<
     .where(
       and(
         inArray(jobs.status, ["applied", "in_progress"]),
-        eq(jobs.tenantId, tenantId),
+        jobsScopeFilter(),
         sql`${jobs.appliedAt} IS NOT NULL`,
       ),
     )
@@ -238,12 +242,11 @@ export async function getAppliedDuplicateMatchCandidates(): Promise<
 export async function getJobsRevision(
   statuses?: JobStatus[],
 ): Promise<JobsRevisionResponse> {
-  const tenantId = getActiveTenantId();
   const statusFilter = normalizeStatusFilter(statuses);
   const whereClause =
     statuses && statuses.length > 0
-      ? and(eq(jobs.tenantId, tenantId), inArray(jobs.status, statuses))
-      : eq(jobs.tenantId, tenantId);
+      ? and(jobsScopeFilter(), inArray(jobs.status, statuses))
+      : jobsScopeFilter();
 
   const baseQuery = db
     .select({
@@ -269,20 +272,18 @@ export async function getJobsRevision(
  * Get a single job by ID.
  */
 export async function getJobById(id: string): Promise<Job | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobs)
-    .where(and(eq(jobs.tenantId, tenantId), eq(jobs.id, id)));
+    .where(and(jobsScopeFilter(), eq(jobs.id, id)));
   return row ? mapRowToJob(row) : null;
 }
 
 export async function listJobNotes(jobId: string): Promise<JobNote[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(jobNotes)
-    .where(and(eq(jobNotes.tenantId, tenantId), eq(jobNotes.jobId, jobId)))
+    .where(and(jobNotesScopeFilter(), eq(jobNotes.jobId, jobId)))
     .orderBy(
       desc(jobNotes.updatedAt),
       desc(jobNotes.createdAt),
@@ -301,13 +302,12 @@ export async function listJobNotesByIds(
   );
   if (normalizedNoteIds.length === 0) return [];
 
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(jobNotes)
     .where(
       and(
-        eq(jobNotes.tenantId, tenantId),
+        jobNotesScopeFilter(),
         eq(jobNotes.jobId, jobId),
         inArray(jobNotes.id, normalizedNoteIds),
       ),
@@ -317,11 +317,10 @@ export async function listJobNotesByIds(
 }
 
 export async function getJobNoteById(noteId: string): Promise<JobNote | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobNotes)
-    .where(and(eq(jobNotes.tenantId, tenantId), eq(jobNotes.id, noteId)));
+    .where(and(jobNotesScopeFilter(), eq(jobNotes.id, noteId)));
   return row ? mapRowToJobNote(row) : null;
 }
 
@@ -329,13 +328,12 @@ export async function getJobNoteForJob(
   jobId: string,
   noteId: string,
 ): Promise<JobNote | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobNotes)
     .where(
       and(
-        eq(jobNotes.tenantId, tenantId),
+        jobNotesScopeFilter(),
         eq(jobNotes.id, noteId),
         eq(jobNotes.jobId, jobId),
       ),
@@ -348,11 +346,12 @@ export async function createJobNote(
 ): Promise<JobNote> {
   const id = randomUUID();
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   await db.insert(jobNotes).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     jobId: input.jobId,
     title: input.title,
     content: input.content,
@@ -371,7 +370,6 @@ export async function updateJobNote(
   input: { jobId: string; noteId: string } & UpdateJobNoteInput,
 ): Promise<JobNote | null> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
 
   await db
     .update(jobNotes)
@@ -382,7 +380,7 @@ export async function updateJobNote(
     })
     .where(
       and(
-        eq(jobNotes.tenantId, tenantId),
+        jobNotesScopeFilter(),
         eq(jobNotes.id, input.noteId),
         eq(jobNotes.jobId, input.jobId),
       ),
@@ -395,12 +393,11 @@ export async function deleteJobNote(input: {
   jobId: string;
   noteId: string;
 }): Promise<number> {
-  const tenantId = getActiveTenantId();
   const result = await db
     .delete(jobNotes)
     .where(
       and(
-        eq(jobNotes.tenantId, tenantId),
+        jobNotesScopeFilter(),
         eq(jobNotes.id, input.noteId),
         eq(jobNotes.jobId, input.jobId),
       ),
@@ -417,7 +414,6 @@ export async function listJobSummariesByIds(jobIds: string[]): Promise<
   }>
 > {
   if (jobIds.length === 0) return [];
-  const tenantId = getActiveTenantId();
 
   return db
     .select({
@@ -426,18 +422,17 @@ export async function listJobSummariesByIds(jobIds: string[]): Promise<
       employer: jobs.employer,
     })
     .from(jobs)
-    .where(and(eq(jobs.tenantId, tenantId), inArray(jobs.id, jobIds)));
+    .where(and(jobsScopeFilter(), inArray(jobs.id, jobIds)));
 }
 
 /**
  * Get a job by its URL (for deduplication).
  */
 export async function getJobByUrl(jobUrl: string): Promise<Job | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobs)
-    .where(and(eq(jobs.tenantId, tenantId), eq(jobs.jobUrl, jobUrl)));
+    .where(and(jobsScopeFilter(), eq(jobs.jobUrl, jobUrl)));
   return row ? mapRowToJob(row) : null;
 }
 
@@ -448,13 +443,12 @@ export async function getJobBySourceJobId(
   source: string,
   sourceJobId: string,
 ): Promise<Job | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(jobs)
     .where(
       and(
-        eq(jobs.tenantId, tenantId),
+        jobsScopeFilter(),
         eq(jobs.source, source),
         eq(jobs.sourceJobId, sourceJobId),
       ),
@@ -466,22 +460,22 @@ export async function getJobBySourceJobId(
  * Get all known job URLs (for deduplication / crawler optimizations).
  */
 export async function getAllJobUrls(): Promise<string[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select({ jobUrl: jobs.jobUrl })
     .from(jobs)
-    .where(eq(jobs.tenantId, tenantId));
+    .where(jobsScopeFilter());
   return rows.map((r) => r.jobUrl);
 }
 
 async function insertJob(input: CreateJobInput): Promise<Job> {
   const id = randomUUID();
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   await db.insert(jobs).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     source: input.source,
     sourceJobId: input.sourceJobId ?? null,
     jobUrlDirect: input.jobUrlDirect ?? null,
@@ -538,7 +532,7 @@ async function insertJob(input: CreateJobInput): Promise<Job> {
 
 function isJobUrlUniqueViolation(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  return /UNIQUE constraint failed: (jobs\.job_url|jobs\.tenant_id, jobs\.job_url)/i.test(
+  return /UNIQUE constraint failed: (jobs\.job_url|jobs\.tenant_id, jobs\.job_url|jobs\.tenant_id, jobs\.user_id, jobs\.job_url)/i.test(
     error.message,
   );
 }
@@ -598,12 +592,7 @@ export async function createJobs(
   const existingRows = await db
     .select({ jobUrl: jobs.jobUrl })
     .from(jobs)
-    .where(
-      and(
-        eq(jobs.tenantId, getActiveTenantId()),
-        inArray(jobs.jobUrl, uniqueUrls),
-      ),
-    );
+    .where(and(jobsScopeFilter(), inArray(jobs.jobUrl, uniqueUrls)));
   const existingUrlSet = new Set(existingRows.map((row) => row.jobUrl));
 
   for (const { input, count } of byUrl.values()) {
@@ -640,7 +629,12 @@ export async function updateJob(
   input: UpdateJobInput,
 ): Promise<Job | null> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
+  if (input.jobUrl !== undefined) {
+    const existing = await getJobByUrl(input.jobUrl);
+    if (existing && existing.id !== id) {
+      throw new Error("UNIQUE constraint failed: jobs.job_url");
+    }
+  }
   const { locationEvidence, ...updateFields } = input;
   const clearsBriefForDescriptionEdit =
     input.jobDescription !== undefined && input.jobBrief === undefined;
@@ -670,7 +664,7 @@ export async function updateJob(
       ...readyAtUpdate,
       ...appliedAtUpdate,
     })
-    .where(and(eq(jobs.tenantId, tenantId), eq(jobs.id, id)));
+    .where(and(jobsScopeFilter(), eq(jobs.id, id)));
 
   return getJobById(id);
 }
@@ -684,9 +678,8 @@ export async function finalizeGeneratedPdfIfCurrent(input: {
   pdfGeneratedAt: string;
 }): Promise<Job | null> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
   const conditions = [
-    eq(jobs.tenantId, tenantId),
+    jobsScopeFilter(),
     eq(jobs.id, input.id),
     eq(jobs.status, input.expectedStatus),
     eq(jobs.pdfRegenerating, true),
@@ -719,14 +712,13 @@ export async function finalizeGeneratedPdfIfCurrent(input: {
  * Get job statistics by status.
  */
 export async function getJobStats(): Promise<Record<JobStatus, number>> {
-  const tenantId = getActiveTenantId();
   const result = await db
     .select({
       status: jobs.status,
       count: sql<number>`count(*)`,
     })
     .from(jobs)
-    .where(eq(jobs.tenantId, tenantId))
+    .where(jobsScopeFilter())
     .groupBy(jobs.status);
 
   const stats: Record<JobStatus, number> = {
@@ -750,14 +742,13 @@ export async function getJobStats(): Promise<Record<JobStatus, number>> {
  * Get jobs ready for processing (discovered with description).
  */
 export async function getJobsForProcessing(limit: number = 10): Promise<Job[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(jobs)
     .where(
       and(
         eq(jobs.status, "discovered"),
-        eq(jobs.tenantId, tenantId),
+        jobsScopeFilter(),
         sql`${jobs.jobDescription} IS NOT NULL`,
       ),
     )
@@ -771,13 +762,12 @@ export async function getReadyJobsWithGeneratedPdfs(
   limit: number,
   offset = 0,
 ): Promise<Job[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(jobs)
     .where(
       and(
-        eq(jobs.tenantId, tenantId),
+        jobsScopeFilter(),
         eq(jobs.status, "ready"),
         eq(jobs.pdfSource, "generated"),
         isNotNull(jobs.pdfPath),
@@ -796,13 +786,12 @@ export async function getReadyJobsWithGeneratedPdfs(
 export async function getUnscoredDiscoveredJobs(
   limit?: number,
 ): Promise<Job[]> {
-  const tenantId = getActiveTenantId();
   const query = db
     .select()
     .from(jobs)
     .where(
       and(
-        eq(jobs.tenantId, tenantId),
+        jobsScopeFilter(),
         eq(jobs.status, "discovered"),
         isNull(jobs.suitabilityScore),
       ),
@@ -818,10 +807,9 @@ export async function getUnscoredDiscoveredJobs(
  * Delete jobs by status.
  */
 export async function deleteJobsByStatus(status: JobStatus): Promise<number> {
-  const tenantId = getActiveTenantId();
   const result = await db
     .delete(jobs)
-    .where(and(eq(jobs.tenantId, tenantId), eq(jobs.status, status)))
+    .where(and(jobsScopeFilter(), eq(jobs.status, status)))
     .run();
   return result.changes;
 }
@@ -830,13 +818,12 @@ export async function deleteJobsByStatus(status: JobStatus): Promise<number> {
  * Delete jobs with suitability score below threshold (excluding applied and in_progress jobs).
  */
 export async function deleteJobsBelowScore(threshold: number): Promise<number> {
-  const tenantId = getActiveTenantId();
   const result = await db
     .delete(jobs)
     .where(
       and(
         lt(jobs.suitabilityScore, threshold),
-        eq(jobs.tenantId, tenantId),
+        jobsScopeFilter(),
         ne(jobs.status, "applied"),
         ne(jobs.status, "in_progress"),
       ),

--- a/orchestrator/src/server/repositories/pipeline.ts
+++ b/orchestrator/src/server/repositories/pipeline.ts
@@ -12,9 +12,20 @@ import type {
 } from "@shared/types";
 import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db, schema } from "../db/index";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { jobs, pipelineRuns } = schema;
+
+function pipelineRunsScopeFilter() {
+  return privateDataScopeFilter(pipelineRuns);
+}
+
+function jobsScopeFilter() {
+  return privateDataScopeFilter(jobs);
+}
 
 function mapRowToPipelineRun(
   row: typeof schema.pipelineRuns.$inferSelect,
@@ -75,11 +86,12 @@ export async function createPipelineRun(args?: {
 }): Promise<PipelineRun> {
   const id = randomUUID();
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   await db.insert(pipelineRuns).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     startedAt: now,
     status: "running",
     configSnapshot: serializeConfigSnapshot(args?.configSnapshot ?? null),
@@ -116,7 +128,6 @@ export async function updatePipelineRun(
   }>,
 ): Promise<void> {
   const { configSnapshot, resultSummary, ...rest } = update;
-  const tenantId = getActiveTenantId();
   await db
     .update(pipelineRuns)
     .set({
@@ -130,18 +141,17 @@ export async function updatePipelineRun(
         ? { resultSummary: resultSummary ?? null }
         : {}),
     })
-    .where(and(eq(pipelineRuns.tenantId, tenantId), eq(pipelineRuns.id, id)));
+    .where(and(pipelineRunsScopeFilter(), eq(pipelineRuns.id, id)));
 }
 
 /**
  * Get the latest pipeline run.
  */
 export async function getLatestPipelineRun(): Promise<PipelineRun | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(pipelineRuns)
-    .where(eq(pipelineRuns.tenantId, tenantId))
+    .where(pipelineRunsScopeFilter())
     .orderBy(desc(pipelineRuns.startedAt))
     .limit(1);
 
@@ -156,11 +166,10 @@ export async function getLatestPipelineRun(): Promise<PipelineRun | null> {
 export async function getRecentPipelineRuns(
   limit: number = 10,
 ): Promise<PipelineRun[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(pipelineRuns)
-    .where(eq(pipelineRuns.tenantId, tenantId))
+    .where(pipelineRunsScopeFilter())
     .orderBy(desc(pipelineRuns.startedAt))
     .limit(limit);
 
@@ -170,11 +179,10 @@ export async function getRecentPipelineRuns(
 export async function getPipelineRunById(
   id: string,
 ): Promise<PipelineRun | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(pipelineRuns)
-    .where(and(eq(pipelineRuns.tenantId, tenantId), eq(pipelineRuns.id, id)))
+    .where(and(pipelineRunsScopeFilter(), eq(pipelineRuns.id, id)))
     .limit(1);
 
   return row ? mapRowToPipelineRun(row) : null;
@@ -183,11 +191,10 @@ export async function getPipelineRunById(
 export async function getPipelineRunInsights(
   id: string,
 ): Promise<PipelineRunInsights | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(pipelineRuns)
-    .where(and(eq(pipelineRuns.tenantId, tenantId), eq(pipelineRuns.id, id)))
+    .where(and(pipelineRunsScopeFilter(), eq(pipelineRuns.id, id)))
     .limit(1);
   if (!row) return null;
 
@@ -225,7 +232,7 @@ export async function getPipelineRunInsights(
         and(
           gte(jobs.createdAt, run.startedAt),
           lte(jobs.createdAt, run.completedAt),
-          eq(jobs.tenantId, tenantId),
+          jobsScopeFilter(),
         ),
       ),
     db
@@ -235,7 +242,7 @@ export async function getPipelineRunInsights(
         and(
           gte(jobs.updatedAt, run.startedAt),
           lte(jobs.updatedAt, run.completedAt),
-          eq(jobs.tenantId, tenantId),
+          jobsScopeFilter(),
         ),
       ),
     db
@@ -245,7 +252,7 @@ export async function getPipelineRunInsights(
         and(
           gte(jobs.processedAt, run.startedAt),
           lte(jobs.processedAt, run.completedAt),
-          eq(jobs.tenantId, tenantId),
+          jobsScopeFilter(),
         ),
       ),
   ]);

--- a/orchestrator/src/server/repositories/post-application-integrations.ts
+++ b/orchestrator/src/server/repositories/post-application-integrations.ts
@@ -6,9 +6,16 @@ import type {
 } from "@shared/types";
 import { and, eq } from "drizzle-orm";
 import { db, schema } from "../db";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { postApplicationIntegrations } = schema;
+
+function integrationsScopeFilter() {
+  return privateDataScopeFilter(postApplicationIntegrations);
+}
 
 type IntegrationCredentials = Record<string, unknown>;
 
@@ -57,7 +64,6 @@ export async function getPostApplicationIntegration(
   provider: PostApplicationProvider,
   accountKey: string,
 ): Promise<PostApplicationIntegration | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(postApplicationIntegrations)
@@ -65,7 +71,7 @@ export async function getPostApplicationIntegration(
       and(
         eq(postApplicationIntegrations.provider, provider),
         eq(postApplicationIntegrations.accountKey, accountKey),
-        eq(postApplicationIntegrations.tenantId, tenantId),
+        integrationsScopeFilter(),
       ),
     );
 
@@ -77,7 +83,7 @@ export async function upsertConnectedPostApplicationIntegration(
 ): Promise<PostApplicationIntegration> {
   const nowEpoch = Date.now();
   const nowIso = new Date(nowEpoch).toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
   const existing = await getPostApplicationIntegration(
     input.provider,
     input.accountKey,
@@ -111,7 +117,8 @@ export async function upsertConnectedPostApplicationIntegration(
   const id = randomUUID();
   await db.insert(postApplicationIntegrations).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     provider: input.provider,
     accountKey: input.accountKey,
     displayName: input.displayName ?? null,
@@ -151,7 +158,12 @@ export async function disconnectPostApplicationIntegration(
       lastError: null,
       updatedAt: nowIso,
     })
-    .where(eq(postApplicationIntegrations.id, existing.id));
+    .where(
+      and(
+        integrationsScopeFilter(),
+        eq(postApplicationIntegrations.id, existing.id),
+      ),
+    );
 
   return getPostApplicationIntegration(provider, accountKey);
 }
@@ -179,7 +191,12 @@ export async function updatePostApplicationIntegrationSyncState(
         : {}),
       updatedAt: nowIso,
     })
-    .where(eq(postApplicationIntegrations.id, existing.id));
+    .where(
+      and(
+        integrationsScopeFilter(),
+        eq(postApplicationIntegrations.id, existing.id),
+      ),
+    );
 
   return getPostApplicationIntegration(input.provider, input.accountKey);
 }

--- a/orchestrator/src/server/repositories/post-application-messages.ts
+++ b/orchestrator/src/server/repositories/post-application-messages.ts
@@ -14,9 +14,20 @@ import {
   normalizeStageTarget,
   stageTargetFromMessageType,
 } from "../services/post-application/stage-target";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { postApplicationIntegrations, postApplicationMessages } = schema;
+
+function messagesScopeFilter() {
+  return privateDataScopeFilter(postApplicationMessages);
+}
+
+function integrationsScopeFilter() {
+  return privateDataScopeFilter(postApplicationIntegrations);
+}
 
 type UpsertPostApplicationMessageInput = {
   provider: PostApplicationProvider;
@@ -148,7 +159,6 @@ function integrationKey(
 async function listIntegrationDisplayMetadata(): Promise<
   PostApplicationIntegrationDisplayMetadata[]
 > {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select({
       id: postApplicationIntegrations.id,
@@ -157,7 +167,7 @@ async function listIntegrationDisplayMetadata(): Promise<
       displayName: postApplicationIntegrations.displayName,
     })
     .from(postApplicationIntegrations)
-    .where(eq(postApplicationIntegrations.tenantId, tenantId));
+    .where(integrationsScopeFilter());
 
   return rows.map((row) => ({
     id: row.id,
@@ -172,7 +182,6 @@ export async function getPostApplicationMessageByExternalId(
   accountKey: string,
   externalMessageId: string,
 ): Promise<PostApplicationMessage | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(postApplicationMessages)
@@ -181,7 +190,7 @@ export async function getPostApplicationMessageByExternalId(
         eq(postApplicationMessages.provider, provider),
         eq(postApplicationMessages.accountKey, accountKey),
         eq(postApplicationMessages.externalMessageId, externalMessageId),
-        eq(postApplicationMessages.tenantId, tenantId),
+        messagesScopeFilter(),
       ),
     );
   return row ? mapRowToPostApplicationMessage(row) : null;
@@ -190,16 +199,10 @@ export async function getPostApplicationMessageByExternalId(
 export async function getPostApplicationMessageById(
   id: string,
 ): Promise<PostApplicationMessage | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(postApplicationMessages)
-    .where(
-      and(
-        eq(postApplicationMessages.tenantId, tenantId),
-        eq(postApplicationMessages.id, id),
-      ),
-    );
+    .where(and(messagesScopeFilter(), eq(postApplicationMessages.id, id)));
   return row ? mapRowToPostApplicationMessage(row) : null;
 }
 
@@ -215,7 +218,7 @@ export async function upsertPostApplicationMessage(
     suggestedStageTarget: stageTarget,
   };
   const nowIso = new Date().toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
   const existing =
     input.existingMessage ??
     (await getPostApplicationMessageByExternalId(
@@ -263,10 +266,7 @@ export async function upsertPostApplicationMessage(
         updatedAt: nowIso,
       })
       .where(
-        and(
-          eq(postApplicationMessages.tenantId, tenantId),
-          eq(postApplicationMessages.id, existing.id),
-        ),
+        and(messagesScopeFilter(), eq(postApplicationMessages.id, existing.id)),
       );
 
     const updated = await getPostApplicationMessageByExternalId(
@@ -290,7 +290,8 @@ export async function upsertPostApplicationMessage(
   const id = randomUUID();
   await db.insert(postApplicationMessages).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     provider: input.provider,
     accountKey: input.accountKey,
     integrationId: input.integrationId,
@@ -343,7 +344,6 @@ export async function updatePostApplicationMessageSuggestion(
   input: UpdatePostApplicationMessageSuggestionInput,
 ): Promise<PostApplicationMessage | null> {
   const nowIso = new Date().toISOString();
-  const tenantId = getActiveTenantId();
   await db
     .update(postApplicationMessages)
     .set({
@@ -355,20 +355,14 @@ export async function updatePostApplicationMessageSuggestion(
       updatedAt: nowIso,
     })
     .where(
-      and(
-        eq(postApplicationMessages.tenantId, tenantId),
-        eq(postApplicationMessages.id, input.id),
-      ),
+      and(messagesScopeFilter(), eq(postApplicationMessages.id, input.id)),
     );
 
   const [row] = await db
     .select()
     .from(postApplicationMessages)
     .where(
-      and(
-        eq(postApplicationMessages.tenantId, tenantId),
-        eq(postApplicationMessages.id, input.id),
-      ),
+      and(messagesScopeFilter(), eq(postApplicationMessages.id, input.id)),
     );
   return row ? mapRowToPostApplicationMessage(row) : null;
 }
@@ -379,7 +373,6 @@ export async function listPostApplicationMessagesByProcessingStatus(
   processingStatus: PostApplicationProcessingStatus,
   limit = 50,
 ): Promise<PostApplicationMessage[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(postApplicationMessages)
@@ -388,7 +381,7 @@ export async function listPostApplicationMessagesByProcessingStatus(
         eq(postApplicationMessages.provider, provider),
         eq(postApplicationMessages.accountKey, accountKey),
         eq(postApplicationMessages.processingStatus, processingStatus),
-        eq(postApplicationMessages.tenantId, tenantId),
+        messagesScopeFilter(),
       ),
     )
     .orderBy(desc(postApplicationMessages.receivedAt))
@@ -403,7 +396,6 @@ export async function listPostApplicationMessagesBySyncRun(
   syncRunId: string,
   limit = 300,
 ): Promise<PostApplicationMessage[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(postApplicationMessages)
@@ -412,7 +404,7 @@ export async function listPostApplicationMessagesBySyncRun(
         eq(postApplicationMessages.provider, provider),
         eq(postApplicationMessages.accountKey, accountKey),
         eq(postApplicationMessages.syncRunId, syncRunId),
-        eq(postApplicationMessages.tenantId, tenantId),
+        messagesScopeFilter(),
       ),
     )
     .orderBy(desc(postApplicationMessages.receivedAt))
@@ -425,9 +417,8 @@ export async function listPostApplicationMessagesForJob(
   jobId: string,
   limit = 100,
 ): Promise<ListPostApplicationMessagesForJobResult> {
-  const tenantId = getActiveTenantId();
   const whereClause = and(
-    eq(postApplicationMessages.tenantId, tenantId),
+    messagesScopeFilter(),
     eq(postApplicationMessages.matchedJobId, jobId),
   );
   const rows = await db
@@ -481,13 +472,12 @@ export async function listPostApplicationMessagesForJobByIds(
   );
   if (ids.length === 0) return [];
 
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(postApplicationMessages)
     .where(
       and(
-        eq(postApplicationMessages.tenantId, tenantId),
+        messagesScopeFilter(),
         eq(postApplicationMessages.matchedJobId, jobId),
         inArray(postApplicationMessages.id, ids),
       ),
@@ -532,7 +522,6 @@ export async function updatePostApplicationMessageDecision(
 ): Promise<PostApplicationMessage | null> {
   const decidedAt = input.decidedAt ?? Date.now();
   const nowIso = new Date(decidedAt).toISOString();
-  const tenantId = getActiveTenantId();
 
   await db
     .update(postApplicationMessages)
@@ -544,20 +533,14 @@ export async function updatePostApplicationMessageDecision(
       updatedAt: nowIso,
     })
     .where(
-      and(
-        eq(postApplicationMessages.tenantId, tenantId),
-        eq(postApplicationMessages.id, input.id),
-      ),
+      and(messagesScopeFilter(), eq(postApplicationMessages.id, input.id)),
     );
 
   const [row] = await db
     .select()
     .from(postApplicationMessages)
     .where(
-      and(
-        eq(postApplicationMessages.tenantId, tenantId),
-        eq(postApplicationMessages.id, input.id),
-      ),
+      and(messagesScopeFilter(), eq(postApplicationMessages.id, input.id)),
     );
   return row ? mapRowToPostApplicationMessage(row) : null;
 }

--- a/orchestrator/src/server/repositories/post-application-sync-runs.ts
+++ b/orchestrator/src/server/repositories/post-application-sync-runs.ts
@@ -6,9 +6,16 @@ import type {
 } from "@shared/types";
 import { and, desc, eq } from "drizzle-orm";
 import { db, schema } from "../db";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { postApplicationSyncRuns } = schema;
+
+function syncRunsScopeFilter() {
+  return privateDataScopeFilter(postApplicationSyncRuns);
+}
 
 type StartPostApplicationSyncRunInput = {
   provider: PostApplicationProvider;
@@ -61,11 +68,12 @@ export async function startPostApplicationSyncRun(
   const id = randomUUID();
   const nowEpoch = Date.now();
   const nowIso = new Date(nowEpoch).toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   await db.insert(postApplicationSyncRuns).values({
     id,
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     provider: input.provider,
     accountKey: input.accountKey,
     integrationId: input.integrationId,
@@ -97,7 +105,6 @@ export async function completePostApplicationSyncRun(
 ): Promise<PostApplicationSyncRun | null> {
   const nowEpoch = Date.now();
   const nowIso = new Date(nowEpoch).toISOString();
-  const tenantId = getActiveTenantId();
 
   await db
     .update(postApplicationSyncRuns)
@@ -116,10 +123,7 @@ export async function completePostApplicationSyncRun(
       updatedAt: nowIso,
     })
     .where(
-      and(
-        eq(postApplicationSyncRuns.tenantId, tenantId),
-        eq(postApplicationSyncRuns.id, input.id),
-      ),
+      and(syncRunsScopeFilter(), eq(postApplicationSyncRuns.id, input.id)),
     );
 
   return getPostApplicationSyncRunById(input.id);
@@ -128,16 +132,10 @@ export async function completePostApplicationSyncRun(
 export async function getPostApplicationSyncRunById(
   id: string,
 ): Promise<PostApplicationSyncRun | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(postApplicationSyncRuns)
-    .where(
-      and(
-        eq(postApplicationSyncRuns.tenantId, tenantId),
-        eq(postApplicationSyncRuns.id, id),
-      ),
-    );
+    .where(and(syncRunsScopeFilter(), eq(postApplicationSyncRuns.id, id)));
   return row ? mapRowToSyncRun(row) : null;
 }
 
@@ -146,7 +144,6 @@ export async function listPostApplicationSyncRuns(
   accountKey: string,
   limit = 20,
 ): Promise<PostApplicationSyncRun[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(postApplicationSyncRuns)
@@ -154,7 +151,7 @@ export async function listPostApplicationSyncRuns(
       and(
         eq(postApplicationSyncRuns.provider, provider),
         eq(postApplicationSyncRuns.accountKey, accountKey),
-        eq(postApplicationSyncRuns.tenantId, tenantId),
+        syncRunsScopeFilter(),
       ),
     )
     .orderBy(desc(postApplicationSyncRuns.startedAt))

--- a/orchestrator/src/server/repositories/product-analytics.ts
+++ b/orchestrator/src/server/repositories/product-analytics.ts
@@ -1,6 +1,13 @@
 import { randomUUID } from "node:crypto";
 import { db, schema } from "@server/db";
+import {
+  getPrivateDataScope,
+  isHostedUserIsolationEnabled,
+  privateDataScopeFilter,
+} from "@server/tenancy/private-scope";
+import type { SQL } from "drizzle-orm";
 import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
 
 const {
   analyticsInstallState,
@@ -48,6 +55,10 @@ const INTERVIEW_STAGES = [
 
 type InstallState = typeof analyticsInstallState.$inferSelect;
 type MilestoneRow = typeof analyticsMilestones.$inferSelect;
+type UserScopedAnalyticsTable = {
+  tenantId: AnySQLiteColumn;
+  userId: AnySQLiteColumn;
+};
 
 type Primitive = string | number | boolean | null;
 
@@ -60,6 +71,7 @@ export type HistoricalServerEventReplayCandidate = {
 };
 
 const RAW_EVENT_REPLAY_CLAIM_STALE_MS = 10 * 60 * 1000;
+const HOSTED_ANALYTICS_SCOPE_SEPARATOR = "::";
 const HISTORICAL_REPLAY_EVENT_RANK: Record<string, number> = {
   jobs_pipeline_run_started: 0,
   application_marked_applied: 1,
@@ -71,6 +83,52 @@ const HISTORICAL_REPLAY_EVENT_RANK: Record<string, number> = {
   tracking_email_matched: 7,
   tracer_human_click_recorded: 8,
 };
+
+function getAnalyticsInstallStateId(): string {
+  if (!isHostedUserIsolationEnabled()) return ANALYTICS_INSTALL_STATE_ID;
+  const scope = getPrivateDataScope();
+  return `${scope.tenantId}${HOSTED_ANALYTICS_SCOPE_SEPARATOR}${scope.userId}`;
+}
+
+function analyticsPrivateDataFilter(table: UserScopedAnalyticsTable): SQL {
+  return isHostedUserIsolationEnabled()
+    ? privateDataScopeFilter(table)
+    : sql`1 = 1`;
+}
+
+function toScopedActivationMilestone(milestone: ActivationMilestone): string {
+  const stateId = getAnalyticsInstallStateId();
+  if (stateId === ANALYTICS_INSTALL_STATE_ID) return milestone;
+  return `${stateId}${HOSTED_ANALYTICS_SCOPE_SEPARATOR}${milestone}`;
+}
+
+function toScopedActivationMilestones(): string[] {
+  return ACTIVATION_MILESTONES.map((milestone) =>
+    toScopedActivationMilestone(milestone),
+  );
+}
+
+function fromScopedActivationMilestone(milestone: string): string {
+  const stateId = getAnalyticsInstallStateId();
+  if (stateId === ANALYTICS_INSTALL_STATE_ID) return milestone;
+  const prefix = `${stateId}${HOSTED_ANALYTICS_SCOPE_SEPARATOR}`;
+  return milestone.startsWith(prefix)
+    ? milestone.slice(prefix.length)
+    : milestone;
+}
+
+function mapMilestoneRow(row: MilestoneRow): MilestoneRow {
+  return {
+    ...row,
+    milestone: fromScopedActivationMilestone(row.milestone),
+  };
+}
+
+function toScopedServerEventKey(eventKey: string): string {
+  const stateId = getAnalyticsInstallStateId();
+  if (stateId === ANALYTICS_INSTALL_STATE_ID) return eventKey;
+  return `${stateId}${HOSTED_ANALYTICS_SCOPE_SEPARATOR}${eventKey}`;
+}
 
 function toEpochMs(value: string | number | null | undefined): number | null {
   if (typeof value === "number") {
@@ -175,31 +233,40 @@ async function estimateInstallTimestampMs(): Promise<number> {
     earliestIntegrationCreatedAt,
     earliestTracerLinkCreatedAt,
   ] = await Promise.all([
-    db.select({ value: sql<string | null>`min(${jobs.createdAt})` }).from(jobs),
+    db
+      .select({ value: sql<string | null>`min(${jobs.createdAt})` })
+      .from(jobs)
+      .where(analyticsPrivateDataFilter(jobs)),
     db
       .select({ value: sql<string | null>`min(${pipelineRuns.startedAt})` })
-      .from(pipelineRuns),
+      .from(pipelineRuns)
+      .where(analyticsPrivateDataFilter(pipelineRuns)),
     db
       .select({ value: sql<string | null>`min(${settings.createdAt})` })
-      .from(settings),
+      .from(settings)
+      .where(analyticsPrivateDataFilter(settings)),
     db
       .select({ value: sql<string | null>`min(${authSessions.createdAt})` })
-      .from(authSessions),
+      .from(authSessions)
+      .where(analyticsPrivateDataFilter(authSessions)),
     db
       .select({
         value: sql<string | null>`min(${designResumeDocuments.createdAt})`,
       })
-      .from(designResumeDocuments),
+      .from(designResumeDocuments)
+      .where(analyticsPrivateDataFilter(designResumeDocuments)),
     db
       .select({
         value: sql<
           string | null
         >`min(${postApplicationIntegrations.createdAt})`,
       })
-      .from(postApplicationIntegrations),
+      .from(postApplicationIntegrations)
+      .where(analyticsPrivateDataFilter(postApplicationIntegrations)),
     db
       .select({ value: sql<string | null>`min(${tracerLinks.createdAt})` })
-      .from(tracerLinks),
+      .from(tracerLinks)
+      .where(analyticsPrivateDataFilter(tracerLinks)),
   ]);
 
   const installTimestampCandidates = [
@@ -226,10 +293,11 @@ function mapInstallState(row: InstallState): InstallState {
 }
 
 export async function getAnalyticsInstallState(): Promise<InstallState | null> {
+  const installStateId = getAnalyticsInstallStateId();
   const [row] = await db
     .select()
     .from(analyticsInstallState)
-    .where(eq(analyticsInstallState.id, ANALYTICS_INSTALL_STATE_ID))
+    .where(eq(analyticsInstallState.id, installStateId))
     .limit(1);
   return row ? mapInstallState(row) : null;
 }
@@ -243,7 +311,7 @@ export async function getOrCreateAnalyticsInstallState(): Promise<InstallState> 
 
   try {
     await db.insert(analyticsInstallState).values({
-      id: ANALYTICS_INSTALL_STATE_ID,
+      id: getAnalyticsInstallStateId(),
       distinctId: randomUUID(),
       installedAt,
       createdAt: now,
@@ -263,21 +331,25 @@ export async function getOrCreateAnalyticsInstallState(): Promise<InstallState> 
 }
 
 export async function listActivationMilestones(): Promise<MilestoneRow[]> {
-  return db
+  const rows = await db
     .select()
     .from(analyticsMilestones)
-    .where(inArray(analyticsMilestones.milestone, [...ACTIVATION_MILESTONES]));
+    .where(
+      inArray(analyticsMilestones.milestone, toScopedActivationMilestones()),
+    );
+  return rows.map(mapMilestoneRow);
 }
 
 export async function getActivationMilestone(
   milestone: ActivationMilestone,
 ): Promise<MilestoneRow | null> {
+  const scopedMilestone = toScopedActivationMilestone(milestone);
   const [row] = await db
     .select()
     .from(analyticsMilestones)
-    .where(eq(analyticsMilestones.milestone, milestone))
+    .where(eq(analyticsMilestones.milestone, scopedMilestone))
     .limit(1);
-  return row ?? null;
+  return row ? mapMilestoneRow(row) : null;
 }
 
 export async function recordActivationMilestone(args: {
@@ -293,7 +365,7 @@ export async function recordActivationMilestone(args: {
 
   if (!existing) {
     await db.insert(analyticsMilestones).values({
-      milestone: args.milestone,
+      milestone: toScopedActivationMilestone(args.milestone),
       firstSeenAt: args.firstSeenAt,
       firstSessionId: args.sessionId ?? null,
       reportedAt: null,
@@ -315,7 +387,12 @@ export async function recordActivationMilestone(args: {
         ...(args.sessionId ? { firstSessionId: args.sessionId } : {}),
         updatedAt: now,
       })
-      .where(eq(analyticsMilestones.milestone, args.milestone));
+      .where(
+        eq(
+          analyticsMilestones.milestone,
+          toScopedActivationMilestone(args.milestone),
+        ),
+      );
     const updated = await getActivationMilestone(args.milestone);
     if (!updated) {
       throw new Error(`Failed to update milestone '${args.milestone}'`);
@@ -339,7 +416,12 @@ export async function setActivationMilestoneFromHistory(args: {
       firstSessionId: null,
       updatedAt: now,
     })
-    .where(eq(analyticsMilestones.milestone, args.milestone));
+    .where(
+      eq(
+        analyticsMilestones.milestone,
+        toScopedActivationMilestone(args.milestone),
+      ),
+    );
 
   const updated = await getActivationMilestone(args.milestone);
   if (!updated) {
@@ -354,7 +436,9 @@ export async function deleteActivationMilestone(
 ): Promise<void> {
   await db
     .delete(analyticsMilestones)
-    .where(eq(analyticsMilestones.milestone, milestone));
+    .where(
+      eq(analyticsMilestones.milestone, toScopedActivationMilestone(milestone)),
+    );
 }
 
 export async function markActivationMilestoneReported(
@@ -366,21 +450,24 @@ export async function markActivationMilestoneReported(
       reportedAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     })
-    .where(eq(analyticsMilestones.milestone, milestone));
+    .where(
+      eq(analyticsMilestones.milestone, toScopedActivationMilestone(milestone)),
+    );
 }
 
 export async function listPendingActivationMilestones(): Promise<
   MilestoneRow[]
 > {
-  return db
+  const rows = await db
     .select()
     .from(analyticsMilestones)
     .where(
       and(
-        inArray(analyticsMilestones.milestone, [...ACTIVATION_MILESTONES]),
+        inArray(analyticsMilestones.milestone, toScopedActivationMilestones()),
         sql`${analyticsMilestones.reportedAt} IS NULL`,
       ),
     );
+  return rows.map(mapMilestoneRow);
 }
 
 export async function getHistoricalActivationMilestoneCandidates(): Promise<
@@ -397,31 +484,58 @@ export async function getHistoricalActivationMilestoneCandidates(): Promise<
   ] = await Promise.all([
     db
       .select({ value: sql<string | null>`min(${pipelineRuns.startedAt})` })
-      .from(pipelineRuns),
+      .from(pipelineRuns)
+      .where(analyticsPrivateDataFilter(pipelineRuns)),
     db
       .select({ value: sql<string | null>`min(${jobs.appliedAt})` })
       .from(jobs)
-      .where(isNotNull(jobs.appliedAt)),
+      .where(and(analyticsPrivateDataFilter(jobs), isNotNull(jobs.appliedAt))),
     db
       .select({ value: sql<number | null>`min(${stageEvents.occurredAt})` })
       .from(stageEvents)
-      .where(inArray(stageEvents.toStage, [...POSITIVE_RESPONSE_STAGES])),
+      .where(
+        and(
+          analyticsPrivateDataFilter(stageEvents),
+          inArray(stageEvents.toStage, [...POSITIVE_RESPONSE_STAGES]),
+        ),
+      ),
     db
       .select({ value: sql<number | null>`min(${stageEvents.occurredAt})` })
       .from(stageEvents)
-      .where(inArray(stageEvents.toStage, [...INTERVIEW_STAGES])),
+      .where(
+        and(
+          analyticsPrivateDataFilter(stageEvents),
+          inArray(stageEvents.toStage, [...INTERVIEW_STAGES]),
+        ),
+      ),
     db
       .select({ value: sql<number | null>`min(${stageEvents.occurredAt})` })
       .from(stageEvents)
-      .where(eq(stageEvents.toStage, "offer")),
+      .where(
+        and(
+          analyticsPrivateDataFilter(stageEvents),
+          eq(stageEvents.toStage, "offer"),
+        ),
+      ),
     db
       .select({ value: sql<number | null>`min(${jobs.closedAt})` })
       .from(jobs)
-      .where(and(eq(jobs.outcome, "offer_accepted"), isNotNull(jobs.closedAt))),
+      .where(
+        and(
+          analyticsPrivateDataFilter(jobs),
+          eq(jobs.outcome, "offer_accepted"),
+          isNotNull(jobs.closedAt),
+        ),
+      ),
     db
       .select({ value: sql<number | null>`min(${stageEvents.occurredAt})` })
       .from(stageEvents)
-      .where(eq(stageEvents.outcome, "offer_accepted")),
+      .where(
+        and(
+          analyticsPrivateDataFilter(stageEvents),
+          eq(stageEvents.outcome, "offer_accepted"),
+        ),
+      ),
   ]);
 
   const earliestPipelineRunValue = earliestPipelineRun[0]?.value ?? null;
@@ -482,7 +596,7 @@ export async function markAnalyticsRawEventReplayCompleted(args: {
   completedAt?: string;
 }): Promise<void> {
   const now = new Date().toISOString();
-  await getOrCreateAnalyticsInstallState();
+  const installState = await getOrCreateAnalyticsInstallState();
   await db
     .update(analyticsInstallState)
     .set({
@@ -490,7 +604,7 @@ export async function markAnalyticsRawEventReplayCompleted(args: {
       rawEventReplayCompletedAt: args.completedAt ?? now,
       updatedAt: now,
     })
-    .where(eq(analyticsInstallState.id, ANALYTICS_INSTALL_STATE_ID));
+    .where(eq(analyticsInstallState.id, installState.id));
 }
 
 export async function claimAnalyticsServerEventReplay(args: {
@@ -499,6 +613,7 @@ export async function claimAnalyticsServerEventReplay(args: {
   occurredAt: number;
   payload: Record<string, Primitive> | undefined;
 }): Promise<boolean> {
+  const eventKey = toScopedServerEventKey(args.eventKey);
   const nowMs = Date.now();
   const nowIso = new Date(nowMs).toISOString();
   const staleBefore = nowMs - RAW_EVENT_REPLAY_CLAIM_STALE_MS;
@@ -514,7 +629,7 @@ export async function claimAnalyticsServerEventReplay(args: {
     })
     .where(
       and(
-        eq(analyticsServerEventReplays.eventKey, args.eventKey),
+        eq(analyticsServerEventReplays.eventKey, eventKey),
         sql`${analyticsServerEventReplays.reportedAt} IS NULL`,
         sql`(${analyticsServerEventReplays.claimedAt} IS NULL OR ${analyticsServerEventReplays.claimedAt} < ${staleBefore})`,
       ),
@@ -526,7 +641,7 @@ export async function claimAnalyticsServerEventReplay(args: {
 
   try {
     await db.insert(analyticsServerEventReplays).values({
-      eventKey: args.eventKey,
+      eventKey,
       eventName: args.eventName,
       occurredAt: args.occurredAt,
       payload: args.payload ?? {},
@@ -540,7 +655,7 @@ export async function claimAnalyticsServerEventReplay(args: {
     const [existing] = await db
       .select()
       .from(analyticsServerEventReplays)
-      .where(eq(analyticsServerEventReplays.eventKey, args.eventKey))
+      .where(eq(analyticsServerEventReplays.eventKey, eventKey))
       .limit(1);
 
     if (!existing || existing.reportedAt !== null) {
@@ -564,7 +679,7 @@ export async function claimAnalyticsServerEventReplay(args: {
       })
       .where(
         and(
-          eq(analyticsServerEventReplays.eventKey, args.eventKey),
+          eq(analyticsServerEventReplays.eventKey, eventKey),
           sql`${analyticsServerEventReplays.reportedAt} IS NULL`,
           sql`(${analyticsServerEventReplays.claimedAt} IS NULL OR ${analyticsServerEventReplays.claimedAt} < ${staleBefore})`,
         ),
@@ -577,6 +692,7 @@ export async function claimAnalyticsServerEventReplay(args: {
 export async function markAnalyticsServerEventReplayDelivered(
   eventKey: string,
 ): Promise<void> {
+  const scopedEventKey = toScopedServerEventKey(eventKey);
   const nowMs = Date.now();
   const nowIso = new Date(nowMs).toISOString();
 
@@ -586,13 +702,14 @@ export async function markAnalyticsServerEventReplayDelivered(
       reportedAt: nowMs,
       updatedAt: nowIso,
     })
-    .where(eq(analyticsServerEventReplays.eventKey, eventKey));
+    .where(eq(analyticsServerEventReplays.eventKey, scopedEventKey));
 }
 
 export async function hasPendingAnalyticsServerEventReplays(
   eventKeys: string[],
 ): Promise<boolean> {
   if (eventKeys.length === 0) return false;
+  const scopedEventKeys = eventKeys.map(toScopedServerEventKey);
 
   const [row] = await db
     .select({
@@ -601,7 +718,7 @@ export async function hasPendingAnalyticsServerEventReplays(
     .from(analyticsServerEventReplays)
     .where(
       and(
-        inArray(analyticsServerEventReplays.eventKey, [...eventKeys]),
+        inArray(analyticsServerEventReplays.eventKey, scopedEventKeys),
         sql`${analyticsServerEventReplays.reportedAt} IS NULL`,
       ),
     )
@@ -622,7 +739,8 @@ export async function getHistoricalServerEventReplayCandidates(args: {
           id: pipelineRuns.id,
           startedAt: pipelineRuns.startedAt,
         })
-        .from(pipelineRuns),
+        .from(pipelineRuns)
+        .where(analyticsPrivateDataFilter(pipelineRuns)),
       db
         .select({
           id: stageEvents.id,
@@ -633,7 +751,12 @@ export async function getHistoricalServerEventReplayCandidates(args: {
           outcome: stageEvents.outcome,
         })
         .from(stageEvents)
-        .where(sql`${stageEvents.occurredAt} < ${cutoffSeconds}`),
+        .where(
+          and(
+            analyticsPrivateDataFilter(stageEvents),
+            sql`${stageEvents.occurredAt} < ${cutoffSeconds}`,
+          ),
+        ),
       db
         .select({
           id: postApplicationMessages.id,
@@ -645,6 +768,7 @@ export async function getHistoricalServerEventReplayCandidates(args: {
         .from(postApplicationMessages)
         .where(
           and(
+            analyticsPrivateDataFilter(postApplicationMessages),
             inArray(postApplicationMessages.processingStatus, [
               "auto_linked",
               "manual_linked",
@@ -662,7 +786,12 @@ export async function getHistoricalServerEventReplayCandidates(args: {
           referrerHost: tracerClickEvents.referrerHost,
         })
         .from(tracerClickEvents)
-        .where(sql`${tracerClickEvents.clickedAt} < ${cutoffSeconds}`),
+        .where(
+          and(
+            analyticsPrivateDataFilter(tracerClickEvents),
+            sql`${tracerClickEvents.clickedAt} < ${cutoffSeconds}`,
+          ),
+        ),
     ]);
 
   const candidates: HistoricalServerEventReplayCandidate[] = [];

--- a/orchestrator/src/server/repositories/settings.ts
+++ b/orchestrator/src/server/repositories/settings.ts
@@ -5,9 +5,16 @@
 import type { settingsRegistry } from "@shared/settings-registry";
 import { and, eq } from "drizzle-orm";
 import { db, schema } from "../db/index";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { settings } = schema;
+
+function settingsScopeFilter() {
+  return privateDataScopeFilter(settings);
+}
 
 export type SettingKey = Exclude<
   {
@@ -19,22 +26,17 @@ export type SettingKey = Exclude<
 >;
 
 export async function getSetting(key: SettingKey): Promise<string | null> {
-  const tenantId = getActiveTenantId();
   const [row] = await db
     .select()
     .from(settings)
-    .where(and(eq(settings.tenantId, tenantId), eq(settings.key, key)));
+    .where(and(settingsScopeFilter(), eq(settings.key, key)));
   return row?.value ?? null;
 }
 
 export async function getAllSettings(): Promise<
   Partial<Record<SettingKey, string>>
 > {
-  const tenantId = getActiveTenantId();
-  const rows = await db
-    .select()
-    .from(settings)
-    .where(eq(settings.tenantId, tenantId));
+  const rows = await db.select().from(settings).where(settingsScopeFilter());
   return rows.reduce(
     (acc, row) => {
       acc[row.key as SettingKey] = row.value;
@@ -49,30 +51,31 @@ export async function setSetting(
   value: string | null,
 ): Promise<void> {
   const now = new Date().toISOString();
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   if (value === null) {
     await db
       .delete(settings)
-      .where(and(eq(settings.tenantId, tenantId), eq(settings.key, key)));
+      .where(and(settingsScopeFilter(), eq(settings.key, key)));
     return;
   }
 
   const [existing] = await db
     .select({ key: settings.key })
     .from(settings)
-    .where(and(eq(settings.tenantId, tenantId), eq(settings.key, key)));
+    .where(and(settingsScopeFilter(), eq(settings.key, key)));
 
   if (existing) {
     await db
       .update(settings)
       .set({ value, updatedAt: now })
-      .where(and(eq(settings.tenantId, tenantId), eq(settings.key, key)));
+      .where(and(settingsScopeFilter(), eq(settings.key, key)));
     return;
   }
 
   await db.insert(settings).values({
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     key,
     value,
     createdAt: now,

--- a/orchestrator/src/server/repositories/tracer-links.ts
+++ b/orchestrator/src/server/repositories/tracer-links.ts
@@ -2,6 +2,10 @@ import { createId } from "@paralleldrive/cuid2";
 import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db, schema } from "../db";
 import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { jobs, tracerClickEvents, tracerLinks } = schema;
 const TRACE_CODE_ALPHABET = "abcdefghijklmnopqrstuvwxyz";
@@ -71,11 +75,10 @@ function isUniqueConstraintError(error: unknown): boolean {
 }
 
 function buildEventFilters(args: AnalyticsFilterArgs) {
-  const tenantId = getActiveTenantId();
   const filters = [];
 
-  filters.push(eq(tracerLinks.tenantId, tenantId));
-  filters.push(eq(tracerClickEvents.tenantId, tenantId));
+  filters.push(privateDataScopeFilter(tracerLinks));
+  filters.push(privateDataScopeFilter(tracerClickEvents));
 
   if (typeof args.from === "number") {
     filters.push(gte(tracerClickEvents.clickedAt, args.from));
@@ -106,14 +109,14 @@ export async function getOrCreateTracerLink(args: {
 }): Promise<typeof tracerLinks.$inferSelect> {
   const now = new Date().toISOString();
   const slugPrefix = normalizeSlugPrefix(args.slugPrefix);
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   const [existing] = await db
     .select()
     .from(tracerLinks)
     .where(
       and(
-        eq(tracerLinks.tenantId, tenantId),
+        privateDataScopeFilter(tracerLinks),
         eq(tracerLinks.jobId, args.jobId),
         eq(tracerLinks.sourcePath, args.sourcePath),
         eq(tracerLinks.destinationUrlHash, args.destinationUrlHash),
@@ -139,7 +142,8 @@ export async function getOrCreateTracerLink(args: {
         .insert(tracerLinks)
         .values({
           id: createId(),
-          tenantId,
+          tenantId: scope.tenantId,
+          userId: scope.userId,
           token,
           jobId: args.jobId,
           sourcePath: args.sourcePath,
@@ -150,14 +154,7 @@ export async function getOrCreateTracerLink(args: {
           createdAt: now,
           updatedAt: now,
         })
-        .onConflictDoNothing({
-          target: [
-            tracerLinks.tenantId,
-            tracerLinks.jobId,
-            tracerLinks.sourcePath,
-            tracerLinks.destinationUrlHash,
-          ],
-        })
+        .onConflictDoNothing()
         .run();
     } catch (error) {
       if (!isUniqueConstraintError(error)) {
@@ -170,7 +167,10 @@ export async function getOrCreateTracerLink(args: {
         .select()
         .from(tracerLinks)
         .where(
-          and(eq(tracerLinks.tenantId, tenantId), eq(tracerLinks.token, token)),
+          and(
+            privateDataScopeFilter(tracerLinks),
+            eq(tracerLinks.token, token),
+          ),
         )
         .limit(1);
       if (created) return created;
@@ -181,7 +181,7 @@ export async function getOrCreateTracerLink(args: {
       .from(tracerLinks)
       .where(
         and(
-          eq(tracerLinks.tenantId, tenantId),
+          privateDataScopeFilter(tracerLinks),
           eq(tracerLinks.jobId, args.jobId),
           eq(tracerLinks.sourcePath, args.sourcePath),
           eq(tracerLinks.destinationUrlHash, args.destinationUrlHash),
@@ -235,7 +235,7 @@ export async function insertTracerClickEvent(args: {
   uniqueFingerprintHash: string | null;
 }): Promise<void> {
   const [link] = await db
-    .select({ tenantId: tracerLinks.tenantId })
+    .select({ tenantId: tracerLinks.tenantId, userId: tracerLinks.userId })
     .from(tracerLinks)
     .where(eq(tracerLinks.id, args.tracerLinkId))
     .limit(1);
@@ -243,6 +243,7 @@ export async function insertTracerClickEvent(args: {
   await db.insert(tracerClickEvents).values({
     id: createId(),
     tenantId: link?.tenantId ?? getActiveTenantId(),
+    userId: link?.userId ?? null,
     tracerLinkId: args.tracerLinkId,
     clickedAt: args.clickedAt,
     requestId: args.requestId,
@@ -260,7 +261,6 @@ export async function listTracerLinkStatsByJob(
   jobId: string,
   args: Omit<AnalyticsFilterArgs, "jobId"> = {},
 ): Promise<TracerLinkStatsRow[]> {
-  const tenantId = getActiveTenantId();
   const joinFilters = [];
   if (typeof args.from === "number") {
     joinFilters.push(gte(tracerClickEvents.clickedAt, args.from));
@@ -293,7 +293,7 @@ export async function listTracerLinkStatsByJob(
       and(eq(tracerLinks.id, tracerClickEvents.tracerLinkId), ...joinFilters),
     )
     .where(
-      and(eq(tracerLinks.tenantId, tenantId), eq(tracerLinks.jobId, jobId)),
+      and(privateDataScopeFilter(tracerLinks), eq(tracerLinks.jobId, jobId)),
     )
     .groupBy(tracerLinks.id)
     .orderBy(

--- a/orchestrator/src/server/services/ai-resilience.test.ts
+++ b/orchestrator/src/server/services/ai-resilience.test.ts
@@ -5,10 +5,32 @@ import { pickProjectIdsForJob } from "./projectSelection";
 import { scoreJobSuitability } from "./scorer";
 
 // --- Mocks ---
-vi.mock("../repositories/settings", () => ({
+const settingsMocks = vi.hoisted(() => ({
   getSetting: vi.fn().mockResolvedValue(null),
   getAllSettings: vi.fn().mockResolvedValue({}),
+  getEffectiveSettings: vi.fn(),
 }));
+
+vi.mock("../repositories/settings", () => settingsMocks);
+vi.mock("@server/repositories/settings", () => settingsMocks);
+vi.mock("@server/services/settings", () => ({
+  getEffectiveSettings: settingsMocks.getEffectiveSettings,
+}));
+
+function effectiveSettings(raw: Record<string, unknown>) {
+  return {
+    model: { value: raw.model ?? "gpt-4o-mini" },
+    llmProvider: { value: raw.llmProvider ?? "openrouter" },
+    llmBaseUrl: { value: raw.llmBaseUrl ?? null },
+    llmPurposeOverrides: { value: {} },
+    modelScorer: { value: null },
+    modelProjectSelection: { value: null },
+    scoringInstructions: { value: "" },
+    scoringPromptTemplate: { value: null },
+    penalizeMissingSalary: { value: false },
+    missingSalaryPenalty: { value: 0 },
+  };
+}
 
 // We need to mock 'fetch' globally for these tests
 const globalFetch = global.fetch;
@@ -35,6 +57,9 @@ describe("AI Service Resilience", () => {
       llmProvider: "openrouter",
       llmApiKey: "mock-key",
     });
+    settingsMocks.getEffectiveSettings.mockImplementation(async () =>
+      effectiveSettings(await settingsMocks.getAllSettings()),
+    );
   });
 
   afterEach(() => {

--- a/orchestrator/src/server/services/applicationTracking.ts
+++ b/orchestrator/src/server/services/applicationTracking.ts
@@ -13,9 +13,24 @@ import type {
 import { and, asc, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db, schema } from "../db/index";
-import { getActiveTenantId } from "../tenancy/context";
+import {
+  getPrivateDataScope,
+  privateDataScopeFilter,
+} from "../tenancy/private-scope";
 
 const { jobs, stageEvents, tasks } = schema;
+
+function jobsScopeFilter() {
+  return privateDataScopeFilter(jobs);
+}
+
+function stageEventsScopeFilter() {
+  return privateDataScopeFilter(stageEvents);
+}
+
+function tasksScopeFilter() {
+  return privateDataScopeFilter(tasks);
+}
 
 const STAGE_TO_STATUS: Record<ApplicationStage, JobStatus> = {
   applied: "applied",
@@ -62,13 +77,12 @@ export const stageEventMetadataSchema = z
 export async function getStageEvents(
   applicationId: string,
 ): Promise<StageEvent[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(stageEvents)
     .where(
       and(
-        eq(stageEvents.tenantId, tenantId),
+        stageEventsScopeFilter(),
         eq(stageEvents.applicationId, applicationId),
       ),
     )
@@ -91,18 +105,14 @@ export async function getTasks(
   applicationId: string,
   includeCompleted = false,
 ): Promise<ApplicationTask[]> {
-  const tenantId = getActiveTenantId();
   const rows = await db
     .select()
     .from(tasks)
     .where(
       includeCompleted
-        ? and(
-            eq(tasks.tenantId, tenantId),
-            eq(tasks.applicationId, applicationId),
-          )
+        ? and(tasksScopeFilter(), eq(tasks.applicationId, applicationId))
         : and(
-            eq(tasks.tenantId, tenantId),
+            tasksScopeFilter(),
             eq(tasks.applicationId, applicationId),
             eq(tasks.isCompleted, false),
           ),
@@ -133,13 +143,13 @@ export function transitionStage(
 
   const now = Math.floor(Date.now() / 1000);
   const timestamp = occurredAt ?? now;
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
 
   const { event, previousOutcome } = db.transaction((tx) => {
     const job = tx
       .select()
       .from(jobs)
-      .where(and(eq(jobs.tenantId, tenantId), eq(jobs.id, applicationId)))
+      .where(and(jobsScopeFilter(), eq(jobs.id, applicationId)))
       .get();
     if (!job) {
       throw new Error("Job not found");
@@ -150,7 +160,7 @@ export function transitionStage(
       .from(stageEvents)
       .where(
         and(
-          eq(stageEvents.tenantId, tenantId),
+          stageEventsScopeFilter(),
           eq(stageEvents.applicationId, applicationId),
         ),
       )
@@ -168,7 +178,8 @@ export function transitionStage(
     tx.insert(stageEvents)
       .values({
         id: eventId,
-        tenantId,
+        tenantId: scope.tenantId,
+        userId: scope.userId,
         applicationId,
         title: parsedMetadata?.eventLabel ?? finalToStage,
         groupId: parsedMetadata?.groupId ?? null,
@@ -203,7 +214,7 @@ export function transitionStage(
 
     tx.update(jobs)
       .set(updates)
-      .where(and(eq(jobs.tenantId, tenantId), eq(jobs.id, applicationId)))
+      .where(and(jobsScopeFilter(), eq(jobs.id, applicationId)))
       .run();
 
     return {
@@ -240,15 +251,11 @@ export function updateStageEvent(
     ? stageEventMetadataSchema.parse(metadata)
     : undefined;
   const hasOutcome = Object.hasOwn(payload, "outcome");
-  const tenantId = getActiveTenantId();
-
   db.transaction((tx) => {
     const event = tx
       .select()
       .from(stageEvents)
-      .where(
-        and(eq(stageEvents.tenantId, tenantId), eq(stageEvents.id, eventId)),
-      )
+      .where(and(stageEventsScopeFilter(), eq(stageEvents.id, eventId)))
       .get();
     if (!event) throw new Error("Event not found");
 
@@ -268,9 +275,7 @@ export function updateStageEvent(
 
     tx.update(stageEvents)
       .set(updates)
-      .where(
-        and(eq(stageEvents.tenantId, tenantId), eq(stageEvents.id, eventId)),
-      )
+      .where(and(stageEventsScopeFilter(), eq(stageEvents.id, eventId)))
       .run();
 
     // If this was the latest event, update the job status
@@ -279,7 +284,7 @@ export function updateStageEvent(
       .from(stageEvents)
       .where(
         and(
-          eq(stageEvents.tenantId, tenantId),
+          stageEventsScopeFilter(),
           eq(stageEvents.applicationId, event.applicationId),
         ),
       )
@@ -291,9 +296,7 @@ export function updateStageEvent(
       const job = tx
         .select()
         .from(jobs)
-        .where(
-          and(eq(jobs.tenantId, tenantId), eq(jobs.id, event.applicationId)),
-        )
+        .where(and(jobsScopeFilter(), eq(jobs.id, event.applicationId)))
         .get();
       if (!job) throw new Error("Job not found");
 
@@ -315,30 +318,23 @@ export function updateStageEvent(
           closedAt,
           updatedAt: new Date().toISOString(),
         })
-        .where(
-          and(eq(jobs.tenantId, tenantId), eq(jobs.id, event.applicationId)),
-        )
+        .where(and(jobsScopeFilter(), eq(jobs.id, event.applicationId)))
         .run();
     }
   });
 }
 
 export function deleteStageEvent(eventId: string): void {
-  const tenantId = getActiveTenantId();
   db.transaction((tx) => {
     const event = tx
       .select()
       .from(stageEvents)
-      .where(
-        and(eq(stageEvents.tenantId, tenantId), eq(stageEvents.id, eventId)),
-      )
+      .where(and(stageEventsScopeFilter(), eq(stageEvents.id, eventId)))
       .get();
     if (!event) return;
 
     tx.delete(stageEvents)
-      .where(
-        and(eq(stageEvents.tenantId, tenantId), eq(stageEvents.id, eventId)),
-      )
+      .where(and(stageEventsScopeFilter(), eq(stageEvents.id, eventId)))
       .run();
 
     // Update job status based on the new latest event
@@ -347,7 +343,7 @@ export function deleteStageEvent(eventId: string): void {
       .from(stageEvents)
       .where(
         and(
-          eq(stageEvents.tenantId, tenantId),
+          stageEventsScopeFilter(),
           eq(stageEvents.applicationId, event.applicationId),
         ),
       )
@@ -359,9 +355,7 @@ export function deleteStageEvent(eventId: string): void {
       const job = tx
         .select()
         .from(jobs)
-        .where(
-          and(eq(jobs.tenantId, tenantId), eq(jobs.id, event.applicationId)),
-        )
+        .where(and(jobsScopeFilter(), eq(jobs.id, event.applicationId)))
         .get();
       if (!job) throw new Error("Job not found");
 
@@ -383,9 +377,7 @@ export function deleteStageEvent(eventId: string): void {
           closedAt,
           updatedAt: new Date().toISOString(),
         })
-        .where(
-          and(eq(jobs.tenantId, tenantId), eq(jobs.id, event.applicationId)),
-        )
+        .where(and(jobsScopeFilter(), eq(jobs.id, event.applicationId)))
         .run();
     } else {
       // If no events left, maybe revert to discovered?
@@ -398,9 +390,7 @@ export function deleteStageEvent(eventId: string): void {
           closedAt: null,
           updatedAt: new Date().toISOString(),
         })
-        .where(
-          and(eq(jobs.tenantId, tenantId), eq(jobs.id, event.applicationId)),
-        )
+        .where(and(jobsScopeFilter(), eq(jobs.id, event.applicationId)))
         .run();
     }
   });

--- a/orchestrator/src/server/services/auto-pdf-regeneration.test.ts
+++ b/orchestrator/src/server/services/auto-pdf-regeneration.test.ts
@@ -27,6 +27,15 @@ vi.mock("@server/tenancy/context", () => ({
   getActiveTenantId: vi.fn(() => "tenant-test"),
 }));
 
+vi.mock("@server/tenancy/private-scope", () => ({
+  getPrivateDataScope: vi.fn(() => ({
+    tenantId: "tenant-test",
+    userId: null,
+    enforceUserIsolation: false,
+    scopeKey: "tenant-test",
+  })),
+}));
+
 vi.mock("./pdf-fingerprint", () => ({
   resolvePdfFingerprintContext: vi.fn().mockResolvedValue({
     version: "v1",
@@ -42,6 +51,7 @@ vi.mock("./pdf-fingerprint", () => ({
   ),
 }));
 
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import {
   enqueueAutoPdfRegenerationForSettingsChanges,
   shouldEnqueueTailoringAutoPdfRegeneration,
@@ -51,6 +61,12 @@ import { resolvePdfFingerprintContext } from "./pdf-fingerprint";
 describe("auto PDF regeneration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getPrivateDataScope).mockReturnValue({
+      tenantId: "tenant-test",
+      userId: null,
+      enforceUserIsolation: false,
+      scopeKey: "tenant-test",
+    });
     mocks.enqueue.mockResolvedValue({
       id: "queue-job-1",
       queue: "auto_pdf_regeneration",
@@ -114,22 +130,58 @@ describe("auto PDF regeneration", () => {
       "auto_pdf_regeneration",
       expect.objectContaining({
         tenantId: "tenant-test",
+        userId: null,
         jobId: "job-1",
         reason: "settings_changed",
         requestedBy: "user",
       }),
-      { dedupeKey: "tenant-test:job-1" },
+      { dedupeKey: "tenant-test:tenant:job-1" },
     );
     expect(mocks.enqueue).toHaveBeenNthCalledWith(
       2,
       "auto_pdf_regeneration",
       expect.objectContaining({
         tenantId: "tenant-test",
+        userId: null,
         jobId: "job-2",
         reason: "settings_changed",
         requestedBy: "user",
       }),
-      { dedupeKey: "tenant-test:job-2" },
+      { dedupeKey: "tenant-test:tenant:job-2" },
+    );
+  });
+
+  it("carries hosted user ownership into queued regeneration jobs", async () => {
+    vi.mocked(getPrivateDataScope).mockReturnValue({
+      tenantId: "tenant-hosted",
+      userId: "user-a",
+      enforceUserIsolation: true,
+      scopeKey: "tenant-hosted:user-a",
+    });
+    mocks.getReadyJobsWithGeneratedPdfs.mockResolvedValue([
+      createJob({
+        id: "job-hosted",
+        status: "ready",
+        pdfPath: "data/pdfs/job-hosted.pdf",
+        pdfSource: "generated",
+        pdfFingerprint: "stale",
+      }),
+    ]);
+
+    const enqueued = await enqueueAutoPdfRegenerationForSettingsChanges({
+      updatedSettingKeys: ["pdfRenderer"],
+      requestedBy: "user",
+    });
+
+    expect(enqueued).toBe(1);
+    expect(mocks.enqueue).toHaveBeenCalledWith(
+      "auto_pdf_regeneration",
+      expect.objectContaining({
+        tenantId: "tenant-hosted",
+        userId: "user-a",
+        jobId: "job-hosted",
+      }),
+      { dedupeKey: "tenant-hosted:user-a:job-hosted" },
     );
   });
 
@@ -161,7 +213,7 @@ describe("auto PDF regeneration", () => {
     expect(mocks.enqueue).toHaveBeenCalledWith(
       "auto_pdf_regeneration",
       expect.objectContaining({ jobId: "job-stale" }),
-      { dedupeKey: "tenant-test:job-stale" },
+      { dedupeKey: "tenant-test:tenant:job-stale" },
     );
   });
 
@@ -205,7 +257,7 @@ describe("auto PDF regeneration", () => {
     expect(mocks.enqueue).toHaveBeenCalledWith(
       "auto_pdf_regeneration",
       expect.objectContaining({ jobId: "job-typst" }),
-      { dedupeKey: "tenant-test:job-typst" },
+      { dedupeKey: "tenant-test:tenant:job-typst" },
     );
   });
 

--- a/orchestrator/src/server/services/auto-pdf-regeneration.ts
+++ b/orchestrator/src/server/services/auto-pdf-regeneration.ts
@@ -4,7 +4,7 @@ import type { AutoPdfRegenerationReason } from "@server/infra/job-queue";
 import { getJobQueue } from "@server/infra/job-queue-registry";
 import * as jobsRepo from "@server/repositories/jobs";
 import type { SettingKey } from "@server/repositories/settings";
-import { getActiveTenantId } from "@server/tenancy/context";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import type { Job } from "@shared/types";
 import { generateFinalPdf } from "../pipeline";
 import {
@@ -100,6 +100,7 @@ async function drainQueue(): Promise<void> {
         await runWithRequestContext(
           {
             tenantId: queuedJob.payload.tenantId,
+            userId: queuedJob.payload.userId ?? undefined,
             jobId: queuedJob.payload.jobId,
           },
           async () => {
@@ -154,6 +155,7 @@ async function getStaleReadyGeneratedPdfJobs(limit: number): Promise<Job[]> {
 
 async function processQueuedAutoPdfRegeneration(input: {
   tenantId: string;
+  userId?: string | null;
   jobId: string;
   reason: AutoPdfRegenerationReason;
   requestedAt: string;
@@ -162,6 +164,7 @@ async function processQueuedAutoPdfRegeneration(input: {
   return runWithRequestContext(
     {
       tenantId: input.tenantId,
+      userId: input.userId ?? undefined,
       jobId: input.jobId,
     },
     async () => {
@@ -211,6 +214,7 @@ async function processQueuedAutoPdfRegeneration(input: {
 async function enqueueAutoPdfRegenerationPayload(
   payload: {
     tenantId: string;
+    userId?: string | null;
     jobId: string;
     reason: AutoPdfRegenerationReason;
     requestedAt: string;
@@ -219,7 +223,11 @@ async function enqueueAutoPdfRegenerationPayload(
   options?: { delayMs?: number },
 ): Promise<void> {
   await getJobQueue().enqueue("auto_pdf_regeneration", payload, {
-    dedupeKey: `${payload.tenantId}:${payload.jobId}`,
+    dedupeKey: [
+      payload.tenantId,
+      payload.userId ?? "tenant",
+      payload.jobId,
+    ].join(":"),
     delayMs: options?.delayMs,
   });
   scheduleWorker(options?.delayMs);
@@ -230,9 +238,10 @@ export async function enqueueAutoPdfRegenerationForJob(input: {
   reason: AutoPdfRegenerationReason;
   requestedBy: "system" | "user";
 }): Promise<void> {
-  const tenantId = getActiveTenantId();
+  const scope = getPrivateDataScope();
   await enqueueAutoPdfRegenerationPayload({
-    tenantId,
+    tenantId: scope.tenantId,
+    userId: scope.userId,
     jobId: input.jobId,
     reason: input.reason,
     requestedAt: new Date().toISOString(),

--- a/orchestrator/src/server/services/design-resume.test.ts
+++ b/orchestrator/src/server/services/design-resume.test.ts
@@ -47,6 +47,14 @@ vi.mock("@server/services/tracer-links", () => ({
 vi.mock("@server/tenancy/context", () => ({
   getActiveTenantId: vi.fn(() => "tenant-test-2"),
 }));
+vi.mock("@server/tenancy/private-scope", () => ({
+  getPrivateDataScope: vi.fn(() => ({
+    tenantId: "tenant-test-2",
+    userId: null,
+    enforceUserIsolation: false,
+    scopeKey: "tenant-test-2",
+  })),
+}));
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(() => true),
   default: {
@@ -62,6 +70,7 @@ import { getSetting } from "@server/repositories/settings";
 import { getOriginalEnvValue } from "@server/services/envSettings";
 import { getResume } from "@server/services/rxresume";
 import { getConfiguredRxResumeBaseResumeId } from "@server/services/rxresume/baseResumeId";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import {
   deleteDesignResumePicture,
   getCurrentDesignResume,
@@ -108,6 +117,12 @@ describe("design resume service", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getPrivateDataScope).mockReturnValue({
+      tenantId: "tenant-test-2",
+      userId: null,
+      enforceUserIsolation: false,
+      scopeKey: "tenant-test-2",
+    });
     repo.getLatestDesignResumeDocument.mockResolvedValue(makeDocumentRow());
     repo.listDesignResumeAssets.mockResolvedValue([]);
     repo.getDesignResumeAssetById.mockResolvedValue(null);
@@ -161,6 +176,29 @@ describe("design resume service", () => {
     expect(repo.upsertDesignResumeDocument).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "primary_tenant-test-2",
+      }),
+    );
+  });
+
+  it("uses a user-scoped design resume id in hosted mode", async () => {
+    repo.getLatestDesignResumeDocument.mockResolvedValueOnce(null);
+    vi.mocked(getPrivateDataScope).mockReturnValue({
+      tenantId: "tenant-test-2",
+      userId: "user-2",
+      enforceUserIsolation: true,
+      scopeKey: "tenant-test-2:user-2",
+    });
+
+    await replaceCurrentDesignResumeDocument({
+      importedAt: "2026-04-11T00:00:00.000Z",
+      resumeJson: makeValidResumeJson(),
+      sourceResumeId: null,
+      sourceMode: null,
+    });
+
+    expect(repo.upsertDesignResumeDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "primary_tenant-test-2_user-2",
       }),
     );
   });

--- a/orchestrator/src/server/services/design-resume/index.ts
+++ b/orchestrator/src/server/services/design-resume/index.ts
@@ -18,6 +18,7 @@ import {
   safeParseV5ResumeData,
 } from "@server/services/rxresume/schema/v5";
 import { getActiveTenantId } from "@server/tenancy/context";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import type {
   DesignResumeAsset,
   DesignResumeDocument,
@@ -39,7 +40,21 @@ const LEGACY_REIMPORT_MESSAGE =
 const INVALID_V5_PREFIX =
   "Resume Studio must be a valid Reactive Resume v5 document.";
 
+function getDesignResumeAssetDir(): string {
+  const scope = getPrivateDataScope();
+  if (scope.enforceUserIsolation && scope.userId) {
+    return join(DESIGN_RESUME_ASSET_DIR, scope.tenantId, "users", scope.userId);
+  }
+  return DESIGN_RESUME_ASSET_DIR;
+}
+
 function buildTenantScopedDesignResumeDocumentId(): string {
+  const scope = getPrivateDataScope();
+  if (scope.enforceUserIsolation && scope.userId) {
+    return [DESIGN_RESUME_DEFAULT_ID, scope.tenantId, scope.userId]
+      .map((part) => part.replace(/[^a-zA-Z0-9_-]/g, "_"))
+      .join("_");
+  }
   return `${DESIGN_RESUME_DEFAULT_ID}_${getActiveTenantId()}`;
 }
 
@@ -265,12 +280,13 @@ async function storeDesignResumePictureAsset(input: {
   data: Buffer;
   updatedAt: string;
 }) {
-  await ensureStorageDirs();
+  const assetDir = getDesignResumeAssetDir();
+  await ensureStorageDirs(assetDir);
   assertImageByteSize(input.data.byteLength);
 
   const assetId = createId();
   const storagePath = join(
-    DESIGN_RESUME_ASSET_DIR,
+    assetDir,
     `${assetId}${extensionForMimeType(input.mimeType)}`,
   );
 
@@ -574,9 +590,11 @@ function isMissingDesignResumeTableError(error: unknown): boolean {
   );
 }
 
-async function ensureStorageDirs(): Promise<void> {
-  if (!existsSync(DESIGN_RESUME_ASSET_DIR)) {
-    await mkdir(DESIGN_RESUME_ASSET_DIR, { recursive: true });
+async function ensureStorageDirs(
+  assetDir = DESIGN_RESUME_ASSET_DIR,
+): Promise<void> {
+  if (!existsSync(assetDir)) {
+    await mkdir(assetDir, { recursive: true });
   }
 }
 

--- a/orchestrator/src/server/services/ghostwriter.test.ts
+++ b/orchestrator/src/server/services/ghostwriter.test.ts
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
     updateThreadContext: vi.fn(),
   },
   jobsRepo: {
+    getJobById: vi.fn(),
     listJobNotesByIds: vi.fn(),
   },
   jobDocumentsRepo: {
@@ -86,6 +87,7 @@ vi.mock("../repositories/ghostwriter", () => ({
 }));
 
 vi.mock("../repositories/jobs", () => ({
+  getJobById: mocks.jobsRepo.getJobById,
   listJobNotesByIds: mocks.jobsRepo.listJobNotesByIds,
 }));
 
@@ -194,6 +196,7 @@ describe("ghostwriter service", () => {
     });
 
     mocks.jobsRepo.listJobNotesByIds.mockResolvedValue([]);
+    mocks.jobsRepo.getJobById.mockResolvedValue({ id: "job-1" });
     mocks.jobDocumentsRepo.listJobDocumentsByIds.mockResolvedValue([]);
     mocks.jobEmails.listJobPostApplicationEmailsByIds.mockResolvedValue([]);
     mocks.repo.getOrCreateThreadForJob.mockResolvedValue(thread);

--- a/orchestrator/src/server/services/ghostwriter.ts
+++ b/orchestrator/src/server/services/ghostwriter.ts
@@ -355,6 +355,11 @@ async function resolveAndValidateImageInput(
 }
 
 async function ensureJobThread(jobId: string) {
+  const job = await jobsRepo.getJobById(jobId);
+  if (!job) {
+    throw notFound("Job not found");
+  }
+
   return jobChatRepo.getOrCreateThreadForJob({
     jobId,
     title: null,

--- a/orchestrator/src/server/services/job-document-storage.ts
+++ b/orchestrator/src/server/services/job-document-storage.ts
@@ -4,6 +4,7 @@ import { extname, join } from "node:path";
 import { badRequest } from "@infra/errors";
 import { getDataDir } from "@server/config/dataDir";
 import { getActiveTenantId } from "@server/tenancy/context";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import { decodeBase64Upload } from "./upload-base64";
 
 const MAX_JOB_DOCUMENT_BYTES = 10 * 1024 * 1024;
@@ -19,6 +20,21 @@ function getTenantJobDocumentsDir(
   jobId: string,
   tenantId = getActiveTenantId(),
 ): string {
+  const scope = getPrivateDataScope();
+  if (
+    scope.enforceUserIsolation &&
+    scope.userId &&
+    tenantId === scope.tenantId
+  ) {
+    return join(
+      getDataDir(),
+      "job-documents",
+      tenantId,
+      "users",
+      scope.userId,
+      jobId,
+    );
+  }
   return join(getDataDir(), "job-documents", tenantId, jobId);
 }
 

--- a/orchestrator/src/server/services/manualJob.test.ts
+++ b/orchestrator/src/server/services/manualJob.test.ts
@@ -2,10 +2,27 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as settingsRepo from "../repositories/settings";
 import { inferManualJobDetails } from "./manualJob";
 
-vi.mock("../repositories/settings", () => ({
+const settingsMocks = vi.hoisted(() => ({
   getSetting: vi.fn(),
   getAllSettings: vi.fn().mockResolvedValue({}),
+  getEffectiveSettings: vi.fn(),
 }));
+
+vi.mock("../repositories/settings", () => settingsMocks);
+vi.mock("@server/repositories/settings", () => settingsMocks);
+vi.mock("@server/services/settings", () => ({
+  getEffectiveSettings: settingsMocks.getEffectiveSettings,
+}));
+
+function effectiveSettings(raw: Record<string, unknown>) {
+  return {
+    model: { value: raw.model ?? "gpt-4o-mini" },
+    llmProvider: { value: raw.llmProvider ?? "openrouter" },
+    llmBaseUrl: { value: raw.llmBaseUrl ?? null },
+    llmPurposeOverrides: { value: {} },
+    modelTailoring: { value: null },
+  };
+}
 
 const originalEnv = process.env;
 const originalFetch = global.fetch;
@@ -20,6 +37,9 @@ describe("manual job inference", () => {
       llmProvider: "openrouter",
       llmApiKey: "test-key",
     });
+    settingsMocks.getEffectiveSettings.mockImplementation(async () =>
+      effectiveSettings(await settingsMocks.getAllSettings()),
+    );
   });
 
   afterEach(() => {

--- a/orchestrator/src/server/services/pdf-storage.ts
+++ b/orchestrator/src/server/services/pdf-storage.ts
@@ -1,8 +1,17 @@
 import { join } from "node:path";
 import { getDataDir } from "@server/config/dataDir";
 import { getActiveTenantId } from "@server/tenancy/context";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 
 export function getTenantPdfDir(tenantId = getActiveTenantId()): string {
+  const scope = getPrivateDataScope();
+  if (
+    scope.enforceUserIsolation &&
+    scope.userId &&
+    tenantId === scope.tenantId
+  ) {
+    return join(getDataDir(), "pdfs", tenantId, "users", scope.userId);
+  }
   return join(getDataDir(), "pdfs", tenantId);
 }
 

--- a/orchestrator/src/server/services/post-application/ingestion/gmail-sync.idempotency.test.ts
+++ b/orchestrator/src/server/services/post-application/ingestion/gmail-sync.idempotency.test.ts
@@ -1,4 +1,21 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getPostApplicationMessageByExternalId: vi.fn(),
+  upsertPostApplicationMessage: vi.fn(),
+  transitionStage: vi.fn(),
+}));
+
+vi.mock("@infra/product-analytics", () => ({
+  trackServerProductEvent: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@server/infra/product-analytics", () => ({
+  trackServerProductEvent: vi.fn().mockResolvedValue(false),
+}));
 
 vi.mock("@server/repositories/post-application-integrations", () => ({
   getPostApplicationIntegration: vi.fn().mockResolvedValue({
@@ -40,16 +57,18 @@ vi.mock("@server/repositories/jobs", () => ({
   ]),
 }));
 
-const getPostApplicationMessageByExternalId = vi.fn();
-const upsertPostApplicationMessage = vi.fn();
 vi.mock("@server/repositories/post-application-messages", () => ({
-  getPostApplicationMessageByExternalId,
-  upsertPostApplicationMessage,
+  getPostApplicationMessageByExternalId:
+    mocks.getPostApplicationMessageByExternalId,
+  upsertPostApplicationMessage: mocks.upsertPostApplicationMessage,
 }));
 
-const transitionStage = vi.fn();
 vi.mock("@server/services/applicationTracking", () => ({
-  transitionStage,
+  transitionStage: mocks.transitionStage,
+}));
+
+vi.mock("../../applicationTracking", () => ({
+  transitionStage: mocks.transitionStage,
 }));
 
 vi.mock("@server/repositories/settings", () => ({
@@ -85,7 +104,21 @@ function makeJsonResponse(body: unknown): Response {
 }
 
 describe("gmail sync auto-log idempotency", () => {
-  beforeEach(() => {
+  const originalEnv = { ...process.env };
+  let tempDir: string;
+  let closeDb: (() => void) | null = null;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-gmail-sync-"));
+    process.env = {
+      ...originalEnv,
+      DATA_DIR: tempDir,
+      NODE_ENV: "test",
+      JOBOPS_APP_MODE: "local",
+    };
+    await import("@server/db/migrate");
+    ({ closeDb } = await import("@server/db"));
+
     vi.clearAllMocks();
     llmCallJson.mockClear();
 
@@ -131,10 +164,17 @@ describe("gmail sync auto-log idempotency", () => {
     );
   });
 
+  afterEach(async () => {
+    closeDb?.();
+    closeDb = null;
+    process.env = { ...originalEnv };
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
   it("creates auto stage event only on first auto_linked transition", async () => {
     const { runGmailIngestionSync } = await import("./gmail-sync");
 
-    getPostApplicationMessageByExternalId
+    mocks.getPostApplicationMessageByExternalId
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({
         id: "post-msg-1",
@@ -169,7 +209,7 @@ describe("gmail sync auto-log idempotency", () => {
         updatedAt: new Date().toISOString(),
       });
 
-    upsertPostApplicationMessage
+    mocks.upsertPostApplicationMessage
       .mockResolvedValueOnce({
         message: {
           id: "post-msg-1",
@@ -198,7 +238,7 @@ describe("gmail sync auto-log idempotency", () => {
     await runGmailIngestionSync({ accountKey: "default", maxMessages: 1 });
     await runGmailIngestionSync({ accountKey: "default", maxMessages: 1 });
 
-    expect(upsertPostApplicationMessage).toHaveBeenCalledTimes(2);
-    expect(transitionStage).toHaveBeenCalledTimes(1);
+    expect(mocks.upsertPostApplicationMessage).toHaveBeenCalledTimes(2);
+    expect(mocks.transitionStage).toHaveBeenCalledTimes(1);
   });
 });

--- a/orchestrator/src/server/services/post-application/review/service.ts
+++ b/orchestrator/src/server/services/post-application/review/service.ts
@@ -21,7 +21,7 @@ import {
   resolveStageTransitionForTarget,
   stageTargetFromMessageType,
 } from "@server/services/post-application/stage-target";
-import { getActiveTenantId } from "@server/tenancy/context";
+import { privateDataScopeFilter } from "@server/tenancy/private-scope";
 import type {
   ApplicationStage,
   PostApplicationActionRequest,
@@ -36,6 +36,14 @@ import type {
 import { and, eq, sql } from "drizzle-orm";
 
 const { postApplicationMessages, postApplicationSyncRuns } = schema;
+
+function messagesScopeFilter() {
+  return privateDataScopeFilter(postApplicationMessages);
+}
+
+function syncRunsScopeFilter() {
+  return privateDataScopeFilter(postApplicationSyncRuns);
+}
 
 function buildMatchedJobMap(
   items: PostApplicationMessage[],
@@ -109,7 +117,6 @@ export async function approvePostApplicationInboxItem(args: {
   }
 
   const decidedAt = Date.now();
-  const tenantId = getActiveTenantId();
   const updated = db.transaction((tx) => {
     let stageEventId: string | null = null;
     const decidedAtIso = new Date(decidedAt).toISOString();
@@ -125,8 +132,8 @@ export async function approvePostApplicationInboxItem(args: {
       })
       .where(
         and(
+          messagesScopeFilter(),
           eq(postApplicationMessages.id, message.id),
-          eq(postApplicationMessages.tenantId, tenantId),
           eq(postApplicationMessages.processingStatus, "pending_user"),
         ),
       )
@@ -173,8 +180,8 @@ export async function approvePostApplicationInboxItem(args: {
         })
         .where(
           and(
+            syncRunsScopeFilter(),
             eq(postApplicationSyncRuns.id, message.syncRunId),
-            eq(postApplicationSyncRuns.tenantId, tenantId),
           ),
         )
         .run();
@@ -228,7 +235,6 @@ export async function denyPostApplicationInboxItem(args: {
   }
 
   const decidedAt = Date.now();
-  const tenantId = getActiveTenantId();
   db.transaction((tx) => {
     const decidedAtIso = new Date(decidedAt).toISOString();
     const messageUpdateResult = tx
@@ -242,8 +248,8 @@ export async function denyPostApplicationInboxItem(args: {
       })
       .where(
         and(
+          messagesScopeFilter(),
           eq(postApplicationMessages.id, message.id),
-          eq(postApplicationMessages.tenantId, tenantId),
           eq(postApplicationMessages.processingStatus, "pending_user"),
         ),
       )
@@ -262,8 +268,8 @@ export async function denyPostApplicationInboxItem(args: {
         })
         .where(
           and(
+            syncRunsScopeFilter(),
             eq(postApplicationSyncRuns.id, message.syncRunId),
-            eq(postApplicationSyncRuns.tenantId, tenantId),
           ),
         )
         .run();

--- a/orchestrator/src/server/services/profile.ts
+++ b/orchestrator/src/server/services/profile.ts
@@ -1,6 +1,7 @@
 import { logger } from "@infra/logger";
-import { getTenantId } from "@infra/request-context";
+import { getRequestContext } from "@infra/request-context";
 import { getActiveTenantId } from "@server/tenancy/context";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import type { ResumeProfile } from "@shared/types";
 import {
   designResumeToProfile,
@@ -18,34 +19,34 @@ type TenantProfileCache = {
 
 const PROFILE_CACHE_TTL_MS = 30 * 60 * 1000;
 const PROFILE_CACHE_MAX_TENANTS = 100;
-const profileCacheByTenant = new Map<string, TenantProfileCache>();
+const profileCacheByScope = new Map<string, TenantProfileCache>();
 
 function pruneProfileCache(now = Date.now()): void {
-  for (const [tenantId, cache] of profileCacheByTenant.entries()) {
+  for (const [tenantId, cache] of profileCacheByScope.entries()) {
     if (now - cache.lastAccessedAt > PROFILE_CACHE_TTL_MS) {
-      profileCacheByTenant.delete(tenantId);
+      profileCacheByScope.delete(tenantId);
     }
   }
 
-  while (profileCacheByTenant.size >= PROFILE_CACHE_MAX_TENANTS) {
+  while (profileCacheByScope.size >= PROFILE_CACHE_MAX_TENANTS) {
     let oldestTenantId: string | null = null;
     let oldestAccessedAt = Number.POSITIVE_INFINITY;
-    for (const [tenantId, cache] of profileCacheByTenant.entries()) {
+    for (const [tenantId, cache] of profileCacheByScope.entries()) {
       if (cache.lastAccessedAt < oldestAccessedAt) {
         oldestTenantId = tenantId;
         oldestAccessedAt = cache.lastAccessedAt;
       }
     }
     if (!oldestTenantId) return;
-    profileCacheByTenant.delete(oldestTenantId);
+    profileCacheByScope.delete(oldestTenantId);
   }
 }
 
 function getTenantProfileCache(): TenantProfileCache {
   const now = Date.now();
   pruneProfileCache(now);
-  const tenantId = getActiveTenantId();
-  let cache = profileCacheByTenant.get(tenantId);
+  const scopeKey = getPrivateDataScope().scopeKey;
+  let cache = profileCacheByScope.get(scopeKey);
   if (!cache) {
     cache = {
       profile: null,
@@ -53,7 +54,7 @@ function getTenantProfileCache(): TenantProfileCache {
       localProfile: null,
       lastAccessedAt: now,
     };
-    profileCacheByTenant.set(tenantId, cache);
+    profileCacheByScope.set(scopeKey, cache);
   }
   cache.lastAccessedAt = now;
   return cache;
@@ -153,14 +154,18 @@ export async function getPersonName(): Promise<string> {
  * Clear the profile cache.
  */
 export function clearProfileCache(): void {
-  const tenantId = getTenantId();
-  if (tenantId) {
-    profileCacheByTenant.delete(tenantId);
+  if (!getRequestContext()) {
+    profileCacheByScope.clear();
     return;
   }
-  profileCacheByTenant.clear();
+
+  try {
+    profileCacheByScope.delete(getPrivateDataScope().scopeKey);
+  } catch {
+    profileCacheByScope.delete(getActiveTenantId());
+  }
 }
 
 export function __getProfileCacheSizeForTests(): number {
-  return profileCacheByTenant.size;
+  return profileCacheByScope.size;
 }

--- a/orchestrator/src/server/services/summary.test.ts
+++ b/orchestrator/src/server/services/summary.test.ts
@@ -4,9 +4,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const callJsonMock = vi.fn();
 const getProviderMock = vi.fn();
 const getBaseUrlMock = vi.fn();
-
-vi.mock("../repositories/settings", () => ({
+const settingsMocks = vi.hoisted(() => ({
   getSetting: vi.fn(),
+  getEffectiveSettings: vi.fn(),
+}));
+
+vi.mock("../repositories/settings", () => settingsMocks);
+vi.mock("@server/repositories/settings", () => settingsMocks);
+vi.mock("@server/services/settings", () => ({
+  getEffectiveSettings: settingsMocks.getEffectiveSettings,
 }));
 
 vi.mock("./llm/service", () => ({
@@ -35,6 +41,13 @@ describe("generateTailoring", () => {
     vi.clearAllMocks();
     getProviderMock.mockReturnValue("openrouter");
     getBaseUrlMock.mockReturnValue("https://openrouter.ai");
+    settingsMocks.getEffectiveSettings.mockResolvedValue({
+      model: { value: "gpt-4o-mini" },
+      llmProvider: { value: "openrouter" },
+      llmBaseUrl: { value: null },
+      llmPurposeOverrides: { value: {} },
+      modelTailoring: { value: null },
+    });
     callJsonMock.mockResolvedValue({
       success: true,
       data: {

--- a/orchestrator/src/server/tenancy/private-scope.ts
+++ b/orchestrator/src/server/tenancy/private-scope.ts
@@ -1,0 +1,61 @@
+import { unauthorized } from "@infra/errors";
+import {
+  getRequestContext,
+  getUserId,
+  requireTenantId,
+} from "@infra/request-context";
+import { getJobOpsAppConfig } from "@server/config/app-mode";
+import { and, eq, type SQL } from "drizzle-orm";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
+import { getActiveTenantId } from "./context";
+
+export type PrivateDataScope = {
+  tenantId: string;
+  userId: string | null;
+  enforceUserIsolation: boolean;
+  scopeKey: string;
+};
+
+type UserScopedTable = {
+  tenantId: AnySQLiteColumn;
+  userId: AnySQLiteColumn;
+};
+
+export function isHostedUserIsolationEnabled(): boolean {
+  return getJobOpsAppConfig().appMode === "hosted";
+}
+
+export function getPrivateDataScope(): PrivateDataScope {
+  const tenantId = getActiveTenantId();
+  const userId = getUserId() ?? null;
+  const enforceUserIsolation = isHostedUserIsolationEnabled();
+
+  if (enforceUserIsolation && !userId) {
+    throw unauthorized("Authentication required");
+  }
+
+  return {
+    tenantId,
+    userId,
+    enforceUserIsolation,
+    scopeKey:
+      enforceUserIsolation && userId ? `${tenantId}:${userId}` : tenantId,
+  };
+}
+
+export function requirePrivateTenantId(): string {
+  return requireTenantId();
+}
+
+export function getPrivateDataOwnerId(): string | null {
+  return getRequestContext()?.userId ?? null;
+}
+
+export function privateDataScopeFilter(table: UserScopedTable): SQL {
+  const scope = getPrivateDataScope();
+  const filters = [eq(table.tenantId, scope.tenantId)];
+  if (scope.enforceUserIsolation && scope.userId) {
+    filters.push(eq(table.userId, scope.userId));
+  }
+  return and(...filters) as SQL;
+}


### PR DESCRIPTION
## Summary
- Add user-aware private data scoping across OAuth state, queued jobs, design resume storage, and post-application review flows.
- Rebuild tenant-private tables and unique indexes to include `user_id` where needed.
- Block secret-only webhook triggers in hosted mode and cover the new behavior with tests.

## Testing
- Added and updated unit tests for webhook access control, auto PDF regeneration, design resume scoping, and migration/index expectations.
- Not run (not requested)