### PR TITLE
Increase search cities setting limit and surface save failures

### DIFF
--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -1057,6 +1057,37 @@ describe("OrchestratorPage", () => {
     setIntervalSpy.mockRestore();
   });
 
+  it("shows an error when automatic settings fail to save", async () => {
+    window.matchMedia = createMatchMedia(
+      true,
+    ) as unknown as typeof window.matchMedia;
+    vi.mocked(api.updateSettings).mockRejectedValueOnce(
+      new Error("Search cities must be 3000 characters or fewer."),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/ready"]}>
+        <Routes>
+          <Route path="/jobs/:tab" element={<OrchestratorPage />} />
+          <Route path="/jobs/:tab/:jobId" element={<OrchestratorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    openAutomaticRunComposer();
+    fireEvent.click(screen.getByTestId("run-automatic"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Search cities must be 3000 characters or fewer.",
+      );
+    });
+    expect(api.runPipeline).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole("heading", { name: "Something went wrong" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("swaps the dashboard for the full-screen search composer", async () => {
     window.matchMedia = createMatchMedia(
       true,

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
@@ -566,6 +566,8 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
         ...values,
         watchlistSelectedSourceIds: [...selectedWatchlistSourceIds],
       });
+    } catch (error) {
+      showErrorToast(error, "Failed to start search");
     } finally {
       setIsSaving(false);
     }

--- a/orchestrator/src/client/pages/orchestrator/usePipelineControls.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineControls.ts
@@ -194,33 +194,39 @@ export function usePipelineControls(
         searchTerms: values.searchTerms,
         sources: compatibleSources,
       });
-      const searchCities = serializeCityLocationsSetting(values.cityLocations);
-      await api.updateSettings({
-        searchTerms: values.searchTerms,
-        workplaceTypes: values.workplaceTypes,
-        locationSearchScope: values.searchScope,
-        locationMatchStrictness: values.matchStrictness,
-        jobspyResultsWanted: limits.jobspyResultsWanted,
-        gradcrackerMaxJobsPerTerm: limits.gradcrackerMaxJobsPerTerm,
-        ukvisajobsMaxJobs: limits.ukvisajobsMaxJobs,
-        adzunaMaxJobsPerTerm: limits.adzunaMaxJobsPerTerm,
-        startupjobsMaxJobsPerTerm: limits.startupjobsMaxJobsPerTerm,
-        jobindexMaxJobsPerTerm: limits.jobindexMaxJobsPerTerm,
-        seekMaxJobsPerTerm: limits.seekMaxJobsPerTerm,
-        naukriMaxJobsPerTerm: limits.naukriMaxJobsPerTerm,
-        jobspyCountryIndeed: values.country,
-        searchCities,
-      });
-      await refreshSettings();
-      await startPipelineRun({
-        ...values,
-        sources: compatibleSources,
-        topN: values.topN,
-        minSuitabilityScore: values.minSuitabilityScore,
-        watchlistSelectedSourceIds:
-          values.watchlistSelectedSourceIds ?? watchlistSelectedSourceIds,
-      });
-      setIsRunModeModalOpen(false);
+      try {
+        const searchCities = serializeCityLocationsSetting(
+          values.cityLocations,
+        );
+        await api.updateSettings({
+          searchTerms: values.searchTerms,
+          workplaceTypes: values.workplaceTypes,
+          locationSearchScope: values.searchScope,
+          locationMatchStrictness: values.matchStrictness,
+          jobspyResultsWanted: limits.jobspyResultsWanted,
+          gradcrackerMaxJobsPerTerm: limits.gradcrackerMaxJobsPerTerm,
+          ukvisajobsMaxJobs: limits.ukvisajobsMaxJobs,
+          adzunaMaxJobsPerTerm: limits.adzunaMaxJobsPerTerm,
+          startupjobsMaxJobsPerTerm: limits.startupjobsMaxJobsPerTerm,
+          jobindexMaxJobsPerTerm: limits.jobindexMaxJobsPerTerm,
+          seekMaxJobsPerTerm: limits.seekMaxJobsPerTerm,
+          naukriMaxJobsPerTerm: limits.naukriMaxJobsPerTerm,
+          jobspyCountryIndeed: values.country,
+          searchCities,
+        });
+        await refreshSettings();
+        await startPipelineRun({
+          ...values,
+          sources: compatibleSources,
+          topN: values.topN,
+          minSuitabilityScore: values.minSuitabilityScore,
+          watchlistSelectedSourceIds:
+            values.watchlistSelectedSourceIds ?? watchlistSelectedSourceIds,
+        });
+        setIsRunModeModalOpen(false);
+      } catch (error) {
+        showErrorToast(error, "Failed to start search");
+      }
     },
     [
       pipelineSources,

--- a/shared/src/settings-registry.ts
+++ b/shared/src/settings-registry.ts
@@ -578,7 +578,7 @@ export const settingsRegistry = {
   },
   searchCities: {
     kind: "typed" as const,
-    schema: z.string().trim().max(100),
+    schema: z.string().trim().max(3000),
     default: (): string =>
       typeof process !== "undefined"
         ? process.env.SEARCH_CITIES || process.env.JOBSPY_LOCATION || ""


### PR DESCRIPTION
## Summary
- Raise the `searchCities` setting cap from 100 to 3000 characters to support longer city lists.
- Show a toast when automatic settings saves fail instead of falling through to a generic error state.
- Add coverage for the failed-save path in the orchestrator page tests.

## Testing
- Updated client test coverage for the automatic run flow failure case.
- Not run (not requested).