### PR TITLE
fix(llm): strip unsupported JSON Schema keywords for Anthropic structured output (fixes #650)

### DIFF
--- a/orchestrator/src/server/services/llm/providers/anthropic.ts
+++ b/orchestrator/src/server/services/llm/providers/anthropic.ts
@@ -6,6 +6,79 @@ import { createProviderStrategy } from "./factory";
 
 const DEFAULT_MAX_TOKENS = 4096;
 
+/**
+ * Anthropic's structured output (`output_config.format.schema`) only supports a
+ * subset of JSON Schema. Validation/constraint keywords such as `maxItems`
+ * cause a 400 (e.g. "For 'array' type, property 'maxItems' is not supported").
+ * Schemas in this codebase are authored to work across providers (OpenAI /
+ * OpenRouter accept these keywords), so strip the unsupported keywords before
+ * sending to Anthropic instead of maintaining a separate schema per provider.
+ */
+const ANTHROPIC_UNSUPPORTED_SCHEMA_KEYWORDS = new Set([
+  "minItems",
+  "maxItems",
+  "uniqueItems",
+  "minLength",
+  "maxLength",
+  "pattern",
+  "format",
+  "minimum",
+  "maximum",
+  "exclusiveMinimum",
+  "exclusiveMaximum",
+  "multipleOf",
+  "minProperties",
+  "maxProperties",
+]);
+
+// Keys whose values are maps of (arbitrary) names to nested schemas. Their keys
+// must be preserved verbatim and only their values sanitized, so a property
+// legitimately named e.g. "format" or "pattern" is never dropped.
+const SCHEMA_NAME_MAP_KEYS = new Set([
+  "properties",
+  "patternProperties",
+  "$defs",
+  "definitions",
+]);
+
+function sanitizeAnthropicSchema(node: unknown): unknown {
+  if (Array.isArray(node)) {
+    return node.map(sanitizeAnthropicSchema);
+  }
+  if (!node || typeof node !== "object") {
+    return node;
+  }
+
+  const source = node as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(source)) {
+    if (ANTHROPIC_UNSUPPORTED_SCHEMA_KEYWORDS.has(key)) {
+      continue;
+    }
+
+    if (
+      SCHEMA_NAME_MAP_KEYS.has(key) &&
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value)
+    ) {
+      const nested: Record<string, unknown> = {};
+      for (const [name, schema] of Object.entries(
+        value as Record<string, unknown>,
+      )) {
+        nested[name] = sanitizeAnthropicSchema(schema);
+      }
+      result[key] = nested;
+      continue;
+    }
+
+    result[key] = sanitizeAnthropicSchema(value);
+  }
+
+  return result;
+}
+
 type AnthropicContentBlock =
   | { type: "text"; text: string }
   | {
@@ -39,7 +112,7 @@ export const anthropicStrategy = createProviderStrategy({
       body.output_config = {
         format: {
           type: "json_schema",
-          schema: jsonSchema.schema,
+          schema: sanitizeAnthropicSchema(jsonSchema.schema),
         },
       };
     } else if (mode === "json_object") {

--- a/orchestrator/src/server/services/llm/providers/providers.test.ts
+++ b/orchestrator/src/server/services/llm/providers/providers.test.ts
@@ -385,4 +385,54 @@ describe("provider adapters", () => {
       },
     });
   });
+
+  it("strips JSON Schema keywords Anthropic does not support", () => {
+    const request = anthropicStrategy.buildRequest({
+      mode: "json_schema",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "sk-ant",
+      model: "claude-sonnet-4-6",
+      messages: [{ role: "user", content: "hi" }],
+      jsonSchema: {
+        name: "job_brief",
+        schema: {
+          type: "object",
+          properties: {
+            they_want: {
+              type: "array",
+              maxItems: 6,
+              minItems: 1,
+              items: { type: "string", maxLength: 200 },
+            },
+            // A property legitimately named like a stripped keyword must survive.
+            format: { type: "string" },
+          },
+          required: ["they_want"],
+          additionalProperties: false,
+        },
+      },
+    });
+
+    const sentSchema = (
+      request.body as {
+        output_config: { format: { schema: Record<string, unknown> } };
+      }
+    ).output_config.format.schema;
+    const properties = sentSchema.properties as Record<
+      string,
+      Record<string, unknown>
+    >;
+
+    expect(properties.they_want).not.toHaveProperty("maxItems");
+    expect(properties.they_want).not.toHaveProperty("minItems");
+    expect(properties.they_want.items).not.toHaveProperty("maxLength");
+    // The nested array type and its items are still present.
+    expect(properties.they_want).toMatchObject({
+      type: "array",
+      items: { type: "string" },
+    });
+    // A property whose name collides with a stripped keyword is preserved.
+    expect(properties).toHaveProperty("format");
+    expect(properties.format).toMatchObject({ type: "string" });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #650.

Job-brief generation (and any Anthropic structured-output call) fails with:

```
LLM API error: 400 - output_config.format.schema: For 'array' type, property 'maxItems' is not supported
```

## Root cause

`orchestrator/src/server/services/job-brief.ts` builds its schema with a `stringList` helper that sets `maxItems` on every array. That schema is passed straight through to Anthropic in `orchestrator/src/server/services/llm/providers/anthropic.ts` (`output_config.format.schema`). Anthropic's structured output only supports a subset of JSON Schema and rejects validation keywords like `maxItems`, so the request 400s and the brief never generates (UI stalls in a partial phase).

The schemas are intentionally authored to work across providers (OpenAI / OpenRouter accept `maxItems`), so the right place to fix this is the Anthropic provider rather than each schema.

## Change

- Add `sanitizeAnthropicSchema` in the Anthropic provider that recursively strips JSON-Schema keywords Anthropic does not support (`maxItems`, `minItems`, `uniqueItems`, `minLength`, `maxLength`, `pattern`, `format`, `minimum`, `maximum`, `exclusiveMinimum`, `exclusiveMaximum`, `multipleOf`, `minProperties`, `maxProperties`).
- Property **names** that happen to collide with those keywords (e.g. a field literally named `format`) are preserved â€” only schema-level keywords are stripped.
- Applied to the `json_schema` request path before building `output_config.format.schema`.

## Tests

- Added a provider test asserting `maxItems` / `minItems` / `maxLength` are stripped, the array `type`/`items` survive, and a property named `format` is preserved.
- Existing Anthropic request test still passes (clean schemas are unaffected).

## Verification

- `biome check` on changed files: clean
- `npm run check:types:shared` and `npm --workspace orchestrator run check:types`: pass
- `npm --workspace orchestrator run build:client`: pass
- Provider test suite: pass (9/9)

Note: two unrelated `formatSalarySummary` tests fail only on my local machine due to an `en-IN` locale producing lakh digit grouping (`1,00,000`); they are independent of this change and unaffected by it.

## Scope note

This resolves the reported failure (async schema rejection). It does not change extractor process isolation or any unrelated behavior.
