### PR TITLE
Fix project selection gating and expose max projects in resume UI

### DIFF
--- a/orchestrator/src/client/components/ReactiveResumeConfigPanel.tsx
+++ b/orchestrator/src/client/components/ReactiveResumeConfigPanel.tsx
@@ -138,8 +138,9 @@ export const ReactiveResumeConfigPanel: React.FC<
   v5,
   projectSelection,
 }) => {
+  const hasProjectCatalog = Boolean(projectSelection?.projects.length);
   const canShowProjectSelection = Boolean(
-    projectSelection && hasRxResumeAccess,
+    projectSelection && (hasRxResumeAccess || hasProjectCatalog),
   );
   const selectedValidationStatus = validationStatus;
   const showInlineValidationAlert = Boolean(
@@ -297,21 +298,34 @@ export const ReactiveResumeConfigPanel: React.FC<
 
           {!canShowProjectSelection ? (
             <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
-              Connect Reactive Resume and choose a template resume to configure
-              resume projects.
+              No resume projects were found. Add projects to your active resume
+              to configure automatic project selection.
             </div>
           ) : (
             <div className="space-y-4">
-              <BaseResumeSelection
-                value={projectSelection.baseResumeId}
-                onValueChange={projectSelection.onBaseResumeIdChange}
-                hasRxResumeAccess={hasRxResumeAccess}
-                disabled={projectSelection.disabled}
-              />
+              {hasRxResumeAccess ? (
+                <BaseResumeSelection
+                  value={projectSelection.baseResumeId}
+                  onValueChange={projectSelection.onBaseResumeIdChange}
+                  hasRxResumeAccess={hasRxResumeAccess}
+                  disabled={projectSelection.disabled}
+                />
+              ) : null}
 
-              {!projectSelection.baseResumeId ? (
+              {projectSelection.isProjectsLoading ? (
+                <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+                  Loading resume projects...
+                </div>
+              ) : hasRxResumeAccess &&
+                !projectSelection.baseResumeId &&
+                !hasProjectCatalog ? (
                 <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
                   Choose a PDF to configure resume projects.
+                </div>
+              ) : !hasProjectCatalog ? (
+                <div className="rounded-md border border-dashed border-muted-foreground/40 bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+                  No resume projects were found. Add projects to your active
+                  resume to configure automatic project selection.
                 </div>
               ) : (
                 <>

--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.test.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.test.tsx
@@ -77,4 +77,34 @@ describe("DesignResumeListSection", () => {
 
     expect(onUpdateItems).toHaveBeenCalledWith([projects[0]]);
   });
+
+  it("shows max project selection controls for project sections", () => {
+    const onMaxProjectsChange = vi.fn();
+    render(
+      <Accordion type="multiple" defaultValue={["projects"]}>
+        <DesignResumeListSection
+          definition={projectsDefinition}
+          items={projects}
+          onAdd={vi.fn()}
+          onEdit={vi.fn()}
+          onUpdateItems={vi.fn()}
+          projectPolicy={{
+            getMode: () => "ai-selectable",
+            onModeChange: vi.fn(),
+            maxProjects: 2,
+            minProjects: 0,
+            maxProjectsTotal: 2,
+            onMaxProjectsChange,
+          }}
+        />
+      </Accordion>,
+    );
+
+    const maxProjectsInput = screen.getByLabelText("Max projects");
+    expect(maxProjectsInput).toHaveValue(2);
+
+    fireEvent.change(maxProjectsInput, { target: { value: "1" } });
+
+    expect(onMaxProjectsChange).toHaveBeenCalledWith(1);
+  });
 });

--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.test.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.test.tsx
@@ -100,7 +100,9 @@ describe("DesignResumeListSection", () => {
       </Accordion>,
     );
 
-    const maxProjectsInput = screen.getByLabelText("Max projects");
+    const maxProjectsInput = screen.getByLabelText(
+      "Maximum projects in Tailored Resumes",
+    );
     expect(maxProjectsInput).toHaveValue(2);
 
     fireEvent.change(maxProjectsInput, { target: { value: "1" } });

--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
 } from "lucide-react";
 import type { DragEvent } from "react";
-import { useMemo, useRef, useState } from "react";
+import { useId, useMemo, useRef, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,6 +21,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   Tooltip,
   TooltipContent,
@@ -28,7 +29,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { bucketCount, trackProductEvent } from "@/lib/analytics";
-import { cn } from "@/lib/utils";
+import { clampInt, cn } from "@/lib/utils";
 import { DesignResumeSection } from "./DesignResumeSection";
 import type { ItemDefinition } from "./definitions";
 import { getByPath, toBoolean, toText } from "./utils";
@@ -117,6 +118,10 @@ export type ProjectTailoringMode = "manual" | "ai-selectable" | "must-include";
 export type ProjectPolicyConfig = {
   getMode: (projectId: string) => ProjectTailoringMode;
   onModeChange: (projectId: string, mode: ProjectTailoringMode) => void;
+  maxProjects: number;
+  minProjects: number;
+  maxProjectsTotal: number;
+  onMaxProjectsChange: (maxProjects: number) => void;
   disabled?: boolean;
   isSaving?: boolean;
 };
@@ -386,6 +391,7 @@ export function DesignResumeListSectionContent({
   );
   const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const maxProjectsInputId = useId();
   const cardRefs = useRef<Array<HTMLLIElement | null>>([]);
   const pendingRemovalItem = useMemo(
     () =>
@@ -412,6 +418,9 @@ export function DesignResumeListSectionContent({
     });
     setPendingRemovalIndex(null);
   };
+
+  const showProjectPolicyControls =
+    definition.key === "projects" && projectPolicy;
 
   const toggleItemHidden = (index: number) => {
     const isHidden = toBoolean(items[index]?.hidden, false);
@@ -493,21 +502,71 @@ export function DesignResumeListSectionContent({
   return (
     <>
       <div className="space-y-3">
-        <div className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-4 py-3">
-          <div>
-            <div className="text-sm font-medium text-foreground">
-              {items.length} item{items.length === 1 ? "" : "s"}
+        <div className="flex items-center justify-between rounded-lg border border-border/60 bg-muted/20 px-4 py-3 flex-wrap gap-3">
+          <div className="flex items-center gap-4">
+            <div>
+              <div className="text-sm font-medium text-foreground">
+                {items.length} item{items.length === 1 ? "" : "s"}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {definition.key === "projects"
+                  ? "Add entries, reorder them, or choose when each one appears."
+                  : "Add entries, reorder them, or hide the ones you do not want to show."}
+              </div>
             </div>
-            <div className="text-xs text-muted-foreground">
-              {definition.key === "projects"
-                ? "Add entries, reorder them, or choose when each one appears."
-                : "Add entries, reorder them, or hide the ones you do not want to show."}
-            </div>
+
+            <Button type="button" variant="outline" onClick={onAdd}>
+              <Plus className="mr-2 h-4 w-4" />
+              Add
+            </Button>
           </div>
-          <Button type="button" variant="outline" onClick={onAdd}>
-            <Plus className="mr-2 h-4 w-4" />
-            Add
-          </Button>
+          {showProjectPolicyControls ? (
+            <div className="flex items-center gap-2 w-full">
+              <TooltipProvider delayDuration={0}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <label
+                      htmlFor={maxProjectsInputId}
+                      className="text-xs font-medium text-muted-foreground w-full"
+                    >
+                      Maximum projects in Tailored Resumes
+                    </label>
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-96 text-center" side="top">
+                    Set the maximum number of projects that Job Tailoring can
+                    include in tailored resumes. <br/><br/> Always-selected projects count
+                    toward this limit. <br/><br/> Setting it to 0 prevents automatic
+                    project selection unless projects are marked Always.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+
+              <Input
+                id={maxProjectsInputId}
+                type="number"
+                inputMode="numeric"
+                min={projectPolicy.minProjects}
+                max={projectPolicy.maxProjectsTotal}
+                value={projectPolicy.maxProjects}
+                onChange={(event) => {
+                  const next = Number(event.target.value);
+                  projectPolicy.onMaxProjectsChange(
+                    clampInt(
+                      next,
+                      projectPolicy.minProjects,
+                      projectPolicy.maxProjectsTotal,
+                    ),
+                  );
+                }}
+                disabled={
+                  projectPolicy.disabled ||
+                  projectPolicy.isSaving ||
+                  projectPolicy.maxProjectsTotal === 0
+                }
+                className="text-center w-28"
+              />
+            </div>
+          ) : null}
         </div>
 
         {items.length === 0 ? (

--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
@@ -534,9 +534,11 @@ export function DesignResumeListSectionContent({
                   </TooltipTrigger>
                   <TooltipContent className="max-w-96 text-center" side="top">
                     Set the maximum number of projects that Job Tailoring can
-                    include in tailored resumes. <br/><br/> Always-selected projects count
-                    toward this limit. <br/><br/> Setting it to 0 prevents automatic
-                    project selection unless projects are marked Always.
+                    include in tailored resumes. <br />
+                    <br /> Always-selected projects count toward this limit.{" "}
+                    <br />
+                    <br /> Setting it to 0 prevents automatic project selection
+                    unless projects are marked Always.
                   </TooltipContent>
                 </Tooltip>
               </TooltipProvider>

--- a/orchestrator/src/client/components/design-resume/DesignResumeRail.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeRail.tsx
@@ -413,6 +413,27 @@ export function DesignResumeRail({
                   ),
                   projectId,
                 ),
+              maxProjects: normalizeResumeProjectsForDesignItems(
+                items,
+                settings?.resumeProjects?.value ?? null,
+              ).maxProjects,
+              minProjects: normalizeResumeProjectsForDesignItems(
+                items,
+                settings?.resumeProjects?.value ?? null,
+              ).lockedProjectIds.length,
+              maxProjectsTotal: items.length,
+              onMaxProjectsChange: (maxProjects: number) => {
+                const current = normalizeResumeProjectsForDesignItems(
+                  items,
+                  settings?.resumeProjects?.value ?? null,
+                );
+                updateSettingsMutation.mutate({
+                  resumeProjects: {
+                    ...current,
+                    maxProjects,
+                  },
+                });
+              },
               onModeChange: (projectId: string, mode: ProjectTailoringMode) => {
                 const current = normalizeResumeProjectsForDesignItems(
                   items,

--- a/orchestrator/src/client/components/tailoring/TailoringSections.test.ts
+++ b/orchestrator/src/client/components/tailoring/TailoringSections.test.ts
@@ -1,0 +1,97 @@
+import type {
+  ResumeProjectCatalogItem,
+  ResumeProjectsSettings,
+} from "@shared/types.js";
+import { describe, expect, it } from "vitest";
+import { getNoSelectedProjectsInfo } from "./TailoringSections";
+
+const project = (id: string): ResumeProjectCatalogItem => ({
+  id,
+  name: id,
+  description: "",
+  date: "",
+  isVisibleInBase: true,
+});
+
+const settings = (
+  overrides: Partial<ResumeProjectsSettings> = {},
+): ResumeProjectsSettings => ({
+  maxProjects: 3,
+  lockedProjectIds: [],
+  aiSelectableProjectIds: ["p1", "p2"],
+  ...overrides,
+});
+
+describe("getNoSelectedProjectsInfo", () => {
+  const catalog = [project("p1"), project("p2")];
+
+  it("returns null when projects are selected", () => {
+    expect(
+      getNoSelectedProjectsInfo({
+        catalog,
+        isCatalogLoading: false,
+        selectedIds: new Set(["p1"]),
+        resumeProjectsSettings: settings(),
+      }),
+    ).toBeNull();
+  });
+
+  it("explains when no resume projects exist", () => {
+    expect(
+      getNoSelectedProjectsInfo({
+        catalog: [],
+        isCatalogLoading: false,
+        selectedIds: new Set(),
+        resumeProjectsSettings: settings(),
+      })?.reason,
+    ).toBe("no-projects");
+  });
+
+  it("explains when settings allow no project slots", () => {
+    expect(
+      getNoSelectedProjectsInfo({
+        catalog,
+        isCatalogLoading: false,
+        selectedIds: new Set(),
+        resumeProjectsSettings: settings({ maxProjects: 0 }),
+      })?.reason,
+    ).toBe("no-project-slots");
+  });
+
+  it("explains when must-include projects fill all automatic slots", () => {
+    expect(
+      getNoSelectedProjectsInfo({
+        catalog,
+        isCatalogLoading: false,
+        selectedIds: new Set(),
+        resumeProjectsSettings: settings({
+          maxProjects: 2,
+          lockedProjectIds: ["p1", "p2"],
+          aiSelectableProjectIds: [],
+        }),
+      })?.reason,
+    ).toBe("no-available-slots");
+  });
+
+  it("explains when no projects are AI-selectable", () => {
+    expect(
+      getNoSelectedProjectsInfo({
+        catalog,
+        isCatalogLoading: false,
+        selectedIds: new Set(),
+        resumeProjectsSettings: settings({ aiSelectableProjectIds: [] }),
+      })?.reason,
+    ).toBe("no-ai-selectable-projects");
+  });
+
+  it("explains when automatic selection produced no saved selection", () => {
+    expect(
+      getNoSelectedProjectsInfo({
+        catalog,
+        isCatalogLoading: false,
+        selectedIds: new Set(),
+        resumeProjectsSettings: settings({ aiSelectableProjectIds: ["p1"] }),
+      })?.reason,
+    ).toBe("selection-empty");
+  });
+});

--- a/orchestrator/src/client/components/tailoring/TailoringSections.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringSections.tsx
@@ -4,6 +4,7 @@ import {
   CheckCircle2,
   Circle,
   CircleAlert,
+  Info,
   Plus,
   Redo2,
   Sparkles,
@@ -150,9 +151,10 @@ const SectionTriggerLabel: React.FC<{
   title: string;
   state: SectionState;
   badgeLabel?: string;
+  badgeAdornment?: React.ReactNode;
   count?: number;
   children?: React.ReactNode;
-}> = ({ title, state, badgeLabel, count, children }) => {
+}> = ({ title, state, badgeLabel, badgeAdornment, count, children }) => {
   const copy = stateCopy[state];
   const resolvedBadgeLabel =
     badgeLabel ??
@@ -172,6 +174,7 @@ const SectionTriggerLabel: React.FC<{
         >
           {resolvedBadgeLabel}
         </span>
+        {badgeAdornment}
       </span>
       {children ? (
         <span className="hidden shrink-0 items-center gap-1 sm:flex">
@@ -181,6 +184,26 @@ const SectionTriggerLabel: React.FC<{
     </span>
   );
 };
+
+const NoSelectedProjectsInfo = () => (
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <span
+        aria-label="Why no projects are selected"
+        className="inline-flex h-5 w-5 shrink-0 cursor-help items-center justify-center rounded-full text-muted-foreground/70 transition-colors hover:bg-muted/40 hover:text-foreground"
+        role="img"
+        title="Why no projects are selected"
+      >
+        <Info className="h-3.5 w-3.5" />
+      </span>
+    </TooltipTrigger>
+    <TooltipContent className="max-w-72 text-left text-xs leading-5" side="top">
+      No projects are saved for this job yet. The generated PDF will not include
+      tailored project choices until you select projects below or run automatic
+      generation again.
+    </TooltipContent>
+  </Tooltip>
+);
 
 export const TailoringSections: React.FC<TailoringSectionsProps> = ({
   catalog,
@@ -599,6 +622,9 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
                 state={projectsState}
                 badgeLabel={
                   selectedIds.size > 0 ? String(selectedIds.size) : undefined
+                }
+                badgeAdornment={
+                  projectsState === "none" ? <NoSelectedProjectsInfo /> : null
                 }
               />
             </AccordionTrigger>

--- a/orchestrator/src/client/components/tailoring/TailoringSections.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringSections.tsx
@@ -1,5 +1,8 @@
 import { TokenizedInput } from "@client/pages/orchestrator/TokenizedInput";
-import type { ResumeProjectCatalogItem } from "@shared/types.js";
+import type {
+  ResumeProjectCatalogItem,
+  ResumeProjectsSettings,
+} from "@shared/types.js";
 import {
   CheckCircle2,
   Circle,
@@ -39,6 +42,8 @@ interface TailoringSectionsProps {
   jobDescription: string;
   skillsDraft: EditableSkillGroup[];
   selectedIds: Set<string>;
+  resumeProjectsSettings?: ResumeProjectsSettings | null;
+  isResumeProjectsSettingsLoading?: boolean;
   tracerLinksEnabled: boolean;
   tracerEnableBlocked: boolean;
   tracerEnableBlockedReason: string | null;
@@ -84,6 +89,22 @@ type SectionState =
   | "optional"
   | "source"
   | "none";
+
+type NoSelectedProjectsReason =
+  | "projects-loading"
+  | "settings-loading"
+  | "no-projects"
+  | "no-project-slots"
+  | "no-available-slots"
+  | "no-ai-selectable-projects"
+  | "selection-empty"
+  | "unknown";
+
+type NoSelectedProjectsInfoCopy = {
+  reason: NoSelectedProjectsReason;
+  title: string;
+  description: string;
+};
 
 const sectionClass =
   "overflow-hidden rounded-md border border-border/55 bg-background/25 px-0 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)]";
@@ -147,6 +168,98 @@ const skillGroupHasKeywords = (keywordsText: string) =>
 const skillGroupNeedsReview = (group: EditableSkillGroup) =>
   !textHasValue(group.name) || !skillGroupHasKeywords(group.keywordsText);
 
+export function getNoSelectedProjectsInfo(args: {
+  catalog: ResumeProjectCatalogItem[];
+  isCatalogLoading: boolean;
+  selectedIds: Set<string>;
+  resumeProjectsSettings?: ResumeProjectsSettings | null;
+  isResumeProjectsSettingsLoading?: boolean;
+}): NoSelectedProjectsInfoCopy | null {
+  if (args.selectedIds.size > 0) return null;
+
+  if (args.isCatalogLoading) {
+    return {
+      reason: "projects-loading",
+      title: "Projects are still loading",
+      description:
+        "Project options are still loading. Wait a moment before deciding whether this job has no selected projects.",
+    };
+  }
+
+  if (args.catalog.length === 0) {
+    return {
+      reason: "no-projects",
+      title: "No projects found",
+      description:
+        "No projects were found in your base resume. Add projects to your resume to include them here.",
+    };
+  }
+
+  if (args.isResumeProjectsSettingsLoading) {
+    return {
+      reason: "settings-loading",
+      title: "Project settings are still loading",
+      description:
+        "Project options are available, but selection settings are still loading. Wait a moment or select projects manually below.",
+    };
+  }
+
+  const settings = args.resumeProjectsSettings;
+  if (!settings) {
+    return {
+      reason: "unknown",
+      title: "No projects selected",
+      description:
+        "No projects are saved for this job yet. The generated PDF will not include tailored project choices until you select projects below or run automatic generation again.",
+    };
+  }
+
+  const catalogIds = new Set(args.catalog.map((project) => project.id));
+  const lockedProjectIds = settings.lockedProjectIds.filter((id) =>
+    catalogIds.has(id),
+  );
+  const lockedSet = new Set(lockedProjectIds);
+  const aiSelectableProjectIds = settings.aiSelectableProjectIds
+    .filter((id) => catalogIds.has(id))
+    .filter((id) => !lockedSet.has(id));
+  const maxProjects = Math.max(0, Math.floor(settings.maxProjects));
+  const availableSlots = Math.max(0, maxProjects - lockedProjectIds.length);
+
+  if (maxProjects === 0) {
+    return {
+      reason: "no-project-slots",
+      title: "No project slots available",
+      description:
+        "Project settings currently allow 0 projects. Increase the max project count or select projects manually before generating the PDF.",
+    };
+  }
+
+  if (availableSlots === 0) {
+    return {
+      reason: "no-available-slots",
+      title: "No AI selection slots available",
+      description:
+        "Your max project count is already filled by must-include projects, so automatic selection cannot add more projects. Select projects manually or adjust the max project count.",
+    };
+  }
+
+  if (aiSelectableProjectIds.length === 0) {
+    return {
+      reason: "no-ai-selectable-projects",
+      title: "No AI-selectable projects",
+      description:
+        "Your resume has projects, but none are available for automatic selection. Select projects manually here, or mark projects as AI-selectable in resume project settings.",
+    };
+  }
+
+  return {
+    reason: "selection-empty",
+    title: "No projects selected",
+    description:
+      "Automatic tailoring created the draft, but no projects were selected for this job. Choose the projects to include below before generating the PDF.",
+  };
+}
+
 const SectionTriggerLabel: React.FC<{
   title: string;
   state: SectionState;
@@ -185,22 +298,25 @@ const SectionTriggerLabel: React.FC<{
   );
 };
 
-const NoSelectedProjectsInfo = () => (
+const NoSelectedProjectsInfo = ({
+  info,
+}: {
+  info: NoSelectedProjectsInfoCopy;
+}) => (
   <Tooltip>
     <TooltipTrigger asChild>
       <span
-        aria-label="Why no projects are selected"
+        aria-label={info.title}
         className="inline-flex h-5 w-5 shrink-0 cursor-help items-center justify-center rounded-full text-muted-foreground/70 transition-colors hover:bg-muted/40 hover:text-foreground"
         role="img"
-        title="Why no projects are selected"
+        title={info.title}
       >
         <Info className="h-3.5 w-3.5" />
       </span>
     </TooltipTrigger>
     <TooltipContent className="max-w-72 text-left text-xs leading-5" side="top">
-      No projects are saved for this job yet. The generated PDF will not include
-      tailored project choices until you select projects below or run automatic
-      generation again.
+      <div className="font-semibold text-foreground">{info.title}</div>
+      <div className="mt-1 text-muted-foreground">{info.description}</div>
     </TooltipContent>
   </Tooltip>
 );
@@ -213,6 +329,8 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
   jobDescription,
   skillsDraft,
   selectedIds,
+  resumeProjectsSettings,
+  isResumeProjectsSettingsLoading = false,
   tracerLinksEnabled,
   tracerEnableBlocked,
   tracerEnableBlockedReason,
@@ -261,6 +379,13 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
         ? "review"
         : "ready";
   const projectsState: SectionState = selectedIds.size > 0 ? "ready" : "none";
+  const noSelectedProjectsInfo = getNoSelectedProjectsInfo({
+    catalog,
+    isCatalogLoading,
+    selectedIds,
+    resumeProjectsSettings,
+    isResumeProjectsSettingsLoading,
+  });
 
   return (
     <TooltipProvider>
@@ -624,7 +749,9 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
                   selectedIds.size > 0 ? String(selectedIds.size) : undefined
                 }
                 badgeAdornment={
-                  projectsState === "none" ? <NoSelectedProjectsInfo /> : null
+                  noSelectedProjectsInfo ? (
+                    <NoSelectedProjectsInfo info={noSelectedProjectsInfo} />
+                  ) : null
                 }
               />
             </AccordionTrigger>

--- a/orchestrator/src/client/components/tailoring/TailoringWorkspace.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringWorkspace.tsx
@@ -1,5 +1,6 @@
 import * as api from "@client/api";
 import { useProfile } from "@client/hooks/useProfile";
+import { useSettings } from "@client/hooks/useSettings";
 import { useTracerReadiness } from "@client/hooks/useTracerReadiness";
 import type { Job } from "@shared/types.js";
 import {
@@ -173,6 +174,7 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
   const persistedPayloadKeyRef = useRef(savedPayloadKey);
   const isMountedRef = useRef(true);
   const { profile, error: profileError } = useProfile();
+  const { settings, isLoading: isSettingsLoading } = useSettings();
   const { readiness: tracerReadiness, isChecking: isTracerReadinessChecking } =
     useTracerReadiness();
 
@@ -483,6 +485,8 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
       jobDescription,
       skillsDraft,
       selectedIds,
+      resumeProjectsSettings: settings?.resumeProjects.value ?? null,
+      isResumeProjectsSettingsLoading: isSettingsLoading,
       tracerLinksEnabled,
       tracerEnableBlocked,
       tracerEnableBlockedReason,
@@ -534,6 +538,8 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
       jobDescription,
       skillsDraft,
       selectedIds,
+      settings?.resumeProjects.value,
+      isSettingsLoading,
       tracerLinksEnabled,
       tracerEnableBlocked,
       tracerEnableBlockedReason,

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -68,8 +68,6 @@ const DEFAULT_CONFIG: PipelineConfig = {
   enableAutoTailoring: true,
 };
 
-const PROJECT_SELECTION_TRACE = "PROJECT_SELECTION_TRACE";
-
 function parseProjectIdsCsv(value: string | null | undefined): string[] {
   if (!value) return [];
   const seen = new Set<string>();
@@ -656,22 +654,7 @@ export async function summarizeJob(
       // 2. Suggest Projects
       let selectedProjectIds = job.selectedProjectIds;
       const existingSelectedProjectIds = parseProjectIdsCsv(selectedProjectIds);
-      jobLogger.info(`${PROJECT_SELECTION_TRACE} project selection gate`, {
-        marker: PROJECT_SELECTION_TRACE,
-        phase: "summarizeJob.gate",
-        shouldUpdateAllTailoring,
-        hasExistingSelectedProjectIds: existingSelectedProjectIds.length > 0,
-        existingSelectedProjectCount: existingSelectedProjectIds.length,
-        existingSelectedProjectIds,
-        force: Boolean(options?.force),
-        requestedFields: requestedFields ?? null,
-      });
       if (shouldUpdateAllTailoring) {
-        jobLogger.info(`${PROJECT_SELECTION_TRACE} selecting projects`, {
-          marker: PROJECT_SELECTION_TRACE,
-          phase: "summarizeJob.start",
-          force: Boolean(options?.force),
-        });
         try {
           const { catalog, selectionItems } =
             extractProjectsFromProfile(profile);
@@ -709,38 +692,10 @@ export async function summarizeJob(
             disallowedExistingProjectIds.length === 0 &&
             missingLockedProjectIds.length === 0 &&
             !existingSelectionExceedsMax;
-          jobLogger.info(`${PROJECT_SELECTION_TRACE} resolved candidates`, {
-            marker: PROJECT_SELECTION_TRACE,
-            phase: "summarizeJob.candidates",
-            catalogCount: catalog.length,
-            selectionItemCount: selectionItems.length,
-            hasResumeProjectsOverride: Boolean(overrideResumeProjectsRaw),
-            maxProjects: resumeProjects.maxProjects,
-            lockedProjectCount: locked.length,
-            lockedProjectIds: locked,
-            aiSelectableProjectCount:
-              resumeProjects.aiSelectableProjectIds.length,
-            aiSelectableProjectIds: resumeProjects.aiSelectableProjectIds,
-            desiredCount,
-            eligibleProjectCount: eligibleProjects.length,
-            eligibleProjectIds: eligibleProjects.map((project) => project.id),
-            existingSelectionValid,
-            disallowedExistingProjectIds,
-            missingLockedProjectIds,
-            existingSelectionExceedsMax,
-          });
 
           let picked: string[] = [];
           if (existingSelectionValid && !options?.force) {
             selectedProjectIds = existingSelectedProjectIds.join(",");
-            jobLogger.info(
-              `${PROJECT_SELECTION_TRACE} kept existing selection`,
-              {
-                marker: PROJECT_SELECTION_TRACE,
-                phase: "summarizeJob.keptExisting",
-                existingSelectedProjectIds,
-              },
-            );
           } else {
             picked = await pickProjectIdsForJob({
               jobDescription: job.jobDescription || "",
@@ -750,33 +705,9 @@ export async function summarizeJob(
 
             selectedProjectIds = [...locked, ...picked].join(",");
           }
-          jobLogger.info(`${PROJECT_SELECTION_TRACE} saved project selection`, {
-            marker: PROJECT_SELECTION_TRACE,
-            phase: "summarizeJob.saved",
-            pickedProjectCount: picked.length,
-            pickedProjectIds: picked,
-            finalSelectedProjectIds: selectedProjectIds,
-            finalSelectedProjectCount: selectedProjectIds
-              .split(",")
-              .filter(Boolean).length,
-          });
         } catch (error) {
-          jobLogger.warn(
-            `${PROJECT_SELECTION_TRACE} failed to suggest projects`,
-            {
-              marker: PROJECT_SELECTION_TRACE,
-              phase: "summarizeJob.error",
-              error,
-            },
-          );
+          jobLogger.warn("Failed to suggest projects", { error });
         }
-      } else {
-        jobLogger.info(`${PROJECT_SELECTION_TRACE} skipped project selection`, {
-          marker: PROJECT_SELECTION_TRACE,
-          phase: "summarizeJob.skipped",
-          reason: "field-specific-generation",
-          existingSelectedProjectIds: selectedProjectIds ?? null,
-        });
       }
 
       await jobsRepo.updateJob(job.id, {

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -68,6 +68,21 @@ const DEFAULT_CONFIG: PipelineConfig = {
   enableAutoTailoring: true,
 };
 
+const PROJECT_SELECTION_TRACE = "PROJECT_SELECTION_TRACE";
+
+function parseProjectIdsCsv(value: string | null | undefined): string[] {
+  if (!value) return [];
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const rawId of value.split(",")) {
+    const id = rawId.trim();
+    if (!id || seen.has(id)) continue;
+    seen.add(id);
+    ids.push(id);
+  }
+  return ids;
+}
+
 type TenantPipelineState = {
   isRunning: boolean;
   activePipelineRunId: string | null;
@@ -640,8 +655,23 @@ export async function summarizeJob(
 
       // 2. Suggest Projects
       let selectedProjectIds = job.selectedProjectIds;
-      if (shouldUpdateAllTailoring && (!selectedProjectIds || options?.force)) {
-        jobLogger.info("Selecting projects");
+      const existingSelectedProjectIds = parseProjectIdsCsv(selectedProjectIds);
+      jobLogger.info(`${PROJECT_SELECTION_TRACE} project selection gate`, {
+        marker: PROJECT_SELECTION_TRACE,
+        phase: "summarizeJob.gate",
+        shouldUpdateAllTailoring,
+        hasExistingSelectedProjectIds: existingSelectedProjectIds.length > 0,
+        existingSelectedProjectCount: existingSelectedProjectIds.length,
+        existingSelectedProjectIds,
+        force: Boolean(options?.force),
+        requestedFields: requestedFields ?? null,
+      });
+      if (shouldUpdateAllTailoring) {
+        jobLogger.info(`${PROJECT_SELECTION_TRACE} selecting projects`, {
+          marker: PROJECT_SELECTION_TRACE,
+          phase: "summarizeJob.start",
+          force: Boolean(options?.force),
+        });
         try {
           const { catalog, selectionItems } =
             extractProjectsFromProfile(profile);
@@ -661,17 +691,92 @@ export async function summarizeJob(
           const eligibleProjects = selectionItems.filter((p) =>
             eligibleSet.has(p.id),
           );
-
-          const picked = await pickProjectIdsForJob({
-            jobDescription: job.jobDescription || "",
-            eligibleProjects,
+          const allowedProjectIds = new Set([
+            ...locked,
+            ...eligibleProjects.map((project) => project.id),
+          ]);
+          const missingLockedProjectIds = locked.filter(
+            (id) => !existingSelectedProjectIds.includes(id),
+          );
+          const disallowedExistingProjectIds =
+            existingSelectedProjectIds.filter(
+              (id) => !allowedProjectIds.has(id),
+            );
+          const existingSelectionExceedsMax =
+            existingSelectedProjectIds.length > resumeProjects.maxProjects;
+          const existingSelectionValid =
+            existingSelectedProjectIds.length > 0 &&
+            disallowedExistingProjectIds.length === 0 &&
+            missingLockedProjectIds.length === 0 &&
+            !existingSelectionExceedsMax;
+          jobLogger.info(`${PROJECT_SELECTION_TRACE} resolved candidates`, {
+            marker: PROJECT_SELECTION_TRACE,
+            phase: "summarizeJob.candidates",
+            catalogCount: catalog.length,
+            selectionItemCount: selectionItems.length,
+            hasResumeProjectsOverride: Boolean(overrideResumeProjectsRaw),
+            maxProjects: resumeProjects.maxProjects,
+            lockedProjectCount: locked.length,
+            lockedProjectIds: locked,
+            aiSelectableProjectCount:
+              resumeProjects.aiSelectableProjectIds.length,
+            aiSelectableProjectIds: resumeProjects.aiSelectableProjectIds,
             desiredCount,
+            eligibleProjectCount: eligibleProjects.length,
+            eligibleProjectIds: eligibleProjects.map((project) => project.id),
+            existingSelectionValid,
+            disallowedExistingProjectIds,
+            missingLockedProjectIds,
+            existingSelectionExceedsMax,
           });
 
-          selectedProjectIds = [...locked, ...picked].join(",");
+          let picked: string[] = [];
+          if (existingSelectionValid && !options?.force) {
+            selectedProjectIds = existingSelectedProjectIds.join(",");
+            jobLogger.info(
+              `${PROJECT_SELECTION_TRACE} kept existing selection`,
+              {
+                marker: PROJECT_SELECTION_TRACE,
+                phase: "summarizeJob.keptExisting",
+                existingSelectedProjectIds,
+              },
+            );
+          } else {
+            picked = await pickProjectIdsForJob({
+              jobDescription: job.jobDescription || "",
+              eligibleProjects,
+              desiredCount,
+            });
+
+            selectedProjectIds = [...locked, ...picked].join(",");
+          }
+          jobLogger.info(`${PROJECT_SELECTION_TRACE} saved project selection`, {
+            marker: PROJECT_SELECTION_TRACE,
+            phase: "summarizeJob.saved",
+            pickedProjectCount: picked.length,
+            pickedProjectIds: picked,
+            finalSelectedProjectIds: selectedProjectIds,
+            finalSelectedProjectCount: selectedProjectIds
+              .split(",")
+              .filter(Boolean).length,
+          });
         } catch (error) {
-          jobLogger.warn("Failed to suggest projects", error);
+          jobLogger.warn(
+            `${PROJECT_SELECTION_TRACE} failed to suggest projects`,
+            {
+              marker: PROJECT_SELECTION_TRACE,
+              phase: "summarizeJob.error",
+              error,
+            },
+          );
         }
+      } else {
+        jobLogger.info(`${PROJECT_SELECTION_TRACE} skipped project selection`, {
+          marker: PROJECT_SELECTION_TRACE,
+          phase: "summarizeJob.skipped",
+          reason: "field-specific-generation",
+          existingSelectedProjectIds: selectedProjectIds ?? null,
+        });
       }
 
       await jobsRepo.updateJob(job.id, {

--- a/orchestrator/src/server/pipeline/project-selection.test.ts
+++ b/orchestrator/src/server/pipeline/project-selection.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as jobsRepo from "../repositories/jobs";
+import * as settingsRepo from "../repositories/settings";
+import { getProfile } from "../services/profile";
+import { pickProjectIdsForJob } from "../services/projectSelection";
+import { summarizeJob } from "./orchestrator";
+
+vi.mock("@infra/logger", () => {
+  const logger = {
+    child: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return { logger };
+});
+
+vi.mock("@infra/product-analytics", () => ({
+  trackServerProductEvent: vi.fn(),
+}));
+
+vi.mock("../repositories/jobs", () => ({
+  getJobById: vi.fn(),
+  updateJob: vi.fn(),
+}));
+
+vi.mock("../repositories/pipeline", () => ({
+  createPipelineRun: vi.fn(),
+  updatePipelineRun: vi.fn(),
+}));
+
+vi.mock("../repositories/settings", () => ({
+  getSetting: vi.fn(),
+  getAllSettings: vi.fn(),
+}));
+
+vi.mock("../services/pdf", () => ({
+  generatePdf: vi.fn(),
+}));
+
+vi.mock("../services/pdf-fingerprint", () => ({
+  createJobPdfFingerprint: vi.fn(),
+  resolvePdfFingerprintContext: vi.fn(),
+}));
+
+vi.mock("../services/profile", () => ({
+  getProfile: vi.fn(),
+}));
+
+vi.mock("../services/projectSelection", () => ({
+  pickProjectIdsForJob: vi.fn(),
+}));
+
+vi.mock("../services/summary", () => ({
+  generateTailoring: vi.fn(),
+}));
+
+vi.mock("./steps", () => ({
+  discoverJobsStep: vi.fn(),
+  importJobsStep: vi.fn(),
+  loadProfileStep: vi.fn(),
+  notifyPipelineWebhookStep: vi.fn(),
+  processJobsStep: vi.fn(),
+  scoreJobsStep: vi.fn(),
+  selectJobsStep: vi.fn(),
+}));
+
+const profileWithProjects = {
+  sections: {
+    projects: {
+      items: [
+        {
+          id: "mumtaz-urdu",
+          name: "Mumtaz Urdu",
+          summary: "Next.js education platform.",
+          description: "",
+          date: "",
+          visible: false,
+        },
+        {
+          id: "jobops",
+          name: "JobOps",
+          summary: "Job search automation app.",
+          description: "",
+          date: "",
+          visible: false,
+        },
+        {
+          id: "indus-marine",
+          name: "Indus Marine Services",
+          summary: "Induction platform.",
+          description: "",
+          date: "",
+          visible: false,
+        },
+      ],
+    },
+  },
+};
+
+describe("summarizeJob project selection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(jobsRepo.getJobById).mockResolvedValue({
+      id: "job-1",
+      jobDescription: "Data acquisition engineer role.",
+      tailoredSummary: "Existing summary.",
+      tailoredHeadline: "Existing headline.",
+      tailoredSkills: JSON.stringify(["TypeScript"]),
+      selectedProjectIds: "mumtaz-urdu,jobops,indus-marine",
+    } as any);
+    vi.mocked(jobsRepo.updateJob).mockResolvedValue(undefined as any);
+    vi.mocked(getProfile).mockResolvedValue(profileWithProjects as any);
+    vi.mocked(settingsRepo.getSetting).mockImplementation(async (key) => {
+      if (key !== "resumeProjects") return null;
+      return JSON.stringify({
+        maxProjects: 3,
+        lockedProjectIds: [],
+        aiSelectableProjectIds: ["mumtaz-urdu"],
+      });
+    });
+    vi.mocked(pickProjectIdsForJob).mockResolvedValue(["mumtaz-urdu"]);
+  });
+
+  it("reselects stale saved projects using only the AI-selectable pool", async () => {
+    const result = await summarizeJob("job-1");
+
+    expect(result).toEqual({ success: true });
+    expect(pickProjectIdsForJob).toHaveBeenCalledTimes(1);
+    expect(pickProjectIdsForJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        desiredCount: 3,
+        eligibleProjects: [
+          expect.objectContaining({
+            id: "mumtaz-urdu",
+            name: "Mumtaz Urdu",
+          }),
+        ],
+      }),
+    );
+    expect(jobsRepo.updateJob).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({
+        selectedProjectIds: "mumtaz-urdu",
+      }),
+    );
+  });
+});

--- a/orchestrator/src/server/services/projectSelection.ts
+++ b/orchestrator/src/server/services/projectSelection.ts
@@ -2,12 +2,9 @@
  * Service for AI-powered project selection for resumes.
  */
 
-import { logger } from "@infra/logger";
 import type { JsonSchemaDefinition } from "./llm/types";
 import { createConfiguredLlmService, resolveLlmModel } from "./modelSelection";
 import type { ResumeProjectSelectionItem } from "./resumeProjects";
-
-const PROJECT_SELECTION_TRACE = "PROJECT_SELECTION_TRACE";
 
 /** JSON schema for project selection response */
 const PROJECT_SELECTION_SCHEMA: JsonSchemaDefinition = {
@@ -33,39 +30,15 @@ export async function pickProjectIdsForJob(args: {
 }): Promise<string[]> {
   const desiredCount = Math.max(0, Math.floor(args.desiredCount));
   if (desiredCount === 0) {
-    logger.info(`${PROJECT_SELECTION_TRACE} skipped selector`, {
-      marker: PROJECT_SELECTION_TRACE,
-      phase: "pickProjectIdsForJob.skipped",
-      reason: "desired-count-zero",
-      requestedDesiredCount: args.desiredCount,
-      eligibleProjectCount: args.eligibleProjects.length,
-      eligibleProjectIds: args.eligibleProjects.map((project) => project.id),
-    });
     return [];
   }
 
   const eligibleIds = new Set(args.eligibleProjects.map((p) => p.id));
   if (eligibleIds.size === 0) {
-    logger.info(`${PROJECT_SELECTION_TRACE} skipped selector`, {
-      marker: PROJECT_SELECTION_TRACE,
-      phase: "pickProjectIdsForJob.skipped",
-      reason: "no-eligible-projects",
-      requestedDesiredCount: args.desiredCount,
-      desiredCount,
-      eligibleProjectCount: args.eligibleProjects.length,
-    });
     return [];
   }
 
   const model = await resolveLlmModel("projectSelection");
-  logger.info(`${PROJECT_SELECTION_TRACE} calling selector model`, {
-    marker: PROJECT_SELECTION_TRACE,
-    phase: "pickProjectIdsForJob.llm.start",
-    model,
-    desiredCount,
-    eligibleProjectCount: args.eligibleProjects.length,
-    eligibleProjectIds: args.eligibleProjects.map((project) => project.id),
-  });
 
   const prompt = buildProjectSelectionPrompt({
     jobDescription: args.jobDescription,
@@ -86,16 +59,6 @@ export async function pickProjectIdsForJob(args: {
       args.eligibleProjects,
       desiredCount,
     );
-    logger.warn(`${PROJECT_SELECTION_TRACE} selector model failed`, {
-      marker: PROJECT_SELECTION_TRACE,
-      phase: "pickProjectIdsForJob.llm.failed",
-      model,
-      desiredCount,
-      eligibleProjectCount: args.eligibleProjects.length,
-      fallbackProjectIds: fallback,
-      fallbackProjectCount: fallback.length,
-      error: result.error ?? "unknown",
-    });
     return fallback;
   }
 
@@ -123,29 +86,9 @@ export async function pickProjectIdsForJob(args: {
       args.eligibleProjects,
       desiredCount,
     );
-    logger.warn(`${PROJECT_SELECTION_TRACE} selector returned no valid ids`, {
-      marker: PROJECT_SELECTION_TRACE,
-      phase: "pickProjectIdsForJob.llm.empty",
-      model,
-      desiredCount,
-      eligibleProjectCount: args.eligibleProjects.length,
-      rawSelectedProjectIds: selectedProjectIds,
-      fallbackProjectIds: fallback,
-      fallbackProjectCount: fallback.length,
-    });
     return fallback;
   }
 
-  logger.info(`${PROJECT_SELECTION_TRACE} selector returned ids`, {
-    marker: PROJECT_SELECTION_TRACE,
-    phase: "pickProjectIdsForJob.llm.success",
-    model,
-    desiredCount,
-    eligibleProjectCount: args.eligibleProjects.length,
-    rawSelectedProjectIds: selectedProjectIds,
-    selectedProjectIds: unique,
-    selectedProjectCount: unique.length,
-  });
   return unique;
 }
 

--- a/orchestrator/src/server/services/projectSelection.ts
+++ b/orchestrator/src/server/services/projectSelection.ts
@@ -2,9 +2,12 @@
  * Service for AI-powered project selection for resumes.
  */
 
+import { logger } from "@infra/logger";
 import type { JsonSchemaDefinition } from "./llm/types";
 import { createConfiguredLlmService, resolveLlmModel } from "./modelSelection";
 import type { ResumeProjectSelectionItem } from "./resumeProjects";
+
+const PROJECT_SELECTION_TRACE = "PROJECT_SELECTION_TRACE";
 
 /** JSON schema for project selection response */
 const PROJECT_SELECTION_SCHEMA: JsonSchemaDefinition = {
@@ -29,12 +32,40 @@ export async function pickProjectIdsForJob(args: {
   desiredCount: number;
 }): Promise<string[]> {
   const desiredCount = Math.max(0, Math.floor(args.desiredCount));
-  if (desiredCount === 0) return [];
+  if (desiredCount === 0) {
+    logger.info(`${PROJECT_SELECTION_TRACE} skipped selector`, {
+      marker: PROJECT_SELECTION_TRACE,
+      phase: "pickProjectIdsForJob.skipped",
+      reason: "desired-count-zero",
+      requestedDesiredCount: args.desiredCount,
+      eligibleProjectCount: args.eligibleProjects.length,
+      eligibleProjectIds: args.eligibleProjects.map((project) => project.id),
+    });
+    return [];
+  }
 
   const eligibleIds = new Set(args.eligibleProjects.map((p) => p.id));
-  if (eligibleIds.size === 0) return [];
+  if (eligibleIds.size === 0) {
+    logger.info(`${PROJECT_SELECTION_TRACE} skipped selector`, {
+      marker: PROJECT_SELECTION_TRACE,
+      phase: "pickProjectIdsForJob.skipped",
+      reason: "no-eligible-projects",
+      requestedDesiredCount: args.desiredCount,
+      desiredCount,
+      eligibleProjectCount: args.eligibleProjects.length,
+    });
+    return [];
+  }
 
   const model = await resolveLlmModel("projectSelection");
+  logger.info(`${PROJECT_SELECTION_TRACE} calling selector model`, {
+    marker: PROJECT_SELECTION_TRACE,
+    phase: "pickProjectIdsForJob.llm.start",
+    model,
+    desiredCount,
+    eligibleProjectCount: args.eligibleProjects.length,
+    eligibleProjectIds: args.eligibleProjects.map((project) => project.id),
+  });
 
   const prompt = buildProjectSelectionPrompt({
     jobDescription: args.jobDescription,
@@ -50,11 +81,22 @@ export async function pickProjectIdsForJob(args: {
   });
 
   if (!result.success) {
-    return fallbackPickProjectIds(
+    const fallback = fallbackPickProjectIds(
       args.jobDescription,
       args.eligibleProjects,
       desiredCount,
     );
+    logger.warn(`${PROJECT_SELECTION_TRACE} selector model failed`, {
+      marker: PROJECT_SELECTION_TRACE,
+      phase: "pickProjectIdsForJob.llm.failed",
+      model,
+      desiredCount,
+      eligibleProjectCount: args.eligibleProjects.length,
+      fallbackProjectIds: fallback,
+      fallbackProjectCount: fallback.length,
+      error: result.error ?? "unknown",
+    });
+    return fallback;
   }
 
   const selectedProjectIds = Array.isArray(result.data?.selectedProjectIds)
@@ -76,13 +118,34 @@ export async function pickProjectIdsForJob(args: {
   }
 
   if (unique.length === 0) {
-    return fallbackPickProjectIds(
+    const fallback = fallbackPickProjectIds(
       args.jobDescription,
       args.eligibleProjects,
       desiredCount,
     );
+    logger.warn(`${PROJECT_SELECTION_TRACE} selector returned no valid ids`, {
+      marker: PROJECT_SELECTION_TRACE,
+      phase: "pickProjectIdsForJob.llm.empty",
+      model,
+      desiredCount,
+      eligibleProjectCount: args.eligibleProjects.length,
+      rawSelectedProjectIds: selectedProjectIds,
+      fallbackProjectIds: fallback,
+      fallbackProjectCount: fallback.length,
+    });
+    return fallback;
   }
 
+  logger.info(`${PROJECT_SELECTION_TRACE} selector returned ids`, {
+    marker: PROJECT_SELECTION_TRACE,
+    phase: "pickProjectIdsForJob.llm.success",
+    model,
+    desiredCount,
+    eligibleProjectCount: args.eligibleProjects.length,
+    rawSelectedProjectIds: selectedProjectIds,
+    selectedProjectIds: unique,
+    selectedProjectCount: unique.length,
+  });
   return unique;
 }
 


### PR DESCRIPTION
I believe I worked out what the problem is. The problem is that when resumes were being imported, project IDs weren't assigned. And these project IDs are necessary for the AI to choose which projects to select. If these project IDs are empty, the AI selects nothing and it shows as empty.

## Summary
- Revalidate saved project selections during job tailoring so stale IDs no longer suppress automatic selection
- Add structured `PROJECT_SELECTION_TRACE` logging around the project-selection gate, candidate resolution, and saved output
- Show the max-projects control in the Reactive Resume and Projects panels, and clarify the tooltip copy
- Add regression coverage for stale selections and the new Projects-panel max-projects control

## Testing
- Biome formatting and lint checks passed on the touched UI/server files
- Targeted Vitest coverage passed for project selection and Design Resume project controls
- Typecheck passed for the orchestrator workspace
- Client build passed