### PR TITLE
fix: fix empty response and structured JSON schema valiation errors with Gemini models

### DIFF
--- a/docs-site/docs/troubleshooting/common-problems.md
+++ b/docs-site/docs/troubleshooting/common-problems.md
@@ -64,3 +64,9 @@ npm --workspace docs-site run build
 
 - Re-authenticate by removing cached auth file or forcing refresh.
 - Verify extractor credentials and API response behavior.
+
+## Ghostwriter returns empty response / validation error when using Gemini models
+
+- **Symptom**: Chat responses from Ghostwriter are empty, or show a validation/structure error.
+- **Root cause**: Standard Gemini REST API expects `responseMimeType` and `responseSchema` at the top level of `generationConfig`. The app was passing them wrapped in a nested `responseFormat` structure, causing Gemini to silently ignore the schema constraints and return responses with an unexpected shape (e.g. `{ "coverLetter": "..." }` instead of `{ "response": "..." }`).
+- **Fix**: The Gemini integration was updated to correctly pass structured schema parameters. A runtime validation was added to surface formatting issues immediately as an error rather than failing silently with an empty message. If you still encounter issues, verify you are using a model that fully supports JSON schema structured outputs.

--- a/orchestrator/src/server/services/ghostwriter.test.ts
+++ b/orchestrator/src/server/services/ghostwriter.test.ts
@@ -851,6 +851,50 @@ describe("ghostwriter service", () => {
     });
   });
 
+  it("rejects LLM responses with invalid JSON shape", async () => {
+    const assistantPartial: JobChatMessage = {
+      ...baseAssistantMessage,
+      id: "assistant-1",
+      content: "",
+      status: "partial",
+    };
+    const assistantFailed: JobChatMessage = {
+      ...baseAssistantMessage,
+      id: "assistant-1",
+      content: "",
+      status: "failed",
+    };
+
+    mocks.repo.createMessage
+      .mockResolvedValueOnce(baseUserMessage)
+      .mockResolvedValueOnce(assistantPartial);
+    mocks.repo.updateMessage.mockResolvedValue(assistantFailed);
+    mocks.repo.getMessageById.mockResolvedValue(assistantFailed);
+
+    mocks.llmCallJson.mockResolvedValue({
+      success: true,
+      data: { coverLetter: "Dear hiring committee..." },
+    });
+
+    await expect(
+      sendMessageForJob({
+        jobId: "job-1",
+        content: "Tell me about this role",
+      }),
+    ).rejects.toMatchObject({
+      code: "UPSTREAM_ERROR",
+      message:
+        "LLM response structure was invalid: missing 'response' property",
+    });
+
+    expect(mocks.repo.completeRun).toHaveBeenCalledWith("run-1", {
+      status: "failed",
+      errorCode: "UPSTREAM_ERROR",
+      errorMessage:
+        "LLM response structure was invalid: missing 'response' property",
+    });
+  });
+
   it("cancels a running generation during streaming", async () => {
     vi.useFakeTimers();
 

--- a/orchestrator/src/server/services/ghostwriter.ts
+++ b/orchestrator/src/server/services/ghostwriter.ts
@@ -761,12 +761,21 @@ async function runAssistantReply(
       if (controller.signal.aborted) {
         throw requestTimeout("Chat generation was cancelled");
       }
-      throw upstreamError("LLM generation failed", {
+      throw upstreamError(`LLM generation failed: ${llmResult.error}`, {
         reason: llmResult.error,
       });
     }
 
-    const finalText = (llmResult.data.response || "").trim();
+    if (!llmResult.data || typeof llmResult.data.response !== "string") {
+      throw upstreamError(
+        "LLM response structure was invalid: missing 'response' property",
+        {
+          received: llmResult.data,
+        },
+      );
+    }
+
+    const finalText = llmResult.data.response.trim();
     const chunks = chunkText(finalText);
 
     for (const chunk of chunks) {
@@ -831,6 +840,15 @@ async function runAssistantReply(
     const message = isCancelled
       ? "Generation cancelled by user"
       : appError.message || "Generation failed";
+
+    if (!isCancelled) {
+      logger.error("Job chat generation failed", {
+        jobId: options.jobId,
+        threadId: options.threadId,
+        runId: run.id,
+        error: appError,
+      });
+    }
 
     const failedMessage = await jobChatRepo.updateMessage(assistantMessage.id, {
       content: accumulated,

--- a/orchestrator/src/server/services/llm/providers/gemini.ts
+++ b/orchestrator/src/server/services/llm/providers/gemini.ts
@@ -23,12 +23,8 @@ export const geminiStrategy = createProviderStrategy({
       body.generationConfig = {
         // Gemini JSON Schema structured outputs support nullable type arrays here.
         // https://ai.google.dev/gemini-api/docs/structured-output#json_schemas
-        responseFormat: {
-          text: {
-            mimeType: "application/json",
-            schema: toGeminiJsonSchema(jsonSchema.schema),
-          },
-        },
+        responseMimeType: "application/json",
+        responseSchema: toGeminiJsonSchema(jsonSchema.schema),
       };
     } else if (mode === "json_object") {
       body.generationConfig = {
@@ -78,6 +74,9 @@ function toGeminiJsonSchema(schema: unknown): unknown {
 
   const out: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(schema)) {
+    if (key === "additionalProperties") {
+      continue;
+    }
     out[key] = toGeminiJsonSchema(value);
   }
 

--- a/orchestrator/src/server/services/llm/providers/providers.test.ts
+++ b/orchestrator/src/server/services/llm/providers/providers.test.ts
@@ -234,7 +234,7 @@ describe("provider adapters", () => {
     ).toBe("gemini");
   });
 
-  it("sends Gemini structured outputs through the JSON Schema responseFormat", () => {
+  it("sends Gemini structured outputs through the JSON Schema responseSchema", () => {
     const request = geminiStrategy.buildRequest({
       mode: "json_schema",
       baseUrl: "https://generativelanguage.googleapis.com",
@@ -272,12 +272,10 @@ describe("provider adapters", () => {
 
     const generationConfig = (request.body as Record<string, unknown>)
       .generationConfig as Record<string, unknown>;
-    const responseFormat = generationConfig.responseFormat as Record<
+    const responseSchema = generationConfig.responseSchema as Record<
       string,
       unknown
     >;
-    const textFormat = responseFormat.text as Record<string, unknown>;
-    const responseSchema = textFormat.schema as Record<string, unknown>;
     const skills = (responseSchema.properties as Record<string, unknown>)
       .skills as Record<string, unknown>;
     const bestMatchIndex = (
@@ -285,14 +283,14 @@ describe("provider adapters", () => {
     ).bestMatchIndex as Record<string, unknown>;
     const itemSchema = skills.items as Record<string, unknown>;
 
-    expect(textFormat.mimeType).toBe("application/json");
+    expect(generationConfig.responseMimeType).toBe("application/json");
     expect(bestMatchIndex.type).toEqual(["integer", "null"]);
-    expect(responseSchema.additionalProperties).toBe(false);
+    expect(responseSchema.additionalProperties).toBeUndefined();
     expect(responseSchema.propertyOrdering).toEqual([
       "bestMatchIndex",
       "skills",
     ]);
-    expect(itemSchema.additionalProperties).toBe(false);
+    expect(itemSchema.additionalProperties).toBeUndefined();
     expect(itemSchema.propertyOrdering).toEqual(["name", "keywords"]);
   });
 });

--- a/orchestrator/src/server/services/resume-renderer/typst.test.ts
+++ b/orchestrator/src/server/services/resume-renderer/typst.test.ts
@@ -90,7 +90,9 @@ describe("typst resume renderer", () => {
   });
 
   it("exposes the bundled Typst template", async () => {
-    expect(getTypstTemplatePath()).toContain("typst-themes/classic/main.typ");
+    expect(getTypstTemplatePath().replace(/\\/g, "/")).toContain(
+      "typst-themes/classic/main.typ",
+    );
     const template = await readTypstTemplate();
     expect(template).toContain("#set page");
     expect(template).toContain("__BODY__");
@@ -107,7 +109,7 @@ describe("typst resume renderer", () => {
       } else {
         expect(manifest.tokens).toBeUndefined();
       }
-      expect(getTypstTemplatePath(theme)).toContain(
+      expect(getTypstTemplatePath(theme).replace(/\\/g, "/")).toContain(
         `typst-themes/${theme}/main.typ`,
       );
     }


### PR DESCRIPTION
This pull request addresses a critical integration bug with the Gemini LLM provider and improves validation and error handling for structured JSON responses in the Ghostwriter service. The Gemini provider now correctly passes schema parameters, and runtime validation ensures that malformed LLM responses are surfaced as explicit errors. Additional changes improve test robustness and logging for easier troubleshooting.

**Gemini Provider Integration Fixes:**

- Updated the Gemini provider to pass `responseMimeType` and `responseSchema` at the top level of `generationConfig` instead of the incorrect nested `responseFormat` structure, ensuring compatibility with the Gemini REST API and correct schema enforcement.
- Modified the Gemini schema transformation to omit the `additionalProperties` key, aligning with Gemini's expectations for structured outputs.

**Validation and Error Handling Improvements:**

- Added runtime validation in the Ghostwriter service to check for a valid `response` property in LLM responses; if missing, an explicit error is thrown and logged, preventing silent failures and empty responses. [[1]](diffhunk://#diff-f447495a26c8d481ab23d43531347c728ccaf818dd130801cc8f826a48144c80L764-R778) [[2]](diffhunk://#diff-f447495a26c8d481ab23d43531347c728ccaf818dd130801cc8f826a48144c80R844-R852)
- Enhanced tests to verify that invalid LLM response shapes are rejected and surfaced as upstream errors, ensuring robust handling of malformed outputs.

**Documentation and Test Updates:**

- Updated troubleshooting documentation to explain the Gemini schema integration issue, symptoms, root cause, and resolution steps for users.
- Adjusted provider and resume renderer tests for improved accuracy and cross-platform compatibility, including path normalization and updated assertions for schema handling. [[1]](diffhunk://#diff-358d9c80714478879199d15111693499e00570a6d1271892641bb36620c4065bL237-R237) [[2]](diffhunk://#diff-358d9c80714478879199d15111693499e00570a6d1271892641bb36620c4065bL275-R293) [[3]](diffhunk://#diff-87878aad07a5f6ff1216fdf5a94dfdc6e4a88974dc9010d8891052371ba69c87L93-R95) [[4]](diffhunk://#diff-87878aad07a5f6ff1216fdf5a94dfdc6e4a88974dc9010d8891052371ba69c87L110-R112)

addresses #602 