### PR TITLE
Add native Anthropic provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ JobOps works with the model provider you already use:
 
 - Codex (local app-server in Docker, authenticated with `codex login`)
 - OpenAI
+- Claude (Anthropic)
 - GLM / Zhipu AI
 - Google Gemini
 - OpenRouter

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -41,10 +41,11 @@ orchestrator/
    Then open **Resume Studio** in the app and import your base resume once. JobOps will use that local Resume Studio document as the primary resume context for tailoring, scoring, and PDF generation.
 
 
-   OpenRouter is the default LLM provider, but OpenAI, GLM, LM Studio, Ollama, `openai-compatible` endpoints, and Gemini are also supported.
+   OpenRouter is the default LLM provider, but OpenAI, Claude (Anthropic), GLM, LM Studio, Ollama, `openai-compatible` endpoints, and Gemini are also supported.
 
    Use `LLM_API_KEY` / `llmApiKey` to configure providers that require an API key.
    To use the native OpenAI integration, set `LLM_PROVIDER=openai`.
+   To use Claude through Anthropic's native Messages API, set `LLM_PROVIDER=anthropic`.
    To use GLM through Z.AI, set `LLM_PROVIDER=glm`; the default base URL is `https://api.z.ai/api/paas/v4`.
    For third-party services that expose an OpenAI-style API but are not OpenAI itself, use `LLM_PROVIDER=openai-compatible`.
 
@@ -147,6 +148,6 @@ npm start
 
 - **Backend:** Express, TypeScript, Drizzle ORM, SQLite
 - **Frontend:** React, Vite, CSS (custom design system)
-- **AI:** Configurable LLM provider (OpenRouter default; also supports OpenAI via the dedicated `openai` provider, GLM, `openai-compatible` endpoints, Gemini, LM Studio, and Ollama)
+- **AI:** Configurable LLM provider (OpenRouter default; also supports OpenAI via the dedicated `openai` provider, Claude through Anthropic's native API, GLM, `openai-compatible` endpoints, Gemini, LM Studio, and Ollama)
 - **PDF Generation:** Reactive Resume v5 API export (configured via Settings)
 - **Job Crawling:** Wraps existing TypeScript Crawlee crawler

--- a/orchestrator/src/client/pages/settings/utils.test.ts
+++ b/orchestrator/src/client/pages/settings/utils.test.ts
@@ -24,6 +24,9 @@ describe("settings utils", () => {
     expect(getLlmProviderConfig("openai").keyHelperHref).toBe(
       "https://platform.openai.com/api-keys",
     );
+    expect(getLlmProviderConfig("anthropic").keyHelperHref).toBe(
+      "https://platform.claude.com/settings/keys",
+    );
     expect(getLlmProviderConfig("glm").keyHelperHref).toBe(
       "https://z.ai/manage-apikey/apikey-list",
     );
@@ -83,12 +86,26 @@ describe("settings utils", () => {
     expect(config.baseUrlPlaceholder).toBe("https://api.z.ai/api/paas/v4");
   });
 
+  it("treats Anthropic as a hosted native API-key provider", () => {
+    const config = getLlmProviderConfig("claude");
+
+    expect(config.normalizedProvider).toBe("anthropic");
+    expect(config.label).toBe("Claude (Anthropic)");
+    expect(config.showApiKey).toBe(true);
+    expect(config.requiresApiKey).toBe(true);
+    expect(config.showBaseUrl).toBe(false);
+    expect(config.providerHint).toBe(
+      "Claude uses Anthropic's native Messages API with your Anthropic API key.",
+    );
+  });
+
   it("defaults unknown providers to openrouter", () => {
     expect(normalizeLlmProvider("unknown-provider")).toBe("openrouter");
   });
 
   it("only enables model suggestions for supported providers", () => {
     expect(supportsLlmModelSuggestions("openai")).toBe(true);
+    expect(supportsLlmModelSuggestions("anthropic")).toBe(true);
     expect(supportsLlmModelSuggestions("glm")).toBe(true);
     expect(supportsLlmModelSuggestions("gemini")).toBe(true);
     expect(supportsLlmModelSuggestions("gemini_cli")).toBe(true);

--- a/orchestrator/src/client/pages/settings/utils.ts
+++ b/orchestrator/src/client/pages/settings/utils.ts
@@ -25,6 +25,7 @@ export const LLM_PROVIDERS = [
   "lmstudio",
   "ollama",
   "openai",
+  "anthropic",
   "openai_compatible",
   "glm",
   "gemini",
@@ -35,6 +36,7 @@ export const LLM_PROVIDERS = [
 export type LlmProviderId = (typeof LLM_PROVIDERS)[number];
 export const LLM_MODEL_SUGGESTION_PROVIDERS = [
   "openai",
+  "anthropic",
   "glm",
   "gemini",
   "gemini_cli",
@@ -46,6 +48,7 @@ export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
   lmstudio: "LM Studio",
   ollama: "Ollama",
   openai: "OpenAI",
+  anthropic: "Claude (Anthropic)",
   openai_compatible: "OpenAI-compatible",
   glm: "GLM",
   gemini: "Gemini",
@@ -56,6 +59,7 @@ export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
 const PROVIDERS_WITH_API_KEY = new Set<LlmProviderId>([
   "openrouter",
   "openai",
+  "anthropic",
   "openai_compatible",
   "glm",
   "gemini",
@@ -77,6 +81,8 @@ const PROVIDER_HINTS: Record<LlmProviderId, string> = {
   ollama:
     "Ollama typically runs locally. Add an API key only for Ollama-compatible endpoints protected by bearer auth.",
   openai: "OpenAI uses the Responses API with structured outputs.",
+  anthropic:
+    "Claude uses Anthropic's native Messages API with your Anthropic API key.",
   openai_compatible:
     "Use a bearer token with any chat-completions-compatible endpoint.",
   glm: "GLM uses the Z.AI chat completions API (OpenAI-compatible) with your API key.",
@@ -102,6 +108,10 @@ const PROVIDER_KEY_HELPERS: Record<
   openai: {
     text: "Create a key at platform.openai.com",
     href: "https://platform.openai.com/api-keys",
+  },
+  anthropic: {
+    text: "Create a key at platform.claude.com",
+    href: "https://platform.claude.com/settings/keys",
   },
   openai_compatible: {
     text: "Use the bearer token issued by your compatible provider",
@@ -141,6 +151,7 @@ export function normalizeLlmProvider(
   const normalized = value?.trim().toLowerCase();
   if (!normalized) return "openrouter";
   const normalizedId = normalized.replace(/[-.]/g, "_");
+  if (normalizedId === "claude") return "anthropic";
   if (normalizedId === "openai_compatible") return "openai_compatible";
   const mapped = mapGlmProviderAlias(normalizedId);
   return (LLM_PROVIDERS as readonly string[]).includes(mapped)

--- a/orchestrator/src/server/api/routes/settings.ts
+++ b/orchestrator/src/server/api/routes/settings.ts
@@ -109,7 +109,8 @@ function normalizeLlmProviderValue(
 ): string | undefined {
   if (!provider) return undefined;
   const normalized = provider.trim().toLowerCase().replace(/[-.]/g, "_");
-  return mapGlmProviderAlias(normalized);
+  const mapped = mapGlmProviderAlias(normalized);
+  return mapped === "claude" ? "anthropic" : mapped;
 }
 
 function getDefaultValidationBaseUrl(

--- a/orchestrator/src/server/services/llm/providers/anthropic.ts
+++ b/orchestrator/src/server/services/llm/providers/anthropic.ts
@@ -1,0 +1,144 @@
+import type { LlmMessageContent, LlmRequestOptions } from "../types";
+import { getLlmMessageText } from "../types";
+import { buildHeaders, joinUrl } from "../utils/http";
+import { getNestedValue } from "../utils/object";
+import { createProviderStrategy } from "./factory";
+
+const DEFAULT_MAX_TOKENS = 4096;
+
+type AnthropicContentBlock =
+  | { type: "text"; text: string }
+  | {
+      type: "image";
+      source: AnthropicImageSource;
+    };
+
+type AnthropicImageSource =
+  | { type: "base64"; media_type: string; data: string }
+  | { type: "url"; url: string };
+
+export const anthropicStrategy = createProviderStrategy({
+  provider: "anthropic",
+  defaultBaseUrl: "https://api.anthropic.com",
+  requiresApiKey: true,
+  modes: ["json_schema", "json_object", "none"],
+  validationPaths: ["/v1/models"],
+  buildRequest: ({ mode, baseUrl, apiKey, model, messages, jsonSchema }) => {
+    const { system, anthropicMessages } = toAnthropicMessages(messages);
+    const body: Record<string, unknown> = {
+      model,
+      max_tokens: DEFAULT_MAX_TOKENS,
+      messages: anthropicMessages,
+    };
+
+    if (system) {
+      body.system = system;
+    }
+
+    if (mode === "json_schema") {
+      body.output_config = {
+        format: {
+          type: "json_schema",
+          schema: jsonSchema.schema,
+        },
+      };
+    } else if (mode === "json_object") {
+      body.output_config = {
+        format: {
+          type: "json_schema",
+          schema: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+      };
+    }
+
+    return {
+      url: joinUrl(baseUrl, "/v1/messages"),
+      headers: buildHeaders({ apiKey, provider: "anthropic" }),
+      body,
+    };
+  },
+  extractText: (response) => {
+    const content = getNestedValue(response, ["content"]);
+    if (!Array.isArray(content)) return null;
+
+    const text = content
+      .map((part) => {
+        if (!part || typeof part !== "object") return "";
+        const type = getNestedValue(part, ["type"]);
+        const value = getNestedValue(part, ["text"]);
+        return type === "text" && typeof value === "string" ? value : "";
+      })
+      .join("");
+
+    return text || null;
+  },
+});
+
+function toAnthropicMessages(
+  messages: LlmRequestOptions<unknown>["messages"],
+): {
+  system: string | null;
+  anthropicMessages: Array<{
+    role: "user" | "assistant";
+    content: string | AnthropicContentBlock[];
+  }>;
+} {
+  const systemMessages: string[] = [];
+  const anthropicMessages: Array<{
+    role: "user" | "assistant";
+    content: string | AnthropicContentBlock[];
+  }> = [];
+
+  for (const message of messages) {
+    if (message.role === "system") {
+      const text = getLlmMessageText(message.content).trim();
+      if (text) systemMessages.push(text);
+      continue;
+    }
+
+    anthropicMessages.push({
+      role: message.role,
+      content: toAnthropicContent(message.content),
+    });
+  }
+
+  return {
+    system: systemMessages.length > 0 ? systemMessages.join("\n\n") : null,
+    anthropicMessages,
+  };
+}
+
+function toAnthropicContent(
+  content: LlmMessageContent,
+): string | AnthropicContentBlock[] {
+  if (typeof content === "string") return content;
+  return content.map((part) => {
+    if (part.type === "text") {
+      return { type: "text", text: part.text };
+    }
+
+    return {
+      type: "image",
+      source: toAnthropicImageSource(part.imageUrl, part.mediaType),
+    };
+  });
+}
+
+function toAnthropicImageSource(
+  imageUrl: string,
+  fallbackMediaType: string,
+): AnthropicImageSource {
+  const match = imageUrl.match(/^data:([^;,]+);base64,(.+)$/);
+  if (!match) {
+    return { type: "url", url: imageUrl };
+  }
+
+  return {
+    type: "base64",
+    media_type: match[1] || fallbackMediaType,
+    data: match[2],
+  };
+}

--- a/orchestrator/src/server/services/llm/providers/index.ts
+++ b/orchestrator/src/server/services/llm/providers/index.ts
@@ -1,4 +1,5 @@
 import type { LlmProvider, ProviderStrategy } from "../types";
+import { anthropicStrategy } from "./anthropic";
 import { codexStrategy } from "./codex";
 import { geminiStrategy } from "./gemini";
 import { geminiCliStrategy } from "./gemini_cli";
@@ -14,6 +15,7 @@ export const strategies: Record<LlmProvider, ProviderStrategy> = {
   lmstudio: lmStudioStrategy,
   ollama: ollamaStrategy,
   openai: openAiStrategy,
+  anthropic: anthropicStrategy,
   openai_compatible: openAiCompatibleStrategy,
   glm: glmStrategy,
   gemini: geminiStrategy,

--- a/orchestrator/src/server/services/llm/providers/providers.test.ts
+++ b/orchestrator/src/server/services/llm/providers/providers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { anthropicStrategy } from "./anthropic";
 import { geminiStrategy } from "./gemini";
 import { glmStrategy } from "./glm";
 import { lmStudioStrategy } from "./lmstudio";
@@ -44,6 +45,17 @@ describe("provider adapters", () => {
           model: "model-a",
         },
         expectedUrl: "https://api.openai.com/v1/responses",
+      },
+      {
+        name: "anthropic-json_schema",
+        strategy: anthropicStrategy,
+        args: {
+          mode: "json_schema" as const,
+          baseUrl: "https://api.anthropic.com",
+          apiKey: "x",
+          model: "claude-sonnet-4-6",
+        },
+        expectedUrl: "https://api.anthropic.com/v1/messages",
       },
       {
         name: "openai-compatible-json_object",
@@ -231,6 +243,15 @@ describe("provider adapters", () => {
       "openai-direct",
     );
     expect(
+      anthropicStrategy.extractText({
+        content: [
+          { type: "text", text: "hello " },
+          { type: "thinking", thinking: "hidden" },
+          { type: "text", text: "claude" },
+        ],
+      }),
+    ).toBe("hello claude");
+    expect(
       openAiStrategy.extractText({
         output: [
           {
@@ -305,5 +326,63 @@ describe("provider adapters", () => {
     ]);
     expect(itemSchema.additionalProperties).toBeUndefined();
     expect(itemSchema.propertyOrdering).toEqual(["name", "keywords"]);
+  });
+
+  it("builds native Anthropic Messages API requests", () => {
+    const request = anthropicStrategy.buildRequest({
+      mode: "json_schema",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "sk-ant",
+      model: "claude-sonnet-4-6",
+      messages: [
+        { role: "system", content: "You are concise." },
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Read this image." },
+            {
+              type: "image",
+              imageUrl: "data:image/png;base64,abc123",
+              mediaType: "image/png",
+            },
+          ],
+        },
+      ],
+      jsonSchema: schema,
+    });
+
+    expect(request.url).toBe("https://api.anthropic.com/v1/messages");
+    expect(request.headers).toMatchObject({
+      "anthropic-version": "2023-06-01",
+      "x-api-key": "sk-ant",
+    });
+    expect(request.headers).not.toHaveProperty("Authorization");
+    expect(request.body).toMatchObject({
+      model: "claude-sonnet-4-6",
+      max_tokens: 4096,
+      system: "You are concise.",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Read this image." },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "abc123",
+              },
+            },
+          ],
+        },
+      ],
+      output_config: {
+        format: {
+          type: "json_schema",
+          schema: schema.schema,
+        },
+      },
+    });
   });
 });

--- a/orchestrator/src/server/services/llm/service.test.ts
+++ b/orchestrator/src/server/services/llm/service.test.ts
@@ -80,6 +80,17 @@ describe("LlmService provider normalization", () => {
     expect(anthropic.getProvider()).toBe("anthropic");
     expect(anthropic.getBaseUrl()).toBe("https://api.anthropic.com");
     expect(claude.getProvider()).toBe("anthropic");
+    expect(claude.getBaseUrl()).toBe("https://api.anthropic.com");
+  });
+
+  it("ignores stale configured base URLs for native Anthropic", () => {
+    const llm = new LlmService({
+      provider: "anthropic",
+      baseUrl: "https://openrouter.ai",
+    });
+
+    expect(llm.getProvider()).toBe("anthropic");
+    expect(llm.getBaseUrl()).toBe("https://api.anthropic.com");
   });
 
   it("retries codex JSON parsing failures and succeeds on a later attempt", async () => {

--- a/orchestrator/src/server/services/llm/service.test.ts
+++ b/orchestrator/src/server/services/llm/service.test.ts
@@ -69,6 +69,19 @@ describe("LlmService provider normalization", () => {
     expect(zhipu.getProvider()).toBe("glm");
   });
 
+  it("supports Anthropic provider normalization and Claude alias", () => {
+    const anthropic = new LlmService({
+      provider: "anthropic",
+    });
+    const claude = new LlmService({
+      provider: "claude",
+    });
+
+    expect(anthropic.getProvider()).toBe("anthropic");
+    expect(anthropic.getBaseUrl()).toBe("https://api.anthropic.com");
+    expect(claude.getProvider()).toBe("anthropic");
+  });
+
   it("retries codex JSON parsing failures and succeeds on a later attempt", async () => {
     const codexCallSpy = vi
       .spyOn(CodexClient.prototype, "callJson")

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -54,7 +54,9 @@ export class LlmService {
     );
 
     const strategy = strategies[resolvedProvider];
-    const baseUrl = normalizedBaseUrl || strategy.defaultBaseUrl;
+    const baseUrl = providerUsesConfiguredBaseUrl(resolvedProvider)
+      ? normalizedBaseUrl || strategy.defaultBaseUrl
+      : strategy.defaultBaseUrl;
 
     const apiKey = resolveLlmApiKey({
       storedApiKey: options.apiKey,
@@ -619,6 +621,15 @@ function normalizeProviderName(raw: string | null): string | undefined {
   const normalized = raw?.trim().toLowerCase().replace(/[-.]/g, "_");
   if (!normalized) return normalized;
   return mapGlmProviderAlias(normalized);
+}
+
+function providerUsesConfiguredBaseUrl(provider: LlmProvider): boolean {
+  return (
+    provider === "lmstudio" ||
+    provider === "ollama" ||
+    provider === "openai_compatible" ||
+    provider === "glm"
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -223,6 +223,7 @@ export class LlmService {
 
     if (
       this.provider !== "openai" &&
+      this.provider !== "anthropic" &&
       this.provider !== "glm" &&
       this.provider !== "gemini" &&
       this.provider !== "ollama"
@@ -233,6 +234,9 @@ export class LlmService {
     const models = await (async () => {
       if (this.provider === "openai") {
         return this.listOpenAiModels();
+      }
+      if (this.provider === "anthropic") {
+        return this.listAnthropicModels();
       }
       if (this.provider === "gemini") {
         return this.listGeminiModels();
@@ -468,6 +472,29 @@ export class LlmService {
       .filter(Boolean);
   }
 
+  private async listAnthropicModels(): Promise<string[]> {
+    const response = await fetch(joinUrl(this.baseUrl, "/v1/models"), {
+      method: "GET",
+      headers: buildHeaders({
+        apiKey: this.apiKey,
+        provider: this.provider,
+      }),
+    });
+
+    if (!response.ok) {
+      const detail = await getResponseDetail(response);
+      throw new Error(detail || `Anthropic returned ${response.status}.`);
+    }
+
+    const payload = (await response.json()) as {
+      data?: Array<{ id?: string | null }>;
+    };
+    return (payload.data ?? [])
+      .map((entry) => entry.id?.trim() ?? "")
+      .filter(isAnthropicTextGenerationModel)
+      .filter(Boolean);
+  }
+
   private async listGeminiModels(): Promise<string[]> {
     const url = addQueryParam(
       joinUrl(this.baseUrl, "/v1beta/models"),
@@ -571,6 +598,9 @@ function normalizeProvider(
     return "openai_compatible";
   }
   if (normalized === "openai") return "openai";
+  if (normalized === "anthropic" || normalized === "claude") {
+    return "anthropic";
+  }
   if (normalized === "glm") return "glm";
   if (normalized === "gemini") return "gemini";
   if (normalized === "gemini_cli") return "gemini_cli";
@@ -612,6 +642,7 @@ function normalizeGeminiModelName(value: string): string {
 
 function getPreferredModel(provider: LlmProvider): string | null {
   if (provider === "openai") return "gpt-5.4-mini";
+  if (provider === "anthropic") return "claude-sonnet-4-6";
   if (provider === "glm") return "glm-5.1";
   if (provider === "gemini" || provider === "gemini_cli") {
     return "google/gemini-3-flash-preview";
@@ -647,6 +678,11 @@ function isOpenAiTextGenerationModel(model: string): boolean {
   }
 
   return /^(gpt|o1|o3|o4|chatgpt|codex)/.test(normalized);
+}
+
+function isAnthropicTextGenerationModel(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return normalized.startsWith("claude-");
 }
 
 function isGeminiTextGenerationModel(model: string): boolean {

--- a/orchestrator/src/server/services/llm/types.ts
+++ b/orchestrator/src/server/services/llm/types.ts
@@ -3,6 +3,7 @@ export type LlmProvider =
   | "lmstudio"
   | "ollama"
   | "openai"
+  | "anthropic"
   | "openai_compatible"
   | "glm"
   | "gemini"

--- a/orchestrator/src/server/services/llm/utils/http.ts
+++ b/orchestrator/src/server/services/llm/utils/http.ts
@@ -19,6 +19,14 @@ export function buildHeaders(args: {
     "Content-Type": "application/json",
   };
 
+  if (args.provider === "anthropic") {
+    headers["anthropic-version"] = "2023-06-01";
+    if (args.apiKey) {
+      headers["x-api-key"] = args.apiKey;
+    }
+    return headers;
+  }
+
   if (args.apiKey) {
     headers.Authorization = `Bearer ${args.apiKey}`;
   }

--- a/orchestrator/src/server/services/modelSelection.test.ts
+++ b/orchestrator/src/server/services/modelSelection.test.ts
@@ -370,6 +370,51 @@ describe("Model Selection Logic", () => {
       );
     });
 
+    it("uses Anthropic defaults for a purpose-specific provider override", async () => {
+      vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+        llmApiKey: "sk-global",
+        llmPurposeApiKeys: JSON.stringify({ tailoring: "sk-ant" }),
+      });
+      vi.mocked(getEffectiveSettings).mockResolvedValue({
+        model: {
+          value: "llama3.2",
+          default: "llama3.2",
+          override: "llama3.2",
+        },
+        modelScorer: { value: "llama3.2", override: null },
+        modelTailoring: { value: "claude-sonnet-4-6", override: null },
+        modelProjectSelection: { value: "llama3.2", override: null },
+        llmProvider: {
+          value: "ollama",
+          default: "ollama",
+          override: "ollama",
+        },
+        llmBaseUrl: {
+          value: "http://localhost:11434",
+          default: "http://localhost:11434",
+          override: null,
+        },
+        llmPurposeOverrides: {
+          value: {
+            tailoring: { provider: "anthropic" },
+          },
+          default: {},
+          override: {
+            tailoring: { provider: "anthropic" },
+          },
+        },
+      } as any);
+
+      await expect(
+        resolveLlmRuntimeSettings("tailoring"),
+      ).resolves.toMatchObject({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        baseUrl: "https://api.anthropic.com",
+        apiKey: "sk-ant",
+      });
+    });
+
     it("uses the Codex default model when tailoring uses Codex with no model override", async () => {
       vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({});
       vi.mocked(getEffectiveSettings).mockResolvedValue({

--- a/orchestrator/src/server/services/modelSelection.test.ts
+++ b/orchestrator/src/server/services/modelSelection.test.ts
@@ -415,6 +415,46 @@ describe("Model Selection Logic", () => {
       });
     });
 
+    it("does not carry stale OpenRouter base URLs into native Anthropic", async () => {
+      vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+        llmApiKey: "sk-ant",
+      });
+      vi.mocked(getEffectiveSettings).mockResolvedValue({
+        model: {
+          value: "claude-sonnet-4-6",
+          default: "claude-sonnet-4-6",
+          override: null,
+        },
+        modelScorer: { value: "claude-sonnet-4-6", override: null },
+        modelTailoring: { value: "claude-sonnet-4-6", override: null },
+        modelProjectSelection: { value: "claude-sonnet-4-6", override: null },
+        llmProvider: {
+          value: "anthropic",
+          default: "anthropic",
+          override: "anthropic",
+        },
+        llmBaseUrl: {
+          value: "https://openrouter.ai",
+          default: "https://openrouter.ai",
+          override: "https://openrouter.ai",
+        },
+        llmPurposeOverrides: {
+          value: {},
+          default: {},
+          override: {},
+        },
+      } as any);
+
+      await expect(
+        resolveLlmRuntimeSettings("tailoring"),
+      ).resolves.toMatchObject({
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        baseUrl: "https://api.anthropic.com",
+        apiKey: "sk-ant",
+      });
+    });
+
     it("uses the Codex default model when tailoring uses Codex with no model override", async () => {
       vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({});
       vi.mocked(getEffectiveSettings).mockResolvedValue({

--- a/orchestrator/src/server/services/modelSelection.ts
+++ b/orchestrator/src/server/services/modelSelection.ts
@@ -91,6 +91,18 @@ function getDefaultBaseUrlForProvider(
   return "https://openrouter.ai";
 }
 
+function providerUsesConfiguredBaseUrl(
+  provider: string | null | undefined,
+): boolean {
+  const normalized = provider?.trim().toLowerCase().replace(/[-.]/g, "_");
+  return (
+    normalized === "lmstudio" ||
+    normalized === "ollama" ||
+    normalized === "openai_compatible" ||
+    normalized === "glm"
+  );
+}
+
 function readPurposeApiKeys(raw: string | null | undefined) {
   return settingsRegistry.llmPurposeApiKeys.parse(raw ?? undefined) ?? {};
 }
@@ -125,10 +137,11 @@ export async function resolveLlmRuntimeSettings(
     ? settings?.llmPurposeOverrides?.value?.[purpose]
     : undefined;
   const provider = purposeOverride?.provider?.trim() || defaultProvider;
-  const baseUrl =
-    purposeOverride?.baseUrl?.trim() ||
-    (provider === defaultProvider ? defaultBaseUrl : null) ||
-    getDefaultBaseUrlForProvider(provider);
+  const configuredBaseUrl = providerUsesConfiguredBaseUrl(provider)
+    ? purposeOverride?.baseUrl?.trim() ||
+      (provider === defaultProvider ? defaultBaseUrl : null)
+    : null;
+  const baseUrl = configuredBaseUrl || getDefaultBaseUrlForProvider(provider);
   const purposeApiKeys = readPurposeApiKeys(overrides?.llmPurposeApiKeys);
   const purposeApiKey =
     isLlmPurpose(purpose) && purposeApiKeys[purpose]?.trim()

--- a/orchestrator/src/server/services/modelSelection.ts
+++ b/orchestrator/src/server/services/modelSelection.ts
@@ -79,6 +79,9 @@ function getDefaultBaseUrlForProvider(
   if (normalized === "ollama") return "http://localhost:11434";
   if (normalized === "lmstudio") return "http://localhost:1234";
   if (normalized === "openai") return "https://api.openai.com";
+  if (normalized === "anthropic" || normalized === "claude") {
+    return "https://api.anthropic.com";
+  }
   if (normalized === "openai_compatible") return "https://api.openai.com";
   if (normalized === "glm") return "https://api.z.ai/api/paas/v4";
   if (normalized === "gemini") {

--- a/orchestrator/src/server/services/onboarding-status.ts
+++ b/orchestrator/src/server/services/onboarding-status.ts
@@ -66,6 +66,7 @@ export function normalizeLlmProviderValue(
   if (!provider) return undefined;
   const normalized = provider.trim().toLowerCase().replace(/[-.]/g, "_");
   const mapped = mapGlmProviderAlias(normalized);
+  if (mapped === "claude") return "anthropic";
   return (LLM_PROVIDER_VALUES as readonly string[]).includes(mapped)
     ? (mapped as LlmProviderId)
     : undefined;

--- a/shared/src/settings-registry.test.ts
+++ b/shared/src/settings-registry.test.ts
@@ -352,8 +352,13 @@ describe("settingsRegistry helpers", () => {
       expect(settingsRegistry.llmProvider.parse("bigmodel")).toBe("glm");
     });
 
+    it("accepts the Claude alias for Anthropic", () => {
+      expect(settingsRegistry.llmProvider.parse("claude")).toBe("anthropic");
+    });
+
     it("uses provider-specific default models", () => {
       expect(getDefaultModelForProvider("openai")).toBe("gpt-5.4-mini");
+      expect(getDefaultModelForProvider("anthropic")).toBe("claude-sonnet-4-6");
       expect(getDefaultModelForProvider("glm")).toBe("glm-5.1");
       expect(getDefaultModelForProvider("gemini")).toBe(
         "google/gemini-3-flash-preview",

--- a/shared/src/settings-registry.ts
+++ b/shared/src/settings-registry.ts
@@ -69,11 +69,13 @@ function normalizeLlmProviderOrNull(raw: string | undefined): string | null {
   if (raw === undefined) return null;
   const normalized = raw.trim().toLowerCase().replace(/[-.]/g, "_");
   const mapped = mapGlmProviderAlias(normalized);
+  if (mapped === "claude") return "anthropic";
   return mapped || null;
 }
 
 export const DEFAULT_GEMINI_MODEL = "google/gemini-3-flash-preview";
 export const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini";
+export const DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-4-6";
 export const DEFAULT_GLM_MODEL = "glm-5.1";
 export const DEFAULT_CODEX_MODEL = "gpt-5.4-mini";
 
@@ -90,6 +92,10 @@ export function getDefaultModelForProvider(
 
   if (normalizedProvider === "openai") {
     return DEFAULT_OPENAI_MODEL;
+  }
+
+  if (normalizedProvider === "anthropic") {
+    return DEFAULT_ANTHROPIC_MODEL;
   }
 
   if (normalizedProvider === "gemini" || normalizedProvider === "gemini_cli") {

--- a/shared/src/types/settings.ts
+++ b/shared/src/types/settings.ts
@@ -28,6 +28,7 @@ export const LLM_PROVIDER_VALUES = [
   "lmstudio",
   "ollama",
   "openai",
+  "anthropic",
   "openai_compatible",
   "glm",
   "gemini",


### PR DESCRIPTION

<img width="973" height="726" alt="image" src="https://github.com/user-attachments/assets/56cf7aa8-4844-4592-9c8e-dca0afb49ab7" />

Tested and working!

## Summary
- Add Anthropic as a first-class LLM provider with native Messages API support.
- Normalize `claude` to `anthropic` across settings, runtime selection, and onboarding.
- Update provider defaults, model suggestions, and docs to reflect Claude support.
- Add tests covering request building, model listing, normalization, and base URL handling.

## Testing
- Added and updated unit coverage for provider normalization, Anthropic request construction, and model selection behavior.
- Not run (not requested).