### PR TITLE
feat(orchestrator): expose Watchlist sources in pipeline run selector (#621)

### DIFF
--- a/orchestrator/src/client/api/pipeline.ts
+++ b/orchestrator/src/client/api/pipeline.ts
@@ -129,6 +129,7 @@ export async function runPipeline(config?: {
   workplaceTypes?: Array<"remote" | "hybrid" | "onsite">;
   searchScope?: LocationSearchScope;
   matchStrictness?: LocationMatchStrictness;
+  watchlistSelectedSourceIds?: string[];
 }): Promise<{ message: string }> {
   return fetchApi<{ message: string }>("/pipeline/run", {
     method: "POST",

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -43,6 +43,11 @@ vi.mock("../api", () => ({
   skipJob: vi.fn().mockResolvedValue({}),
   markAsApplied: vi.fn().mockResolvedValue({}),
   processJob: vi.fn().mockResolvedValue({}),
+  getWatchlistSources: vi.fn().mockResolvedValue({
+    catalogSources: [],
+    selectedSources: [],
+    availableSourceTypes: [],
+  }),
 }));
 
 vi.mock("sonner", () => ({
@@ -969,6 +974,7 @@ describe("OrchestratorPage", () => {
       workplaceTypes: ["remote", "hybrid", "onsite"],
       searchScope: "selected_only",
       matchStrictness: "exact_only",
+      watchlistSelectedSourceIds: [],
     });
     expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 5000);
 

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -31,6 +31,7 @@ import { useOrchestratorFilters } from "./orchestrator/useOrchestratorFilters";
 import { usePipelineControls } from "./orchestrator/usePipelineControls";
 import { usePipelineSources } from "./orchestrator/usePipelineSources";
 import { useScrollToJobItem } from "./orchestrator/useScrollToJobItem";
+import { useWatchlistPipelineSources } from "./orchestrator/useWatchlistPipelineSources";
 import {
   getEnabledSources,
   getJobCounts,
@@ -143,6 +144,13 @@ export const OrchestratorPage: React.FC = () => {
   );
   const { pipelineSources, setPipelineSources, toggleSource } =
     usePipelineSources(enabledSources);
+  const {
+    watchlistSources,
+    selectedWatchlistSourceIds,
+    setSelectedWatchlistSourceIds,
+    toggleWatchlistSource,
+    isLoading: isWatchlistSourcesLoading,
+  } = useWatchlistPipelineSources();
 
   const {
     isRunModeModalOpen,
@@ -159,6 +167,7 @@ export const OrchestratorPage: React.FC = () => {
     setIsPipelineRunning,
     pipelineTerminalEvent,
     pipelineSources,
+    watchlistSelectedSourceIds: selectedWatchlistSourceIds,
     loadJobs,
     navigateWithContext,
   });
@@ -583,6 +592,11 @@ export const OrchestratorPage: React.FC = () => {
         pipelineSources={pipelineSources}
         onToggleSource={toggleSource}
         onSetPipelineSources={setPipelineSources}
+        watchlistSources={watchlistSources}
+        selectedWatchlistSourceIds={selectedWatchlistSourceIds}
+        onToggleWatchlistSource={toggleWatchlistSource}
+        onSetSelectedWatchlistSourceIds={setSelectedWatchlistSourceIds}
+        isWatchlistSourcesLoading={isWatchlistSourcesLoading}
         isPipelineRunning={isPipelineRunning}
         onOpenChange={setIsRunModeModalOpen}
         onModeChange={setRunMode}

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
@@ -23,6 +23,7 @@ import type {
   PipelineSearchPreset,
   PipelineSearchPresetConfig,
   UpdatePipelineSearchPresetInput,
+  WatchlistSelectedSource,
 } from "@shared/types";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import {
@@ -96,6 +97,11 @@ interface AutomaticRunTabProps {
   pipelineSources: JobSource[];
   onToggleSource: (source: JobSource, checked: boolean) => void;
   onSetPipelineSources: (sources: JobSource[]) => void;
+  watchlistSources?: WatchlistSelectedSource[];
+  selectedWatchlistSourceIds?: string[];
+  onToggleWatchlistSource?: (sourceId: string, checked: boolean) => void;
+  onSetSelectedWatchlistSourceIds?: (ids: string[]) => void;
+  isWatchlistSourcesLoading?: boolean;
   isPipelineRunning: boolean;
   onSaveAndRun: (values: AutomaticRunValues) => Promise<void>;
   savedSearches?: PipelineSearchPreset[];
@@ -286,6 +292,11 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
   pipelineSources,
   onToggleSource,
   onSetPipelineSources,
+  watchlistSources = [],
+  selectedWatchlistSourceIds = [],
+  onToggleWatchlistSource,
+  onSetSelectedWatchlistSourceIds,
+  isWatchlistSourcesLoading = false,
   isPipelineRunning,
   onSaveAndRun,
   savedSearches = [],
@@ -641,8 +652,9 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
       minSuitabilityScore: values.minSuitabilityScore,
       runBudget: values.runBudget,
       automaticPresetId: selectedPreset,
+      watchlistSelectedSourceIds: [...selectedWatchlistSourceIds],
     }),
-    [pipelineSources, selectedPreset, values],
+    [pipelineSources, selectedPreset, selectedWatchlistSourceIds, values],
   );
 
   const runDisabled =
@@ -694,7 +706,10 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
         runBudget: values.runBudget,
         presetId: selectedPreset,
       });
-      await onSaveAndRun(values);
+      await onSaveAndRun({
+        ...values,
+        watchlistSelectedSourceIds: [...selectedWatchlistSourceIds],
+      });
     } finally {
       setIsSaving(false);
     }
@@ -727,6 +742,18 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
     );
     if (nextSources.length > 0) {
       onSetPipelineSources(nextSources);
+    }
+
+    // Restore Watchlist selection if the saved preset captured it (#621).
+    // Filter against the user's currently-saved Watchlist sources so stale
+    // IDs (deleted on the Watchlist page after the preset was saved) don't
+    // resurrect.
+    if (Array.isArray(config.watchlistSelectedSourceIds)) {
+      const availableIds = new Set(watchlistSources.map((source) => source.id));
+      const restored = config.watchlistSelectedSourceIds.filter((id) =>
+        availableIds.has(id),
+      );
+      onSetSelectedWatchlistSourceIds?.(restored);
     }
 
     await onApplySavedSearch?.(preset);
@@ -1310,9 +1337,11 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                       className="min-w-0 space-y-1"
                     >
                       <p className="text-sm font-semibold text-foreground">
-                        {selectedSourceRows.length === 0
+                        {selectedSourceRows.length +
+                          selectedWatchlistSourceIds.length ===
+                        0
                           ? "Choose sources for this run"
-                          : `${selectedSourceRows.length} source${selectedSourceRows.length === 1 ? "" : "s"} selected`}
+                          : `${selectedSourceRows.length + selectedWatchlistSourceIds.length} source${selectedSourceRows.length + selectedWatchlistSourceIds.length === 1 ? "" : "s"} selected`}
                       </p>
                     </motion.div>
                     <motion.div
@@ -1321,13 +1350,13 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                       className="flex shrink-0 flex-wrap gap-2"
                     >
                       <Badge variant="outline" className="rounded-full">
-                        {selectedSourceRows.length} selected
+                        {selectedSourceRows.length +
+                          selectedWatchlistSourceIds.length}{" "}
+                        selected
                       </Badge>
                       <Badge variant="outline" className="rounded-full">
-                        {
-                          sourceRows.filter((row) => row.status.available)
-                            .length
-                        }{" "}
+                        {sourceRows.filter((row) => row.status.available)
+                          .length + watchlistSources.length}{" "}
                         available
                       </Badge>
                       {unavailableSourceRows.length > 0 ? (
@@ -1506,6 +1535,111 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
                         </motion.div>
                       </motion.div>
                     ) : null}
+
+                    <motion.div
+                      layout
+                      transition={sourceMotionTransition}
+                      className="space-y-2"
+                    >
+                      <motion.div
+                        layout
+                        transition={sourceMotionTransition}
+                        className="flex items-center justify-between"
+                      >
+                        <motion.p
+                          layout
+                          transition={sourceMotionTransition}
+                          className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground"
+                        >
+                          Watchlist
+                        </motion.p>
+                        {watchlistSources.length > 0 ? (
+                          <Badge
+                            variant="outline"
+                            className="rounded-full text-[10px] font-semibold uppercase tracking-[0.18em]"
+                          >
+                            {selectedWatchlistSourceIds.length} of{" "}
+                            {watchlistSources.length} selected
+                          </Badge>
+                        ) : null}
+                      </motion.div>
+                      {isWatchlistSourcesLoading ? (
+                        <p className="text-xs text-muted-foreground">
+                          Loading Watchlist sources…
+                        </p>
+                      ) : watchlistSources.length === 0 ? (
+                        <p className="text-xs text-muted-foreground">
+                          No Watchlist sources saved yet. Add company career
+                          pages on the{" "}
+                          <a
+                            href="/watchlist"
+                            className="font-medium text-foreground underline underline-offset-2 hover:text-primary"
+                          >
+                            Watchlist page
+                          </a>{" "}
+                          to include them in pipeline runs.
+                        </p>
+                      ) : (
+                        <motion.div
+                          layout
+                          transition={sourceMotionTransition}
+                          className="grid gap-2 md:grid-cols-2"
+                        >
+                          {watchlistSources.map((source) => {
+                            const isSelected =
+                              selectedWatchlistSourceIds.includes(source.id);
+                            return (
+                              <motion.div
+                                key={source.id}
+                                layout
+                                initial={sourceRowInitial}
+                                animate={sourceSectionAnimate}
+                                exit={sourceRowExit}
+                                transition={sourceMotionTransition}
+                              >
+                                <Button
+                                  type="button"
+                                  variant="ghost"
+                                  aria-label={`Watchlist: ${source.label}`}
+                                  aria-pressed={isSelected}
+                                  title={
+                                    isSelected
+                                      ? "Included in this run. Click to exclude."
+                                      : "Click to include in this run."
+                                  }
+                                  onClick={() =>
+                                    onToggleWatchlistSource?.(
+                                      source.id,
+                                      !isSelected,
+                                    )
+                                  }
+                                  className={
+                                    isSelected
+                                      ? "flex h-auto w-full items-start justify-between gap-3 rounded-xl border border-primary/20 bg-primary/10 px-3 py-3 text-left text-foreground transition-colors duration-200 hover:bg-primary/15"
+                                      : "flex h-auto w-full items-start justify-between gap-3 rounded-xl border border-border/60 bg-background/60 px-3 py-3 text-left text-foreground transition-colors duration-200 hover:bg-muted/40"
+                                  }
+                                >
+                                  <span className="min-w-0 space-y-1">
+                                    <span className="block truncate text-sm font-semibold">
+                                      {source.label}
+                                    </span>
+                                    <span className="block text-xs text-muted-foreground">
+                                      {source.sourceType}
+                                    </span>
+                                  </span>
+                                  <Badge
+                                    variant="outline"
+                                    className="shrink-0 rounded-full px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em]"
+                                  >
+                                    Watchlist
+                                  </Badge>
+                                </Button>
+                              </motion.div>
+                            );
+                          })}
+                        </motion.div>
+                      )}
+                    </motion.div>
                   </motion.div>
                 </AccordionContent>
               </AccordionItem>

--- a/orchestrator/src/client/pages/orchestrator/RunModeModal.tsx
+++ b/orchestrator/src/client/pages/orchestrator/RunModeModal.tsx
@@ -6,6 +6,7 @@ import type {
   JobSource,
   PipelineSearchPreset,
   UpdatePipelineSearchPresetInput,
+  WatchlistSelectedSource,
 } from "@shared/types";
 import type React from "react";
 import { Separator } from "@/components/ui/separator";
@@ -29,6 +30,11 @@ interface RunModeModalProps {
   pipelineSources: JobSource[];
   onToggleSource: (source: JobSource, checked: boolean) => void;
   onSetPipelineSources: (sources: JobSource[]) => void;
+  watchlistSources?: WatchlistSelectedSource[];
+  selectedWatchlistSourceIds?: string[];
+  onToggleWatchlistSource?: (sourceId: string, checked: boolean) => void;
+  onSetSelectedWatchlistSourceIds?: (ids: string[]) => void;
+  isWatchlistSourcesLoading?: boolean;
   isPipelineRunning: boolean;
   onOpenChange: (open: boolean) => void;
   onModeChange: (mode: RunMode) => void;
@@ -55,6 +61,11 @@ export const RunModeModal: React.FC<RunModeModalProps> = ({
   pipelineSources,
   onToggleSource,
   onSetPipelineSources,
+  watchlistSources,
+  selectedWatchlistSourceIds,
+  onToggleWatchlistSource,
+  onSetSelectedWatchlistSourceIds,
+  isWatchlistSourcesLoading,
   isPipelineRunning,
   onOpenChange,
   onModeChange,
@@ -104,6 +115,13 @@ export const RunModeModal: React.FC<RunModeModalProps> = ({
                 pipelineSources={pipelineSources}
                 onToggleSource={onToggleSource}
                 onSetPipelineSources={onSetPipelineSources}
+                watchlistSources={watchlistSources}
+                selectedWatchlistSourceIds={selectedWatchlistSourceIds}
+                onToggleWatchlistSource={onToggleWatchlistSource}
+                onSetSelectedWatchlistSourceIds={
+                  onSetSelectedWatchlistSourceIds
+                }
+                isWatchlistSourcesLoading={isWatchlistSourcesLoading}
                 isPipelineRunning={isPipelineRunning}
                 onSaveAndRun={onSaveAndRunAutomatic}
                 savedSearches={savedSearches}

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.ts
@@ -31,6 +31,9 @@ export interface AutomaticRunValues {
   workplaceTypes: WorkplaceType[];
   searchScope: LocationSearchScope;
   matchStrictness: LocationMatchStrictness;
+  // Optional override for per-#621 Watchlist source selection. When
+  // omitted, usePipelineControls falls back to the global hook selection.
+  watchlistSelectedSourceIds?: string[];
 }
 
 export interface AutomaticPresetValues {

--- a/orchestrator/src/client/pages/orchestrator/constants.ts
+++ b/orchestrator/src/client/pages/orchestrator/constants.ts
@@ -12,6 +12,8 @@ export const DEFAULT_PIPELINE_SOURCES: JobSource[] = [
   "ukvisajobs",
 ];
 export const PIPELINE_SOURCES_STORAGE_KEY = "jobops.pipeline.sources";
+export const PIPELINE_WATCHLIST_SOURCES_STORAGE_KEY =
+  "jobops.pipeline.watchlist-sources";
 
 export const orderedSources: JobSource[] = [
   ...PIPELINE_EXTRACTOR_SOURCE_IDS,

--- a/orchestrator/src/client/pages/orchestrator/usePipelineControls.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineControls.ts
@@ -22,6 +22,7 @@ type UsePipelineControlsArgs = {
   setIsPipelineRunning: (value: boolean) => void;
   pipelineTerminalEvent: { status: string; errorMessage: string | null } | null;
   pipelineSources: JobSource[];
+  watchlistSelectedSourceIds?: string[];
   loadJobs: () => Promise<void>;
   navigateWithContext: (
     newTab: string,
@@ -51,6 +52,7 @@ export function usePipelineControls(
     setIsPipelineRunning,
     pipelineTerminalEvent,
     pipelineSources,
+    watchlistSelectedSourceIds,
     loadJobs,
     navigateWithContext,
   } = args;
@@ -108,6 +110,7 @@ export function usePipelineControls(
       workplaceTypes: Array<"remote" | "hybrid" | "onsite">;
       searchScope: AutomaticRunValues["searchScope"];
       matchStrictness: AutomaticRunValues["matchStrictness"];
+      watchlistSelectedSourceIds?: string[];
     }) => {
       try {
         setIsPipelineRunning(true);
@@ -123,6 +126,7 @@ export function usePipelineControls(
           workplaceTypes: config.workplaceTypes,
           searchScope: config.searchScope,
           matchStrictness: config.matchStrictness,
+          watchlistSelectedSourceIds: config.watchlistSelectedSourceIds,
         });
         toast.message("Pipeline started", {
           description: `Sources: ${config.sources.join(", ")}. This may take a few minutes.`,
@@ -211,10 +215,17 @@ export function usePipelineControls(
         sources: compatibleSources,
         topN: values.topN,
         minSuitabilityScore: values.minSuitabilityScore,
+        watchlistSelectedSourceIds:
+          values.watchlistSelectedSourceIds ?? watchlistSelectedSourceIds,
       });
       setIsRunModeModalOpen(false);
     },
-    [pipelineSources, refreshSettings, startPipelineRun],
+    [
+      pipelineSources,
+      refreshSettings,
+      startPipelineRun,
+      watchlistSelectedSourceIds,
+    ],
   );
 
   const handleManualImported = useCallback(

--- a/orchestrator/src/client/pages/orchestrator/useWatchlistPipelineSources.ts
+++ b/orchestrator/src/client/pages/orchestrator/useWatchlistPipelineSources.ts
@@ -1,0 +1,189 @@
+import * as api from "@client/api";
+import { queryKeys } from "@client/lib/queryKeys";
+import type { WatchlistSelectedSource } from "@shared/types";
+import { useQuery } from "@tanstack/react-query";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { getAuthScopedStorageKey } from "@/client/api/client";
+import { PIPELINE_WATCHLIST_SOURCES_STORAGE_KEY } from "./constants";
+
+export function getWatchlistPipelineSourcesStorageKey(): string {
+  return getAuthScopedStorageKey(PIPELINE_WATCHLIST_SOURCES_STORAGE_KEY);
+}
+
+type StoredSelection = {
+  selectedIds: string[];
+  knownIds: string[];
+};
+
+function readStoredSelection(storageKey: string): StoredSelection | null {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const candidate = parsed as Partial<StoredSelection>;
+    const selectedIds = Array.isArray(candidate.selectedIds)
+      ? candidate.selectedIds.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : [];
+    const knownIds = Array.isArray(candidate.knownIds)
+      ? candidate.knownIds.filter(
+          (value): value is string => typeof value === "string",
+        )
+      : selectedIds;
+    return { selectedIds, knownIds };
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredSelection(
+  storageKey: string,
+  selection: StoredSelection,
+): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify(selection));
+  } catch {
+    // Ignore localStorage errors (quota, disabled storage, etc).
+  }
+}
+
+function reconcileSelection(args: {
+  available: WatchlistSelectedSource[];
+  stored: StoredSelection | null;
+}): { selectedIds: string[]; knownIds: string[] } {
+  const availableIds = args.available.map((source) => source.id);
+  const availableSet = new Set(availableIds);
+
+  if (!args.stored) {
+    // First-run default: include every Watchlist source the user has saved.
+    // Preserves the pre-#621 "Watchlist participates automatically" behavior.
+    return { selectedIds: availableIds, knownIds: availableIds };
+  }
+
+  const previouslyKnown = new Set(args.stored.knownIds);
+  // Auto-select sources that appeared since the last reconciliation — they
+  // would have been included automatically before #621, so keep them in
+  // unless the user later opts out.
+  const newlyAddedSelected = availableIds.filter(
+    (id) => !previouslyKnown.has(id),
+  );
+
+  const selectedIds = [
+    ...args.stored.selectedIds.filter((id) => availableSet.has(id)),
+    ...newlyAddedSelected,
+  ];
+
+  // De-duplicate while preserving order.
+  const seen = new Set<string>();
+  const deduped = selectedIds.filter((id) => {
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+
+  return { selectedIds: deduped, knownIds: availableIds };
+}
+
+export type UseWatchlistPipelineSourcesResult = {
+  watchlistSources: WatchlistSelectedSource[];
+  selectedWatchlistSourceIds: string[];
+  setSelectedWatchlistSourceIds: (ids: string[]) => void;
+  toggleWatchlistSource: (sourceId: string, checked: boolean) => void;
+  isLoading: boolean;
+  isError: boolean;
+};
+
+export function useWatchlistPipelineSources(): UseWatchlistPipelineSourcesResult {
+  const storageKey = useMemo(() => getWatchlistPipelineSourcesStorageKey(), []);
+
+  const watchlistSourcesQuery = useQuery({
+    queryKey: queryKeys.watchlist.sources(),
+    queryFn: api.getWatchlistSources,
+    staleTime: 30_000,
+  });
+
+  const watchlistSources = useMemo(
+    () => watchlistSourcesQuery.data?.selectedSources ?? [],
+    [watchlistSourcesQuery.data],
+  );
+
+  const [selectedIds, setSelectedIds] = useState<string[]>(() => {
+    const stored = readStoredSelection(storageKey);
+    return stored?.selectedIds ?? [];
+  });
+
+  // Reconcile against the live list whenever it changes.
+  useEffect(() => {
+    if (watchlistSourcesQuery.isLoading) return;
+    const stored = readStoredSelection(storageKey);
+    const reconciled = reconcileSelection({
+      available: watchlistSources,
+      stored,
+    });
+    writeStoredSelection(storageKey, reconciled);
+    setSelectedIds((current) => {
+      if (
+        current.length === reconciled.selectedIds.length &&
+        current.every((id, index) => id === reconciled.selectedIds[index])
+      ) {
+        return current;
+      }
+      return reconciled.selectedIds;
+    });
+  }, [storageKey, watchlistSources, watchlistSourcesQuery.isLoading]);
+
+  const persistSelection = useCallback(
+    (next: string[]) => {
+      const availableIds = watchlistSources.map((source) => source.id);
+      writeStoredSelection(storageKey, {
+        selectedIds: next,
+        knownIds: availableIds,
+      });
+    },
+    [storageKey, watchlistSources],
+  );
+
+  const setSelectedWatchlistSourceIds = useCallback(
+    (ids: string[]) => {
+      const availableSet = new Set(watchlistSources.map((source) => source.id));
+      const seen = new Set<string>();
+      const filtered = ids.filter((id) => {
+        if (!availableSet.has(id)) return false;
+        if (seen.has(id)) return false;
+        seen.add(id);
+        return true;
+      });
+      setSelectedIds(filtered);
+      persistSelection(filtered);
+    },
+    [persistSelection, watchlistSources],
+  );
+
+  const toggleWatchlistSource = useCallback(
+    (sourceId: string, checked: boolean) => {
+      setSelectedIds((current) => {
+        const availableSet = new Set(
+          watchlistSources.map((source) => source.id),
+        );
+        if (!availableSet.has(sourceId)) return current;
+        const next = checked
+          ? Array.from(new Set([...current, sourceId]))
+          : current.filter((id) => id !== sourceId);
+        persistSelection(next);
+        return next;
+      });
+    },
+    [persistSelection, watchlistSources],
+  );
+
+  return {
+    watchlistSources,
+    selectedWatchlistSourceIds: selectedIds,
+    setSelectedWatchlistSourceIds,
+    toggleWatchlistSource,
+    isLoading: watchlistSourcesQuery.isLoading,
+    isError: watchlistSourcesQuery.isError,
+  };
+}

--- a/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.test.tsx
+++ b/orchestrator/src/client/pages/overview/OverviewPipelineRunsSection.test.tsx
@@ -84,6 +84,7 @@ describe("OverviewPipelineRunsSection", () => {
           enableScoring: true,
           enableImporting: true,
           enableAutoTailoring: false,
+          watchlistSelectedSourceIds: null,
         },
         effectiveConfig: {
           country: "united states",

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -119,6 +119,7 @@ describe.sequential("Pipeline API routes", () => {
       minSuitabilityScore: 55,
       runBudget: 250,
       automaticPresetId: "custom",
+      watchlistSelectedSourceIds: ["wl-source-a"],
     };
 
     const createRes = await fetch(`${baseUrl}/api/pipeline/search-presets`, {
@@ -139,6 +140,9 @@ describe.sequential("Pipeline API routes", () => {
         lastUsedAt: null,
       }),
     );
+    expect(createBody.data.config.watchlistSelectedSourceIds).toEqual([
+      "wl-source-a",
+    ]);
 
     const duplicateRes = await fetch(`${baseUrl}/api/pipeline/search-presets`, {
       method: "POST",
@@ -313,6 +317,7 @@ describe.sequential("Pipeline API routes", () => {
         enableScoring: true,
         enableImporting: true,
         enableAutoTailoring: true,
+        watchlistSelectedSourceIds: null,
       },
       effectiveConfig: {
         country: "united states",
@@ -609,6 +614,58 @@ describe.sequential("Pipeline API routes", () => {
     expect(blockedNaukriRes.status).toBe(400);
     expect(blockedNaukriBody.ok).toBe(false);
     expect(blockedNaukriBody.error.message).toContain("incompatible");
+  });
+
+  it("forwards Watchlist source filter to the pipeline runner (#621)", async () => {
+    const { runPipeline } = await import("@server/pipeline/index");
+    const { trackCanonicalActivationEvent } = await import(
+      "@server/services/activation-funnel"
+    );
+
+    const runRes = await fetch(`${baseUrl}/api/pipeline/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        topN: 5,
+        minSuitabilityScore: 50,
+        sources: ["linkedin"],
+        searchTerms: ["engineer"],
+        country: "united kingdom",
+        cityLocations: ["London"],
+        workplaceTypes: ["remote"],
+        searchScope: "selected_only",
+        matchStrictness: "exact_only",
+        watchlistSelectedSourceIds: ["watchlist-a", "watchlist-b"],
+      }),
+    });
+    const runBody = await runRes.json();
+    expect(runBody.ok).toBe(true);
+
+    expect(runPipeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        watchlistSelectedSourceIds: ["watchlist-a", "watchlist-b"],
+      }),
+    );
+    // Analytics records the count only — never raw IDs (tenant safety).
+    expect(trackCanonicalActivationEvent).toHaveBeenCalledWith(
+      "jobs_pipeline_run_started",
+      expect.objectContaining({
+        watchlist_source_filter_count: 2,
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects malformed Watchlist source IDs on /pipeline/run (#621)", async () => {
+    const badRun = await fetch(`${baseUrl}/api/pipeline/run`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sources: ["linkedin"],
+        watchlistSelectedSourceIds: [123, ""],
+      }),
+    });
+    expect(badRun.status).toBe(400);
   });
 
   it("returns conflict when cancelling with no active pipeline", async () => {

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -206,6 +206,12 @@ const pipelineSearchPresetConfigSchema = z.object({
   automaticPresetId: z
     .enum(["fast", "balanced", "detailed", "custom"])
     .optional(),
+  // Optional per-#621 Watchlist source selection persisted with the preset.
+  // Omitted = legacy behavior (include every saved Watchlist source).
+  watchlistSelectedSourceIds: z
+    .array(z.string().min(1).max(128))
+    .max(200)
+    .optional(),
 });
 
 const createPipelineSearchPresetSchema = z
@@ -406,6 +412,12 @@ const runPipelineSchema = z.object({
     .optional(),
   searchScope: z.enum(LOCATION_SEARCH_SCOPE_VALUES).optional(),
   matchStrictness: z.enum(LOCATION_MATCH_STRICTNESS_VALUES).optional(),
+  // Per-#621: optional client-supplied per-run Watchlist source filter.
+  // Omitted preserves the legacy "include every saved Watchlist source"
+  // behavior; [] disables Watchlist entirely; non-empty restricts to a
+  // subset. Cross-tenant safety is enforced by re-resolving IDs against
+  // the user's saved Watchlist sources inside discoverJobsStep.
+  watchlistSelectedSourceIds: z.array(z.string().min(1).max(128)).optional(),
 });
 
 pipelineRouter.post("/run", async (req: Request, res: Response) => {
@@ -494,6 +506,7 @@ pipelineRouter.post("/run", async (req: Request, res: Response) => {
         minSuitabilityScore: config.minSuitabilityScore,
         sources: config.sources,
         locationIntent,
+        watchlistSelectedSourceIds: config.watchlistSelectedSourceIds,
       }).catch((error) => {
         logger.error("Background pipeline run failed", error);
       });
@@ -511,6 +524,12 @@ pipelineRouter.post("/run", async (req: Request, res: Response) => {
           : false,
         search_terms_count: searchTermsState.searchTermsCount,
         search_terms_source: searchTermsState.source,
+        // Count-only, never raw IDs (tenant safety / PII).
+        watchlist_source_filter_count: Array.isArray(
+          config.watchlistSelectedSourceIds,
+        )
+          ? config.watchlistSelectedSourceIds.length
+          : undefined,
       },
       {
         requestOrigin: resolveRequestOrigin(req),

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -324,6 +324,7 @@ export async function runPipeline(
       let { discoveredJobs, sourceErrors, pendingChallenges } =
         await discoverJobsStep({
           mergedConfig,
+          watchlistSelectedSourceIds: mergedConfig.watchlistSelectedSourceIds,
           shouldCancel: () =>
             getPipelineState(scopeKey).cancelRequestedAt !== null,
         });

--- a/orchestrator/src/server/pipeline/run-details.ts
+++ b/orchestrator/src/server/pipeline/run-details.ts
@@ -36,6 +36,7 @@ function resolveLocationIntentSnapshot(args: {
 export function buildRequestedConfigSnapshot(
   config: PipelineConfig,
 ): PipelineRunRequestedConfig {
+  const watchlistFilter = config.watchlistSelectedSourceIds;
   return {
     topN: config.topN,
     minSuitabilityScore: config.minSuitabilityScore,
@@ -44,6 +45,10 @@ export function buildRequestedConfigSnapshot(
     enableScoring: config.enableScoring !== false,
     enableImporting: config.enableImporting !== false,
     enableAutoTailoring: config.enableAutoTailoring !== false,
+    watchlistSelectedSourceIds:
+      watchlistFilter === undefined || watchlistFilter === null
+        ? null
+        : [...watchlistFilter],
   };
 }
 

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -539,6 +539,163 @@ describe("discoverJobsStep", () => {
     );
   });
 
+  it("filters watchlist sources to the requested subset (#621)", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+    const watchlistResults = await import("@server/watchlist/results");
+    const watchlistStep = await import("./watchlist-jobs");
+
+    const acmeSource = {
+      id: "watchlist-acme",
+      catalogSourceId: null,
+      label: "Acme",
+      careersUrl: "https://acme.example/careers",
+      cxsJobsUrl: null,
+      sourceType: "workday",
+      isCustom: false,
+      sortOrder: 0,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+    const beetaSource = {
+      ...acmeSource,
+      id: "watchlist-beeta",
+      label: "Beeta",
+    };
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["engineer"]),
+    } as any);
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map(),
+      manifestBySource: new Map(),
+      availableSources: [],
+    } as any);
+    vi.mocked(
+      watchlistResults.listHydratedWatchlistSelectedSources,
+    ).mockResolvedValue([acmeSource as any, beetaSource as any]);
+    vi.mocked(watchlistStep.discoverWatchlistJobsForPipeline).mockResolvedValue(
+      {
+        discoveredJobs: [],
+        sourceErrors: [],
+        selectedSourceCount: 1,
+        failedSourceCount: 0,
+        searchFilteredCount: 0,
+      },
+    );
+
+    await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverJobsStep({
+          mergedConfig: {
+            ...baseConfig,
+            sources: [],
+          },
+          watchlistSelectedSourceIds: ["watchlist-beeta"],
+        }),
+    );
+
+    expect(watchlistStep.discoverWatchlistJobsForPipeline).toHaveBeenCalledWith(
+      {
+        selectedSources: [beetaSource],
+        searchTerms: ["engineer"],
+        shouldCancel: undefined,
+      },
+    );
+  });
+
+  it("drops unknown / cross-tenant watchlist source IDs without calling discovery (#621)", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+    const watchlistResults = await import("@server/watchlist/results");
+    const watchlistStep = await import("./watchlist-jobs");
+
+    const owned = {
+      id: "watchlist-owned",
+      catalogSourceId: null,
+      label: "Owned",
+      careersUrl: "https://owned.example/careers",
+      cxsJobsUrl: null,
+      sourceType: "workday",
+      isCustom: false,
+      sortOrder: 0,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    };
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["engineer"]),
+    } as any);
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map(),
+      manifestBySource: new Map(),
+      availableSources: [],
+    } as any);
+    vi.mocked(
+      watchlistResults.listHydratedWatchlistSelectedSources,
+    ).mockResolvedValue([owned as any]);
+
+    await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverJobsStep({
+          mergedConfig: {
+            ...baseConfig,
+            sources: [],
+          },
+          // None of these IDs belong to user-a.
+          watchlistSelectedSourceIds: ["other-tenant-id"],
+        }),
+    );
+
+    // Owned sources were resolved (proves cross-tenant safety re-resolves
+    // via the user-scoped listHydratedWatchlistSelectedSources call), but
+    // the cross-tenant ID was dropped so the watchlist discovery step is
+    // never invoked.
+    expect(
+      watchlistResults.listHydratedWatchlistSelectedSources,
+    ).toHaveBeenCalled();
+    expect(
+      watchlistStep.discoverWatchlistJobsForPipeline,
+    ).not.toHaveBeenCalled();
+  });
+
+  it("disables watchlist discovery when explicitly passed an empty list (#621)", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+    const watchlistResults = await import("@server/watchlist/results");
+    const watchlistStep = await import("./watchlist-jobs");
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["engineer"]),
+    } as any);
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map(),
+      manifestBySource: new Map(),
+      availableSources: [],
+    } as any);
+
+    await runWithRequestContext(
+      { requestId: "test", tenantId: "tenant-a", userId: "user-a" },
+      () =>
+        discoverJobsStep({
+          mergedConfig: {
+            ...baseConfig,
+            sources: [],
+          },
+          watchlistSelectedSourceIds: [],
+        }),
+    );
+
+    expect(
+      watchlistResults.listHydratedWatchlistSelectedSources,
+    ).not.toHaveBeenCalled();
+    expect(
+      watchlistStep.discoverWatchlistJobsForPipeline,
+    ).not.toHaveBeenCalled();
+  });
+
   it("drops discovered jobs when employer matches blocked company keywords", async () => {
     const settingsRepo = await import("@server/repositories/settings");
     const registryModule = await import("@server/extractors/registry");

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -122,6 +122,7 @@ function buildLocationEvidence(args: {
 export async function discoverJobsStep(args: {
   mergedConfig: PipelineConfig;
   includeWatchlist?: boolean;
+  watchlistSelectedSourceIds?: string[] | null;
   shouldCancel?: () => boolean;
 }): Promise<{
   discoveredJobs: CreateJobInput[];
@@ -133,6 +134,12 @@ export async function discoverJobsStep(args: {
   const discoveredJobs: CreateJobInput[] = [];
   const sourceErrors: string[] = [];
   const includeWatchlist = args.includeWatchlist !== false;
+  const watchlistFilterIds = args.watchlistSelectedSourceIds ?? null;
+  // [] explicitly disables Watchlist for this run; treat as "no Watchlist
+  // sources" without short-circuiting includeWatchlist (so the explicit
+  // disable still emits accurate progress totals).
+  const watchlistExplicitlyDisabled =
+    Array.isArray(watchlistFilterIds) && watchlistFilterIds.length === 0;
 
   const settings = await settingsRepo.getAllSettings();
   const registry = await getExtractorRegistry();
@@ -314,7 +321,7 @@ export async function discoverJobsStep(args: {
   let watchlistSelectedSources: Awaited<
     ReturnType<typeof listHydratedWatchlistSelectedSources>
   > = [];
-  if (includeWatchlist && getUserId()) {
+  if (includeWatchlist && !watchlistExplicitlyDisabled && getUserId()) {
     try {
       watchlistSelectedSources = await listHydratedWatchlistSelectedSources();
     } catch (error) {
@@ -323,6 +330,35 @@ export async function discoverJobsStep(args: {
         error: sanitizeUnknown(error),
       });
       sourceErrors.push("Watchlist: failed to load selected sources");
+    }
+
+    // When the caller passed an explicit subset, intersect by ID and drop
+    // anything the current user does not own. Never trust the client to
+    // scope across tenants — IDs always re-resolve through the user-scoped
+    // listHydratedWatchlistSelectedSources() call above.
+    if (
+      Array.isArray(watchlistFilterIds) &&
+      watchlistFilterIds.length > 0 &&
+      watchlistSelectedSources.length > 0
+    ) {
+      const ownedIds = new Set(
+        watchlistSelectedSources.map((source) => source.id),
+      );
+      const requestedIds = new Set(watchlistFilterIds);
+      const unknownIds = watchlistFilterIds.filter((id) => !ownedIds.has(id));
+      if (unknownIds.length > 0) {
+        logger.warn(
+          "Ignoring unknown Watchlist source IDs in pipeline discovery",
+          {
+            step: "discover-jobs",
+            unknownIdCount: unknownIds.length,
+            requestedIdCount: watchlistFilterIds.length,
+          },
+        );
+      }
+      watchlistSelectedSources = watchlistSelectedSources.filter((source) =>
+        requestedIds.has(source.id),
+      );
     }
   }
 

--- a/shared/src/types/pipeline.ts
+++ b/shared/src/types/pipeline.ts
@@ -17,6 +17,12 @@ export interface PipelineConfig {
   enableScoring?: boolean;
   enableImporting?: boolean;
   enableAutoTailoring?: boolean;
+  // Per-run filter over the current user's saved Watchlist sources.
+  // undefined/null = include every Watchlist source the user has saved
+  // (legacy behavior pre-#621). [] = explicitly exclude all Watchlist
+  // sources. Non-empty = include only those source IDs that still belong
+  // to the current user; unknown IDs are dropped server-side.
+  watchlistSelectedSourceIds?: string[] | null;
 }
 
 export interface PipelineRunConfigSnapshot {
@@ -55,6 +61,10 @@ export interface PipelineRunRequestedConfig {
   enableScoring: boolean;
   enableImporting: boolean;
   enableAutoTailoring: boolean;
+  // null = run did not constrain Watchlist (legacy / pre-#621 behavior);
+  // [] = explicitly disabled all Watchlist sources;
+  // non-empty = subset of the user's saved Watchlist source IDs.
+  watchlistSelectedSourceIds: string[] | null;
 }
 
 export interface PipelineRunSourceLimitSnapshot {
@@ -139,6 +149,9 @@ export interface PipelineSearchPresetConfig {
   minSuitabilityScore: number;
   runBudget: number;
   automaticPresetId?: PipelineSearchPresetMode;
+  // Optional per-run Watchlist source selection. Omitted = legacy behavior
+  // (include every Watchlist source the user has saved). See issue #621.
+  watchlistSelectedSourceIds?: string[];
 }
 
 export interface PipelineSearchPreset {


### PR DESCRIPTION
Closes #621

## What

Adds per-source toggles for saved Watchlist sources to the Automatic Run tab's Sources accordion, so users can see (and choose) which Watchlist sources participate in each pipeline run.

## Behavior

- New Watchlist subsection in the Sources accordion with per-source toggles, badges, and an empty state linking to `/watchlist`.
- Selection is persisted per-user under an auth-scoped `localStorage` key (separate from extractor sources).
- Default on first run: all of the user's saved Watchlist sources are selected — preserves today's 'Watchlist participates automatically' behavior.
- Newly added Watchlist sources are auto-selected on next reconciliation.
- Saved searches round-trip the selection.

## API

`POST /api/pipeline/run` accepts optional `watchlistSelectedSourceIds`:
- `undefined`/`null` → legacy (include all of the user's selected Watchlist sources)
- `[]` → explicitly include no Watchlist sources
- non-empty → subset; server intersects against the user's hydrated list, so the request can never opt-in to another user's sources.

## Multi-tenancy / safety

- `discoverJobsStep` always re-resolves IDs via `listHydratedWatchlistSelectedSources()` and drops anything not owned by the current user (with a sanitized warn log).
- Analytics records only `watchlist_source_filter_count` — never raw IDs.

## Tests

- Server: new cases in `discover-jobs.test.ts` (subset filter, cross-tenant rejection, empty disables) and `pipeline.test.ts` (route forwarding, malformed rejection, preset round-trip).
- Client: `OrchestratorPage.test.tsx` mocks `getWatchlistSources` and asserts the new field is forwarded to `runPipeline`.

## Validation

- `biome ci .` ✅
- `check:types:shared` + `check:types` ✅
- `build:client` ✅
- `test:run` — 1696 passed ✅
- `docker compose build` ✅ — container starts healthy on `/health`.
