### PR TITLE
feat: Make timeouts configurable through env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,16 @@ MODEL=google/gemini-3-flash-preview
 # GEMINI_CLI_TRUST_WORKSPACE=true
 # GEMINI_CLI_REQUEST_TIMEOUT_MS=120000
 # GEMINI_CLI_VALIDATION_TIMEOUT_MS=60000
+# LLM import timeouts (resume upload during onboarding). Increase for slow local models.
+# LLM_IMPORT_OPENAI_TIMEOUT_MS=60000
+# LLM_IMPORT_OPENROUTER_TIMEOUT_MS=90000
+# LLM_IMPORT_GEMINI_TIMEOUT_MS=90000
+# LLM_IMPORT_LOCAL_TIMEOUT_MS=120000
+# Ghostwriter capability check timeout.
+# LLM_GHOSTWRITER_CAPABILITY_TIMEOUT_MS=2500
+# Codex login timeouts.
+# CODEX_APP_SERVER_DEVICE_AUTH_TIMEOUT_MS=15000
+# CODEX_APP_SERVER_LOGOUT_TIMEOUT_MS=10000
 
 # Optional: Authentication for protected app and API access
 # The app is fully unauthenticated if this isn't set, which is the default.

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -259,10 +259,23 @@ type ResumeImportFileInput = {
 };
 
 const MAX_IMPORT_FILE_BYTES = 10 * 1024 * 1024;
-const OPENAI_DEFAULT_TIMEOUT_MS = 60_000;
-const OPENROUTER_DEFAULT_TIMEOUT_MS = 90_000;
-const GEMINI_DEFAULT_TIMEOUT_MS = 90_000;
-const LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS = 120_000;
+
+function getPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+const OPENAI_DEFAULT_TIMEOUT_MS = () =>
+  getPositiveIntEnv("LLM_IMPORT_OPENAI_TIMEOUT_MS", 60_000);
+const OPENROUTER_DEFAULT_TIMEOUT_MS = () =>
+  getPositiveIntEnv("LLM_IMPORT_OPENROUTER_TIMEOUT_MS", 90_000);
+const GEMINI_DEFAULT_TIMEOUT_MS = () =>
+  getPositiveIntEnv("LLM_IMPORT_GEMINI_TIMEOUT_MS", 90_000);
+const LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS = () =>
+  getPositiveIntEnv("LLM_IMPORT_LOCAL_TIMEOUT_MS", 120_000);
 const CHAT_COMPLETIONS_SUFFIX = "/v1/chat/completions";
 const GLM_CHAT_COMPLETIONS_SUFFIX = "/chat/completions";
 const API_VERSION_SUFFIX = "/v1";
@@ -1258,7 +1271,7 @@ async function extractWithOpenAi(args: {
         },
       ],
     }),
-    signal: AbortSignal.timeout(OPENAI_DEFAULT_TIMEOUT_MS),
+    signal: AbortSignal.timeout(OPENAI_DEFAULT_TIMEOUT_MS()),
   });
 
   if (!response.ok) {
@@ -1356,7 +1369,7 @@ async function extractWithOpenRouter(args: {
             }
           : {}),
       }),
-      signal: AbortSignal.timeout(OPENROUTER_DEFAULT_TIMEOUT_MS),
+      signal: AbortSignal.timeout(OPENROUTER_DEFAULT_TIMEOUT_MS()),
     });
 
     if (!response.ok) {
@@ -1454,7 +1467,7 @@ async function extractWithGemini(args: {
         responseMimeType: "application/json",
       },
     }),
-    signal: AbortSignal.timeout(GEMINI_DEFAULT_TIMEOUT_MS),
+    signal: AbortSignal.timeout(GEMINI_DEFAULT_TIMEOUT_MS()),
   });
 
   if (!response.ok) {
@@ -1525,7 +1538,7 @@ async function extractWithTextChatCompletions(args: {
         },
       ],
     }),
-    signal: AbortSignal.timeout(LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS),
+    signal: AbortSignal.timeout(LOCAL_CHAT_COMPLETIONS_TIMEOUT_MS()),
   });
 
   if (!response.ok) {

--- a/orchestrator/src/server/services/ghostwriter.ts
+++ b/orchestrator/src/server/services/ghostwriter.ts
@@ -50,7 +50,17 @@ type LlmRuntimeSettings = {
 };
 
 const abortControllers = new Map<string, AbortController>();
-const OPENROUTER_CAPABILITY_TIMEOUT_MS = 2500;
+
+function getPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+const getCapabilityTimeoutMs = () =>
+  getPositiveIntEnv("LLM_GHOSTWRITER_CAPABILITY_TIMEOUT_MS", 2500);
 const OPENROUTER_CAPABILITY_CACHE_TTL_MS = 5 * 60 * 1000;
 const openRouterImageCapabilityCache = new Map<
   string,
@@ -224,7 +234,7 @@ async function getOpenRouterImageCapabilityReason(
   const controller = new AbortController();
   const timeout = setTimeout(
     () => controller.abort(),
-    OPENROUTER_CAPABILITY_TIMEOUT_MS,
+    getCapabilityTimeoutMs(),
   );
 
   try {

--- a/orchestrator/src/server/services/llm/codex/login.ts
+++ b/orchestrator/src/server/services/llm/codex/login.ts
@@ -2,8 +2,18 @@ import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
 import { logger } from "@infra/logger";
 import { truncate } from "../utils/string";
 
-const DEVICE_AUTH_TIMEOUT_MS = 15_000;
-const LOGOUT_TIMEOUT_MS = 10_000;
+function getPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+const DEVICE_AUTH_TIMEOUT_MS = () =>
+  getPositiveIntEnv("CODEX_APP_SERVER_DEVICE_AUTH_TIMEOUT_MS", 15_000);
+const LOGOUT_TIMEOUT_MS = () =>
+  getPositiveIntEnv("CODEX_APP_SERVER_LOGOUT_TIMEOUT_MS", 10_000);
 const MAX_BUFFERED_LINES = 80;
 const DEVICE_CODE_REGEX = /\b[A-Z0-9]{4,}-[A-Z0-9]{4,}\b/;
 const URL_REGEX = /(https?:\/\/[^\s]+)/i;
@@ -176,7 +186,7 @@ async function waitForDeviceCode(
       stopSessionProcess(session);
       cleanup();
       reject(new Error(session.message));
-    }, DEVICE_AUTH_TIMEOUT_MS);
+    }, DEVICE_AUTH_TIMEOUT_MS());
 
     const cleanup = () => {
       proc.stdout.off("data", onStdout);
@@ -379,7 +389,7 @@ export async function disconnectCodexAuth(): Promise<CodexDeviceAuthSnapshot> {
     const timer = setTimeout(() => {
       proc.kill("SIGTERM");
       reject(new Error("Timed out while disconnecting Codex."));
-    }, LOGOUT_TIMEOUT_MS);
+    }, LOGOUT_TIMEOUT_MS());
 
     proc.stdout.on("data", appendOutput);
     proc.stderr.on("data", appendOutput);


### PR DESCRIPTION
### Summary

Makes LLM request timeouts during onboarding resume data extraction and ghostwriter sessions configurable. This is especially useful for local LLM inference with particularly long resumes (related to #642)