### PR TITLE
fix: correct grammar in job source tooltip when source is manual

### DIFF
--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -277,7 +277,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
           {job.source && (
             <StatusIndicator
               variant="sky"
-              tooltip={`Job found on ${formatJobSourceLabel(job.source)}`}
+              tooltip={`Job found ${job.source === "manual" ? "manually" : `on ${formatJobSourceLabel(job.source)}`}`}
               label={
                 sourceLabel[job.source] ?? formatJobSourceLabel(job.source)
               }


### PR DESCRIPTION
Fixes #617

Changed `Job found on Manual` to `Job found manually` when the job source is manual, fixing grammatically incorrect tooltip text.