### PR TITLE
Repair blank project IDs in stored Resume Studio docs

### DIFF
--- a/orchestrator/src/client/components/ai-assist/AiAssistComposer.tsx
+++ b/orchestrator/src/client/components/ai-assist/AiAssistComposer.tsx
@@ -1,4 +1,5 @@
 import { getMetaShortcutLabel, isMetaKeyPressed } from "@client/lib/meta-key";
+import { createId } from "@paralleldrive/cuid2";
 import type { JobChatImageAttachment } from "@shared/types";
 import { Eraser, ImagePlus, Send, Square } from "lucide-react";
 import type React from "react";
@@ -82,7 +83,7 @@ export const AiAssistComposer: React.FC<AiAssistComposerProps> = ({
       }
 
       nextAttachments.push({
-        id: crypto.randomUUID(),
+        id: createId(),
         name: file.name,
         mediaType: file.type as JobChatImageAttachment["mediaType"],
         dataUrl,

--- a/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeInlineSections.tsx
@@ -1,4 +1,5 @@
 import { getDesignResumeAssetContentBlob } from "@client/api/settings-profile";
+import { createId } from "@paralleldrive/cuid2";
 import type { DesignResumeJson } from "@shared/types";
 import { FileImage, ImagePlus, Plus, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -429,7 +430,7 @@ export function BasicsCustomFieldsSection({
           onChange([
             ...customFields,
             {
-              id: crypto.randomUUID(),
+              id: createId(),
               title: "",
               icon: "",
               text: "",

--- a/orchestrator/src/client/components/design-resume/definitions.test.ts
+++ b/orchestrator/src/client/components/design-resume/definitions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { ITEM_DEFINITIONS } from "./definitions";
+
+describe("ITEM_DEFINITIONS", () => {
+  it("creates new project items without browser randomUUID support", () => {
+    const originalCrypto = globalThis.crypto;
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: {
+        getRandomValues<TArray extends ArrayBufferView | null>(
+          array: TArray,
+        ): TArray {
+          if (array && ArrayBuffer.isView(array)) {
+            const bytes = new Uint8Array(
+              array.buffer,
+              array.byteOffset,
+              array.byteLength,
+            );
+            bytes.fill(1);
+          }
+          return array;
+        },
+      },
+    });
+
+    try {
+      const projectsDefinition = ITEM_DEFINITIONS.find(
+        (definition) => definition.key === "projects",
+      );
+
+      expect(projectsDefinition).toBeDefined();
+      const item = projectsDefinition?.createItem();
+
+      expect(item?.id).toEqual(expect.any(String));
+      expect(String(item?.id).trim()).not.toBe("");
+      expect(item?.name).toBe("");
+      expect(item?.hidden).toBe(false);
+    } finally {
+      Object.defineProperty(globalThis, "crypto", {
+        configurable: true,
+        value: originalCrypto,
+      });
+    }
+  });
+});

--- a/orchestrator/src/client/components/design-resume/definitions.ts
+++ b/orchestrator/src/client/components/design-resume/definitions.ts
@@ -1,3 +1,4 @@
+import { createId } from "@paralleldrive/cuid2";
 import type { ItemFieldConfig } from "./ItemDialog";
 
 export type ItemDefinition = {
@@ -41,7 +42,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       icon: "",
       network: "",
@@ -81,7 +82,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       company: "",
       location: "",
@@ -121,7 +122,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       school: "",
       area: "",
@@ -159,7 +160,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       name: "",
       period: "",
@@ -195,7 +196,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       { key: "keywords", label: "Keywords", type: "tags", aiAssist: true },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       icon: "",
       name: "",
@@ -217,7 +218,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       { key: "level", label: "Level", type: "number", min: 0, step: 1 },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       language: "",
       fluency: "",
@@ -242,7 +243,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       { key: "keywords", label: "Keywords", type: "tags", aiAssist: true },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       icon: "",
       name: "",
@@ -274,7 +275,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       title: "",
       awarder: "",
@@ -309,7 +310,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       title: "",
       issuer: "",
@@ -344,7 +345,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       title: "",
       publisher: "",
@@ -384,7 +385,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       organization: "",
       location: "",
@@ -419,7 +420,7 @@ export const ITEM_DEFINITIONS: ItemDefinition[] = [
       },
     ],
     createItem: () => ({
-      id: crypto.randomUUID(),
+      id: createId(),
       hidden: false,
       name: "",
       position: "",

--- a/orchestrator/src/server/services/design-resume.test.ts
+++ b/orchestrator/src/server/services/design-resume.test.ts
@@ -66,6 +66,7 @@ vi.mock("node:fs/promises", () => ({
   default: fsMocks,
 }));
 
+import { createId } from "@paralleldrive/cuid2";
 import { getSetting } from "@server/repositories/settings";
 import { getOriginalEnvValue } from "@server/services/envSettings";
 import { getResume } from "@server/services/rxresume";
@@ -341,6 +342,84 @@ describe("design resume service", () => {
         link: "",
       },
     ]);
+  });
+
+  it("repairs blank project ids in existing stored documents", async () => {
+    vi.mocked(createId)
+      .mockReturnValueOnce("project-generated-1")
+      .mockReturnValueOnce("project-generated-2");
+    const resumeJson = makeValidResumeJson({
+      sections: {
+        ...(buildDefaultReactiveResumeDocument().sections as Record<
+          string,
+          unknown
+        >),
+        projects: {
+          title: "Projects",
+          columns: 1,
+          hidden: false,
+          items: [
+            {
+              id: "",
+              hidden: false,
+              name: "Blank ID",
+              period: "2024",
+              website: { url: "", label: "" },
+              description: "Blank ID project",
+              options: { showLinkInTitle: false },
+            },
+            {
+              id: "   ",
+              hidden: false,
+              name: "Whitespace ID",
+              period: "2025",
+              website: { url: "", label: "" },
+              description: "Whitespace ID project",
+              options: { showLinkInTitle: false },
+            },
+            {
+              id: "project-keep",
+              hidden: false,
+              name: "Existing ID",
+              period: "2026",
+              website: { url: "", label: "" },
+              description: "Existing ID project",
+              options: { showLinkInTitle: false },
+            },
+          ],
+        },
+      },
+    });
+    repo.getLatestDesignResumeDocument.mockResolvedValueOnce(
+      makeDocumentRow({ resumeJson }),
+    );
+
+    const result = await getCurrentDesignResume();
+
+    if (!result) {
+      throw new Error("Expected stored design resume document");
+    }
+    expect(
+      result.resumeJson.sections.projects.items.map((project) => project.id),
+    ).toEqual(["project-generated-1", "project-generated-2", "project-keep"]);
+    expect(result.revision).toBe(2);
+    expect(repo.upsertDesignResumeDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "primary",
+        revision: 2,
+        resumeJson: expect.objectContaining({
+          sections: expect.objectContaining({
+            projects: expect.objectContaining({
+              items: [
+                expect.objectContaining({ id: "project-generated-1" }),
+                expect.objectContaining({ id: "project-generated-2" }),
+                expect.objectContaining({ id: "project-keep" }),
+              ],
+            }),
+          }),
+        }),
+      }),
+    );
   });
 
   it("localizes Reactive Resume relative picture URLs into design resume assets", async () => {

--- a/orchestrator/src/server/services/design-resume/index.ts
+++ b/orchestrator/src/server/services/design-resume/index.ts
@@ -421,23 +421,69 @@ function toDesignResumeAsset(
   };
 }
 
+type DesignResumeDocumentRow = NonNullable<
+  Awaited<ReturnType<typeof designResumeRepo.getLatestDesignResumeDocument>>
+>;
+
+async function persistMissingProjectIdRepair(
+  row: DesignResumeDocumentRow,
+  resumeJson: DesignResumeJson,
+): Promise<DesignResumeDocumentRow> {
+  const nextRevision = row.revision + 1;
+  const updatedAt = new Date().toISOString();
+  const saved = await designResumeRepo.upsertDesignResumeDocument({
+    id: row.id,
+    title: buildDocumentTitle(resumeJson),
+    resumeJson,
+    revision: nextRevision,
+    sourceResumeId: row.sourceResumeId ?? null,
+    sourceMode: row.sourceMode ?? null,
+    importedAt: row.importedAt ?? null,
+    updatedAt,
+  });
+
+  logger.info("Repaired missing Resume Studio project IDs", {
+    documentId: row.id,
+    previousRevision: row.revision,
+    nextRevision,
+  });
+
+  return (
+    saved ?? {
+      ...row,
+      title: buildDocumentTitle(resumeJson),
+      resumeJson,
+      revision: nextRevision,
+      updatedAt,
+    }
+  );
+}
+
 async function hydrateDocument(
   row: Awaited<
     ReturnType<typeof designResumeRepo.getLatestDesignResumeDocument>
   >,
 ): Promise<DesignResumeDocument | null> {
   if (!row) return null;
-  const assets = await designResumeRepo.listDesignResumeAssets(row.id);
+  const validatedResumeJson = validateStoredDesignResumeDocument(
+    row.resumeJson ?? {},
+  );
+  const resumeJson = ensureImportedProjectIds(validatedResumeJson);
+  const documentRow =
+    resumeJson === validatedResumeJson
+      ? row
+      : await persistMissingProjectIdRepair(row, resumeJson);
+  const assets = await designResumeRepo.listDesignResumeAssets(documentRow.id);
   return {
-    id: row.id,
-    title: row.title,
-    resumeJson: validateStoredDesignResumeDocument(row.resumeJson ?? {}),
-    revision: row.revision,
-    sourceResumeId: row.sourceResumeId ?? null,
-    sourceMode: (row.sourceMode as "v4" | "v5" | null) ?? null,
-    importedAt: row.importedAt ?? null,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
+    id: documentRow.id,
+    title: documentRow.title,
+    resumeJson,
+    revision: documentRow.revision,
+    sourceResumeId: documentRow.sourceResumeId ?? null,
+    sourceMode: (documentRow.sourceMode as "v4" | "v5" | null) ?? null,
+    importedAt: documentRow.importedAt ?? null,
+    createdAt: documentRow.createdAt,
+    updatedAt: documentRow.updatedAt,
     assets: assets.map(toDesignResumeAsset),
   };
 }


### PR DESCRIPTION
## Summary
- Repair existing stored Resume Studio project items with blank or whitespace-only IDs when the document is hydrated.
- Persist the repaired document with a revision bump so old data is normalized on read, not just on import.
- Keep the client-side CUID2 swap from the earlier fix so new item creation no longer depends on `crypto.randomUUID()`.

## Testing
- Added unit coverage for hydrating a stored document that contains blank project IDs, preserving existing IDs while generating replacements for missing ones.
- Ran focused server and client tests, plus the full orchestrator test suite, with all checks passing.