### PR TITLE
Handle 'Expired Job' case in hiring cafe implementation

### DIFF
--- a/extractors/hiringcafe/src/run.ts
+++ b/extractors/hiringcafe/src/run.ts
@@ -333,6 +333,10 @@ function parseNextData(html: string, challengeUrl = BASE_URL): unknown {
   }
 }
 
+function isExpiredHiringCafeJobPage(html: string): boolean {
+  return /<title[^>]*>\s*HiringCafe\s*-\s*Expired Job\s*<\/title>/i.test(html);
+}
+
 export function parseHiringCafeSsrPage(html: string): HiringCafeSsrPage {
   const data = parseNextData(html);
 
@@ -360,6 +364,8 @@ export function parseHiringCafeJobDetailPage(
   html: string,
   challengeUrl = BASE_URL,
 ): HiringCafeRawJob | null {
+  if (isExpiredHiringCafeJobPage(html)) return null;
+
   const data = parseNextData(html, challengeUrl);
 
   const props = asRecord(asRecord(data)?.props);

--- a/extractors/hiringcafe/tests/run.test.ts
+++ b/extractors/hiringcafe/tests/run.test.ts
@@ -70,6 +70,22 @@ function createJobDetailHtml(job: unknown): string {
   `;
 }
 
+function createExpiredJobDetailHtml(): string {
+  return `
+    <!doctype html>
+    <html>
+      <head>
+        <title>HiringCafe - Expired Job</title>
+      </head>
+      <body>
+        <h1>Expired Job</h1>
+        <p>We're sorry, but this job has expired.</p>
+        <script>window.__hcAsset = "challenge-platform";</script>
+      </body>
+    </html>
+  `;
+}
+
 function createRawJob(overrides: Record<string, unknown> = {}) {
   return {
     original_source_id: "job-1",
@@ -123,6 +139,12 @@ describe("Hiring Cafe SSR parser", () => {
         description: "<p>Full job description.</p>",
       }),
     });
+  });
+
+  it("returns null for an expired detail page", () => {
+    expect(
+      parseHiringCafeJobDetailPage(createExpiredJobDetailHtml()),
+    ).toBeNull();
   });
 
   it("builds the public search URL with url-encoded JSON state", () => {
@@ -240,7 +262,7 @@ describe("runHiringCafe", () => {
     const fetchMock = vi.fn((url: string) => {
       if (url === "https://hiring.cafe/job/req-1") {
         return Promise.resolve(
-          createTextResponse("<html>cloudflare challenge-platform</html>"),
+          createTextResponse("<html>challenges.cloudflare.com</html>"),
         );
       }
 
@@ -258,6 +280,42 @@ describe("runHiringCafe", () => {
       success: false,
       challengeRequired: "https://hiring.cafe/job/req-1",
     });
+  });
+
+  it("falls back to the search hit when enrichment finds an expired job", async () => {
+    const searchHit = createRawJob({
+      requisition_id: "req-1",
+      job_information: {
+        title: "Web Developer",
+      },
+    });
+    const fetchMock = vi.fn((url: string) => {
+      if (url === "https://hiring.cafe/job/req-1") {
+        return Promise.resolve(
+          createTextResponse(createExpiredJobDetailHtml()),
+        );
+      }
+
+      return Promise.resolve(createTextResponse(createSearchHtml([searchHit])));
+    });
+
+    const result = await runHiringCafe({
+      searchTerms: ["web developer"],
+      country: "worldwide",
+      maxJobsPerTerm: 1,
+      fetchImpl: fetchMock as typeof fetch,
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      jobs: [
+        expect.objectContaining({
+          sourceJobId: "job-1",
+          title: "Web Developer",
+        }),
+      ],
+    });
+    expect(result.challengeRequired).toBeUndefined();
   });
 
   it("serializes locality search state for strict city filters", async () => {


### PR DESCRIPTION
The issue was that the internal regex for detecting a cloudflare challenge was too wide. it'd think "Job Expired" is a challenge, open the page, realise it's not a challenge, and then come back with no challenge resolved. A false alarm for challenge. 

so the fix is just to notice an expired page, and disregard that job

Closes #645 