### PR TITLE
Add job-advert language matching for Ghostwriter and PDF outputs

### DIFF
--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -104,7 +104,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 - Choose how AI output language is resolved:
   - `Manual`: always use the language you select, such as English, German, French, or Spanish
   - `Match Resume`: detect the dominant language from your resume/profile content and use that language for generated output
-  - `Match job advert language (auto-detect from JD)`: detect the dominant supported language from each job description and use it for job-specific output
+  - `Match job description`: detect the dominant supported language from each job description and use it for job-specific output
 - Automatic language detection currently supports English, German, French, and Spanish. If detection is unclear or the text is not in a supported language, JobOps falls back to English.
 - Resume tailoring keeps the exact source wording for ATS-sensitive resume headlines and job titles, even when the rest of the tailored content is generated in the selected language
 - When using the local LaTeX PDF renderer, fixed resume section titles follow the resolved output language
@@ -125,7 +125,7 @@ Use these steps when you want Ghostwriter and resume tailoring to stay in a spec
 4. Under the language control, choose one of these modes:
    - **Manual**: pick the output language directly.
    - **Match Resume**: let JobOps infer the language from your resume/profile text.
-   - **Match job advert language**: let JobOps infer the language from each job description.
+   - **Match job description**: let JobOps infer the language from each job description.
 5. If you chose **Manual**, select the language you want the AI to use.
 6. Review the rest of the writing defaults such as tone, formality, constraints, and do-not-use terms.
 7. Click **Save Changes**.
@@ -135,7 +135,7 @@ Defaults and constraints:
 
 - `Manual` is best when you always want output in one language regardless of the resume source text.
 - `Match Resume` is best when your base resume is already written in the language you want to preserve.
-- `Match job advert language` is best when you want each application to follow the job advert's language.
+- `Match job description` is best when you want each application to follow the job description's language.
 - If JobOps cannot determine a reliable supported language, it safely uses English.
 - The generated resume content follows the resolved language, but ATS-sensitive headline and job-title wording stays exact so matching and parsing remain safer.
 - The local LaTeX PDF renderer uses the resolved language for fixed section headings such as Summary, Experience, Education, Projects, and Technical Skills.

--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -104,7 +104,8 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 - Choose how AI output language is resolved:
   - `Manual`: always use the language you select, such as English, German, French, or Spanish
   - `Match Resume`: detect the dominant language from your resume/profile content and use that language for generated output
-- If language detection is unclear or there is not enough resume/profile text, JobOps falls back to English
+  - `Match job advert language (auto-detect from JD)`: detect the dominant supported language from each job description and use it for job-specific output
+- Automatic language detection currently supports English, German, French, and Spanish. If detection is unclear or the text is not in a supported language, JobOps falls back to English.
 - Resume tailoring keeps the exact source wording for ATS-sensitive resume headlines and job titles, even when the rest of the tailored content is generated in the selected language
 - When using the local LaTeX PDF renderer, fixed resume section titles follow the resolved output language
 - Downloaded resume filenames are ASCII-transliterated using the resolved language. For German, umlauts use `ä -> ae`, `ö -> oe`, `ü -> ue`, and `ß -> ss`.
@@ -124,6 +125,7 @@ Use these steps when you want Ghostwriter and resume tailoring to stay in a spec
 4. Under the language control, choose one of these modes:
    - **Manual**: pick the output language directly.
    - **Match Resume**: let JobOps infer the language from your resume/profile text.
+   - **Match job advert language**: let JobOps infer the language from each job description.
 5. If you chose **Manual**, select the language you want the AI to use.
 6. Review the rest of the writing defaults such as tone, formality, constraints, and do-not-use terms.
 7. Click **Save Changes**.
@@ -133,7 +135,8 @@ Defaults and constraints:
 
 - `Manual` is best when you always want output in one language regardless of the resume source text.
 - `Match Resume` is best when your base resume is already written in the language you want to preserve.
-- If JobOps cannot determine a reliable resume/profile language, it safely uses English.
+- `Match job advert language` is best when you want each application to follow the job advert's language.
+- If JobOps cannot determine a reliable supported language, it safely uses English.
 - The generated resume content follows the resolved language, but ATS-sensitive headline and job-title wording stays exact so matching and parsing remain safer.
 - The local LaTeX PDF renderer uses the resolved language for fixed section headings such as Summary, Experience, Education, Projects, and Technical Skills.
 

--- a/docs-site/versioned_docs/version-0.6.2/features/settings.md
+++ b/docs-site/versioned_docs/version-0.6.2/features/settings.md
@@ -95,7 +95,8 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 - Choose how AI output language is resolved:
   - `Manual`: always use the language you select, such as English, German, French, or Spanish
   - `Match Resume`: detect the dominant language from your resume/profile content and use that language for generated output
-- If language detection is unclear or there is not enough resume/profile text, JobOps falls back to English
+  - `Match job advert language (auto-detect from JD)`: detect the dominant supported language from each job description and use it for job-specific output
+- Automatic language detection currently supports English, German, French, and Spanish. If detection is unclear or the text is not in a supported language, JobOps falls back to English.
 - Resume tailoring keeps the exact source wording for ATS-sensitive resume headlines and job titles, even when the rest of the tailored content is generated in the selected language
 - When using the local LaTeX PDF renderer, fixed resume section titles follow the resolved output language
 - Summary max words: optional cap on AI-generated summary length (empty = no limit)
@@ -114,6 +115,7 @@ Use these steps when you want Ghostwriter and resume tailoring to stay in a spec
 4. Under the language control, choose one of these modes:
    - **Manual**: pick the output language directly.
    - **Match Resume**: let JobOps infer the language from your resume/profile text.
+   - **Match job advert language**: let JobOps infer the language from each job description.
 5. If you chose **Manual**, select the language you want the AI to use.
 6. Review the rest of the writing defaults such as tone, formality, constraints, and do-not-use terms.
 7. Click **Save Changes**.
@@ -123,7 +125,8 @@ Defaults and constraints:
 
 - `Manual` is best when you always want output in one language regardless of the resume source text.
 - `Match Resume` is best when your base resume is already written in the language you want to preserve.
-- If JobOps cannot determine a reliable resume/profile language, it safely uses English.
+- `Match job advert language` is best when you want each application to follow the job advert's language.
+- If JobOps cannot determine a reliable supported language, it safely uses English.
 - The generated resume content follows the resolved language, but ATS-sensitive headline and job-title wording stays exact so matching and parsing remain safer.
 - The local LaTeX PDF renderer uses the resolved language for fixed section headings such as Summary, Experience, Education, Projects, and Technical Skills.
 

--- a/docs-site/versioned_docs/version-0.6.2/features/settings.md
+++ b/docs-site/versioned_docs/version-0.6.2/features/settings.md
@@ -95,7 +95,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 - Choose how AI output language is resolved:
   - `Manual`: always use the language you select, such as English, German, French, or Spanish
   - `Match Resume`: detect the dominant language from your resume/profile content and use that language for generated output
-  - `Match job advert language (auto-detect from JD)`: detect the dominant supported language from each job description and use it for job-specific output
+  - `Match job description`: detect the dominant supported language from each job description and use it for job-specific output
 - Automatic language detection currently supports English, German, French, and Spanish. If detection is unclear or the text is not in a supported language, JobOps falls back to English.
 - Resume tailoring keeps the exact source wording for ATS-sensitive resume headlines and job titles, even when the rest of the tailored content is generated in the selected language
 - When using the local LaTeX PDF renderer, fixed resume section titles follow the resolved output language
@@ -115,7 +115,7 @@ Use these steps when you want Ghostwriter and resume tailoring to stay in a spec
 4. Under the language control, choose one of these modes:
    - **Manual**: pick the output language directly.
    - **Match Resume**: let JobOps infer the language from your resume/profile text.
-   - **Match job advert language**: let JobOps infer the language from each job description.
+   - **Match job description**: let JobOps infer the language from each job description.
 5. If you chose **Manual**, select the language you want the AI to use.
 6. Review the rest of the writing defaults such as tone, formality, constraints, and do-not-use terms.
 7. Click **Save Changes**.
@@ -125,7 +125,7 @@ Defaults and constraints:
 
 - `Manual` is best when you always want output in one language regardless of the resume source text.
 - `Match Resume` is best when your base resume is already written in the language you want to preserve.
-- `Match job advert language` is best when you want each application to follow the job advert's language.
+- `Match job description` is best when you want each application to follow the job description's language.
 - If JobOps cannot determine a reliable supported language, it safely uses English.
 - The generated resume content follows the resolved language, but ATS-sensitive headline and job-title wording stays exact so matching and parsing remain safer.
 - The local LaTeX PDF renderer uses the resolved language for fixed section headings such as Summary, Experience, Education, Projects, and Technical Skills.

--- a/orchestrator/src/client/lib/pdf-filename.test.ts
+++ b/orchestrator/src/client/lib/pdf-filename.test.ts
@@ -51,4 +51,32 @@ describe("resolveFilenameLanguage", () => {
       }),
     ).toBe("german");
   });
+
+  it("falls back to english in match-job-description mode without JD text", () => {
+    const profile: ResumeProfile = {
+      basics: {
+        summary:
+          "Ich entwickle Plattformen und arbeite mit der Entwicklung zusammen.",
+      },
+      sections: {
+        summary: {
+          content:
+            "Erfahrung mit APIs und verantwortlicher Lieferung für das Team.",
+        },
+      },
+    };
+
+    expect(
+      resolveFilenameLanguage({
+        settings: createAppSettings({
+          chatStyleLanguageMode: {
+            value: "match-job-description",
+            default: "manual",
+            override: null,
+          },
+        }),
+        profile,
+      }),
+    ).toBe("english");
+  });
 });

--- a/orchestrator/src/client/lib/pdf-filename.ts
+++ b/orchestrator/src/client/lib/pdf-filename.ts
@@ -22,7 +22,11 @@ export function resolveFilenameLanguage(args: {
     );
   }
 
-  return args.profile
-    ? (detectProfileLanguage(args.profile) ?? "english")
-    : "english";
+  if (languageMode === "match-resume") {
+    return args.profile
+      ? (detectProfileLanguage(args.profile) ?? "english")
+      : "english";
+  }
+
+  return "english";
 }

--- a/orchestrator/src/client/pages/SettingsPage.test.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.test.tsx
@@ -974,6 +974,45 @@ describe("SettingsPage", () => {
     );
   });
 
+  it("saves the match job advert language mode through the settings page", async () => {
+    vi.mocked(api.getSettings).mockResolvedValue(baseSettings);
+    vi.mocked(api.updateSettings).mockResolvedValue(
+      createAppSettings({
+        chatStyleLanguageMode: {
+          value: "match-job-description",
+          default: "manual",
+          override: "match-job-description",
+        },
+      }),
+    );
+
+    renderPage();
+    await openWritingStyleSection();
+
+    fireEvent.click(screen.getByRole("combobox", { name: /output language/i }));
+    fireEvent.click(
+      await screen.findByText(
+        "Match job advert language (auto-detect from JD)",
+      ),
+    );
+
+    expect(
+      screen.queryByRole("combobox", { name: /specific language/i }),
+    ).not.toBeInTheDocument();
+
+    const saveButton = getSaveButton();
+    await waitFor(() => expect(saveButton).toBeEnabled());
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(api.updateSettings).toHaveBeenCalled());
+    expect(api.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatStyleLanguageMode: "match-job-description",
+        chatStyleManualLanguage: null,
+      }),
+    );
+  });
+
   it("saves the Ghostwriter Stop Slop toggle through the settings page", async () => {
     vi.mocked(api.getSettings).mockResolvedValue(baseSettings);
     vi.mocked(api.updateSettings).mockResolvedValue(

--- a/orchestrator/src/client/pages/SettingsPage.test.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.test.tsx
@@ -974,7 +974,7 @@ describe("SettingsPage", () => {
     );
   });
 
-  it("saves the match job advert language mode through the settings page", async () => {
+  it("saves the match job description language mode through the settings page", async () => {
     vi.mocked(api.getSettings).mockResolvedValue(baseSettings);
     vi.mocked(api.updateSettings).mockResolvedValue(
       createAppSettings({
@@ -990,11 +990,7 @@ describe("SettingsPage", () => {
     await openWritingStyleSection();
 
     fireEvent.click(screen.getByRole("combobox", { name: /output language/i }));
-    fireEvent.click(
-      await screen.findByText(
-        "Match job advert language (auto-detect from JD)",
-      ),
-    );
+    fireEvent.click(await screen.findByText("Match job description"));
 
     expect(
       screen.queryByRole("combobox", { name: /specific language/i }),

--- a/orchestrator/src/client/pages/settings/components/ChatSettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/ChatSettingsSection.tsx
@@ -38,7 +38,7 @@ type ChatSettingsSectionProps = {
 const LANGUAGE_MODE_LABELS: Record<ChatStyleLanguageMode, string> = {
   manual: "Choose specific language",
   "match-resume": "Match current resume language",
-  "match-job-description": "Match job advert language (auto-detect from JD)",
+  "match-job-description": "Match job description",
 };
 
 function parseTokenizedTerms(input: string): string[] {
@@ -250,7 +250,7 @@ export const ChatSettingsSection: React.FC<ChatSettingsSectionProps> = ({
                       Match current resume language
                     </SelectItem>
                     <SelectItem value="match-job-description">
-                      Match job advert language (auto-detect from JD)
+                      Match job description
                     </SelectItem>
                     <SelectItem value="manual">
                       Choose specific language

--- a/orchestrator/src/client/pages/settings/components/ChatSettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/ChatSettingsSection.tsx
@@ -38,6 +38,7 @@ type ChatSettingsSectionProps = {
 const LANGUAGE_MODE_LABELS: Record<ChatStyleLanguageMode, string> = {
   manual: "Choose specific language",
   "match-resume": "Match current resume language",
+  "match-job-description": "Match job advert language (auto-detect from JD)",
 };
 
 function parseTokenizedTerms(input: string): string[] {
@@ -247,6 +248,9 @@ export const ChatSettingsSection: React.FC<ChatSettingsSectionProps> = ({
                   <SelectContent>
                     <SelectItem value="match-resume">
                       Match current resume language
+                    </SelectItem>
+                    <SelectItem value="match-job-description">
+                      Match job advert language (auto-detect from JD)
                     </SelectItem>
                     <SelectItem value="manual">
                       Choose specific language

--- a/orchestrator/src/server/services/ghostwriter-context.test.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.test.ts
@@ -240,6 +240,37 @@ describe("buildJobChatPromptContext", () => {
     );
   });
 
+  it("matches Ghostwriter language to detected job description language when configured", async () => {
+    const job = createJob({
+      id: "job-ctx-jd-language",
+      jobDescription:
+        "Wir suchen Erfahrung mit Entwicklung und Verantwortung für APIs.",
+    });
+    vi.mocked(getJobById).mockResolvedValue(job);
+    vi.mocked(getWritingStyle).mockResolvedValue({
+      tone: "professional",
+      formality: "medium",
+      constraints: "",
+      doNotUse: "",
+      languageMode: "match-job-description",
+      manualLanguage: "english",
+      summaryMaxWords: null,
+      maxKeywordsPerSkill: null,
+    });
+    vi.mocked(getProfile).mockResolvedValue({
+      basics: {
+        name: "Claire",
+        summary: "I build reliable data platforms and work with product teams.",
+      },
+    });
+
+    const context = await buildJobChatPromptContext(job.id);
+
+    expect(context.systemPrompt).toContain(
+      "When the user does not request a language, default to writing user-visible resume or application content in German.",
+    );
+  });
+
   it("removes language instructions from global writing constraints", async () => {
     const job = createJob({ id: "job-ctx-4" });
     vi.mocked(getJobById).mockResolvedValue(job);

--- a/orchestrator/src/server/services/ghostwriter-context.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.ts
@@ -337,10 +337,12 @@ async function buildSelectedDocumentsSnapshot(
 async function buildSystemPrompt(
   style: WritingStyle,
   profile: ResumeProfile,
+  jobDescription?: string | null,
 ): Promise<string> {
   const resolvedLanguage = resolveWritingOutputLanguage({
     style,
     profile,
+    jobDescription,
   });
   const outputLanguage = getWritingLanguageLabel(resolvedLanguage.language);
   const effectiveConstraints = stripLanguageDirectivesFromConstraints(
@@ -402,7 +404,7 @@ export async function buildJobChatPromptContext(
     selectedEmailsSnapshot,
     selectedDocumentsSnapshot,
   ] = await Promise.all([
-    buildSystemPrompt(style, profile),
+    buildSystemPrompt(style, profile, job.jobDescription),
     isStopSlopEnabled(),
     buildSelectedNotesSnapshot(jobId, selectedNoteIds),
     buildSelectedEmailsSnapshot(jobId, selectedEmailIds),

--- a/orchestrator/src/server/services/output-language.test.ts
+++ b/orchestrator/src/server/services/output-language.test.ts
@@ -1,6 +1,7 @@
 import type { ResumeProfile } from "@shared/types";
 import { describe, expect, it } from "vitest";
 import {
+  detectJobDescriptionLanguage,
   detectProfileLanguage,
   detectReactiveResumeV5Language,
   resolveWritingOutputLanguage,
@@ -63,6 +64,56 @@ describe("resolveWritingOutputLanguage", () => {
           headline: "Senior Engineer",
         },
       },
+    });
+
+    expect(result).toEqual({
+      language: "english",
+      source: "fallback",
+    });
+  });
+
+  it.each([
+    [
+      "english",
+      "We are looking for an engineer with experience building reliable APIs and working with product teams.",
+    ],
+    [
+      "german",
+      "Wir suchen eine Person mit Erfahrung in der Entwicklung skalierbarer Plattformen und Verantwortung für APIs.",
+    ],
+    [
+      "french",
+      "Nous recherchons une personne avec expérience dans le développement et responsable des plateformes pour les équipes.",
+    ],
+    [
+      "spanish",
+      "Buscamos una persona con experiencia en desarrollo, responsable de APIs y colaboración con los equipos.",
+    ],
+  ] as const)("detects %s from job description text", (language, jobDescription) => {
+    expect(detectJobDescriptionLanguage(jobDescription)).toBe(language);
+    expect(
+      resolveWritingOutputLanguage({
+        style: {
+          languageMode: "match-job-description",
+          manualLanguage: "english",
+        },
+        profile: {},
+        jobDescription,
+      }),
+    ).toEqual({
+      language,
+      source: "detected",
+    });
+  });
+
+  it("falls back to english when job description language detection is weak", () => {
+    const result = resolveWritingOutputLanguage({
+      style: {
+        languageMode: "match-job-description",
+        manualLanguage: "french",
+      },
+      profile: {},
+      jobDescription: "Senior platform role with Kubernetes.",
     });
 
     expect(result).toEqual({
@@ -181,6 +232,21 @@ describe("resolveWritingOutputLanguage", () => {
     ).toEqual({
       language: "english",
       source: "fallback",
+    });
+
+    expect(
+      resolveWritingOutputLanguageForResumeJson({
+        style: {
+          languageMode: "match-job-description",
+          manualLanguage: "french",
+        },
+        resumeJson,
+        jobDescription:
+          "Wir suchen Erfahrung mit Entwicklung und Verantwortung für APIs.",
+      }),
+    ).toEqual({
+      language: "german",
+      source: "detected",
     });
   });
 });

--- a/orchestrator/src/server/services/output-language.ts
+++ b/orchestrator/src/server/services/output-language.ts
@@ -1,4 +1,5 @@
 import {
+  detectJobDescriptionLanguage,
   detectProfileLanguage,
   detectReactiveResumeV5Language,
 } from "@shared/language-detection";
@@ -10,6 +11,7 @@ import {
 } from "@shared/types";
 
 export {
+  detectJobDescriptionLanguage,
   detectProfileLanguage,
   detectReactiveResumeV5Language,
 } from "@shared/language-detection";
@@ -27,6 +29,7 @@ export type ResolvedWritingLanguage = {
 export function resolveWritingOutputLanguage(args: {
   style: WritingLanguageConfig;
   profile: ResumeProfile;
+  jobDescription?: string | null;
 }): ResolvedWritingLanguage {
   if (args.style.languageMode === "manual") {
     return {
@@ -35,7 +38,10 @@ export function resolveWritingOutputLanguage(args: {
     };
   }
 
-  const detectedLanguage = detectProfileLanguage(args.profile);
+  const detectedLanguage =
+    args.style.languageMode === "match-job-description"
+      ? detectJobDescriptionLanguage(args.jobDescription)
+      : detectProfileLanguage(args.profile);
   if (detectedLanguage) {
     return {
       language: detectedLanguage,
@@ -52,6 +58,7 @@ export function resolveWritingOutputLanguage(args: {
 export function resolveWritingOutputLanguageForResumeJson(args: {
   style: WritingLanguageConfig;
   resumeJson: Record<string, unknown>;
+  jobDescription?: string | null;
 }): ResolvedWritingLanguage {
   if (args.style.languageMode === "manual") {
     return {
@@ -60,7 +67,10 @@ export function resolveWritingOutputLanguageForResumeJson(args: {
     };
   }
 
-  const detectedLanguage = detectReactiveResumeV5Language(args.resumeJson);
+  const detectedLanguage =
+    args.style.languageMode === "match-job-description"
+      ? detectJobDescriptionLanguage(args.jobDescription)
+      : detectReactiveResumeV5Language(args.resumeJson);
   if (detectedLanguage) {
     return {
       language: detectedLanguage,

--- a/orchestrator/src/server/services/pdf-tailoring.test.ts
+++ b/orchestrator/src/server/services/pdf-tailoring.test.ts
@@ -209,7 +209,7 @@ const {
 
   return {
     currentLanguageSettings: {
-      mode: "manual" as "manual" | "match-resume",
+      mode: "manual" as "manual" | "match-resume" | "match-job-description",
       manual: "english" as "english" | "german" | "french" | "spanish",
     },
     currentPdfRenderer: { value: "latex" as "latex" | "rxresume" | "typst" },
@@ -601,6 +601,23 @@ describe("PDF Service Tailoring Logic", () => {
       expect.objectContaining({
         jobId: "job-french-latex",
         language: "french",
+      }),
+    );
+  });
+
+  it("detects the job description language for local LaTeX rendering", async () => {
+    currentLanguageSettings.mode = "match-job-description";
+
+    await generatePdf(
+      "job-german-jd-latex",
+      {},
+      "Wir suchen Erfahrung mit Entwicklung und Verantwortung für APIs.",
+    );
+
+    expect(mockResumeRenderer.renderResumePdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-german-jd-latex",
+        language: "german",
       }),
     );
   });

--- a/orchestrator/src/server/services/pdf.ts
+++ b/orchestrator/src/server/services/pdf.ts
@@ -79,11 +79,15 @@ async function resolveTypstTheme() {
   );
 }
 
-async function resolveLocalResumeLanguage(resumeJson: Record<string, unknown>) {
+async function resolveLocalResumeLanguage(
+  resumeJson: Record<string, unknown>,
+  jobDescription?: string | null,
+) {
   const writingStyle = await getWritingStyle();
   return resolveWritingOutputLanguageForResumeJson({
     style: writingStyle,
     resumeJson,
+    jobDescription,
   }).language;
 }
 
@@ -375,7 +379,7 @@ export async function generatePdf(
     const outputPath = getTenantJobPdfPath(jobId);
     if (renderer !== "rxresume") {
       const [language, typstTheme] = await Promise.all([
-        resolveLocalResumeLanguage(preparedResume.data),
+        resolveLocalResumeLanguage(preparedResume.data, jobDescription),
         renderer === "typst" ? resolveTypstTheme() : Promise.resolve(undefined),
       ]);
       await renderResumePdf({

--- a/orchestrator/src/server/services/summary.test.ts
+++ b/orchestrator/src/server/services/summary.test.ts
@@ -136,6 +136,59 @@ describe("generateTailoring", () => {
     );
   });
 
+  it("uses the detected job description language when configured", async () => {
+    vi.mocked(getWritingStyle).mockResolvedValue({
+      tone: "friendly",
+      formality: "low",
+      constraints: "",
+      doNotUse: "",
+      languageMode: "match-job-description",
+      manualLanguage: "english",
+      summaryMaxWords: null,
+      maxKeywordsPerSkill: null,
+    });
+
+    await generateTailoring(
+      "Wir suchen Erfahrung mit Entwicklung und Verantwortung für APIs.",
+      {
+        basics: {
+          name: "Test User",
+          label: "Engineer",
+        },
+      },
+    );
+
+    const request = callJsonMock.mock.calls.at(-1)?.[0];
+    expect(request?.messages?.[0]?.content).toContain(
+      "Output language for summary and skills: German",
+    );
+  });
+
+  it("falls back to english when job description language detection is weak", async () => {
+    vi.mocked(getWritingStyle).mockResolvedValue({
+      tone: "friendly",
+      formality: "low",
+      constraints: "",
+      doNotUse: "",
+      languageMode: "match-job-description",
+      manualLanguage: "german",
+      summaryMaxWords: null,
+      maxKeywordsPerSkill: null,
+    });
+
+    await generateTailoring("Senior platform role with Kubernetes.", {
+      basics: {
+        name: "Test User",
+        label: "Engineer",
+      },
+    });
+
+    const request = callJsonMock.mock.calls.at(-1)?.[0];
+    expect(request?.messages?.[0]?.content).toContain(
+      "Output language for summary and skills: English",
+    );
+  });
+
   it("uses a stored tailoring prompt template override", async () => {
     vi.mocked(getSetting).mockImplementation(async (key) =>
       key === "tailoringPromptTemplate"

--- a/orchestrator/src/server/services/summary.ts
+++ b/orchestrator/src/server/services/summary.ts
@@ -151,6 +151,7 @@ async function buildTailoringPrompt(
   const resolvedLanguage = resolveWritingOutputLanguage({
     style: writingStyle,
     profile,
+    jobDescription: jd,
   });
   const outputLanguage = getWritingLanguageLabel(resolvedLanguage.language);
   let effectiveConstraints = stripLanguageDirectivesFromConstraints(

--- a/shared/src/language-detection.ts
+++ b/shared/src/language-detection.ts
@@ -232,6 +232,12 @@ export function detectProfileLanguage(
   return detectLanguageFromSample(collectProfileLanguageSample(profile));
 }
 
+export function detectJobDescriptionLanguage(
+  jobDescription: string | null | undefined,
+): ChatStyleManualLanguage | null {
+  return detectLanguageFromSample(jobDescription ?? "");
+}
+
 export function detectReactiveResumeV5Language(
   resumeJson: Record<string, unknown>,
 ): ChatStyleManualLanguage | null {

--- a/shared/src/settings-registry.test.ts
+++ b/shared/src/settings-registry.test.ts
@@ -296,11 +296,16 @@ describe("settingsRegistry helpers", () => {
       expect(settingsRegistry.chatStyleLanguageMode.parse("match-resume")).toBe(
         "match-resume",
       );
+      expect(
+        settingsRegistry.chatStyleLanguageMode.parse("match-job-description"),
+      ).toBe("match-job-description");
       expect(settingsRegistry.chatStyleLanguageMode.parse("auto")).toBeNull();
       expect(settingsRegistry.chatStyleLanguageMode.parse("")).toBeNull();
       expect(
-        settingsRegistry.chatStyleLanguageMode.serialize("match-resume"),
-      ).toBe("match-resume");
+        settingsRegistry.chatStyleLanguageMode.serialize(
+          "match-job-description",
+        ),
+      ).toBe("match-job-description");
       expect(settingsRegistry.chatStyleLanguageMode.serialize(null)).toBeNull();
 
       expect(settingsRegistry.chatStyleManualLanguage.parse("english")).toBe(

--- a/shared/src/settings-schema.test.ts
+++ b/shared/src/settings-schema.test.ts
@@ -99,6 +99,16 @@ describe("updateSettingsSchema", () => {
       chatStyleLanguageMode: null,
       chatStyleManualLanguage: null,
     });
+
+    expect(
+      updateSettingsSchema.parse({
+        chatStyleLanguageMode: "match-job-description",
+        chatStyleManualLanguage: null,
+      }),
+    ).toEqual({
+      chatStyleLanguageMode: "match-job-description",
+      chatStyleManualLanguage: null,
+    });
   });
 
   it("rejects unsupported language mode and manual language values", () => {

--- a/shared/src/types/settings.ts
+++ b/shared/src/types/settings.ts
@@ -69,6 +69,7 @@ export type TypstTheme = (typeof TYPST_THEME_VALUES)[number];
 export const CHAT_STYLE_LANGUAGE_MODE_VALUES = [
   "manual",
   "match-resume",
+  "match-job-description",
 ] as const;
 
 export type ChatStyleLanguageMode =


### PR DESCRIPTION
## Summary
- Add a new `match-job-description` language mode that detects output language from the current job description.
- Thread job-description language resolution through Ghostwriter prompts, tailoring, and local PDF generation.
- Update settings UI, shared schema/types, and docs to describe the new mode and its fallback behavior.
- Extend tests to cover language detection, settings persistence, prompt generation, and PDF filename/rendering behavior.

## Testing
- Added and updated unit tests for shared settings validation, language resolution, Ghostwriter context, tailoring, PDF rendering, and settings-page persistence.
- Not run (not requested).