### PR TITLE
Add Anthropic fallback for resume imports

### DIFF
--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -43,7 +43,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 ![Model settings section](/img/features/settings-model-section.png)
 
 - In hosted deployments with platform-managed LLM enabled, this section is hidden because provider, API key, and model selection are managed by the hosted platform.
-- Choose provider (`openrouter`, `lmstudio`, `ollama`, `openai`, `glm`, `gemini`, `gemini_cli`, `codex`)
+- Choose provider (`openrouter`, `lmstudio`, `ollama`, `openai`, `anthropic`, `glm`, `gemini`, `gemini_cli`, `codex`)
 - Set provider-specific base URL/API key when required
 - Configure the default model/runtime, plus purpose-specific overrides for:
   - Scoring
@@ -53,16 +53,19 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 - Purpose API keys are stored as secrets. The settings response shows only redacted hints.
 - Provider defaults are applied automatically when the model fields are left blank:
   - `openai` defaults to `gpt-5.4-mini`
+  - `anthropic` defaults to `claude-sonnet-4-6`
   - `codex` defaults to `gpt-5.4-mini`
   - `glm` defaults to `glm-5.1`
   - `gemini` and `gemini_cli` default to `google/gemini-3-flash-preview`
 - The settings page shows provider-aware model pickers for:
   - `openai`: available text-generation models only
+  - `anthropic`: available Claude text-generation models only
   - `glm`: available GLM text-generation models from the configured BigModel-compatible endpoint
   - `gemini`: available Gemini text-generation models only
   - `gemini_cli`: a curated list of Gemini model ids the CLI typically supports (install [Gemini CLI](https://www.npmjs.com/package/@google/gemini-cli), run `gemini` and complete Google sign-in, or set `GEMINI_API_KEY` for the CLI; JobOps spawns headless `gemini -p ...` with `--approval-mode plan` and no JobOps API key field). **Resume import** uses the CLI with extracted text: DOCX is parsed locally; PDF uses local text extraction then JSON extraction via the CLI (scanned PDFs without a text layer may not import well).
   - `ollama`: locally installed Ollama models
 - `openrouter`, `lmstudio`, and `openai_compatible` stay manual-entry because JobOps cannot safely infer the exact model catalog from those providers
+- Resume import can upload Reactive Resume JSON directly. For PDF and DOCX, JobOps extracts readable text locally when the configured provider cannot accept the file directly, then asks the selected model to convert that text into a local Resume Studio document. Scanned PDFs without a text layer may not import well.
 - For GLM, JobOps uses `https://api.z.ai/api/paas/v4` by default. Override the base URL only when using another Z.AI-compatible endpoint such as a coding-plan endpoint.
 - Changing the provider clears stale model overrides in the form, so inherited fields follow the new provider default unless you explicitly choose a new override
 - The preview under each field and the **Resolved config** block reflect the model currently selected in the form, even before you save

--- a/orchestrator/src/server/services/design-resume/import-file.test.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.test.ts
@@ -1091,32 +1091,16 @@ describe("importDesignResumeFromFile", () => {
     expect(codexCallJsonMock).toHaveBeenCalledWith(
       expect.objectContaining({
         jsonSchema: expect.objectContaining({
-          name: "codex_output_schema",
-          schema: expect.objectContaining({
-            additionalProperties: false,
-            properties: expect.objectContaining({
-              basics: expect.objectContaining({
-                additionalProperties: false,
-              }),
-              sections: expect.objectContaining({
-                additionalProperties: false,
-              }),
-            }),
-            required: [
-              "picture",
-              "basics",
-              "summary",
-              "sections",
-              "customSections",
-              "metadata",
-            ],
-          }),
+          name: "design_resume_import",
         }),
       }),
     );
+    expect(codexCallJsonMock.mock.calls[0]?.[0].messages[1]?.content).toContain(
+      "The resume file was uploaded as PDF and converted locally to plain text before extraction.",
+    );
     expect(
       codexCallJsonMock.mock.calls[0]?.[0].messages[1]?.content,
-    ).not.toContain('property named "json"');
+    ).not.toContain("file_data");
     expect(pdfParse).toHaveBeenCalledOnce();
     expect(fetch).not.toHaveBeenCalled();
   });

--- a/orchestrator/src/server/services/design-resume/import-file.test.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.test.ts
@@ -815,6 +815,59 @@ describe("importDesignResumeFromFile", () => {
     expect(String(body)).toContain("Taylor Quinn");
   });
 
+  it("imports PDFs through extracted text for Claude", async () => {
+    modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
+      provider: "claude",
+      model: "claude-sonnet-4-6",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "anthropic-test",
+    });
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          content: [
+            {
+              type: "text",
+              text: `{"basics":{"name":"Taylor Quinn"}}`,
+            },
+          ],
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ),
+    );
+
+    await importDesignResumeFromFile({
+      fileName: "resume.pdf",
+      mediaType: "application/pdf",
+      dataBase64: Buffer.from("pdf-data").toString("base64"),
+    });
+
+    expect(pdfParse).toHaveBeenCalledOnce();
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/messages",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-api-key": "anthropic-test",
+          "anthropic-version": "2023-06-01",
+        }),
+      }),
+    );
+
+    const fetchCall = vi.mocked(fetch).mock.calls[0];
+    const body =
+      fetchCall?.[1] && "body" in fetchCall[1] ? fetchCall[1].body : "";
+    expect(String(body)).toContain(
+      "The resume file was uploaded as PDF and converted locally to plain text before extraction.",
+    );
+    expect(String(body)).toContain("Taylor Quinn");
+    expect(String(body)).not.toContain("file_data");
+    expect(String(body)).not.toContain("input_file");
+  });
+
   it("imports PDFs through extracted text for OpenAI-compatible endpoints", async () => {
     modelSelection.resolveLlmRuntimeSettings.mockResolvedValueOnce({
       provider: "openai_compatible",

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -15,6 +15,7 @@ import {
 } from "@server/services/document-text-extraction";
 import { CodexClient } from "@server/services/llm/codex/client";
 import { GeminiCliClient } from "@server/services/llm/gemini-cli/client";
+import { LlmService } from "@server/services/llm/service";
 import type { JsonSchemaDefinition } from "@server/services/llm/types";
 import { resolveLlmRuntimeSettings } from "@server/services/modelSelection";
 import { normalizeReactiveResumeV5Document } from "@server/services/rxresume/document";
@@ -41,6 +42,7 @@ type SupportedImportMediaType =
 type SupportedRuntimeProvider =
   | "openai"
   | "openrouter"
+  | "anthropic"
   | "glm"
   | "gemini"
   | "gemini_cli"
@@ -319,6 +321,9 @@ function normalizeRuntimeProvider(
 ): SupportedRuntimeProvider | null {
   const normalized = provider?.trim().toLowerCase().replace(/[-.]/g, "_");
   if (normalized === "openai") return "openai";
+  if (normalized === "anthropic" || normalized === "claude") {
+    return "anthropic";
+  }
   if (normalized === "openrouter" || normalized === "open_router") {
     return "openrouter";
   }
@@ -1091,7 +1096,7 @@ function parseReactiveResumeJsonFile(content: string): DesignResumeJson {
 }
 
 function buildCapabilityErrorMessage(provider: string): string {
-  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, Gemini, Gemini (CLI), Codex, OpenAI-compatible, Ollama, or LM Studio to import resumes. PDF and DOCX files can be converted to plain text locally before extraction when native file upload is unavailable.`;
+  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, Anthropic, Gemini, Gemini (CLI), Codex, OpenAI-compatible, Ollama, or LM Studio to import resumes. PDF and DOCX files can be converted to plain text locally before extraction when native file upload is unavailable.`;
 }
 
 function isFileCapabilityError(message: string): boolean {
@@ -1144,6 +1149,7 @@ function shouldRetryOpenRouterPdfWithAlternateEngine(input: {
 
 function isTextOnlyImportProvider(provider: SupportedRuntimeProvider): boolean {
   return (
+    provider === "anthropic" ||
     provider === "openai_compatible" ||
     provider === "glm" ||
     provider === "ollama" ||
@@ -1156,6 +1162,7 @@ function providerRequiresApiKey(provider: SupportedRuntimeProvider): boolean {
   return (
     provider === "openai" ||
     provider === "openrouter" ||
+    provider === "anthropic" ||
     provider === "gemini" ||
     provider === "glm"
   );
@@ -1599,6 +1606,74 @@ async function extractWithGeminiCli(args: {
   }
 }
 
+async function extractWithAnthropicText(args: {
+  apiKey: string;
+  baseUrl: string | null;
+  model: string;
+  mediaType: SupportedImportMediaType;
+  fileName: string;
+  documentText: string;
+  requestId: string | undefined;
+}): Promise<string> {
+  const startedAt = Date.now();
+  const llm = new LlmService({
+    provider: "anthropic",
+    baseUrl: args.baseUrl,
+    apiKey: args.apiKey,
+  });
+
+  logger.info("Anthropic resume import text extraction started", {
+    requestId: args.requestId ?? null,
+    provider: "anthropic",
+    model: args.model,
+    fileName: args.fileName,
+    mediaType: args.mediaType,
+    documentTextChars: args.documentText.length,
+  });
+
+  const result = await llm.callJson<DesignResumeJson>({
+    model: args.model,
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      {
+        role: "user",
+        content: buildDocumentTextPrompt(
+          args.documentText,
+          args.fileName,
+          args.mediaType,
+        ),
+      },
+    ],
+    jsonSchema: DESIGN_RESUME_IMPORT_CLI_JSON_SCHEMA,
+    signal: AbortSignal.timeout(LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS),
+  });
+
+  if (!result.success) {
+    throw upstreamError(
+      truncate(result.error, 500),
+      args.requestId
+        ? {
+            provider: "anthropic",
+            model: args.model,
+            requestId: args.requestId,
+          }
+        : { provider: "anthropic", model: args.model },
+    );
+  }
+
+  const text = JSON.stringify(result.data);
+  logger.info("Anthropic resume import text extraction completed", {
+    requestId: args.requestId ?? null,
+    provider: "anthropic",
+    model: args.model,
+    fileName: args.fileName,
+    mediaType: args.mediaType,
+    durationMs: elapsedMs(startedAt),
+    resumeJsonChars: text.length,
+  });
+  return text;
+}
+
 async function extractWithCodex(args: {
   model: string;
   mediaType: SupportedImportMediaType;
@@ -1701,6 +1776,23 @@ async function extractResumeFromProvider(args: {
       );
     }
     return extractWithCodex({
+      model: args.model,
+      mediaType: args.mediaType,
+      fileName: args.fileName,
+      documentText: text,
+      requestId: args.requestId,
+    });
+  }
+  if (args.provider === "anthropic") {
+    const text = args.documentText?.trim();
+    if (!text) {
+      throw badRequest(
+        "Anthropic resume import requires plain-text resume content (DOCX or extracted PDF text).",
+      );
+    }
+    return extractWithAnthropicText({
+      apiKey: args.apiKey,
+      baseUrl: args.baseUrl,
       model: args.model,
       mediaType: args.mediaType,
       fileName: args.fileName,

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -13,8 +13,6 @@ import {
   extractPdfText,
   PdfTextExtractionError,
 } from "@server/services/document-text-extraction";
-import { CodexClient } from "@server/services/llm/codex/client";
-import { GeminiCliClient } from "@server/services/llm/gemini-cli/client";
 import { LlmService } from "@server/services/llm/service";
 import type { JsonSchemaDefinition } from "@server/services/llm/types";
 import { resolveLlmRuntimeSettings } from "@server/services/modelSelection";
@@ -75,185 +73,6 @@ const DESIGN_RESUME_IMPORT_CLI_JSON_SCHEMA: JsonSchemaDefinition = {
   },
 };
 
-function strictSchemaObject(properties: Record<string, unknown>) {
-  return {
-    type: "object",
-    properties,
-    required: Object.keys(properties),
-    additionalProperties: false,
-  };
-}
-
-function schemaArrayOf(items: unknown) {
-  return { type: "array", items };
-}
-
-const STRING_SCHEMA = { type: "string" };
-const NUMBER_SCHEMA = { type: "number" };
-const URL_SCHEMA = strictSchemaObject({
-  url: STRING_SCHEMA,
-  label: STRING_SCHEMA,
-});
-
-function sectionSchema(itemSchema: unknown) {
-  return strictSchemaObject({
-    items: schemaArrayOf(itemSchema),
-  });
-}
-
-const DESIGN_RESUME_IMPORT_CODEX_JSON_SCHEMA: JsonSchemaDefinition = {
-  name: "codex_output_schema",
-  schema: {
-    type: "object",
-    properties: {
-      picture: strictSchemaObject({}),
-      basics: strictSchemaObject({
-        name: STRING_SCHEMA,
-        headline: STRING_SCHEMA,
-        email: STRING_SCHEMA,
-        phone: STRING_SCHEMA,
-        location: STRING_SCHEMA,
-        website: URL_SCHEMA,
-        customFields: schemaArrayOf(
-          strictSchemaObject({
-            icon: STRING_SCHEMA,
-            text: STRING_SCHEMA,
-            link: STRING_SCHEMA,
-          }),
-        ),
-      }),
-      summary: strictSchemaObject({
-        content: STRING_SCHEMA,
-      }),
-      sections: strictSchemaObject({
-        profiles: sectionSchema(
-          strictSchemaObject({
-            network: STRING_SCHEMA,
-            username: STRING_SCHEMA,
-            website: URL_SCHEMA,
-          }),
-        ),
-        experience: sectionSchema(
-          strictSchemaObject({
-            company: STRING_SCHEMA,
-            position: STRING_SCHEMA,
-            location: STRING_SCHEMA,
-            period: STRING_SCHEMA,
-            website: URL_SCHEMA,
-            description: STRING_SCHEMA,
-            roles: schemaArrayOf(
-              strictSchemaObject({
-                position: STRING_SCHEMA,
-                period: STRING_SCHEMA,
-                description: STRING_SCHEMA,
-              }),
-            ),
-          }),
-        ),
-        education: sectionSchema(
-          strictSchemaObject({
-            school: STRING_SCHEMA,
-            degree: STRING_SCHEMA,
-            area: STRING_SCHEMA,
-            grade: STRING_SCHEMA,
-            location: STRING_SCHEMA,
-            period: STRING_SCHEMA,
-            website: URL_SCHEMA,
-            description: STRING_SCHEMA,
-          }),
-        ),
-        projects: sectionSchema(
-          strictSchemaObject({
-            name: STRING_SCHEMA,
-            period: STRING_SCHEMA,
-            website: URL_SCHEMA,
-            description: STRING_SCHEMA,
-          }),
-        ),
-        skills: sectionSchema(
-          strictSchemaObject({
-            icon: STRING_SCHEMA,
-            name: STRING_SCHEMA,
-            proficiency: STRING_SCHEMA,
-            level: NUMBER_SCHEMA,
-            keywords: schemaArrayOf(STRING_SCHEMA),
-          }),
-        ),
-        languages: sectionSchema(
-          strictSchemaObject({
-            language: STRING_SCHEMA,
-            fluency: STRING_SCHEMA,
-            level: NUMBER_SCHEMA,
-          }),
-        ),
-        interests: sectionSchema(
-          strictSchemaObject({
-            icon: STRING_SCHEMA,
-            name: STRING_SCHEMA,
-            keywords: schemaArrayOf(STRING_SCHEMA),
-          }),
-        ),
-        awards: sectionSchema(
-          strictSchemaObject({
-            title: STRING_SCHEMA,
-            awarder: STRING_SCHEMA,
-            date: STRING_SCHEMA,
-            website: URL_SCHEMA,
-            description: STRING_SCHEMA,
-          }),
-        ),
-        certifications: sectionSchema(
-          strictSchemaObject({
-            title: STRING_SCHEMA,
-            issuer: STRING_SCHEMA,
-            date: STRING_SCHEMA,
-            website: URL_SCHEMA,
-            description: STRING_SCHEMA,
-          }),
-        ),
-        publications: sectionSchema(
-          strictSchemaObject({
-            title: STRING_SCHEMA,
-            publisher: STRING_SCHEMA,
-            date: STRING_SCHEMA,
-            website: URL_SCHEMA,
-            description: STRING_SCHEMA,
-          }),
-        ),
-        volunteer: sectionSchema(
-          strictSchemaObject({
-            organization: STRING_SCHEMA,
-            location: STRING_SCHEMA,
-            period: STRING_SCHEMA,
-            website: URL_SCHEMA,
-            description: STRING_SCHEMA,
-          }),
-        ),
-        references: sectionSchema(
-          strictSchemaObject({
-            name: STRING_SCHEMA,
-            position: STRING_SCHEMA,
-            website: URL_SCHEMA,
-            phone: STRING_SCHEMA,
-            description: STRING_SCHEMA,
-          }),
-        ),
-      }),
-      customSections: schemaArrayOf(strictSchemaObject({})),
-      metadata: strictSchemaObject({}),
-    },
-    required: [
-      "picture",
-      "basics",
-      "summary",
-      "sections",
-      "customSections",
-      "metadata",
-    ],
-    additionalProperties: false,
-  },
-};
-
 type ResumeImportFileInput = {
   fileName: string;
   mediaType?: string | null;
@@ -265,9 +84,6 @@ const OPENAI_DEFAULT_TIMEOUT_MS = 60_000;
 const OPENROUTER_DEFAULT_TIMEOUT_MS = 90_000;
 const GEMINI_DEFAULT_TIMEOUT_MS = 90_000;
 const LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS = 120_000;
-const CHAT_COMPLETIONS_SUFFIX = "/v1/chat/completions";
-const GLM_CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
-const API_VERSION_SUFFIX = "/v1";
 
 const SUPPORTED_EXTENSION_TO_MEDIA_TYPE: Record<
   string,
@@ -439,34 +255,6 @@ function buildDataUrl(
   dataBase64: string,
 ): string {
   return `data:${mediaType};base64,${dataBase64}`;
-}
-
-function normalizeBaseUrlOrEndpoint(baseUrlOrEndpoint: string): string {
-  return baseUrlOrEndpoint.trim().replace(/\/+$/, "");
-}
-
-function appendVersionedPath(baseUrl: string, path: string): string {
-  if (baseUrl.endsWith(API_VERSION_SUFFIX)) {
-    return joinUrl(baseUrl.slice(0, -API_VERSION_SUFFIX.length), path);
-  }
-  return joinUrl(baseUrl, path);
-}
-
-function resolveChatCompletionsUrl(
-  baseUrlOrEndpoint: string,
-  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio",
-): string {
-  const normalized = normalizeBaseUrlOrEndpoint(baseUrlOrEndpoint);
-  if (
-    normalized.endsWith(CHAT_COMPLETIONS_SUFFIX) ||
-    normalized.endsWith(GLM_CHAT_COMPLETIONS_SUFFIX)
-  ) {
-    return normalized;
-  }
-  if (provider === "glm") {
-    return joinUrl(normalized, GLM_CHAT_COMPLETIONS_SUFFIX);
-  }
-  return appendVersionedPath(normalized, CHAT_COMPLETIONS_SUFFIX);
 }
 
 function buildUserPrompt(): string {
@@ -831,29 +619,6 @@ ${buildUserPrompt()}
 `.trim();
 }
 
-function buildCodexTextExtractPrompt(
-  documentText: string,
-  fileName: string,
-  source: "DOCX" | "PDF",
-): string {
-  const sourceLine =
-    source === "DOCX"
-      ? "The resume file was uploaded as DOCX and converted locally to plain text before extraction."
-      : "The resume file was uploaded as PDF and converted locally to plain text before extraction.";
-  return `
-${sourceLine}
-File name: ${fileName}
-
-Extracted resume text:
-${documentText}
-
-Extract the resume into the provided structured output schema.
-Use empty strings, empty arrays, or empty objects for missing values.
-For rich text descriptions and summaries, use simple HTML tags only: <p>, <ul>, <li>, <strong>, <em>.
-Return normal JSON matching the schema, not JSON serialized inside a string.
-`.trim();
-}
-
 function buildDocumentTextPrompt(
   documentText: string,
   fileName: string,
@@ -950,22 +715,6 @@ function parseImportedResumeJson(content: string): unknown {
       );
     }
   }
-}
-
-function parseCodexResumeImportResponse(content: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(content);
-  } catch (error) {
-    throw upstreamError(
-      `Codex returned malformed resume import JSON. ${error instanceof Error ? error.message : "Unknown parsing error."}`,
-    );
-  }
-
-  if (!asRecord(parsed)) {
-    throw upstreamError("Codex returned an invalid resume import payload.");
-  }
-  return JSON.stringify(parsed);
 }
 
 function filterRequiredItems(items: unknown, requiredField: string): unknown[] {
@@ -1485,129 +1234,9 @@ async function extractWithGemini(args: {
   return text;
 }
 
-function getDefaultChatCompletionsBaseUrl(
-  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio",
-): string {
-  if (provider === "ollama") return "http://localhost:11434";
-  if (provider === "lmstudio") return "http://localhost:1234";
-  if (provider === "glm") return "https://api.z.ai/api/paas/v4";
-  return "https://api.openai.com";
-}
-
-async function extractWithTextChatCompletions(args: {
-  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio";
+async function extractWithConfiguredLlmText(args: {
+  provider: SupportedRuntimeProvider;
   apiKey: string | null;
-  baseUrl: string | null;
-  model: string;
-  mediaType: SupportedImportMediaType;
-  fileName: string;
-  documentText: string;
-  requestId: string | undefined;
-}): Promise<string> {
-  const url = resolveChatCompletionsUrl(
-    args.baseUrl || getDefaultChatCompletionsBaseUrl(args.provider),
-    args.provider,
-  );
-  const response = await fetch(url, {
-    method: "POST",
-    headers: buildHeaders({
-      apiKey: args.apiKey,
-      provider: args.provider,
-    }),
-    body: JSON.stringify({
-      model: args.model,
-      stream: false,
-      messages: [
-        {
-          role: "system",
-          content: SYSTEM_PROMPT,
-        },
-        {
-          role: "user",
-          content: buildDocumentTextPrompt(
-            args.documentText,
-            args.fileName,
-            args.mediaType,
-          ),
-        },
-      ],
-    }),
-    signal: AbortSignal.timeout(LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS),
-  });
-
-  if (!response.ok) {
-    const detail = parseErrorMessage(await getResponseDetail(response));
-    throw new AppError({
-      status: response.status >= 500 ? 502 : 503,
-      message: detail || `${args.provider} returned ${response.status}.`,
-      details: {
-        provider: args.provider,
-        model: args.model,
-        requestId: args.requestId ?? null,
-      },
-    });
-  }
-
-  const payload = await response.json();
-  const text = extractChatCompletionText(payload);
-  if (!text) {
-    throw upstreamError(
-      `${args.provider} returned an empty response for resume import.`,
-    );
-  }
-  return text;
-}
-
-async function extractWithGeminiCli(args: {
-  model: string;
-  mediaType: SupportedImportMediaType;
-  fileName: string;
-  documentText: string;
-  requestId: string | undefined;
-}): Promise<string> {
-  const source: "DOCX" | "PDF" =
-    args.mediaType === "application/pdf" ? "PDF" : "DOCX";
-  const userContent = buildTextExtractPrompt(
-    args.documentText,
-    args.fileName,
-    source,
-  );
-  const client = new GeminiCliClient();
-  try {
-    const { text } = await client.callJson({
-      model: args.model,
-      messages: [
-        { role: "system", content: SYSTEM_PROMPT },
-        { role: "user", content: userContent },
-      ],
-      jsonSchema: DESIGN_RESUME_IMPORT_CLI_JSON_SCHEMA,
-    });
-    if (!text?.trim()) {
-      throw upstreamError(
-        "Gemini CLI returned an empty response for resume import.",
-      );
-    }
-    return text;
-  } catch (error) {
-    if (error instanceof AppError) {
-      throw error;
-    }
-    const message = error instanceof Error ? error.message : String(error);
-    throw upstreamError(
-      truncate(message, 500),
-      args.requestId
-        ? {
-            provider: "gemini_cli",
-            model: args.model,
-            requestId: args.requestId,
-          }
-        : { provider: "gemini_cli", model: args.model },
-    );
-  }
-}
-
-async function extractWithAnthropicText(args: {
-  apiKey: string;
   baseUrl: string | null;
   model: string;
   mediaType: SupportedImportMediaType;
@@ -1617,14 +1246,14 @@ async function extractWithAnthropicText(args: {
 }): Promise<string> {
   const startedAt = Date.now();
   const llm = new LlmService({
-    provider: "anthropic",
+    provider: args.provider,
     baseUrl: args.baseUrl,
     apiKey: args.apiKey,
   });
 
-  logger.info("Anthropic resume import text extraction started", {
+  logger.info("Design resume text import extraction started", {
     requestId: args.requestId ?? null,
-    provider: "anthropic",
+    provider: args.provider,
     model: args.model,
     fileName: args.fileName,
     mediaType: args.mediaType,
@@ -1653,18 +1282,18 @@ async function extractWithAnthropicText(args: {
       truncate(result.error, 500),
       args.requestId
         ? {
-            provider: "anthropic",
+            provider: args.provider,
             model: args.model,
             requestId: args.requestId,
           }
-        : { provider: "anthropic", model: args.model },
+        : { provider: args.provider, model: args.model },
     );
   }
 
   const text = JSON.stringify(result.data);
-  logger.info("Anthropic resume import text extraction completed", {
+  logger.info("Design resume text import extraction completed", {
     requestId: args.requestId ?? null,
-    provider: "anthropic",
+    provider: args.provider,
     model: args.model,
     fileName: args.fileName,
     mediaType: args.mediaType,
@@ -1672,74 +1301,6 @@ async function extractWithAnthropicText(args: {
     resumeJsonChars: text.length,
   });
   return text;
-}
-
-async function extractWithCodex(args: {
-  model: string;
-  mediaType: SupportedImportMediaType;
-  fileName: string;
-  documentText: string;
-  requestId: string | undefined;
-}): Promise<string> {
-  const source: "DOCX" | "PDF" =
-    args.mediaType === "application/pdf" ? "PDF" : "DOCX";
-  const startedAt = Date.now();
-  const userContent = buildCodexTextExtractPrompt(
-    args.documentText,
-    args.fileName,
-    source,
-  );
-  const client = new CodexClient();
-  try {
-    logger.info("Codex resume import extraction started", {
-      requestId: args.requestId ?? null,
-      provider: "codex",
-      model: args.model,
-      fileName: args.fileName,
-      mediaType: args.mediaType,
-      documentTextChars: args.documentText.length,
-    });
-    const { text } = await client.callJson({
-      model: args.model,
-      messages: [
-        { role: "system", content: SYSTEM_PROMPT },
-        { role: "user", content: userContent },
-      ],
-      jsonSchema: DESIGN_RESUME_IMPORT_CODEX_JSON_SCHEMA,
-    });
-    if (!text?.trim()) {
-      throw upstreamError(
-        "Codex returned an empty response for resume import.",
-      );
-    }
-    const parsedText = parseCodexResumeImportResponse(text);
-    logger.info("Codex resume import extraction completed", {
-      requestId: args.requestId ?? null,
-      provider: "codex",
-      model: args.model,
-      fileName: args.fileName,
-      mediaType: args.mediaType,
-      durationMs: elapsedMs(startedAt),
-      responseChars: text.length,
-      resumeJsonChars: parsedText.length,
-    });
-    return parsedText;
-  } catch (error) {
-    if (error instanceof AppError) {
-      throw error;
-    }
-    const message = error instanceof Error ? error.message : String(error);
-    throw upstreamError(
-      truncate(message, 500),
-      args.requestId
-        ? {
-            provider: "codex",
-            model: args.model,
-            requestId: args.requestId,
-          }
-        : { provider: "codex", model: args.model },
-    );
-  }
 }
 
 async function extractResumeFromProvider(args: {
@@ -1753,45 +1314,11 @@ async function extractResumeFromProvider(args: {
   documentText?: string | null;
   requestId: string | undefined;
 }): Promise<string> {
-  if (args.provider === "gemini_cli") {
-    const text = args.documentText?.trim();
-    if (!text) {
-      throw badRequest(
-        "Gemini CLI resume import requires plain-text resume content (DOCX or extracted PDF text).",
-      );
-    }
-    return extractWithGeminiCli({
-      model: args.model,
-      mediaType: args.mediaType,
-      fileName: args.fileName,
-      documentText: text,
-      requestId: args.requestId,
-    });
-  }
-  if (args.provider === "codex") {
-    const text = args.documentText?.trim();
-    if (!text) {
-      throw badRequest(
-        "Codex resume import requires plain-text resume content (DOCX or extracted PDF text).",
-      );
-    }
-    return extractWithCodex({
-      model: args.model,
-      mediaType: args.mediaType,
-      fileName: args.fileName,
-      documentText: text,
-      requestId: args.requestId,
-    });
-  }
-  if (args.provider === "anthropic") {
-    const text = args.documentText?.trim();
-    if (!text) {
-      throw badRequest(
-        "Anthropic resume import requires plain-text resume content (DOCX or extracted PDF text).",
-      );
-    }
-    return extractWithAnthropicText({
-      apiKey: args.apiKey,
+  const text = args.documentText?.trim();
+  if (text) {
+    return extractWithConfiguredLlmText({
+      provider: args.provider,
+      apiKey: args.apiKey || null,
       baseUrl: args.baseUrl,
       model: args.model,
       mediaType: args.mediaType,
@@ -1806,30 +1333,10 @@ async function extractResumeFromProvider(args: {
   if (args.provider === "openrouter") {
     return extractWithOpenRouter(args);
   }
-  if (
-    args.provider === "openai_compatible" ||
-    args.provider === "glm" ||
-    args.provider === "ollama" ||
-    args.provider === "lmstudio"
-  ) {
-    const text = args.documentText?.trim();
-    if (!text) {
-      throw badRequest(
-        `${args.provider} resume import requires plain-text resume content (DOCX or extracted PDF text).`,
-      );
-    }
-    return extractWithTextChatCompletions({
-      provider: args.provider,
-      apiKey: args.apiKey || null,
-      baseUrl: args.baseUrl,
-      model: args.model,
-      mediaType: args.mediaType,
-      fileName: args.fileName,
-      documentText: text,
-      requestId: args.requestId,
-    });
-  }
-  return extractWithGemini(args);
+  if (args.provider === "gemini") return extractWithGemini(args);
+  throw badRequest(
+    `${args.provider} resume import requires plain-text resume content (DOCX or extracted PDF text).`,
+  );
 }
 
 export async function importDesignResumeFromFile(

--- a/orchestrator/src/server/services/llm/providers/openai-compatible.ts
+++ b/orchestrator/src/server/services/llm/providers/openai-compatible.ts
@@ -45,7 +45,7 @@ function resolveModelsUrl(baseUrlOrEndpoint: string): string {
 export const openAiCompatibleStrategy = createProviderStrategy({
   provider: "openai_compatible",
   defaultBaseUrl: "https://api.openai.com",
-  requiresApiKey: true,
+  requiresApiKey: false,
   modes: ["json_schema", "json_object", "text", "none"],
   validationPaths: ["/v1/models"],
   getValidationUrls: ({ baseUrl }) => [resolveModelsUrl(baseUrl)],


### PR DESCRIPTION
## Summary
- Add Anthropic as a supported resume-import provider with local text extraction fallback for PDFs and DOCX files
- Route plain-text imports through the Anthropic LLM service and keep unsupported file cases clearly reported
- Update settings docs and add unit coverage for PDF import via Anthropic

## Testing
- Added unit test coverage for Anthropic PDF import through extracted text
- Not run (not requested)