### PR TITLE
Restore manual job import access from the orchestrator header

### DIFF
--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -83,6 +83,7 @@ let mockAutomaticRunValues: AutomaticRunValues = {
 };
 const mockJobListScrollToIndex = vi.fn();
 let mockIsLoading = false;
+let mockLoadJobs = vi.fn();
 
 const jobFixture = createJob({
   id: "job-1",
@@ -145,7 +146,7 @@ vi.mock("./orchestrator/useOrchestratorData", () => ({
     setIsPipelineRunning: vi.fn(),
     pipelineTerminalEvent: mockPipelineTerminalEvent,
     setIsRefreshPaused: vi.fn(),
-    loadJobs: vi.fn(),
+    loadJobs: mockLoadJobs,
   }),
 }));
 
@@ -180,22 +181,27 @@ vi.mock("../hooks/useSettings", () => ({
 
 vi.mock("./orchestrator/OrchestratorHeader", () => ({
   OrchestratorHeader: ({
-    hideActions,
+    hideRunAction,
     isSearchComposerOpen,
     onOpenAutomaticRun,
     onCancelPipeline,
+    onOpenManualImport,
   }: {
-    hideActions?: boolean;
+    hideRunAction?: boolean;
     isSearchComposerOpen?: boolean;
     onOpenAutomaticRun?: () => void;
     onCancelPipeline: () => void;
+    onOpenManualImport: () => void;
   }) => (
     <div data-testid="header">
-      {!hideActions ? (
+      {!hideRunAction ? (
         <button type="button" onClick={onOpenAutomaticRun}>
           {isSearchComposerOpen ? "Close Search" : "Run Search"}
         </button>
       ) : null}
+      <button type="button" onClick={onOpenManualImport}>
+        Import job manually
+      </button>
       <button type="button" onClick={onCancelPipeline}>
         Cancel Pipeline
       </button>
@@ -440,8 +446,38 @@ vi.mock("./orchestrator/RunModeModal", () => ({
   ),
 }));
 
-vi.mock("../components", () => ({
-  ManualImportSheet: () => <div data-testid="manual-import" />,
+vi.mock("@client/components/ManualImportSheet", () => ({
+  ManualImportSheet: ({
+    open,
+    onOpenChange,
+    onImported,
+  }: {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onImported: (result: {
+      jobId: string;
+      source: "pasted_description";
+      sourceHost: string | null;
+    }) => void | Promise<void>;
+  }) =>
+    open ? (
+      <div data-testid="manual-import">
+        <button
+          type="button"
+          data-testid="complete-manual-import"
+          onClick={async () => {
+            await onImported({
+              jobId: "manual-job-1",
+              source: "pasted_description",
+              sourceHost: null,
+            });
+            onOpenChange(false);
+          }}
+        >
+          Complete manual import
+        </button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("../components/KeyboardShortcutDialog", () => ({
@@ -473,6 +509,10 @@ const openAutomaticRunComposer = () => {
   fireEvent.click(screen.getByRole("button", { name: /run search/i }));
 };
 
+const openManualImport = () => {
+  fireEvent.click(screen.getByRole("button", { name: /import job manually/i }));
+};
+
 describe("OrchestratorPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -486,6 +526,7 @@ describe("OrchestratorPage", () => {
     mockPipelineSources = ["linkedin"];
     mockJobs = [jobFixture, job2, processingJob];
     mockSelectedJob = jobFixture;
+    mockLoadJobs = vi.fn().mockResolvedValue(undefined);
     mockAutomaticRunValues = {
       topN: 12,
       minSuitabilityScore: 55,
@@ -1073,6 +1114,35 @@ describe("OrchestratorPage", () => {
     ).toBeInTheDocument();
   });
 
+  it("opens manual import from the header and navigates to the imported job", async () => {
+    window.matchMedia = createMatchMedia(
+      true,
+    ) as unknown as typeof window.matchMedia;
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/ready"]}>
+        <LocationWatcher />
+        <Routes>
+          <Route path="/jobs/:tab" element={<OrchestratorPage />} />
+          <Route path="/jobs/:tab/:jobId" element={<OrchestratorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    openManualImport();
+
+    expect(screen.getByTestId("manual-import")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("complete-manual-import"));
+
+    await waitFor(() => {
+      expect(mockLoadJobs).toHaveBeenCalled();
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/jobs/ready/manual-job-1",
+      );
+    });
+  });
+
   it("shows the search composer instead of empty columns for brand-new workspaces", () => {
     mockJobs = [];
     mockSelectedJob = null;
@@ -1097,8 +1167,32 @@ describe("OrchestratorPage", () => {
     expect(
       screen.queryByRole("button", { name: /run search/i }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /import job manually/i }),
+    ).toBeInTheDocument();
     expect(screen.queryByTestId("summary")).not.toBeInTheDocument();
     expect(screen.queryByText(/no jobs found/i)).not.toBeInTheDocument();
+  });
+
+  it("opens manual import from the first-run search composer state", () => {
+    mockJobs = [];
+    mockSelectedJob = null;
+    window.matchMedia = createMatchMedia(
+      true,
+    ) as unknown as typeof window.matchMedia;
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/ready"]}>
+        <Routes>
+          <Route path="/jobs/:tab" element={<OrchestratorPage />} />
+          <Route path="/jobs/:tab/:jobId" element={<OrchestratorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    openManualImport();
+
+    expect(screen.getByTestId("manual-import")).toBeInTheDocument();
   });
 
   it("stores multiple cities for JobSpy sources in automatic mode", async () => {

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -1,6 +1,7 @@
+import { ManualImportSheet } from "@client/components/ManualImportSheet";
 import { useSettings } from "@client/hooks/useSettings";
 import type React from "react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { OrchestratorHeader } from "./orchestrator/OrchestratorHeader";
 import { OrchestratorJobWorkspaceContainer } from "./orchestrator/OrchestratorJobWorkspaceContainer";
 import { OrchestratorSearchComposer } from "./orchestrator/OrchestratorSearchComposer";
@@ -18,6 +19,7 @@ import { useWatchlistPipelineSources } from "./orchestrator/useWatchlistPipeline
 import { getEnabledSources } from "./orchestrator/utils";
 
 export const OrchestratorPage: React.FC = () => {
+  const [isManualImportOpen, setIsManualImportOpen] = useState(false);
   const filters = useOrchestratorFilters();
   const navigation = useOrchestratorNavigation({
     searchParams: filters.searchParams,
@@ -104,12 +106,13 @@ export const OrchestratorPage: React.FC = () => {
         isPipelineRunning={isPipelineRunning}
         isCancelling={isCancelling}
         pipelineSources={pipelineSources}
-        hideActions={isSearchComposerVisible && !canToggleSearchComposer}
+        hideRunAction={isSearchComposerVisible && !canToggleSearchComposer}
         isSearchComposerOpen={
           isSearchComposerVisible && canToggleSearchComposer
         }
         onOpenAutomaticRun={handleToggleAutomaticRun}
         onCancelPipeline={handleCancelPipeline}
+        onOpenManualImport={() => setIsManualImportOpen(true)}
       />
 
       <main
@@ -155,6 +158,14 @@ export const OrchestratorPage: React.FC = () => {
           />
         )}
       </main>
+
+      <ManualImportSheet
+        open={isManualImportOpen}
+        onOpenChange={setIsManualImportOpen}
+        onImported={async (result) => {
+          await handleManualImported(result);
+        }}
+      />
     </>
   );
 };

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorHeader.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorHeader.test.tsx
@@ -21,6 +21,33 @@ vi.mock("@/components/ui/sheet", () => ({
   ),
 }));
 
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="menu">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+  }) => (
+    <button type="button" role="menuitem" onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+}));
+
 const renderHeader = (
   overrides: Partial<React.ComponentProps<typeof OrchestratorHeader>> = {},
 ) => {
@@ -32,6 +59,7 @@ const renderHeader = (
     pipelineSources: ["gradcracker"],
     onOpenAutomaticRun: vi.fn(),
     onCancelPipeline: vi.fn(),
+    onOpenManualImport: vi.fn(),
     ...overrides,
   };
 
@@ -62,18 +90,31 @@ describe("OrchestratorHeader", () => {
     expect(props.onOpenAutomaticRun).toHaveBeenCalled();
   });
 
-  it("does not render manual import button", () => {
-    renderHeader();
+  it("opens manual import from the overflow menu", () => {
+    const { props } = renderHeader();
+
     expect(
-      screen.queryByRole("button", { name: /manual import/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: /more job actions/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: /import job manually/i }),
+    );
+
+    expect(props.onOpenManualImport).toHaveBeenCalled();
   });
 
-  it("hides the run action when requested", () => {
-    renderHeader({ hideActions: true });
+  it("hides the run action while keeping manual import reachable", () => {
+    renderHeader({ hideRunAction: true });
     expect(
       screen.queryByRole("button", { name: /run search/i }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /more job actions/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: /import job manually/i }),
+    ).toBeInTheDocument();
   });
 
   it("renders cancel button while running and triggers cancel", () => {

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorHeader.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorHeader.tsx
@@ -1,8 +1,21 @@
 import { PageHeader, StatusIndicator } from "@client/components/layout";
 import type { JobSource } from "@shared/types.js";
-import { Loader2, Play, Square, X } from "lucide-react";
+import {
+  FileText,
+  Loader2,
+  MoreHorizontal,
+  Play,
+  Square,
+  X,
+} from "lucide-react";
 import type React from "react";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface OrchestratorHeaderProps {
   navOpen: boolean;
@@ -10,10 +23,11 @@ interface OrchestratorHeaderProps {
   isPipelineRunning: boolean;
   isCancelling: boolean;
   pipelineSources: JobSource[];
-  hideActions?: boolean;
+  hideRunAction?: boolean;
   isSearchComposerOpen?: boolean;
   onOpenAutomaticRun: () => void;
   onCancelPipeline: () => void;
+  onOpenManualImport: () => void;
 }
 
 export const OrchestratorHeader: React.FC<OrchestratorHeaderProps> = ({
@@ -22,12 +36,13 @@ export const OrchestratorHeader: React.FC<OrchestratorHeaderProps> = ({
   isPipelineRunning,
   isCancelling,
   pipelineSources,
-  hideActions = false,
+  hideRunAction = false,
   isSearchComposerOpen = false,
   onOpenAutomaticRun,
   onCancelPipeline,
+  onOpenManualImport,
 }) => {
-  const actions = hideActions ? null : isPipelineRunning ? (
+  const primaryAction = hideRunAction ? null : isPipelineRunning ? (
     <Button
       size="sm"
       onClick={onCancelPipeline}
@@ -61,6 +76,33 @@ export const OrchestratorHeader: React.FC<OrchestratorHeaderProps> = ({
         {isSearchComposerOpen ? "Close search" : "Run search"}
       </span>
     </Button>
+  );
+  const actions = (
+    <div className="flex items-center gap-2">
+      {primaryAction}
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            aria-label="More job actions"
+          >
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-48">
+          <DropdownMenuItem
+            onSelect={onOpenManualImport}
+            className="cursor-pointer gap-2"
+          >
+            <FileText className="h-4 w-4" />
+            Import job manually
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 
   return (


### PR DESCRIPTION

<img width="1915" height="136" alt="image" src="https://github.com/user-attachments/assets/077ab6ba-7020-42a8-be32-ad576430fb58" />


## Summary
- Move manual job import into the orchestrator header overflow menu
- Keep the import flow available when the search composer is open
- Add coverage for opening the sheet and navigating to the imported job

## Testing
- Unit tests updated for `OrchestratorHeader` and `OrchestratorPage`
- UI behavior verified with route-based interaction tests