### PR TITLE
Add hosted usage tables and shared usage types

### DIFF
--- a/orchestrator/src/server/db/migrate.test.ts
+++ b/orchestrator/src/server/db/migrate.test.ts
@@ -99,6 +99,66 @@ describe.sequential("database migrations", () => {
     );
   });
 
+  it("creates hosted usage tables with user-scoped foreign keys and indexes", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-migrate-"));
+    const script = `
+      import { join } from "node:path";
+      import { pathToFileURL } from "node:url";
+      import Database from "better-sqlite3";
+
+      const dbPath = join(process.env.DATA_DIR, "jobs.db");
+      await import(pathToFileURL(join(process.cwd(), "src/server/db/migrate.ts")).href);
+
+      const migratedDb = new Database(dbPath, { readonly: true });
+
+      function tableExists(tableName) {
+        return Boolean(
+          migratedDb
+            .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?")
+            .get(tableName),
+        );
+      }
+
+      for (const tableName of ["hosted_usage_counters", "hosted_usage_reservations"]) {
+        if (!tableExists(tableName)) {
+          throw new Error(\`\${tableName} was not created\`);
+        }
+        const fks = migratedDb.prepare(\`PRAGMA foreign_key_list(\${tableName})\`).all();
+        const hasTenantCascade = fks.some((fk) => fk.from === "tenant_id" && fk.table === "tenants" && String(fk.on_delete).toUpperCase() === "CASCADE");
+        const hasUserCascade = fks.some((fk) => fk.from === "user_id" && fk.table === "users" && String(fk.on_delete).toUpperCase() === "CASCADE");
+        if (!hasTenantCascade || !hasUserCascade) {
+          throw new Error(\`\${tableName} is missing hosted usage foreign keys\`);
+        }
+      }
+
+      const counterIndexes = migratedDb.prepare("PRAGMA index_list(hosted_usage_counters)").all();
+      const counterUnique = counterIndexes.find((index) => index.name === "idx_hosted_usage_counters_tenant_user_period_action_unique");
+      if (!counterUnique || !counterUnique.unique) {
+        throw new Error("hosted usage counter unique index missing");
+      }
+
+      const reservationIndexes = migratedDb.prepare("PRAGMA index_list(hosted_usage_reservations)").all();
+      const reservationUnique = reservationIndexes.find((index) => index.name === "idx_hosted_usage_reservations_idempotency_unique");
+      if (!reservationUnique || !reservationUnique.unique) {
+        throw new Error("hosted usage reservation idempotency unique index missing");
+      }
+
+      migratedDb.close();
+    `;
+
+    execFileSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", script],
+      {
+        env: {
+          ...process.env,
+          DATA_DIR: tempDir,
+        },
+        stdio: "pipe",
+      },
+    );
+  });
+
   it("backfills legacy PDF rows as generated", async () => {
     tempDir = await mkdtemp(join(tmpdir(), "job-ops-migrate-"));
     const script = `

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -178,6 +178,39 @@ const migrations = [
     UNIQUE(user_id, tenant_id)
   )`,
 
+  `CREATE TABLE IF NOT EXISTS hosted_usage_counters (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    period TEXT NOT NULL,
+    action TEXT NOT NULL CHECK(action IN ('job_search', 'pipeline_run', 'tailoring', 'ghostwriter', 'pdf_export')),
+    used_units INTEGER NOT NULL DEFAULT 0,
+    reserved_units INTEGER NOT NULL DEFAULT 0,
+    limit_units INTEGER NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    UNIQUE(tenant_id, user_id, period, action)
+  )`,
+
+  `CREATE TABLE IF NOT EXISTS hosted_usage_reservations (
+    id TEXT PRIMARY KEY,
+    tenant_id TEXT NOT NULL,
+    user_id TEXT NOT NULL,
+    period TEXT NOT NULL,
+    action TEXT NOT NULL CHECK(action IN ('job_search', 'pipeline_run', 'tailoring', 'ghostwriter', 'pdf_export')),
+    reserved_units INTEGER NOT NULL,
+    used_units INTEGER NOT NULL DEFAULT 0,
+    refunded_units INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'reserved' CHECK(status IN ('reserved', 'settled', 'refunded')),
+    idempotency_key TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+  )`,
+
   `CREATE TABLE IF NOT EXISTS jobs (
     id TEXT PRIMARY KEY,
     tenant_id TEXT NOT NULL DEFAULT 'tenant_default',
@@ -386,6 +419,14 @@ const migrations = [
 
   `CREATE INDEX IF NOT EXISTS idx_auth_sessions_revoked_at
     ON auth_sessions(revoked_at)`,
+  `CREATE INDEX IF NOT EXISTS idx_hosted_usage_counters_tenant_user_period
+    ON hosted_usage_counters(tenant_id, user_id, period)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_hosted_usage_counters_tenant_user_period_action_unique
+    ON hosted_usage_counters(tenant_id, user_id, period, action)`,
+  `CREATE INDEX IF NOT EXISTS idx_hosted_usage_reservations_tenant_user_period
+    ON hosted_usage_reservations(tenant_id, user_id, period)`,
+  `CREATE UNIQUE INDEX IF NOT EXISTS idx_hosted_usage_reservations_idempotency_unique
+    ON hosted_usage_reservations(tenant_id, user_id, period, action, idempotency_key)`,
 
   `CREATE TABLE IF NOT EXISTS pipeline_search_presets (
     id TEXT PRIMARY KEY,

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -6,6 +6,7 @@ import {
   APPLICATION_OUTCOMES,
   APPLICATION_STAGES,
   APPLICATION_TASK_TYPES,
+  HOSTED_USAGE_ACTIONS,
   INTERVIEW_OUTCOMES,
   INTERVIEW_TYPES,
   JOB_CHAT_MESSAGE_ROLES,
@@ -80,6 +81,80 @@ export const tenantMemberships = sqliteTable(
       table.tenantId,
     ),
     tenantIndex: index("idx_tenant_memberships_tenant_id").on(table.tenantId),
+  }),
+);
+
+export const HOSTED_USAGE_RESERVATION_STATUSES = [
+  "reserved",
+  "settled",
+  "refunded",
+] as const;
+
+export const hostedUsageCounters = sqliteTable(
+  "hosted_usage_counters",
+  {
+    id: text("id").primaryKey(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    period: text("period").notNull(),
+    action: text("action", { enum: HOSTED_USAGE_ACTIONS }).notNull(),
+    usedUnits: integer("used_units").notNull().default(0),
+    reservedUnits: integer("reserved_units").notNull().default(0),
+    limitUnits: integer("limit_units").notNull(),
+    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => ({
+    tenantUserPeriodActionUnique: uniqueIndex(
+      "idx_hosted_usage_counters_tenant_user_period_action_unique",
+    ).on(table.tenantId, table.userId, table.period, table.action),
+    tenantUserPeriodIndex: index(
+      "idx_hosted_usage_counters_tenant_user_period",
+    ).on(table.tenantId, table.userId, table.period),
+  }),
+);
+
+export const hostedUsageReservations = sqliteTable(
+  "hosted_usage_reservations",
+  {
+    id: text("id").primaryKey(),
+    tenantId: text("tenant_id")
+      .notNull()
+      .references(() => tenants.id, { onDelete: "cascade" }),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    period: text("period").notNull(),
+    action: text("action", { enum: HOSTED_USAGE_ACTIONS }).notNull(),
+    reservedUnits: integer("reserved_units").notNull(),
+    usedUnits: integer("used_units").notNull().default(0),
+    refundedUnits: integer("refunded_units").notNull().default(0),
+    status: text("status", {
+      enum: HOSTED_USAGE_RESERVATION_STATUSES,
+    })
+      .notNull()
+      .default("reserved"),
+    idempotencyKey: text("idempotency_key"),
+    createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+    updatedAt: text("updated_at").notNull().default(sql`(datetime('now'))`),
+  },
+  (table) => ({
+    tenantUserPeriodIndex: index(
+      "idx_hosted_usage_reservations_tenant_user_period",
+    ).on(table.tenantId, table.userId, table.period),
+    tenantUserPeriodActionIdempotencyUnique: uniqueIndex(
+      "idx_hosted_usage_reservations_idempotency_unique",
+    ).on(
+      table.tenantId,
+      table.userId,
+      table.period,
+      table.action,
+      table.idempotencyKey,
+    ),
   }),
 );
 
@@ -970,6 +1045,12 @@ export type TenantRow = typeof tenants.$inferSelect;
 export type NewTenantRow = typeof tenants.$inferInsert;
 export type TenantMembershipRow = typeof tenantMemberships.$inferSelect;
 export type NewTenantMembershipRow = typeof tenantMemberships.$inferInsert;
+export type HostedUsageCounterRow = typeof hostedUsageCounters.$inferSelect;
+export type NewHostedUsageCounterRow = typeof hostedUsageCounters.$inferInsert;
+export type HostedUsageReservationRow =
+  typeof hostedUsageReservations.$inferSelect;
+export type NewHostedUsageReservationRow =
+  typeof hostedUsageReservations.$inferInsert;
 export type JobRow = typeof jobs.$inferSelect;
 export type NewJobRow = typeof jobs.$inferInsert;
 export type StageEventRow = typeof stageEvents.$inferSelect;

--- a/orchestrator/src/server/services/hosted-usage.test.ts
+++ b/orchestrator/src/server/services/hosted-usage.test.ts
@@ -1,0 +1,381 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe.sequential("hosted usage service", () => {
+  const originalEnv = { ...process.env };
+  let tempDir: string;
+  let closeDb: (() => void) | null = null;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-hosted-usage-"));
+    vi.resetModules();
+    process.env = {
+      ...originalEnv,
+      DATA_DIR: tempDir,
+      NODE_ENV: "test",
+      JOBOPS_TEST_AUTH_BYPASS: "0",
+    };
+    delete process.env.JOBOPS_APP_MODE;
+    delete process.env.JOBOPS_HOSTED_QUOTAS_ENABLED;
+    delete process.env.JOBOPS_HOSTED_SIGNUPS_ENABLED;
+    delete process.env.JOBOPS_HOSTED_TENANT_ID;
+    await import("@server/db/migrate");
+    ({ closeDb } = await import("@server/db"));
+  });
+
+  afterEach(async () => {
+    closeDb?.();
+    closeDb = null;
+    process.env = { ...originalEnv };
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function usageRowCounts(): Promise<{
+    counters: number;
+    reservations: number;
+  }> {
+    const { db, schema } = await import("@server/db");
+    const counters = await db.select().from(schema.hostedUsageCounters);
+    const reservations = await db.select().from(schema.hostedUsageReservations);
+    return { counters: counters.length, reservations: reservations.length };
+  }
+
+  async function createUser(id: string): Promise<void> {
+    const { db, schema } = await import("@server/db");
+    await db.insert(schema.users).values({
+      id,
+      username: id,
+      displayName: id,
+      passwordHash: "hash",
+      passwordSalt: "salt",
+    });
+    await db.insert(schema.tenantMemberships).values({
+      id: `membership-${id}`,
+      userId: id,
+      tenantId: "tenant_default",
+      role: "member",
+    });
+  }
+
+  async function withUser<T>(userId: string, fn: () => Promise<T>): Promise<T> {
+    const { runWithRequestContext } = await import("@infra/request-context");
+    return runWithRequestContext(
+      {
+        requestId: `req-${userId}`,
+        tenantId: "tenant_default",
+        userId,
+        username: userId,
+      },
+      fn,
+    );
+  }
+
+  function enableHostedQuotas(): void {
+    process.env.JOBOPS_APP_MODE = "hosted";
+    process.env.JOBOPS_HOSTED_TENANT_ID = "tenant_default";
+    process.env.JOBOPS_HOSTED_QUOTAS_ENABLED = "true";
+  }
+
+  it("returns no-op allowance and writes no rows outside hosted quota mode", async () => {
+    process.env.JOBOPS_HOSTED_QUOTAS_ENABLED = "true";
+    const service = await import("./hosted-usage");
+
+    const allowance = await service.consumeHostedUsage({
+      action: "job_search",
+      units: 3,
+      now: new Date("2026-01-15T12:00:00.000Z"),
+    });
+    const summary = await service.getHostedUsageSummary(
+      new Date("2026-01-15T12:00:00.000Z"),
+    );
+
+    expect(allowance).toMatchObject({
+      quotasEnabled: false,
+      action: "job_search",
+      period: "2026-01",
+      requestedUnits: 3,
+      limitUnits: null,
+      usedUnits: 0,
+      reservedUnits: 0,
+      availableUnits: null,
+    });
+    expect(summary).toEqual({
+      tenantId: null,
+      userId: null,
+      period: "2026-01",
+      quotasEnabled: false,
+      actions: [],
+    });
+    await expect(usageRowCounts()).resolves.toEqual({
+      counters: 0,
+      reservations: 0,
+    });
+  });
+
+  it("returns no-op allowance and writes no rows when hosted quotas are disabled", async () => {
+    process.env.JOBOPS_APP_MODE = "hosted";
+    process.env.JOBOPS_HOSTED_TENANT_ID = "tenant_default";
+    process.env.JOBOPS_HOSTED_QUOTAS_ENABLED = "false";
+    const service = await import("./hosted-usage");
+
+    const allowance = await service.reserveHostedUsage({
+      action: "pipeline_run",
+      units: 2,
+    });
+
+    expect(allowance.reservation).toBeNull();
+    expect(allowance.allowance.quotasEnabled).toBe(false);
+    await expect(usageRowCounts()).resolves.toEqual({
+      counters: 0,
+      reservations: 0,
+    });
+  });
+
+  it("increments hosted usage per authenticated user", async () => {
+    enableHostedQuotas();
+    await createUser("alice");
+    const service = await import("./hosted-usage");
+
+    await withUser("alice", async () => {
+      await service.consumeHostedUsage({
+        action: "job_search",
+        units: 4,
+        now: new Date("2026-02-01T00:00:00.000Z"),
+      });
+      await service.consumeHostedUsage({
+        action: "job_search",
+        units: 2,
+        now: new Date("2026-02-15T00:00:00.000Z"),
+      });
+      const summary = await service.getHostedUsageSummary(
+        new Date("2026-02-28T23:59:59.000Z"),
+      );
+      const search = summary.actions.find(
+        (action) => action.action === "job_search",
+      );
+
+      expect(search).toMatchObject({
+        period: "2026-02",
+        usedUnits: 6,
+        reservedUnits: 0,
+        limitUnits: 100,
+        availableUnits: 94,
+      });
+      await expect(usageRowCounts()).resolves.toEqual({
+        counters: 1,
+        reservations: 0,
+      });
+    });
+  });
+
+  it("isolates counters between hosted users in the same tenant", async () => {
+    enableHostedQuotas();
+    await createUser("alice");
+    await createUser("bob");
+    const service = await import("./hosted-usage");
+
+    await withUser("alice", () =>
+      service.consumeHostedUsage({ action: "tailoring", units: 7 }),
+    );
+    await withUser("bob", () =>
+      service.consumeHostedUsage({ action: "tailoring", units: 2 }),
+    );
+
+    await withUser("alice", async () => {
+      const summary = await service.getHostedUsageSummary();
+      expect(
+        summary.actions.find((action) => action.action === "tailoring"),
+      ).toMatchObject({ usedUnits: 7, availableUnits: 243 });
+    });
+    await withUser("bob", async () => {
+      const summary = await service.getHostedUsageSummary();
+      expect(
+        summary.actions.find((action) => action.action === "tailoring"),
+      ).toMatchObject({ usedUnits: 2, availableUnits: 248 });
+    });
+  });
+
+  it("reserves, settles, and refunds hosted usage", async () => {
+    enableHostedQuotas();
+    await createUser("alice");
+    const service = await import("./hosted-usage");
+
+    await withUser("alice", async () => {
+      const reserved = await service.reserveHostedUsage({
+        action: "ghostwriter",
+        units: 10,
+      });
+      expect(reserved.reservation).toMatchObject({
+        action: "ghostwriter",
+        reservedUnits: 10,
+        usedUnits: 0,
+        refundedUnits: 0,
+        status: "reserved",
+      });
+
+      let summary = await service.getHostedUsageSummary();
+      expect(
+        summary.actions.find((action) => action.action === "ghostwriter"),
+      ).toMatchObject({ usedUnits: 0, reservedUnits: 10, availableUnits: 240 });
+
+      const settled = await service.settleHostedUsageReservation({
+        reservationId: reserved.reservation?.id ?? "",
+        usedUnits: 6,
+      });
+      expect(settled).toMatchObject({
+        usedUnits: 6,
+        refundedUnits: 4,
+        status: "settled",
+      });
+
+      summary = await service.getHostedUsageSummary();
+      expect(
+        summary.actions.find((action) => action.action === "ghostwriter"),
+      ).toMatchObject({ usedUnits: 6, reservedUnits: 0, availableUnits: 244 });
+
+      const second = await service.reserveHostedUsage({
+        action: "ghostwriter",
+        units: 5,
+      });
+      const refunded = await service.refundHostedUsageReservation(
+        second.reservation?.id ?? "",
+      );
+      expect(refunded).toMatchObject({
+        usedUnits: 0,
+        refundedUnits: 5,
+        status: "refunded",
+      });
+
+      summary = await service.getHostedUsageSummary();
+      expect(
+        summary.actions.find((action) => action.action === "ghostwriter"),
+      ).toMatchObject({ usedUnits: 6, reservedUnits: 0, availableUnits: 244 });
+    });
+  });
+
+  it("does not let another hosted user settle or refund a reservation", async () => {
+    enableHostedQuotas();
+    await createUser("alice");
+    await createUser("bob");
+    const service = await import("./hosted-usage");
+
+    const reservationId = await withUser("alice", async () => {
+      const reserved = await service.reserveHostedUsage({
+        action: "ghostwriter",
+        units: 10,
+      });
+      return reserved.reservation?.id ?? "";
+    });
+
+    await withUser("bob", async () => {
+      await expect(
+        service.settleHostedUsageReservation({
+          reservationId,
+          usedUnits: 1,
+        }),
+      ).rejects.toMatchObject({
+        status: 404,
+        code: "NOT_FOUND",
+      });
+      await expect(
+        service.refundHostedUsageReservation(reservationId),
+      ).rejects.toMatchObject({
+        status: 404,
+        code: "NOT_FOUND",
+      });
+    });
+
+    await withUser("alice", async () => {
+      const summary = await service.getHostedUsageSummary();
+      expect(
+        summary.actions.find((action) => action.action === "ghostwriter"),
+      ).toMatchObject({ usedUnits: 0, reservedUnits: 10, availableUnits: 240 });
+    });
+  });
+
+  it("throws a standard 422-compatible error when quota is exhausted", async () => {
+    enableHostedQuotas();
+    await createUser("alice");
+    const service = await import("./hosted-usage");
+
+    await withUser("alice", async () => {
+      await service.consumeHostedUsage({ action: "pipeline_run", units: 25 });
+      await expect(
+        service.requireHostedUsageAllowance({
+          action: "pipeline_run",
+          units: 1,
+        }),
+      ).rejects.toMatchObject({
+        status: 422,
+        code: "UNPROCESSABLE_ENTITY",
+        details: {
+          action: "pipeline_run",
+          limit: 25,
+          used: 25,
+          reserved: 0,
+          requested: 1,
+        },
+      });
+    });
+  });
+
+  it("uses separate UTC month periods", async () => {
+    enableHostedQuotas();
+    await createUser("alice");
+    const service = await import("./hosted-usage");
+
+    await withUser("alice", async () => {
+      await service.consumeHostedUsage({
+        action: "pdf_export",
+        units: 3,
+        now: new Date("2026-03-31T23:59:59.000Z"),
+      });
+      await service.consumeHostedUsage({
+        action: "pdf_export",
+        units: 1,
+        now: new Date("2026-04-01T00:00:00.000Z"),
+      });
+
+      const march = await service.getHostedUsageSummary(
+        new Date("2026-03-15T00:00:00.000Z"),
+      );
+      const april = await service.getHostedUsageSummary(
+        new Date("2026-04-15T00:00:00.000Z"),
+      );
+
+      expect(
+        march.actions.find((action) => action.action === "pdf_export"),
+      ).toMatchObject({ period: "2026-03", usedUnits: 3 });
+      expect(
+        april.actions.find((action) => action.action === "pdf_export"),
+      ).toMatchObject({ period: "2026-04", usedUnits: 1 });
+    });
+  });
+
+  it("reuses idempotent reservations without double-reserving", async () => {
+    enableHostedQuotas();
+    await createUser("alice");
+    const service = await import("./hosted-usage");
+
+    await withUser("alice", async () => {
+      const first = await service.reserveHostedUsage({
+        action: "job_search",
+        units: 3,
+        idempotencyKey: "pipeline-run-1",
+      });
+      const second = await service.reserveHostedUsage({
+        action: "job_search",
+        units: 10,
+        idempotencyKey: "pipeline-run-1",
+      });
+
+      expect(second.reservation?.id).toBe(first.reservation?.id);
+      const summary = await service.getHostedUsageSummary();
+      expect(
+        summary.actions.find((action) => action.action === "job_search"),
+      ).toMatchObject({ usedUnits: 0, reservedUnits: 3, availableUnits: 97 });
+    });
+  });
+});

--- a/orchestrator/src/server/services/hosted-usage.ts
+++ b/orchestrator/src/server/services/hosted-usage.ts
@@ -1,0 +1,623 @@
+import { randomUUID } from "node:crypto";
+import { badRequest, notFound, unprocessableEntity } from "@infra/errors";
+import { getJobOpsAppConfig } from "@server/config/app-mode";
+import { db, schema } from "@server/db";
+import { getPrivateDataScope } from "@server/tenancy/private-scope";
+import {
+  HOSTED_USAGE_ACTIONS,
+  type HostedUsageAction,
+  type HostedUsageActionSummary,
+  type HostedUsageSummary,
+} from "@shared/types";
+import { and, eq } from "drizzle-orm";
+
+const { hostedUsageCounters, hostedUsageReservations } = schema;
+
+export const DEFAULT_HOSTED_MONTHLY_LIMITS: Record<HostedUsageAction, number> =
+  {
+    job_search: 100,
+    pipeline_run: 25,
+    tailoring: 250,
+    ghostwriter: 250,
+    pdf_export: 250,
+  };
+
+type UsageScope = {
+  tenantId: string;
+  userId: string;
+};
+
+type AllowanceSnapshot = {
+  quotasEnabled: boolean;
+  action: HostedUsageAction;
+  period: string;
+  requestedUnits: number;
+  limitUnits: number | null;
+  usedUnits: number;
+  reservedUnits: number;
+  availableUnits: number | null;
+};
+
+type UsageCounterRow = typeof hostedUsageCounters.$inferSelect;
+type UsageReservationRow = typeof hostedUsageReservations.$inferSelect;
+type UsageTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+export type HostedUsageReservation = {
+  id: string;
+  tenantId: string;
+  userId: string;
+  period: string;
+  action: HostedUsageAction;
+  reservedUnits: number;
+  usedUnits: number;
+  refundedUnits: number;
+  status: "reserved" | "settled" | "refunded";
+  idempotencyKey: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type HostedUsageReservationResult = {
+  allowance: AllowanceSnapshot;
+  reservation: HostedUsageReservation | null;
+};
+
+function isHostedQuotaModeEnabled(): boolean {
+  const config = getJobOpsAppConfig();
+  return config.appMode === "hosted" && config.capabilities.quotas;
+}
+
+function isHostedAppMode(): boolean {
+  return getJobOpsAppConfig().appMode === "hosted";
+}
+
+export function getHostedUsagePeriod(now: Date = new Date()): string {
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+function assertPositiveUnits(units: number): number {
+  if (!Number.isInteger(units) || units < 1) {
+    throw badRequest("Usage units must be a positive integer");
+  }
+  return units;
+}
+
+function assertNonNegativeUnits(units: number): number {
+  if (!Number.isInteger(units) || units < 0) {
+    throw badRequest("Usage units must be a non-negative integer");
+  }
+  return units;
+}
+
+function getHostedUsageScope(): UsageScope {
+  const scope = getPrivateDataScope();
+  if (!scope.userId) {
+    throw badRequest("Hosted usage requires authenticated user context");
+  }
+  return {
+    tenantId: scope.tenantId,
+    userId: scope.userId,
+  };
+}
+
+function getHostedReservationMutationScope(): UsageScope | null {
+  return isHostedAppMode() ? getHostedUsageScope() : null;
+}
+
+function toAllowanceSnapshot(args: {
+  quotasEnabled: boolean;
+  action: HostedUsageAction;
+  period: string;
+  requestedUnits: number;
+  limitUnits: number | null;
+  usedUnits: number;
+  reservedUnits: number;
+}): AllowanceSnapshot {
+  const availableUnits =
+    args.limitUnits === null
+      ? null
+      : Math.max(0, args.limitUnits - args.usedUnits - args.reservedUnits);
+  return { ...args, availableUnits };
+}
+
+function toReservation(row: UsageReservationRow): HostedUsageReservation {
+  return {
+    id: row.id,
+    tenantId: row.tenantId,
+    userId: row.userId,
+    period: row.period,
+    action: row.action,
+    reservedUnits: row.reservedUnits,
+    usedUnits: row.usedUnits,
+    refundedUnits: row.refundedUnits,
+    status: row.status,
+    idempotencyKey: row.idempotencyKey,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function noOpAllowance(
+  action: HostedUsageAction,
+  units: number,
+  now?: Date,
+): AllowanceSnapshot {
+  return toAllowanceSnapshot({
+    quotasEnabled: false,
+    action,
+    period: getHostedUsagePeriod(now),
+    requestedUnits: units,
+    limitUnits: null,
+    usedUnits: 0,
+    reservedUnits: 0,
+  });
+}
+
+function counterFilter(args: {
+  tenantId: string;
+  userId: string;
+  period: string;
+  action: HostedUsageAction;
+}) {
+  return and(
+    eq(hostedUsageCounters.tenantId, args.tenantId),
+    eq(hostedUsageCounters.userId, args.userId),
+    eq(hostedUsageCounters.period, args.period),
+    eq(hostedUsageCounters.action, args.action),
+  );
+}
+
+function getCounter(
+  tx: UsageTransaction,
+  args: {
+    tenantId: string;
+    userId: string;
+    period: string;
+    action: HostedUsageAction;
+  },
+): UsageCounterRow | null {
+  return (
+    tx
+      .select()
+      .from(hostedUsageCounters)
+      .where(counterFilter(args))
+      .limit(1)
+      .get() ?? null
+  );
+}
+
+function ensureCounter(
+  tx: UsageTransaction,
+  args: {
+    tenantId: string;
+    userId: string;
+    period: string;
+    action: HostedUsageAction;
+  },
+): UsageCounterRow {
+  const limitUnits = DEFAULT_HOSTED_MONTHLY_LIMITS[args.action];
+  const now = new Date().toISOString();
+
+  tx.insert(hostedUsageCounters)
+    .values({
+      id: randomUUID(),
+      tenantId: args.tenantId,
+      userId: args.userId,
+      period: args.period,
+      action: args.action,
+      limitUnits,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+    .run();
+
+  const counter = getCounter(tx, args);
+  if (!counter) {
+    throw new Error("Failed to load hosted usage counter");
+  }
+
+  if (counter.limitUnits !== limitUnits) {
+    tx.update(hostedUsageCounters)
+      .set({ limitUnits, updatedAt: now })
+      .where(eq(hostedUsageCounters.id, counter.id))
+      .run();
+    return { ...counter, limitUnits, updatedAt: now };
+  }
+
+  return counter;
+}
+
+function assertAllowance(args: {
+  counter: UsageCounterRow;
+  action: HostedUsageAction;
+  period: string;
+  requestedUnits: number;
+}): AllowanceSnapshot {
+  const snapshot = toAllowanceSnapshot({
+    quotasEnabled: true,
+    action: args.action,
+    period: args.period,
+    requestedUnits: args.requestedUnits,
+    limitUnits: args.counter.limitUnits,
+    usedUnits: args.counter.usedUnits,
+    reservedUnits: args.counter.reservedUnits,
+  });
+
+  if (
+    snapshot.availableUnits !== null &&
+    args.requestedUnits > snapshot.availableUnits
+  ) {
+    throw unprocessableEntity("Monthly usage quota exceeded", {
+      action: args.action,
+      period: args.period,
+      limit: args.counter.limitUnits,
+      used: args.counter.usedUnits,
+      reserved: args.counter.reservedUnits,
+      requested: args.requestedUnits,
+    });
+  }
+
+  return snapshot;
+}
+
+function getReservationById(
+  tx: UsageTransaction,
+  reservationId: string,
+  scope?: UsageScope | null,
+): UsageReservationRow | null {
+  const predicate = scope
+    ? and(
+        eq(hostedUsageReservations.id, reservationId),
+        eq(hostedUsageReservations.tenantId, scope.tenantId),
+        eq(hostedUsageReservations.userId, scope.userId),
+      )
+    : eq(hostedUsageReservations.id, reservationId);
+
+  return (
+    tx.select().from(hostedUsageReservations).where(predicate).limit(1).get() ??
+    null
+  );
+}
+
+function getReservationByIdempotencyKey(
+  tx: UsageTransaction,
+  args: {
+    tenantId: string;
+    userId: string;
+    period: string;
+    action: HostedUsageAction;
+    idempotencyKey: string;
+  },
+): UsageReservationRow | null {
+  return (
+    tx
+      .select()
+      .from(hostedUsageReservations)
+      .where(
+        and(
+          eq(hostedUsageReservations.tenantId, args.tenantId),
+          eq(hostedUsageReservations.userId, args.userId),
+          eq(hostedUsageReservations.period, args.period),
+          eq(hostedUsageReservations.action, args.action),
+          eq(hostedUsageReservations.idempotencyKey, args.idempotencyKey),
+        ),
+      )
+      .limit(1)
+      .get() ?? null
+  );
+}
+
+function applyCounterDeltas(
+  tx: UsageTransaction,
+  counter: UsageCounterRow,
+  deltas: { usedUnits?: number; reservedUnits?: number },
+): UsageCounterRow {
+  const usedUnits = counter.usedUnits + (deltas.usedUnits ?? 0);
+  const reservedUnits = counter.reservedUnits + (deltas.reservedUnits ?? 0);
+  if (usedUnits < 0 || reservedUnits < 0) {
+    throw new Error("Hosted usage counter cannot be negative");
+  }
+
+  const updatedAt = new Date().toISOString();
+  tx.update(hostedUsageCounters)
+    .set({ usedUnits, reservedUnits, updatedAt })
+    .where(eq(hostedUsageCounters.id, counter.id))
+    .run();
+
+  return { ...counter, usedUnits, reservedUnits, updatedAt };
+}
+
+export async function getHostedUsageSummary(
+  now: Date = new Date(),
+): Promise<HostedUsageSummary> {
+  const period = getHostedUsagePeriod(now);
+  if (!isHostedQuotaModeEnabled()) {
+    return {
+      tenantId: null,
+      userId: null,
+      period,
+      quotasEnabled: false,
+      actions: [],
+    };
+  }
+
+  const scope = getHostedUsageScope();
+  const rows = await db
+    .select()
+    .from(hostedUsageCounters)
+    .where(
+      and(
+        eq(hostedUsageCounters.tenantId, scope.tenantId),
+        eq(hostedUsageCounters.userId, scope.userId),
+        eq(hostedUsageCounters.period, period),
+      ),
+    );
+  const rowByAction = new Map(rows.map((row) => [row.action, row]));
+  const actions: HostedUsageActionSummary[] = HOSTED_USAGE_ACTIONS.map(
+    (action) => {
+      const row = rowByAction.get(action);
+      const limitUnits = DEFAULT_HOSTED_MONTHLY_LIMITS[action];
+      const usedUnits = row?.usedUnits ?? 0;
+      const reservedUnits = row?.reservedUnits ?? 0;
+      return {
+        action,
+        period,
+        usedUnits,
+        reservedUnits,
+        limitUnits,
+        availableUnits: Math.max(0, limitUnits - usedUnits - reservedUnits),
+      };
+    },
+  );
+
+  return {
+    tenantId: scope.tenantId,
+    userId: scope.userId,
+    period,
+    quotasEnabled: true,
+    actions,
+  };
+}
+
+export async function requireHostedUsageAllowance(args: {
+  action: HostedUsageAction;
+  units?: number;
+  now?: Date;
+}): Promise<AllowanceSnapshot> {
+  const units = assertPositiveUnits(args.units ?? 1);
+  if (!isHostedQuotaModeEnabled()) {
+    return noOpAllowance(args.action, units, args.now);
+  }
+
+  const scope = getHostedUsageScope();
+  const period = getHostedUsagePeriod(args.now);
+
+  return db.transaction((tx) => {
+    const counter = ensureCounter(tx, {
+      ...scope,
+      period,
+      action: args.action,
+    });
+    return assertAllowance({
+      counter,
+      action: args.action,
+      period,
+      requestedUnits: units,
+    });
+  });
+}
+
+export async function consumeHostedUsage(args: {
+  action: HostedUsageAction;
+  units?: number;
+  now?: Date;
+}): Promise<AllowanceSnapshot> {
+  const units = assertPositiveUnits(args.units ?? 1);
+  if (!isHostedQuotaModeEnabled()) {
+    return noOpAllowance(args.action, units, args.now);
+  }
+
+  const scope = getHostedUsageScope();
+  const period = getHostedUsagePeriod(args.now);
+
+  return db.transaction((tx) => {
+    const counter = ensureCounter(tx, {
+      ...scope,
+      period,
+      action: args.action,
+    });
+    const before = assertAllowance({
+      counter,
+      action: args.action,
+      period,
+      requestedUnits: units,
+    });
+    applyCounterDeltas(tx, counter, { usedUnits: units });
+    return before;
+  });
+}
+
+export async function reserveHostedUsage(args: {
+  action: HostedUsageAction;
+  units?: number;
+  idempotencyKey?: string | null;
+  now?: Date;
+}): Promise<HostedUsageReservationResult> {
+  const units = assertPositiveUnits(args.units ?? 1);
+  if (!isHostedQuotaModeEnabled()) {
+    return {
+      allowance: noOpAllowance(args.action, units, args.now),
+      reservation: null,
+    };
+  }
+
+  const scope = getHostedUsageScope();
+  const period = getHostedUsagePeriod(args.now);
+  const idempotencyKey = args.idempotencyKey?.trim() || null;
+
+  return db.transaction((tx) => {
+    if (idempotencyKey) {
+      const existing = getReservationByIdempotencyKey(tx, {
+        ...scope,
+        period,
+        action: args.action,
+        idempotencyKey,
+      });
+      if (existing) {
+        const counter = ensureCounter(tx, {
+          ...scope,
+          period,
+          action: args.action,
+        });
+        return {
+          allowance: toAllowanceSnapshot({
+            quotasEnabled: true,
+            action: args.action,
+            period,
+            requestedUnits: existing.reservedUnits,
+            limitUnits: counter.limitUnits,
+            usedUnits: counter.usedUnits,
+            reservedUnits: counter.reservedUnits,
+          }),
+          reservation: toReservation(existing),
+        };
+      }
+    }
+
+    const counter = ensureCounter(tx, {
+      ...scope,
+      period,
+      action: args.action,
+    });
+    const before = assertAllowance({
+      counter,
+      action: args.action,
+      period,
+      requestedUnits: units,
+    });
+    applyCounterDeltas(tx, counter, { reservedUnits: units });
+
+    const nowIso = new Date().toISOString();
+    const reservationId = randomUUID();
+    tx.insert(hostedUsageReservations)
+      .values({
+        id: reservationId,
+        ...scope,
+        period,
+        action: args.action,
+        reservedUnits: units,
+        idempotencyKey,
+        createdAt: nowIso,
+        updatedAt: nowIso,
+      })
+      .run();
+
+    const reservation = getReservationById(tx, reservationId, scope);
+    if (!reservation) {
+      throw new Error("Failed to load hosted usage reservation");
+    }
+    return {
+      allowance: before,
+      reservation: toReservation(reservation),
+    };
+  });
+}
+
+export async function settleHostedUsageReservation(args: {
+  reservationId: string;
+  usedUnits: number;
+}): Promise<HostedUsageReservation> {
+  const usedUnits = assertNonNegativeUnits(args.usedUnits);
+  const scope = getHostedReservationMutationScope();
+  return db.transaction((tx) => {
+    const reservation = getReservationById(tx, args.reservationId, scope);
+    if (!reservation) {
+      throw notFound("Hosted usage reservation not found");
+    }
+    if (usedUnits > reservation.reservedUnits) {
+      throw badRequest("Used units cannot exceed reserved units");
+    }
+    if (reservation.status !== "reserved") {
+      return toReservation(reservation);
+    }
+
+    const counter = ensureCounter(tx, {
+      tenantId: reservation.tenantId,
+      userId: reservation.userId,
+      period: reservation.period,
+      action: reservation.action,
+    });
+    applyCounterDeltas(tx, counter, {
+      usedUnits,
+      reservedUnits: -reservation.reservedUnits,
+    });
+
+    const refundedUnits = reservation.reservedUnits - usedUnits;
+    const status = usedUnits > 0 ? "settled" : "refunded";
+    const updatedAt = new Date().toISOString();
+    tx.update(hostedUsageReservations)
+      .set({
+        usedUnits,
+        refundedUnits,
+        status,
+        updatedAt,
+      })
+      .where(eq(hostedUsageReservations.id, reservation.id))
+      .run();
+
+    return {
+      ...toReservation(reservation),
+      usedUnits,
+      refundedUnits,
+      status,
+      updatedAt,
+    };
+  });
+}
+
+export async function refundHostedUsageReservation(
+  reservationId: string,
+): Promise<HostedUsageReservation> {
+  const scope = getHostedReservationMutationScope();
+  return db.transaction((tx) => {
+    const reservation = getReservationById(tx, reservationId, scope);
+    if (!reservation) {
+      throw notFound("Hosted usage reservation not found");
+    }
+    if (reservation.status !== "reserved") {
+      return toReservation(reservation);
+    }
+
+    const counter = ensureCounter(tx, {
+      tenantId: reservation.tenantId,
+      userId: reservation.userId,
+      period: reservation.period,
+      action: reservation.action,
+    });
+    applyCounterDeltas(tx, counter, {
+      reservedUnits: -reservation.reservedUnits,
+    });
+
+    const updatedAt = new Date().toISOString();
+    tx.update(hostedUsageReservations)
+      .set({
+        usedUnits: 0,
+        refundedUnits: reservation.reservedUnits,
+        status: "refunded",
+        updatedAt,
+      })
+      .where(eq(hostedUsageReservations.id, reservation.id))
+      .run();
+
+    return {
+      ...toReservation(reservation),
+      usedUnits: 0,
+      refundedUnits: reservation.reservedUnits,
+      status: "refunded",
+      updatedAt,
+    };
+  });
+}

--- a/shared/src/types.ts
+++ b/shared/src/types.ts
@@ -16,4 +16,5 @@ export * from "./types/location";
 export * from "./types/pipeline";
 export * from "./types/post-application";
 export * from "./types/settings";
+export * from "./types/usage";
 export * from "./types/visa-sponsors";

--- a/shared/src/types/index.ts
+++ b/shared/src/types/index.ts
@@ -8,4 +8,5 @@ export * from "./jobs";
 export * from "./pipeline";
 export * from "./post-application";
 export * from "./settings";
+export * from "./usage";
 export * from "./visa-sponsors";

--- a/shared/src/types/usage.ts
+++ b/shared/src/types/usage.ts
@@ -1,0 +1,28 @@
+export const HOSTED_USAGE_ACTIONS = [
+  "job_search",
+  "pipeline_run",
+  "tailoring",
+  "ghostwriter",
+  "pdf_export",
+] as const;
+
+export type HostedUsageAction = (typeof HOSTED_USAGE_ACTIONS)[number];
+
+export type HostedUsageReservationStatus = "reserved" | "settled" | "refunded";
+
+export interface HostedUsageActionSummary {
+  action: HostedUsageAction;
+  period: string;
+  usedUnits: number;
+  reservedUnits: number;
+  limitUnits: number;
+  availableUnits: number;
+}
+
+export interface HostedUsageSummary {
+  tenantId: string | null;
+  userId: string | null;
+  period: string;
+  quotasEnabled: boolean;
+  actions: HostedUsageActionSummary[];
+}


### PR DESCRIPTION
## Summary
- Add hosted usage counter and reservation tables with tenant/user foreign keys, indexes, and schema types
- Export shared usage types for downstream consumers
- Cover the migration with a test that verifies tables, constraints, and unique indexes

## Testing
- Added unit coverage for the migration schema and index setup
- Added hosted usage service tests