### PR TITLE
Add hosted workspace user management

### DIFF
--- a/orchestrator/src/client/api/auth.ts
+++ b/orchestrator/src/client/api/auth.ts
@@ -35,6 +35,7 @@ export type AuthUser = {
   isDisabled: boolean;
   workspaceId: string;
   workspaceName: string;
+  workspaceRole: "owner" | "member";
   createdAt: string;
   updatedAt: string;
 };

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -126,6 +126,7 @@ const authUser = {
   isDisabled: false,
   workspaceId: "tenant_default",
   workspaceName: "JobOps",
+  workspaceRole: "owner" as const,
   createdAt: "2026-06-01T00:00:00.000Z",
   updatedAt: "2026-06-01T00:00:00.000Z",
 };

--- a/orchestrator/src/client/pages/SettingsPage.test.tsx
+++ b/orchestrator/src/client/pages/SettingsPage.test.tsx
@@ -63,6 +63,7 @@ vi.mock("../api", () => ({
     isDisabled: false,
     workspaceId: "tenant_default",
     workspaceName: "JobOps",
+    workspaceRole: "owner",
     createdAt: "2026-04-27T00:00:00.000Z",
     updatedAt: "2026-04-27T00:00:00.000Z",
   }),

--- a/orchestrator/src/client/pages/SignInPage.test.tsx
+++ b/orchestrator/src/client/pages/SignInPage.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@client/api", () => ({
     isDisabled: false,
     workspaceId: "tenant_default",
     workspaceName: "JobOps",
+    workspaceRole: "owner",
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   })),
@@ -90,6 +91,7 @@ describe("SignInPage", () => {
       isDisabled: false,
       workspaceId: "tenant_default",
       workspaceName: "JobOps",
+      workspaceRole: "owner" as const,
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
@@ -226,6 +228,7 @@ describe("SignInPage", () => {
       isDisabled: false,
       workspaceId: "tenant_hosted",
       workspaceName: "JobOps",
+      workspaceRole: "member",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });

--- a/orchestrator/src/client/pages/settings/components/EnvironmentSettingsSection.test.tsx
+++ b/orchestrator/src/client/pages/settings/components/EnvironmentSettingsSection.test.tsx
@@ -9,6 +9,7 @@ import { EnvironmentSettingsSection } from "./EnvironmentSettingsSection";
 
 vi.mock("@client/api", () => ({
   createWorkspaceUser: vi.fn(),
+  getAppStatus: vi.fn(),
   getCurrentAuthUser: vi.fn(),
   listWorkspaceUsers: vi.fn(),
   resetWorkspaceUserPassword: vi.fn(),
@@ -59,6 +60,17 @@ const EnvironmentSettingsHarness = () => {
 
 describe("EnvironmentSettingsSection", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.getAppStatus).mockResolvedValue({
+      appMode: "local",
+      capabilities: {
+        hostedSignups: false,
+        platformLlm: false,
+        quotas: false,
+        userEditableLlmSettings: true,
+      },
+      hostedTenantConfigured: false,
+    });
     vi.mocked(api.getCurrentAuthUser).mockResolvedValue({
       id: "admin-user",
       username: "admin",
@@ -67,6 +79,7 @@ describe("EnvironmentSettingsSection", () => {
       isDisabled: false,
       workspaceId: "tenant-admin",
       workspaceName: "Admin Workspace",
+      workspaceRole: "owner",
       createdAt: "2026-05-13T00:00:00.000Z",
       updatedAt: "2026-05-13T00:00:00.000Z",
     });
@@ -79,6 +92,7 @@ describe("EnvironmentSettingsSection", () => {
         isDisabled: false,
         workspaceId: "tenant-member",
         workspaceName: "Member Workspace",
+        workspaceRole: "member",
         createdAt: "2026-05-13T00:00:00.000Z",
         updatedAt: "2026-05-13T00:00:00.000Z",
       },
@@ -115,5 +129,71 @@ describe("EnvironmentSettingsSection", () => {
     });
 
     expect(resetPasswordInput).toHaveValue("new-password");
+  });
+
+  it("shows hosted workspace user management for tenant owners", async () => {
+    vi.mocked(api.getAppStatus).mockResolvedValue({
+      appMode: "hosted",
+      capabilities: {
+        hostedSignups: true,
+        platformLlm: false,
+        quotas: false,
+        userEditableLlmSettings: true,
+      },
+      hostedTenantConfigured: true,
+    });
+    vi.mocked(api.getCurrentAuthUser).mockResolvedValue({
+      id: "owner-user",
+      username: "owner",
+      displayName: "Owner User",
+      isSystemAdmin: false,
+      isDisabled: false,
+      workspaceId: "tenant-hosted",
+      workspaceName: "Hosted Workspace",
+      workspaceRole: "owner",
+      createdAt: "2026-05-13T00:00:00.000Z",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    });
+
+    render(<EnvironmentSettingsHarness />);
+
+    expect(await screen.findByText("Workspace Users")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Users join this hosted workspace with private app data.",
+      ),
+    ).toBeInTheDocument();
+    expect(api.listWorkspaceUsers).toHaveBeenCalled();
+  });
+
+  it("hides workspace user management for hosted members", async () => {
+    vi.mocked(api.getAppStatus).mockResolvedValue({
+      appMode: "hosted",
+      capabilities: {
+        hostedSignups: true,
+        platformLlm: false,
+        quotas: false,
+        userEditableLlmSettings: true,
+      },
+      hostedTenantConfigured: true,
+    });
+    vi.mocked(api.getCurrentAuthUser).mockResolvedValue({
+      id: "member-user",
+      username: "member",
+      displayName: "Member User",
+      isSystemAdmin: false,
+      isDisabled: false,
+      workspaceId: "tenant-hosted",
+      workspaceName: "Hosted Workspace",
+      workspaceRole: "member",
+      createdAt: "2026-05-13T00:00:00.000Z",
+      updatedAt: "2026-05-13T00:00:00.000Z",
+    });
+
+    render(<EnvironmentSettingsHarness />);
+
+    expect(await screen.findByText("Workspace")).toBeInTheDocument();
+    expect(screen.queryByText("Workspace Users")).not.toBeInTheDocument();
+    expect(api.listWorkspaceUsers).not.toHaveBeenCalled();
   });
 });

--- a/orchestrator/src/client/pages/settings/components/EnvironmentSettingsSection.tsx
+++ b/orchestrator/src/client/pages/settings/components/EnvironmentSettingsSection.tsx
@@ -24,6 +24,7 @@ type EnvironmentSettingsSectionProps = {
 
 const workspaceUsersQueryKey = ["workspaces", "users"] as const;
 const currentAuthUserQueryKey = ["auth", "me"] as const;
+const appStatusQueryKey = ["app", "status"] as const;
 
 function AccountManagementSection() {
   const queryClient = useQueryClient();
@@ -39,10 +40,19 @@ function AccountManagementSection() {
     queryFn: api.getCurrentAuthUser,
     retry: false,
   });
+  const appStatusQuery = useQuery({
+    queryKey: appStatusQueryKey,
+    queryFn: api.getAppStatus,
+    retry: false,
+  });
+  const canManageWorkspaceUsers =
+    meQuery.data?.isSystemAdmin === true ||
+    (appStatusQuery.data?.appMode === "hosted" &&
+      meQuery.data?.workspaceRole === "owner");
   const usersQuery = useQuery({
     queryKey: workspaceUsersQueryKey,
     queryFn: api.listWorkspaceUsers,
-    enabled: meQuery.data?.isSystemAdmin === true,
+    enabled: canManageWorkspaceUsers,
   });
 
   const createUserMutation = useMutation({
@@ -86,7 +96,7 @@ function AccountManagementSection() {
     },
   });
 
-  if (!meQuery.data?.isSystemAdmin) {
+  if (!canManageWorkspaceUsers) {
     return (
       <div className="space-y-2">
         <div className="text-sm font-semibold">Workspace</div>
@@ -98,13 +108,17 @@ function AccountManagementSection() {
   }
 
   const users = usersQuery.data ?? [];
+  const userManagementDescription =
+    appStatusQuery.data?.appMode === "hosted"
+      ? "Users join this hosted workspace with private app data."
+      : "Each user gets a private workspace with isolated jobs and settings.";
 
   return (
     <div className="space-y-5">
       <div className="space-y-1">
         <div className="text-sm font-semibold">Workspace Users</div>
         <p className="text-sm text-muted-foreground">
-          Each user gets a private workspace with isolated jobs and settings.
+          {userManagementDescription}
         </p>
       </div>
 

--- a/orchestrator/src/server/api/routes/auth.test.ts
+++ b/orchestrator/src/server/api/routes/auth.test.ts
@@ -162,6 +162,7 @@ describe.sequential("Auth routes", () => {
         isDisabled: false,
         workspaceId: "tenant_default",
         workspaceName: "JobOps",
+        workspaceRole: "member",
       });
 
       await expect(countTenants()).resolves.toBe(tenantsBefore);
@@ -183,6 +184,7 @@ describe.sequential("Auth routes", () => {
         username: "newuser",
         workspaceId: "tenant_default",
         isSystemAdmin: false,
+        workspaceRole: "member",
       });
     });
 
@@ -468,6 +470,7 @@ describe.sequential("Auth routes", () => {
         displayName: "Admin",
         isSystemAdmin: true,
         workspaceId: "tenant_default",
+        workspaceRole: "owner",
       });
     });
 

--- a/orchestrator/src/server/api/routes/tenant-isolation.test.ts
+++ b/orchestrator/src/server/api/routes/tenant-isolation.test.ts
@@ -1,4 +1,5 @@
 import type { Server } from "node:http";
+import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startServer, stopServer } from "./test-utils";
 
@@ -29,6 +30,37 @@ async function signup(baseUrl: string, username: string, password: string) {
   const body = await res.json();
   expect(res.status).toBe(201);
   return body.data.token as string;
+}
+
+async function getCurrentUser(baseUrl: string, token: string) {
+  const res = await fetch(`${baseUrl}/api/auth/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const body = await res.json();
+  expect(res.status).toBe(200);
+  expect(body.ok).toBe(true);
+  return body.data.user as {
+    id: string;
+    username: string;
+    workspaceId: string;
+    workspaceRole: "owner" | "member";
+  };
+}
+
+async function promoteUserToTenantOwner(input: {
+  userId: string;
+  tenantId: string;
+}) {
+  const { db, schema } = await import("@server/db");
+  await db
+    .update(schema.tenantMemberships)
+    .set({ role: "owner", updatedAt: new Date().toISOString() })
+    .where(
+      and(
+        eq(schema.tenantMemberships.userId, input.userId),
+        eq(schema.tenantMemberships.tenantId, input.tenantId),
+      ),
+    );
 }
 
 function authHeaders(token: string) {
@@ -353,5 +385,226 @@ describe.sequential("Hosted current-user isolation", () => {
     expect(aliceSearches.data.searches[0].id).not.toBe(
       bobSearches.data.searches[0].id,
     );
+  });
+
+  it("lets hosted tenant owners manage members in the configured tenant", async () => {
+    const ownerToken = await signup(baseUrl, "owner", "owner-secret");
+    const owner = await getCurrentUser(baseUrl, ownerToken);
+    await promoteUserToTenantOwner({
+      userId: owner.id,
+      tenantId: owner.workspaceId,
+    });
+
+    const listBeforeRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      headers: { Authorization: `Bearer ${ownerToken}` },
+    });
+    expect(listBeforeRes.status).toBe(200);
+    const listBefore = await listBeforeRes.json();
+    expect(listBefore.data.users).toEqual([
+      expect.objectContaining({
+        id: owner.id,
+        username: "owner",
+        workspaceId: "tenant_default",
+        workspaceRole: "owner",
+      }),
+    ]);
+
+    const createMemberRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      method: "POST",
+      headers: authHeaders(ownerToken),
+      body: JSON.stringify({
+        username: "member",
+        displayName: "Member User",
+        password: "member-secret",
+        isSystemAdmin: true,
+      }),
+    });
+    expect(createMemberRes.status).toBe(201);
+    const createMemberBody = await createMemberRes.json();
+    expect(createMemberBody.data.user).toMatchObject({
+      username: "member",
+      displayName: "Member User",
+      isSystemAdmin: false,
+      workspaceId: "tenant_default",
+      workspaceRole: "member",
+    });
+    const memberId = createMemberBody.data.user.id as string;
+
+    const memberToken = await login(baseUrl, "member", "member-secret");
+    const resetRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${memberId}/reset-password`,
+      {
+        method: "POST",
+        headers: authHeaders(ownerToken),
+        body: JSON.stringify({ password: "member-secret-2" }),
+      },
+    );
+    expect(resetRes.status).toBe(200);
+
+    const oldSessionRes = await fetch(`${baseUrl}/api/jobs`, {
+      headers: { Authorization: `Bearer ${memberToken}` },
+    });
+    expect(oldSessionRes.status).toBe(401);
+
+    const updatedMemberToken = await login(
+      baseUrl,
+      "member",
+      "member-secret-2",
+    );
+    const disableRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${memberId}/disabled`,
+      {
+        method: "PATCH",
+        headers: authHeaders(ownerToken),
+        body: JSON.stringify({ isDisabled: true }),
+      },
+    );
+    expect(disableRes.status).toBe(200);
+    const disabledLoginRes = await fetch(`${baseUrl}/api/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username: "member",
+        password: "member-secret-2",
+      }),
+    });
+    expect(disabledLoginRes.status).toBe(401);
+
+    const enableRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${memberId}/disabled`,
+      {
+        method: "PATCH",
+        headers: authHeaders(ownerToken),
+        body: JSON.stringify({ isDisabled: false }),
+      },
+    );
+    expect(enableRes.status).toBe(200);
+    await login(baseUrl, "member", "member-secret-2");
+
+    const memberListRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      headers: { Authorization: `Bearer ${updatedMemberToken}` },
+    });
+    expect(memberListRes.status).toBe(403);
+
+    const memberCreateRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      method: "POST",
+      headers: authHeaders(updatedMemberToken),
+      body: JSON.stringify({
+        username: "other-member",
+        password: "other-member-secret",
+      }),
+    });
+    expect(memberCreateRes.status).toBe(403);
+
+    const memberDisableRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${owner.id}/disabled`,
+      {
+        method: "PATCH",
+        headers: authHeaders(updatedMemberToken),
+        body: JSON.stringify({ isDisabled: true }),
+      },
+    );
+    expect(memberDisableRes.status).toBe(403);
+
+    const memberResetRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${owner.id}/reset-password`,
+      {
+        method: "POST",
+        headers: authHeaders(updatedMemberToken),
+        body: JSON.stringify({ password: "owner-secret-2" }),
+      },
+    );
+    expect(memberResetRes.status).toBe(403);
+
+    const selfDisableRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${owner.id}/disabled`,
+      {
+        method: "PATCH",
+        headers: authHeaders(ownerToken),
+        body: JSON.stringify({ isDisabled: true }),
+      },
+    );
+    expect(selfDisableRes.status).toBe(400);
+  });
+
+  it("does not let hosted tenant owners manage users from another tenant", async () => {
+    const ownerToken = await signup(baseUrl, "owner", "owner-secret");
+    const owner = await getCurrentUser(baseUrl, ownerToken);
+    await promoteUserToTenantOwner({
+      userId: owner.id,
+      tenantId: owner.workspaceId,
+    });
+
+    const usersRepo = await import("@server/repositories/users");
+    const outsideUser = await usersRepo.createPrivateWorkspaceUser({
+      username: "outside",
+      displayName: "Outside User",
+      password: "outside-secret",
+    });
+
+    const listRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      headers: { Authorization: `Bearer ${ownerToken}` },
+    });
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json();
+    expect(
+      listBody.data.users.map((user: { username: string }) => user.username),
+    ).not.toContain("outside");
+
+    const resetOutsideRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${outsideUser.id}/reset-password`,
+      {
+        method: "POST",
+        headers: authHeaders(ownerToken),
+        body: JSON.stringify({ password: "outside-secret-2" }),
+      },
+    );
+    expect(resetOutsideRes.status).toBe(404);
+
+    const disableOutsideRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${outsideUser.id}/disabled`,
+      {
+        method: "PATCH",
+        headers: authHeaders(ownerToken),
+        body: JSON.stringify({ isDisabled: true }),
+      },
+    );
+    expect(disableOutsideRes.status).toBe(404);
+  });
+
+  it("does not let hosted tenant owners manage other tenant owners", async () => {
+    const ownerToken = await signup(baseUrl, "owner", "owner-secret");
+    const owner = await getCurrentUser(baseUrl, ownerToken);
+    await promoteUserToTenantOwner({
+      userId: owner.id,
+      tenantId: owner.workspaceId,
+    });
+
+    const coOwnerToken = await signup(baseUrl, "co-owner", "co-owner-secret");
+    const coOwner = await getCurrentUser(baseUrl, coOwnerToken);
+    await promoteUserToTenantOwner({
+      userId: coOwner.id,
+      tenantId: coOwner.workspaceId,
+    });
+
+    const resetCoOwnerRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${coOwner.id}/reset-password`,
+      {
+        method: "POST",
+        headers: authHeaders(ownerToken),
+        body: JSON.stringify({ password: "co-owner-secret-2" }),
+      },
+    );
+    expect(resetCoOwnerRes.status).toBe(403);
+
+    const disableCoOwnerRes = await fetch(
+      `${baseUrl}/api/workspaces/users/${coOwner.id}/disabled`,
+      {
+        method: "PATCH",
+        headers: authHeaders(ownerToken),
+        body: JSON.stringify({ isDisabled: true }),
+      },
+    );
+    expect(disableCoOwnerRes.status).toBe(403);
   });
 });

--- a/orchestrator/src/server/api/routes/workspaces.ts
+++ b/orchestrator/src/server/api/routes/workspaces.ts
@@ -1,6 +1,12 @@
 import { badRequest, conflict, forbidden, notFound } from "@infra/errors";
 import { asyncRoute, fail, ok } from "@infra/http";
-import { getUserId, isSystemAdmin } from "@infra/request-context";
+import {
+  getTenantId,
+  getUserId,
+  getWorkspaceRole,
+  isSystemAdmin,
+} from "@infra/request-context";
+import { getJobOpsAppConfig } from "@server/config/app-mode";
 import * as authSessionsRepo from "@server/repositories/auth-sessions";
 import * as usersRepo from "@server/repositories/users";
 import { type Request, type Response, Router } from "express";
@@ -27,10 +33,30 @@ const changeOwnPasswordSchema = z.object({
   password: z.string().min(8).max(500),
 });
 
-function requireSystemAdmin(res: Response): boolean {
-  if (isSystemAdmin()) return true;
-  fail(res, forbidden("System admin access is required"));
-  return false;
+type WorkspaceUserManagerScope =
+  | { kind: "system" }
+  | { kind: "tenant"; tenantId: string };
+
+function requireWorkspaceUserManager(
+  res: Response,
+): WorkspaceUserManagerScope | null {
+  const appConfig = getJobOpsAppConfig();
+  if (appConfig.appMode !== "hosted" && isSystemAdmin()) {
+    return { kind: "system" };
+  }
+
+  const tenantId = getTenantId();
+  if (
+    appConfig.appMode === "hosted" &&
+    tenantId &&
+    tenantId === appConfig.hostedTenantId &&
+    getWorkspaceRole() === "owner"
+  ) {
+    return { kind: "tenant", tenantId };
+  }
+
+  fail(res, forbidden("Workspace owner access is required"));
+  return null;
 }
 
 function isUsernameConflictError(error: unknown): boolean {
@@ -38,18 +64,36 @@ function isUsernameConflictError(error: unknown): boolean {
   return /UNIQUE constraint failed: users\.username/i.test(error.message);
 }
 
+function failIfTenantTargetIsNotMember(
+  scope: WorkspaceUserManagerScope,
+  user: usersRepo.PublicUser,
+  res: Response,
+): boolean {
+  if (scope.kind === "system" || user.workspaceRole === "member") {
+    return false;
+  }
+  fail(res, forbidden("Only workspace members can be managed"));
+  return true;
+}
+
 workspacesRouter.get(
   "/users",
   asyncRoute(async (_req: Request, res: Response) => {
-    if (!requireSystemAdmin(res)) return;
-    ok(res, { users: await usersRepo.listUsers() });
+    const scope = requireWorkspaceUserManager(res);
+    if (!scope) return;
+    const users =
+      scope.kind === "system"
+        ? await usersRepo.listUsers()
+        : await usersRepo.listUsersByTenant(scope.tenantId);
+    ok(res, { users });
   }),
 );
 
 workspacesRouter.post(
   "/users",
   asyncRoute(async (req: Request, res: Response) => {
-    if (!requireSystemAdmin(res)) return;
+    const scope = requireWorkspaceUserManager(res);
+    if (!scope) return;
     const parsed = createUserSchema.safeParse(req.body);
     if (!parsed.success) {
       fail(res, badRequest("Invalid request body", parsed.error.flatten()));
@@ -57,12 +101,24 @@ workspacesRouter.post(
     }
 
     try {
-      const user = await usersRepo.createPrivateWorkspaceUser({
-        username: parsed.data.username,
-        password: parsed.data.password,
-        displayName: parsed.data.displayName ?? parsed.data.username,
-        isSystemAdmin: parsed.data.isSystemAdmin ?? false,
-      });
+      const user =
+        scope.kind === "system"
+          ? await usersRepo.createPrivateWorkspaceUser({
+              username: parsed.data.username,
+              password: parsed.data.password,
+              displayName: parsed.data.displayName ?? parsed.data.username,
+              isSystemAdmin: parsed.data.isSystemAdmin ?? false,
+            })
+          : await usersRepo.createTenantMemberUser({
+              username: parsed.data.username,
+              password: parsed.data.password,
+              displayName: parsed.data.displayName ?? parsed.data.username,
+              tenantId: scope.tenantId,
+            });
+      if (!user) {
+        fail(res, notFound("Workspace not found"));
+        return;
+      }
       ok(res, { user }, 201);
       return;
     } catch (error) {
@@ -78,7 +134,8 @@ workspacesRouter.post(
 workspacesRouter.patch(
   "/users/:id/disabled",
   asyncRoute(async (req: Request, res: Response) => {
-    if (!requireSystemAdmin(res)) return;
+    const scope = requireWorkspaceUserManager(res);
+    if (!scope) return;
     const parsed = disableUserSchema.safeParse(req.body);
     if (!parsed.success) {
       fail(res, badRequest("Invalid request body", parsed.error.flatten()));
@@ -95,10 +152,27 @@ workspacesRouter.patch(
       return;
     }
 
-    const user = await usersRepo.setUserDisabled(
-      userId,
-      parsed.data.isDisabled,
-    );
+    const existingUser =
+      scope.kind === "system"
+        ? await usersRepo.getUserById(userId)
+        : await usersRepo.getUserByIdInTenant({
+            id: userId,
+            tenantId: scope.tenantId,
+          });
+    if (!existingUser) {
+      fail(res, notFound("User not found"));
+      return;
+    }
+    if (failIfTenantTargetIsNotMember(scope, existingUser, res)) return;
+
+    const user =
+      scope.kind === "system"
+        ? await usersRepo.setUserDisabled(userId, parsed.data.isDisabled)
+        : await usersRepo.setUserDisabledInTenant({
+            id: userId,
+            tenantId: scope.tenantId,
+            isDisabled: parsed.data.isDisabled,
+          });
     if (!user) {
       fail(res, notFound("User not found"));
       return;
@@ -110,7 +184,8 @@ workspacesRouter.patch(
 workspacesRouter.post(
   "/users/:id/reset-password",
   asyncRoute(async (req: Request, res: Response) => {
-    if (!requireSystemAdmin(res)) return;
+    const scope = requireWorkspaceUserManager(res);
+    if (!scope) return;
     const parsed = resetPasswordSchema.safeParse(req.body);
     if (!parsed.success) {
       fail(res, badRequest("Invalid request body", parsed.error.flatten()));
@@ -122,11 +197,18 @@ workspacesRouter.post(
       fail(res, badRequest("User id is required"));
       return;
     }
-    const user = await usersRepo.getUserById(userId);
+    const user =
+      scope.kind === "system"
+        ? await usersRepo.getUserById(userId)
+        : await usersRepo.getUserByIdInTenant({
+            id: userId,
+            tenantId: scope.tenantId,
+          });
     if (!user) {
       fail(res, notFound("User not found"));
       return;
     }
+    if (failIfTenantTargetIsNotMember(scope, user, res)) return;
 
     await usersRepo.updateUserPassword({
       id: userId,

--- a/orchestrator/src/server/app.ts
+++ b/orchestrator/src/server/app.ts
@@ -165,6 +165,7 @@ export function createAuthGuard() {
   async function getAuthorizationContext(req: express.Request): Promise<{
     userId: string;
     tenantId: string;
+    workspaceRole: "owner" | "member";
     username: string;
     isSystemAdmin: boolean;
   } | null> {
@@ -180,6 +181,7 @@ export function createAuthGuard() {
       return {
         userId: user.id,
         tenantId: user.workspaceId,
+        workspaceRole: user.workspaceRole,
         username: user.username,
         isSystemAdmin: user.isSystemAdmin,
       };
@@ -300,6 +302,7 @@ export function createAuthGuard() {
           {
             userId: "test-user",
             tenantId: DEFAULT_TENANT_ID,
+            workspaceRole: "owner",
             username: "test",
             isSystemAdmin: true,
           },

--- a/orchestrator/src/server/basic-auth.test.ts
+++ b/orchestrator/src/server/basic-auth.test.ts
@@ -315,6 +315,7 @@ describe.sequential("Auth read-only enforcement", () => {
       isDisabled: false,
       workspaceId: "tenant-1",
       workspaceName: "Tenant 1",
+      workspaceRole: "member",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });
@@ -354,6 +355,7 @@ describe.sequential("Auth read-only enforcement", () => {
       isDisabled: true,
       workspaceId: "tenant-1",
       workspaceName: "Tenant 1",
+      workspaceRole: "owner",
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     });

--- a/orchestrator/src/server/infra/request-context.ts
+++ b/orchestrator/src/server/infra/request-context.ts
@@ -6,6 +6,7 @@ export type RequestContext = {
   jobId?: string;
   userId?: string;
   tenantId?: string;
+  workspaceRole?: "owner" | "member";
   username?: string;
   isSystemAdmin?: boolean;
   analyticsSessionId?: string;
@@ -53,4 +54,8 @@ export function getUserId(): string | undefined {
 
 export function isSystemAdmin(): boolean {
   return storage.getStore()?.isSystemAdmin === true;
+}
+
+export function getWorkspaceRole(): "owner" | "member" | undefined {
+  return storage.getStore()?.workspaceRole;
 }

--- a/orchestrator/src/server/repositories/users.ts
+++ b/orchestrator/src/server/repositories/users.ts
@@ -9,6 +9,8 @@ import { db, schema } from "../db";
 
 const { tenantMemberships, tenants, users } = schema;
 
+export type WorkspaceRole = "owner" | "member";
+
 export type AuthUser = {
   id: string;
   username: string;
@@ -19,6 +21,7 @@ export type AuthUser = {
   isDisabled: boolean;
   tenantId: string;
   tenantName: string;
+  workspaceRole: WorkspaceRole;
 };
 
 export type PublicUser = {
@@ -29,6 +32,7 @@ export type PublicUser = {
   isDisabled: boolean;
   workspaceId: string;
   workspaceName: string;
+  workspaceRole: WorkspaceRole;
   createdAt: string;
   updatedAt: string;
 };
@@ -53,6 +57,7 @@ function mapUser(row: {
   isDisabled: boolean;
   workspaceId: string;
   workspaceName: string;
+  workspaceRole: WorkspaceRole;
   createdAt: string;
   updatedAt: string;
 }): PublicUser {
@@ -64,6 +69,7 @@ function mapUser(row: {
     isDisabled: row.isDisabled,
     workspaceId: row.workspaceId,
     workspaceName: row.workspaceName,
+    workspaceRole: row.workspaceRole,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -88,6 +94,7 @@ export async function getUserForLogin(
       isDisabled: users.isDisabled,
       tenantId: tenantMemberships.tenantId,
       tenantName: tenants.name,
+      workspaceRole: tenantMemberships.role,
     })
     .from(users)
     .innerJoin(tenantMemberships, eq(tenantMemberships.userId, users.id))
@@ -108,6 +115,7 @@ export async function getUserById(id: string): Promise<PublicUser | null> {
       isDisabled: users.isDisabled,
       workspaceId: tenantMemberships.tenantId,
       workspaceName: tenants.name,
+      workspaceRole: tenantMemberships.role,
       createdAt: users.createdAt,
       updatedAt: users.updatedAt,
     })
@@ -130,12 +138,37 @@ export async function listUsers(): Promise<PublicUser[]> {
       isDisabled: users.isDisabled,
       workspaceId: tenantMemberships.tenantId,
       workspaceName: tenants.name,
+      workspaceRole: tenantMemberships.role,
       createdAt: users.createdAt,
       updatedAt: users.updatedAt,
     })
     .from(users)
     .innerJoin(tenantMemberships, eq(tenantMemberships.userId, users.id))
     .innerJoin(tenants, eq(tenants.id, tenantMemberships.tenantId));
+
+  return rows.map(mapUser);
+}
+
+export async function listUsersByTenant(
+  tenantId: string,
+): Promise<PublicUser[]> {
+  const rows = await db
+    .select({
+      id: users.id,
+      username: users.username,
+      displayName: users.displayName,
+      isSystemAdmin: users.isSystemAdmin,
+      isDisabled: users.isDisabled,
+      workspaceId: tenantMemberships.tenantId,
+      workspaceName: tenants.name,
+      workspaceRole: tenantMemberships.role,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt,
+    })
+    .from(users)
+    .innerJoin(tenantMemberships, eq(tenantMemberships.userId, users.id))
+    .innerJoin(tenants, eq(tenants.id, tenantMemberships.tenantId))
+    .where(eq(tenantMemberships.tenantId, tenantId));
 
   return rows.map(mapUser);
 }
@@ -213,6 +246,15 @@ export async function createPrivateWorkspaceUser(input: {
 }
 
 export async function createHostedTenantUser(input: {
+  username: string;
+  password: string;
+  tenantId: string;
+  displayName?: string | null;
+}): Promise<PublicUser | null> {
+  return createTenantMemberUser(input);
+}
+
+export async function createTenantMemberUser(input: {
   username: string;
   password: string;
   tenantId: string;
@@ -338,6 +380,55 @@ export async function setUserDisabled(
     .set({ isDisabled, updatedAt: new Date().toISOString() })
     .where(eq(users.id, id));
   return getUserById(id);
+}
+
+export async function setUserDisabledInTenant(input: {
+  id: string;
+  tenantId: string;
+  isDisabled: boolean;
+}): Promise<PublicUser | null> {
+  const belongsToTenant = await userBelongsToTenant({
+    userId: input.id,
+    tenantId: input.tenantId,
+  });
+  if (!belongsToTenant) return null;
+
+  await db
+    .update(users)
+    .set({ isDisabled: input.isDisabled, updatedAt: new Date().toISOString() })
+    .where(eq(users.id, input.id));
+  return getUserByIdInTenant({ id: input.id, tenantId: input.tenantId });
+}
+
+export async function getUserByIdInTenant(input: {
+  id: string;
+  tenantId: string;
+}): Promise<PublicUser | null> {
+  const [row] = await db
+    .select({
+      id: users.id,
+      username: users.username,
+      displayName: users.displayName,
+      isSystemAdmin: users.isSystemAdmin,
+      isDisabled: users.isDisabled,
+      workspaceId: tenantMemberships.tenantId,
+      workspaceName: tenants.name,
+      workspaceRole: tenantMemberships.role,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt,
+    })
+    .from(users)
+    .innerJoin(tenantMemberships, eq(tenantMemberships.userId, users.id))
+    .innerJoin(tenants, eq(tenants.id, tenantMemberships.tenantId))
+    .where(
+      and(
+        eq(users.id, input.id),
+        eq(tenantMemberships.tenantId, input.tenantId),
+      ),
+    )
+    .limit(1);
+
+  return row ? mapUser(row) : null;
 }
 
 export async function updateUserPassword(input: {


### PR DESCRIPTION
## Summary
- Add `workspaceRole` to auth user data and thread it through server and client types
- Allow hosted workspace owners to manage members while keeping system admin access intact
- Scope workspace user APIs and repository helpers to the active tenant in hosted mode
- Update UI copy and tests for role-aware workspace management

## Testing
- Added and updated unit tests for auth, workspace settings, and tenant isolation behavior
- UI test coverage now verifies hosted owner visibility and member restrictions