### PR TITLE
Add discovered-at Found entry to job timeline

### DIFF
--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -848,6 +848,7 @@ export const JobPage: React.FC = () => {
                   )}
                   <JobTimeline
                     events={events}
+                    discoveredAt={job.discoveredAt}
                     onEdit={isInProgress ? handleEditEvent : undefined}
                     onDelete={isInProgress ? confirmDeleteEvent : undefined}
                   />

--- a/orchestrator/src/client/pages/job/Timeline.test.tsx
+++ b/orchestrator/src/client/pages/job/Timeline.test.tsx
@@ -17,7 +17,67 @@ const baseEvent: StageEvent = {
   outcome: null,
 };
 
+const makeEvent = (overrides: Partial<StageEvent> = {}): StageEvent => ({
+  ...baseEvent,
+  ...overrides,
+  metadata: overrides.metadata ?? baseEvent.metadata,
+});
+
+const expectTextBefore = (leftText: string, rightText: string) => {
+  const left = screen.getByText(leftText);
+  const right = screen.getByText(rightText);
+
+  expect(left.compareDocumentPosition(right)).toBe(
+    Node.DOCUMENT_POSITION_FOLLOWING,
+  );
+};
+
 describe("JobTimeline", () => {
+  it("renders a read-only Found entry when discoveredAt exists without stage events", () => {
+    render(<JobTimeline events={[]} discoveredAt="2024-12-31T09:30:00.000Z" />);
+
+    expect(screen.getByText("Found")).toBeInTheDocument();
+    expect(screen.queryByText("No stage events yet.")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Edit event")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Delete event")).not.toBeInTheDocument();
+  });
+
+  it("sorts the Found entry chronologically with stage events", () => {
+    const appliedEvent = makeEvent({
+      id: "event-applied",
+      title: "Applied",
+      occurredAt: 1735689600,
+    });
+    const interviewEvent = makeEvent({
+      id: "event-interview",
+      title: "Interview",
+      toStage: "technical_interview",
+      occurredAt: 1735862400,
+    });
+
+    render(
+      <JobTimeline
+        events={[interviewEvent, appliedEvent]}
+        discoveredAt="2025-01-02T00:00:00.000Z"
+      />,
+    );
+
+    expectTextBefore("Applied", "Found");
+    expectTextBefore("Found", "Interview");
+  });
+
+  it("keeps the empty state when discoveredAt is missing or invalid", () => {
+    const { rerender } = render(<JobTimeline events={[]} />);
+
+    expect(screen.getByText("No stage events yet.")).toBeInTheDocument();
+    expect(screen.queryByText("Found")).not.toBeInTheDocument();
+
+    rerender(<JobTimeline events={[]} discoveredAt="not a date" />);
+
+    expect(screen.getByText("No stage events yet.")).toBeInTheDocument();
+    expect(screen.queryByText("Found")).not.toBeInTheDocument();
+  });
+
   it("renders edit and delete controls when callbacks are provided", () => {
     const onEdit = vi.fn();
     const onDelete = vi.fn();
@@ -34,6 +94,24 @@ describe("JobTimeline", () => {
 
     expect(onEdit).toHaveBeenCalledWith(baseEvent);
     expect(onDelete).toHaveBeenCalledWith("event-1");
+  });
+
+  it("does not add edit or delete controls for the Found entry", () => {
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+
+    render(
+      <JobTimeline
+        events={[baseEvent]}
+        discoveredAt="2024-12-31T09:30:00.000Z"
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />,
+    );
+
+    expect(screen.getByText("Found")).toBeInTheDocument();
+    expect(screen.getAllByTitle("Edit event")).toHaveLength(1);
+    expect(screen.getAllByTitle("Delete event")).toHaveLength(1);
   });
 
   it("omits edit and delete controls when callbacks are missing", () => {

--- a/orchestrator/src/client/pages/job/Timeline.test.tsx
+++ b/orchestrator/src/client/pages/job/Timeline.test.tsx
@@ -33,16 +33,21 @@ const expectTextBefore = (leftText: string, rightText: string) => {
 };
 
 describe("JobTimeline", () => {
-  it("renders a read-only Found entry when discoveredAt exists without stage events", () => {
+  it("renders a read-only Discovered entry when discoveredAt exists without stage events", () => {
     render(<JobTimeline events={[]} discoveredAt="2024-12-31T09:30:00.000Z" />);
 
-    expect(screen.getByText("Found")).toBeInTheDocument();
+    expect(screen.getByText("Discovered")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Job Ops discovered this job and added it to your pipeline.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.queryByText("No stage events yet.")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Edit event")).not.toBeInTheDocument();
     expect(screen.queryByTitle("Delete event")).not.toBeInTheDocument();
   });
 
-  it("sorts the Found entry chronologically with stage events", () => {
+  it("sorts the Discovered entry chronologically with stage events", () => {
     const appliedEvent = makeEvent({
       id: "event-applied",
       title: "Applied",
@@ -62,20 +67,20 @@ describe("JobTimeline", () => {
       />,
     );
 
-    expectTextBefore("Applied", "Found");
-    expectTextBefore("Found", "Interview");
+    expectTextBefore("Applied", "Discovered");
+    expectTextBefore("Discovered", "Interview");
   });
 
   it("keeps the empty state when discoveredAt is missing or invalid", () => {
     const { rerender } = render(<JobTimeline events={[]} />);
 
     expect(screen.getByText("No stage events yet.")).toBeInTheDocument();
-    expect(screen.queryByText("Found")).not.toBeInTheDocument();
+    expect(screen.queryByText("Discovered")).not.toBeInTheDocument();
 
     rerender(<JobTimeline events={[]} discoveredAt="not a date" />);
 
     expect(screen.getByText("No stage events yet.")).toBeInTheDocument();
-    expect(screen.queryByText("Found")).not.toBeInTheDocument();
+    expect(screen.queryByText("Discovered")).not.toBeInTheDocument();
   });
 
   it("renders edit and delete controls when callbacks are provided", () => {
@@ -96,7 +101,7 @@ describe("JobTimeline", () => {
     expect(onDelete).toHaveBeenCalledWith("event-1");
   });
 
-  it("does not add edit or delete controls for the Found entry", () => {
+  it("does not add edit or delete controls for the Discovered entry", () => {
     const onEdit = vi.fn();
     const onDelete = vi.fn();
 
@@ -109,7 +114,7 @@ describe("JobTimeline", () => {
       />,
     );
 
-    expect(screen.getByText("Found")).toBeInTheDocument();
+    expect(screen.getByText("Discovered")).toBeInTheDocument();
     expect(screen.getAllByTitle("Edit event")).toHaveLength(1);
     expect(screen.getAllByTitle("Delete event")).toHaveLength(1);
   });

--- a/orchestrator/src/client/pages/job/Timeline.tsx
+++ b/orchestrator/src/client/pages/job/Timeline.tsx
@@ -12,6 +12,7 @@ import {
   MailCheck,
   PhoneCall,
   Presentation,
+  SearchCheck,
   Trash2,
   UserRound,
   Video,
@@ -38,6 +39,10 @@ const formatRange = (start: number, end: number) => {
 };
 
 type TimelineEntry =
+  | {
+      kind: "found";
+      occurredAt: number;
+    }
   | { kind: "event"; event: StageEvent }
   | {
       kind: "group";
@@ -49,12 +54,14 @@ type TimelineEntry =
 
 interface JobTimelineProps {
   events: StageEvent[];
+  discoveredAt?: string | null;
   onEdit?: (event: StageEvent) => void;
   onDelete?: (eventId: string) => void;
 }
 
 export const JobTimeline: React.FC<JobTimelineProps> = ({
   events,
+  discoveredAt,
   onEdit,
   onDelete,
 }) => {
@@ -99,12 +106,18 @@ export const JobTimeline: React.FC<JobTimelineProps> = ({
       });
     });
 
+    const foundTimestamp = toTimestampSeconds(discoveredAt);
+    if (foundTimestamp !== null) {
+      mapped.push({
+        kind: "found",
+        occurredAt: foundTimestamp,
+      });
+    }
+
     return mapped.sort((a, b) => {
-      const timeA = a.kind === "event" ? a.event.occurredAt : a.occurredAt;
-      const timeB = b.kind === "event" ? b.event.occurredAt : b.occurredAt;
-      return timeA - timeB;
+      return getEntryOccurredAt(a) - getEntryOccurredAt(b);
     });
-  }, [events]);
+  }, [events, discoveredAt]);
 
   if (entries.length === 0) {
     return (
@@ -117,6 +130,18 @@ export const JobTimeline: React.FC<JobTimelineProps> = ({
   return (
     <div className="space-y-6">
       {entries.map((entry, entryIndex) => {
+        if (entry.kind === "found") {
+          return (
+            <TimelineRow
+              key="found"
+              date={formatTimestampWithTime(entry.occurredAt)}
+              title="Found"
+              icon={<SearchCheck className="h-4 w-4" />}
+              isLast={entryIndex === entries.length - 1}
+            />
+          );
+        }
+
         if (entry.kind === "event") {
           const title = entry.event.title || STAGE_LABELS[entry.event.toStage];
           const note = entry.event.metadata?.note;
@@ -217,6 +242,18 @@ export const JobTimeline: React.FC<JobTimelineProps> = ({
       })}
     </div>
   );
+};
+
+const toTimestampSeconds = (dateString: string | null | undefined) => {
+  if (!dateString) return null;
+  const timestamp = Date.parse(dateString);
+  if (!Number.isFinite(timestamp)) return null;
+  return Math.floor(timestamp / 1000);
+};
+
+const getEntryOccurredAt = (entry: TimelineEntry) => {
+  if (entry.kind === "event") return entry.event.occurredAt;
+  return entry.occurredAt;
 };
 
 interface TimelineRowProps {

--- a/orchestrator/src/client/pages/job/Timeline.tsx
+++ b/orchestrator/src/client/pages/job/Timeline.tsx
@@ -135,10 +135,14 @@ export const JobTimeline: React.FC<JobTimelineProps> = ({
             <TimelineRow
               key="found"
               date={formatTimestampWithTime(entry.occurredAt)}
-              title="Found"
+              title="Discovered"
               icon={<SearchCheck className="h-4 w-4" />}
               isLast={entryIndex === entries.length - 1}
-            />
+            >
+              <div className="text-sm text-muted-foreground">
+                Job Ops discovered this job and added it to your pipeline.
+              </div>
+            </TimelineRow>
           );
         }
 


### PR DESCRIPTION
## Summary
- Add a read-only `Found` timeline entry when a job has `discoveredAt`
- Sort the `Found` entry chronologically alongside stage events
- Keep the empty timeline state unchanged when `discoveredAt` is missing or invalid
- Update timeline rendering so `Found` never gets edit/delete controls
- Add tests covering ordering, empty-state behavior, and control visibility

## Testing
- Added and updated unit tests for timeline rendering behavior
- Not run (not requested)