### PR TITLE
Add greenhouse support

### DIFF
--- a/career-boards/greenhouse/package.json
+++ b/career-boards/greenhouse/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@career-boards/greenhouse",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./greenhouse-url": "./src/greenhouse-url.ts",
+    "./resolve-greenhouse-source": "./src/resolve-greenhouse-source.ts",
+    "./get-jobs-from-board": "./src/get-jobs-from-board.ts",
+    "./get-job-details": "./src/get-job-details.ts"
+  }
+}

--- a/career-boards/greenhouse/src/get-job-details.test.ts
+++ b/career-boards/greenhouse/src/get-job-details.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeHtmlEntities,
+  getJobDetails,
+  normalizeGreenhouseJobDetails,
+} from "./get-job-details";
+
+describe("decodeHtmlEntities", () => {
+  it("decodes entity-encoded HTML in a single pass", () => {
+    expect(decodeHtmlEntities("&lt;p&gt;Hi&lt;/p&gt;")).toBe("<p>Hi</p>");
+  });
+
+  it("decodes numeric and hex entities", () => {
+    expect(decodeHtmlEntities("A&#38;B &#x2019;")).toBe("A&B ’");
+  });
+
+  it("preserves double-encoded inner entities as valid HTML", () => {
+    // Greenhouse stores `<p>A &amp; B</p>` as `&lt;p&gt;A &amp;amp; B&lt;/p&gt;`.
+    expect(decodeHtmlEntities("&lt;p&gt;A &amp;amp; B&lt;/p&gt;")).toBe(
+      "<p>A &amp; B</p>",
+    );
+  });
+
+  it("leaves unknown entities untouched", () => {
+    expect(decodeHtmlEntities("&notreal;")).toBe("&notreal;");
+  });
+});
+
+describe("normalizeGreenhouseJobDetails", () => {
+  const ref = {
+    token: "epicgames",
+    jobId: "6103058004",
+    detailUrl:
+      "https://boards-api.greenhouse.io/v1/boards/epicgames/jobs/6103058004",
+  };
+
+  it("normalizes a detail response with decoded description", () => {
+    const details = normalizeGreenhouseJobDetails(
+      {
+        id: 6103058004,
+        title: "Animation Systems Programmer",
+        absolute_url: "https://epicgames.com/careers/jobs/6103058004",
+        location: { name: "Larkspur,California" },
+        content: "&lt;p&gt;Build &amp;amp; ship things.&lt;/p&gt;",
+        company_name: "Epic Games",
+        departments: [{ name: "Engineering" }],
+        first_published: "2026-06-01T00:00:00-04:00",
+      },
+      ref,
+    );
+
+    expect(details).toMatchObject({
+      source: "greenhouse",
+      externalId: "6103058004",
+      title: "Animation Systems Programmer",
+      jobUrl: "https://epicgames.com/careers/jobs/6103058004",
+      locationText: "Larkspur, California",
+      company: "Epic Games",
+      department: "Engineering",
+      jobDescriptionHtml: "<p>Build &amp; ship things.</p>",
+    });
+    expect(details.jobDescriptionText).toBe("Build & ship things.");
+  });
+
+  it("throws when content is missing", () => {
+    expect(() => normalizeGreenhouseJobDetails({ title: "X" }, ref)).toThrow(
+      /missing required field content/,
+    );
+  });
+});
+
+describe("getJobDetails", () => {
+  it("fetches from the board API job detail endpoint", async () => {
+    const details = await getJobDetails({
+      jobRef:
+        "https://boards-api.greenhouse.io/v1/boards/epicgames/jobs/6103058004",
+      fetchImpl: async (url) => {
+        expect(String(url)).toBe(
+          "https://boards-api.greenhouse.io/v1/boards/epicgames/jobs/6103058004",
+        );
+        return new Response(
+          JSON.stringify({
+            id: 6103058004,
+            title: "Engineer",
+            content: "&lt;p&gt;Role&lt;/p&gt;",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    expect(details.job.title).toBe("Engineer");
+    expect(details.job.jobDescriptionHtml).toBe("<p>Role</p>");
+  });
+});

--- a/career-boards/greenhouse/src/get-job-details.ts
+++ b/career-boards/greenhouse/src/get-job-details.ts
@@ -1,0 +1,195 @@
+import { formatLocation } from "./get-jobs-from-board";
+import {
+  GREENHOUSE_DEFAULT_USER_AGENT,
+  greenhouseJobApiUrl,
+  parseGreenhouseJobApiUrl,
+} from "./greenhouse-url";
+
+export interface GreenhouseDetailResponse {
+  id?: number | string;
+  title?: string;
+  absolute_url?: string;
+  location?: { name?: string | null } | null;
+  content?: string;
+  updated_at?: string | null;
+  first_published?: string | null;
+  company_name?: string | null;
+  departments?: Array<{ name?: string | null }> | null;
+  [key: string]: unknown;
+}
+
+export interface NormalizedGreenhouseJobDetails {
+  source: "greenhouse";
+  externalId: string;
+  title: string;
+  jobUrl: string;
+  jobApiUrl: string;
+  locationText?: string;
+  postedOn?: string;
+  company?: string;
+  department?: string;
+  jobDescriptionHtml: string;
+  jobDescriptionText: string;
+  raw: GreenhouseDetailResponse;
+}
+
+export interface FetchGreenhouseJobDetailsOptions {
+  /** A Greenhouse board job API URL: `.../v1/boards/<token>/jobs/<id>`. */
+  jobRef: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+  userAgent?: string;
+}
+
+export async function getJobDetails(
+  options: FetchGreenhouseJobDetailsOptions,
+): Promise<{ job: NormalizedGreenhouseJobDetails }> {
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  if (!fetchFn) {
+    throw new Error(
+      "No fetch implementation available. Pass fetchImpl or use Node 18+.",
+    );
+  }
+
+  const { token, jobId } = parseGreenhouseJobApiUrl(options.jobRef);
+  const detailUrl = greenhouseJobApiUrl(token, jobId);
+  const response = await fetchGreenhouseJson<GreenhouseDetailResponse>(
+    fetchFn,
+    {
+      url: detailUrl,
+      signal: options.signal,
+      headers: {
+        accept: "application/json",
+        "user-agent": options.userAgent ?? GREENHOUSE_DEFAULT_USER_AGENT,
+        ...options.headers,
+      },
+    },
+  );
+
+  return {
+    job: normalizeGreenhouseJobDetails(response, { token, jobId, detailUrl }),
+  };
+}
+
+export function normalizeGreenhouseJobDetails(
+  response: GreenhouseDetailResponse,
+  ref: { token: string; jobId: string; detailUrl: string },
+): NormalizedGreenhouseJobDetails {
+  const title = requiredString(response.title, "title", ref.detailUrl);
+  // Greenhouse returns `content` as an HTML-entity-encoded string.
+  const decodedHtml = decodeHtmlEntities(
+    requiredString(response.content, "content", ref.detailUrl),
+  );
+
+  return {
+    source: "greenhouse",
+    externalId: ref.jobId,
+    title,
+    jobUrl: optionalString(response.absolute_url) ?? ref.detailUrl,
+    jobApiUrl: ref.detailUrl,
+    locationText: formatLocation(response.location?.name),
+    postedOn:
+      optionalString(response.first_published) ??
+      optionalString(response.updated_at),
+    company: optionalString(response.company_name),
+    department: optionalString(response.departments?.[0]?.name),
+    jobDescriptionHtml: decodedHtml,
+    jobDescriptionText: htmlToText(decodedHtml),
+    raw: response,
+  };
+}
+
+/**
+ * Decodes HTML entities in a single pass. Greenhouse double-encodes job
+ * `content` (e.g. `&lt;p&gt;` for `<p>`), so one decode pass restores the
+ * intended HTML while leaving legitimately-encoded inner entities intact.
+ */
+export function decodeHtmlEntities(input: string): string {
+  const named: Record<string, string> = {
+    lt: "<",
+    gt: ">",
+    amp: "&",
+    quot: '"',
+    apos: "'",
+    nbsp: " ",
+  };
+  return input.replace(
+    /&(#x?[0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/g,
+    (m, ent) => {
+      if (ent[0] === "#") {
+        const isHex = ent[1] === "x" || ent[1] === "X";
+        const code = isHex
+          ? Number.parseInt(ent.slice(2), 16)
+          : Number.parseInt(ent.slice(1), 10);
+        if (!Number.isFinite(code) || code <= 0 || code > 0x10ffff) return m;
+        try {
+          return String.fromCodePoint(code);
+        } catch {
+          return m;
+        }
+      }
+      return named[ent.toLowerCase()] ?? m;
+    },
+  );
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<\s*br\s*\/?>/gi, "\n")
+    .replace(/<\/\s*(p|div|li|h[1-6]|ul|ol)\s*>/gi, "\n")
+    .replace(/<[^>]*>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n\s+/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function fetchGreenhouseJson<T>(
+  fetchFn: typeof fetch,
+  input: {
+    url: string;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  },
+): Promise<T> {
+  const response = await fetchFn(input.url, {
+    method: "GET",
+    signal: input.signal,
+    headers: input.headers,
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Greenhouse request failed with HTTP ${response.status} for ${input.url}.`,
+    );
+  }
+
+  try {
+    return JSON.parse(responseText) as T;
+  } catch {
+    throw new Error(`Greenhouse response was not valid JSON for ${input.url}.`);
+  }
+}
+
+function requiredString(
+  value: unknown,
+  fieldName: string,
+  url: string,
+): string {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new Error(
+    `Greenhouse response is missing required field ${fieldName} for ${url}.`,
+  );
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/career-boards/greenhouse/src/get-jobs-from-board.test.ts
+++ b/career-boards/greenhouse/src/get-jobs-from-board.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatLocation,
+  getJobsFromBoard,
+  normalizeGreenhouseListJob,
+} from "./get-jobs-from-board";
+import { parseGreenhouseUrl } from "./greenhouse-url";
+
+const source = parseGreenhouseUrl("https://job-boards.greenhouse.io/epicgames");
+
+describe("normalizeGreenhouseListJob", () => {
+  it("maps a Greenhouse list row into a normalized job", () => {
+    expect(
+      normalizeGreenhouseListJob(
+        {
+          id: 6103058004,
+          title: "Animation Systems Programmer",
+          absolute_url:
+            "https://epicgames.com/careers/jobs/6103058004?gh_jid=6103058004",
+          location: { name: "Larkspur,California,United States" },
+          first_published: "2026-06-01T00:00:00-04:00",
+          company_name: "Epic Games",
+        },
+        source,
+      ),
+    ).toMatchObject({
+      source: "greenhouse",
+      externalId: "6103058004",
+      title: "Animation Systems Programmer",
+      jobUrl: "https://epicgames.com/careers/jobs/6103058004?gh_jid=6103058004",
+      jobApiUrl:
+        "https://boards-api.greenhouse.io/v1/boards/epicgames/jobs/6103058004",
+      locationText: "Larkspur, California, United States",
+      postedOn: "2026-06-01T00:00:00-04:00",
+      company: "Epic Games",
+    });
+  });
+
+  it("throws when a required field is missing", () => {
+    expect(() => normalizeGreenhouseListJob({ id: 1 }, source)).toThrow(
+      /missing required field title/,
+    );
+  });
+});
+
+describe("formatLocation", () => {
+  it("adds spacing after commas", () => {
+    expect(formatLocation("A,B,C")).toBe("A, B, C");
+  });
+  it("returns undefined for empty values", () => {
+    expect(formatLocation("  ")).toBeUndefined();
+    expect(formatLocation(null)).toBeUndefined();
+  });
+  it("drops Greenhouse 'BLANK' placeholder components", () => {
+    expect(formatLocation("BLANK,BLANK,Multiple Locations")).toBe(
+      "Multiple Locations",
+    );
+    expect(formatLocation("Cary,BLANK,United States")).toBe(
+      "Cary, United States",
+    );
+  });
+  it("returns undefined when every component is a placeholder", () => {
+    expect(formatLocation("BLANK,BLANK")).toBeUndefined();
+  });
+});
+
+describe("getJobsFromBoard", () => {
+  it("fetches and normalizes the board job list", async () => {
+    const result = await getJobsFromBoard({
+      careersUrl: "https://job-boards.greenhouse.io/epicgames",
+      fetchImpl: async (url) => {
+        expect(String(url)).toBe(
+          "https://boards-api.greenhouse.io/v1/boards/epicgames/jobs",
+        );
+        return new Response(
+          JSON.stringify({
+            meta: { total: 2 },
+            jobs: [
+              {
+                id: 1,
+                title: "Engineer",
+                absolute_url: "https://epicgames.com/careers/jobs/1",
+                location: { name: "Cary,North Carolina" },
+              },
+              {
+                id: 2,
+                title: "Designer",
+                absolute_url: "https://epicgames.com/careers/jobs/2",
+                location: { name: "Remote" },
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      },
+    });
+
+    expect(result.total).toBe(2);
+    expect(result.fetched).toBe(2);
+    expect(result.jobs.map((job) => job.title)).toEqual([
+      "Engineer",
+      "Designer",
+    ]);
+  });
+
+  it("throws on a non-200 response", async () => {
+    await expect(
+      getJobsFromBoard({
+        careersUrl: "https://job-boards.greenhouse.io/nope",
+        fetchImpl: async () => new Response("nope", { status: 404 }),
+      }),
+    ).rejects.toThrow(/HTTP 404/);
+  });
+});

--- a/career-boards/greenhouse/src/get-jobs-from-board.ts
+++ b/career-boards/greenhouse/src/get-jobs-from-board.ts
@@ -1,0 +1,172 @@
+import {
+  GREENHOUSE_DEFAULT_USER_AGENT,
+  type GreenhouseSourceConfig,
+  greenhouseJobApiUrl,
+  parseGreenhouseUrl,
+} from "./greenhouse-url";
+
+export interface GreenhouseListLocation {
+  name?: string | null;
+}
+
+export interface GreenhouseListJob {
+  id?: number | string;
+  title?: string;
+  absolute_url?: string;
+  location?: GreenhouseListLocation | null;
+  updated_at?: string | null;
+  first_published?: string | null;
+  company_name?: string | null;
+  requisition_id?: string | null;
+  [key: string]: unknown;
+}
+
+export interface GreenhouseListResponse {
+  jobs?: GreenhouseListJob[];
+  meta?: { total?: number };
+  [key: string]: unknown;
+}
+
+export interface NormalizedGreenhouseJob {
+  source: "greenhouse";
+  externalId: string;
+  title: string;
+  jobUrl: string;
+  jobApiUrl: string;
+  locationText?: string;
+  postedOn?: string;
+  company?: string;
+  raw: GreenhouseListJob;
+}
+
+export interface FetchGreenhouseJobsOptions {
+  careersUrl: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+  userAgent?: string;
+}
+
+export interface FetchGreenhouseJobsResult {
+  total: number;
+  fetched: number;
+  jobs: NormalizedGreenhouseJob[];
+}
+
+export async function getJobsFromBoard(
+  options: FetchGreenhouseJobsOptions,
+): Promise<FetchGreenhouseJobsResult> {
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  if (!fetchFn) {
+    throw new Error(
+      "No fetch implementation available. Pass fetchImpl or use Node 18+.",
+    );
+  }
+
+  const source = parseGreenhouseUrl(options.careersUrl);
+  const response = await fetchGreenhouseJson<GreenhouseListResponse>(fetchFn, {
+    url: source.boardJobsUrl,
+    signal: options.signal,
+    headers: {
+      accept: "application/json",
+      referer: source.canonicalCareersUrl,
+      "user-agent": options.userAgent ?? GREENHOUSE_DEFAULT_USER_AGENT,
+      ...options.headers,
+    },
+  });
+
+  const rows = Array.isArray(response.jobs) ? response.jobs : [];
+  const jobs = rows.map((job) => normalizeGreenhouseListJob(job, source));
+  const total =
+    typeof response.meta?.total === "number"
+      ? response.meta.total
+      : jobs.length;
+
+  return {
+    total,
+    fetched: jobs.length,
+    jobs,
+  };
+}
+
+export function normalizeGreenhouseListJob(
+  job: GreenhouseListJob,
+  source: GreenhouseSourceConfig,
+): NormalizedGreenhouseJob {
+  const externalId = requiredString(job.id, "id", source.boardJobsUrl);
+  const title = requiredString(job.title, "title", source.boardJobsUrl);
+
+  return {
+    source: "greenhouse",
+    externalId,
+    title,
+    jobUrl: optionalString(job.absolute_url) ?? source.canonicalCareersUrl,
+    jobApiUrl: greenhouseJobApiUrl(source.token, externalId),
+    locationText: formatLocation(job.location?.name),
+    postedOn:
+      optionalString(job.first_published) ?? optionalString(job.updated_at),
+    company: optionalString(job.company_name),
+    raw: job,
+  };
+}
+
+export function formatLocation(
+  value: string | null | undefined,
+): string | undefined {
+  const text = optionalString(value);
+  if (!text) return undefined;
+  // Greenhouse joins location parts without spaces
+  // ("Larkspur,California,United States") and emits the literal "BLANK" as a
+  // placeholder for empty components (e.g. "BLANK,BLANK,Multiple Locations").
+  const parts = text
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0 && part.toUpperCase() !== "BLANK");
+  return parts.length > 0 ? parts.join(", ") : undefined;
+}
+
+async function fetchGreenhouseJson<T>(
+  fetchFn: typeof fetch,
+  input: {
+    url: string;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  },
+): Promise<T> {
+  const response = await fetchFn(input.url, {
+    method: "GET",
+    signal: input.signal,
+    headers: input.headers,
+  });
+
+  const responseText = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Greenhouse request failed with HTTP ${response.status} for ${input.url}.`,
+    );
+  }
+
+  try {
+    return JSON.parse(responseText) as T;
+  } catch {
+    throw new Error(`Greenhouse response was not valid JSON for ${input.url}.`);
+  }
+}
+
+function requiredString(
+  value: unknown,
+  fieldName: string,
+  url: string,
+): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === "string" && value.trim()) return value.trim();
+  throw new Error(
+    `Greenhouse response is missing required field ${fieldName} for ${url}.`,
+  );
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/career-boards/greenhouse/src/greenhouse-url.test.ts
+++ b/career-boards/greenhouse/src/greenhouse-url.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractGreenhouseTokenFromHtml,
+  greenhouseJobApiUrl,
+  greenhouseTokenToLabel,
+  guessTokensFromHostname,
+  isGreenhouseUrl,
+  parseGreenhouseJobApiUrl,
+  parseGreenhouseUrl,
+} from "./greenhouse-url";
+
+describe("parseGreenhouseUrl", () => {
+  it("parses a job-boards.greenhouse.io URL", () => {
+    const parsed = parseGreenhouseUrl(
+      "https://job-boards.greenhouse.io/riotgames",
+    );
+    expect(parsed.token).toBe("riotgames");
+    expect(parsed.canonicalCareersUrl).toBe(
+      "https://job-boards.greenhouse.io/riotgames",
+    );
+    expect(parsed.boardJobsUrl).toBe(
+      "https://boards-api.greenhouse.io/v1/boards/riotgames/jobs",
+    );
+  });
+
+  it("parses a legacy boards.greenhouse.io URL with a job path", () => {
+    expect(
+      parseGreenhouseUrl(
+        "https://boards.greenhouse.io/epicgames/jobs/6103058004",
+      ).token,
+    ).toBe("epicgames");
+  });
+
+  it("parses an embed URL that carries the token in ?for=", () => {
+    expect(
+      parseGreenhouseUrl(
+        "https://boards.greenhouse.io/embed/job_board?for=stripe",
+      ).token,
+    ).toBe("stripe");
+  });
+
+  it("parses a boards-api URL", () => {
+    expect(
+      parseGreenhouseUrl(
+        "https://boards-api.greenhouse.io/v1/boards/riotgames/jobs",
+      ).token,
+    ).toBe("riotgames");
+  });
+
+  it("rejects non-greenhouse hosts", () => {
+    expect(() =>
+      parseGreenhouseUrl("https://www.riotgames.com/en/work-with-us"),
+    ).toThrow(/Unsupported Greenhouse host/);
+    expect(isGreenhouseUrl("https://www.riotgames.com/en/work-with-us")).toBe(
+      false,
+    );
+  });
+
+  it("rejects empty and malformed input", () => {
+    expect(() => parseGreenhouseUrl("   ")).toThrow(/empty/i);
+    expect(() => parseGreenhouseUrl("not a url")).toThrow(/Invalid URL/);
+  });
+});
+
+describe("parseGreenhouseJobApiUrl", () => {
+  it("extracts token + job id", () => {
+    expect(
+      parseGreenhouseJobApiUrl(greenhouseJobApiUrl("epicgames", "6103058004")),
+    ).toEqual({ token: "epicgames", jobId: "6103058004" });
+  });
+
+  it("throws on a non-job URL", () => {
+    expect(() =>
+      parseGreenhouseJobApiUrl("https://job-boards.greenhouse.io/epicgames"),
+    ).toThrow(/Greenhouse job API URL/);
+  });
+});
+
+describe("extractGreenhouseTokenFromHtml", () => {
+  it("extracts the token from the classic embed script", () => {
+    const html = `<script src="https://boards.greenhouse.io/embed/job_board/js?for=riotgames"></script>`;
+    expect(extractGreenhouseTokenFromHtml(html)).toBe("riotgames");
+  });
+
+  it("extracts the token from a board API reference", () => {
+    const html = `fetch("https://boards-api.greenhouse.io/v1/boards/epicgames/jobs")`;
+    expect(extractGreenhouseTokenFromHtml(html)).toBe("epicgames");
+  });
+
+  it("returns null when no board is embedded", () => {
+    expect(extractGreenhouseTokenFromHtml("<html>no board here</html>")).toBe(
+      null,
+    );
+  });
+
+  it("never returns a structural path segment as a token", () => {
+    const html = `<a href="https://job-boards.greenhouse.io/embed/job_board?for=stripe">`;
+    expect(extractGreenhouseTokenFromHtml(html)).toBe("stripe");
+  });
+});
+
+describe("guessTokensFromHostname", () => {
+  it("derives the registrable label first", () => {
+    expect(guessTokensFromHostname("www.epicgames.com")[0]).toBe("epicgames");
+    expect(guessTokensFromHostname("riotgames.com")[0]).toBe("riotgames");
+  });
+
+  it("handles multi-part public suffixes", () => {
+    expect(guessTokensFromHostname("careers.example.co.uk")).toContain(
+      "example",
+    );
+  });
+
+  it("returns an empty list for empty input", () => {
+    expect(guessTokensFromHostname("")).toEqual([]);
+  });
+});
+
+describe("greenhouseTokenToLabel", () => {
+  it("title-cases hyphenated tokens", () => {
+    expect(greenhouseTokenToLabel("acme-corp")).toBe("Acme Corp");
+  });
+});

--- a/career-boards/greenhouse/src/greenhouse-url.ts
+++ b/career-boards/greenhouse/src/greenhouse-url.ts
@@ -1,0 +1,284 @@
+export type GreenhouseUrlParseErrorCode =
+  | "EMPTY_URL"
+  | "INVALID_URL"
+  | "UNSUPPORTED_HOST"
+  | "MISSING_BOARD_TOKEN";
+
+export const GREENHOUSE_BOARDS_API_ORIGIN = "https://boards-api.greenhouse.io";
+export const GREENHOUSE_CANONICAL_BOARD_ORIGIN =
+  "https://job-boards.greenhouse.io";
+
+export const GREENHOUSE_DEFAULT_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36";
+
+// Greenhouse board tokens are lowercase alphanumeric slugs, occasionally with
+// hyphens/underscores. Path segments like "embed"/"v1"/"boards" are structural
+// and must never be treated as a token.
+const TOKEN_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+const RESERVED_SEGMENTS = new Set([
+  "embed",
+  "v1",
+  "boards",
+  "jobs",
+  "job_board",
+  "job_app",
+  "js",
+]);
+
+export interface GreenhouseSourceConfig {
+  inputUrl: string;
+  token: string;
+  canonicalCareersUrl: string;
+  boardApiUrl: string;
+  boardJobsUrl: string;
+}
+
+export class GreenhouseUrlParseError extends Error {
+  readonly code: GreenhouseUrlParseErrorCode;
+  readonly input: string;
+
+  constructor(
+    code: GreenhouseUrlParseErrorCode,
+    message: string,
+    input: string,
+  ) {
+    super(message);
+    this.name = "GreenhouseUrlParseError";
+    this.code = code;
+    this.input = input;
+  }
+}
+
+export function isGreenhouseUrl(input: string): boolean {
+  try {
+    parseGreenhouseUrl(input);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function isGreenhouseHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return host === "greenhouse.io" || host.endsWith(".greenhouse.io");
+}
+
+export function parseGreenhouseUrl(input: string): GreenhouseSourceConfig {
+  if (!input.trim()) {
+    throw new GreenhouseUrlParseError(
+      "EMPTY_URL",
+      "URL cannot be empty.",
+      input,
+    );
+  }
+
+  const url = toUrl(input);
+  const host = url.hostname.toLowerCase();
+  if (!isGreenhouseHost(host)) {
+    throw new GreenhouseUrlParseError(
+      "UNSUPPORTED_HOST",
+      `Unsupported Greenhouse host: ${host}`,
+      input,
+    );
+  }
+
+  const token = extractBoardTokenFromUrl(url, host);
+  if (!token) {
+    throw new GreenhouseUrlParseError(
+      "MISSING_BOARD_TOKEN",
+      "Could not determine a Greenhouse board token from the URL.",
+      input,
+    );
+  }
+
+  return buildSourceConfig(input, token);
+}
+
+export function buildGreenhouseSourceConfig(
+  token: string,
+  inputUrl = "",
+): GreenhouseSourceConfig {
+  const normalized = normalizeToken(token);
+  if (!normalized) {
+    throw new GreenhouseUrlParseError(
+      "MISSING_BOARD_TOKEN",
+      `Invalid Greenhouse board token: ${token}`,
+      inputUrl || token,
+    );
+  }
+  return buildSourceConfig(inputUrl, normalized);
+}
+
+export function greenhouseTokenToLabel(token: string): string {
+  return token
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function greenhouseUrlToSourceKey(input: string): string {
+  return `greenhouse:${parseGreenhouseUrl(input).token}`;
+}
+
+export function greenhouseTokenToSourceKey(token: string): string {
+  return `greenhouse:${normalizeToken(token) ?? token}`;
+}
+
+export function greenhouseJobApiUrl(token: string, jobId: string): string {
+  return `${GREENHOUSE_BOARDS_API_ORIGIN}/v1/boards/${token}/jobs/${jobId}`;
+}
+
+export interface GreenhouseJobApiRef {
+  token: string;
+  jobId: string;
+}
+
+export function parseGreenhouseJobApiUrl(input: string): GreenhouseJobApiRef {
+  const url = toUrl(input);
+  const segments = getPathSegments(url.pathname);
+  const boardsIdx = segments.indexOf("boards");
+  const token =
+    boardsIdx >= 0 ? normalizeToken(segments[boardsIdx + 1]) : undefined;
+  const jobsIdx = segments.indexOf("jobs");
+  const jobId = jobsIdx >= 0 ? segments[jobsIdx + 1] : undefined;
+
+  if (!token || !jobId || !/^\d+$/.test(jobId)) {
+    throw new GreenhouseUrlParseError(
+      "INVALID_URL",
+      `Not a Greenhouse job API URL: ${input}`,
+      input,
+    );
+  }
+  return { token, jobId };
+}
+
+/**
+ * Best-effort extraction of a Greenhouse board token from arbitrary page
+ * markup (HTML/JS). Recruiter pages embed the board via a script tag such as
+ * `.../job_board/js?for=riotgames`, an iframe to `boards.greenhouse.io/<token>`,
+ * or direct calls to the board API. Returns the first plausible token found.
+ */
+export function extractGreenhouseTokenFromHtml(html: string): string | null {
+  const patterns = [
+    /job_board\/js\?[^"'<>]*\bfor=([a-z0-9_-]+)/i,
+    /job_(?:board|app)\?[^"'<>]*\bfor=([a-z0-9_-]+)/i,
+    /boards-api\.greenhouse\.io\/v1\/boards\/([a-z0-9_-]+)/i,
+    /(?:job-)?boards\.greenhouse\.io\/(?:embed\/[a-z_]+\?[^"'<>]*\bfor=)?([a-z0-9_-]+)/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = html.match(pattern);
+    const token = normalizeToken(match?.[1]);
+    if (token && !RESERVED_SEGMENTS.has(token)) {
+      return token;
+    }
+  }
+  return null;
+}
+
+/**
+ * Ordered list of candidate board tokens derived from a company hostname, most
+ * likely first. Greenhouse tokens are frequently the bare second-level domain
+ * (epicgames.com -> "epicgames"). Callers must validate each candidate against
+ * the board API before trusting it.
+ */
+export function guessTokensFromHostname(hostname: string): string[] {
+  const labels = hostname
+    .toLowerCase()
+    .split(".")
+    .filter((label) => label && label !== "www");
+  if (labels.length === 0) return [];
+
+  // Drop the public-suffix tail (e.g. ".com", ".co.uk").
+  const suffixSecondLevel = new Set([
+    "co",
+    "com",
+    "org",
+    "net",
+    "gov",
+    "edu",
+    "ac",
+  ]);
+  const meaningful = [...labels];
+  meaningful.pop(); // TLD label (com, io, uk, ...)
+  if (
+    meaningful.length > 1 &&
+    suffixSecondLevel.has(meaningful[meaningful.length - 1] ?? "")
+  ) {
+    meaningful.pop(); // second-level public suffix (co.uk -> drop "co")
+  }
+
+  const candidates = [
+    meaningful[meaningful.length - 1], // registrable label
+    meaningful.join(""), // subdomain-joined fallback
+    labels.join(""), // whole host joined, last resort
+  ];
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const candidate of candidates) {
+    const token = normalizeToken(candidate);
+    if (token && !seen.has(token)) {
+      seen.add(token);
+      result.push(token);
+    }
+  }
+  return result;
+}
+
+function buildSourceConfig(
+  inputUrl: string,
+  token: string,
+): GreenhouseSourceConfig {
+  const boardApiUrl = `${GREENHOUSE_BOARDS_API_ORIGIN}/v1/boards/${token}`;
+  return {
+    inputUrl,
+    token,
+    canonicalCareersUrl: `${GREENHOUSE_CANONICAL_BOARD_ORIGIN}/${token}`,
+    boardApiUrl,
+    boardJobsUrl: `${boardApiUrl}/jobs`,
+  };
+}
+
+function extractBoardTokenFromUrl(url: URL, host: string): string | undefined {
+  const segments = getPathSegments(url.pathname);
+  const forParam = normalizeToken(url.searchParams.get("for"));
+
+  if (host === "boards-api.greenhouse.io") {
+    const boardsIdx = segments.indexOf("boards");
+    if (boardsIdx >= 0) return normalizeToken(segments[boardsIdx + 1]);
+    return undefined;
+  }
+
+  // boards.greenhouse.io, job-boards.greenhouse.io, boards.eu.greenhouse.io, ...
+  const first = segments[0]?.toLowerCase();
+  if (first && !RESERVED_SEGMENTS.has(first)) {
+    return normalizeToken(first);
+  }
+  // Embedded board/app URLs carry the token in the `for` query parameter.
+  return forParam;
+}
+
+function normalizeToken(value: string | null | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  return normalized && TOKEN_PATTERN.test(normalized) ? normalized : undefined;
+}
+
+function toUrl(input: string): URL {
+  try {
+    return new URL(input.trim());
+  } catch {
+    throw new GreenhouseUrlParseError(
+      "INVALID_URL",
+      `Invalid URL: ${input}`,
+      input,
+    );
+  }
+}
+
+function getPathSegments(pathname: string): string[] {
+  return pathname.split("/").filter(Boolean);
+}

--- a/career-boards/greenhouse/src/index.ts
+++ b/career-boards/greenhouse/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./get-job-details";
+export * from "./get-jobs-from-board";
+export * from "./greenhouse-url";
+export * from "./resolve-greenhouse-source";

--- a/career-boards/greenhouse/src/resolve-greenhouse-source.test.ts
+++ b/career-boards/greenhouse/src/resolve-greenhouse-source.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  GreenhouseResolutionError,
+  resolveGreenhouseSource,
+} from "./resolve-greenhouse-source";
+
+interface MockOptions {
+  validTokens: Record<string, string | null>;
+  pagesByHost?: Record<string, { status: number; html?: string }>;
+}
+
+function makeFetch(opts: MockOptions): typeof fetch {
+  return (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    const boardMatch = url.match(
+      /boards-api\.greenhouse\.io\/v1\/boards\/([a-z0-9_-]+)$/,
+    );
+    if (boardMatch) {
+      const token = boardMatch[1];
+      if (Object.hasOwn(opts.validTokens, token)) {
+        return new Response(JSON.stringify({ name: opts.validTokens[token] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    }
+
+    const host = new URL(url).hostname;
+    const page = opts.pagesByHost?.[host];
+    if (page) {
+      return new Response(page.html ?? "", { status: page.status });
+    }
+    return new Response("blocked", { status: 403 });
+  }) as typeof fetch;
+}
+
+describe("resolveGreenhouseSource", () => {
+  it("layer 1: parses a Greenhouse URL directly", async () => {
+    const resolved = await resolveGreenhouseSource({
+      url: "https://job-boards.greenhouse.io/riotgames",
+      fetchImpl: makeFetch({ validTokens: { riotgames: "Riot Games" } }),
+    });
+    expect(resolved).toMatchObject({
+      token: "riotgames",
+      method: "greenhouse_url",
+      companyName: "Riot Games",
+      canonicalCareersUrl: "https://job-boards.greenhouse.io/riotgames",
+    });
+  });
+
+  it("layer 2: scrapes the embedded board token from a company page", async () => {
+    const resolved = await resolveGreenhouseSource({
+      url: "https://careers.playvalorant.com/openings",
+      fetchImpl: makeFetch({
+        validTokens: { riotgames: "Riot Games" },
+        pagesByHost: {
+          "careers.playvalorant.com": {
+            status: 200,
+            html: '<script src="https://boards.greenhouse.io/embed/job_board/js?for=riotgames"></script>',
+          },
+        },
+      }),
+    });
+    // Domain guess would be "playvalorant" (invalid), so this must come from scraping.
+    expect(resolved.token).toBe("riotgames");
+    expect(resolved.method).toBe("page_scrape");
+  });
+
+  it("layer 3: guesses the token from the domain when scraping is blocked", async () => {
+    const resolved = await resolveGreenhouseSource({
+      url: "https://www.epicgames.com/site/careers/jobs",
+      fetchImpl: makeFetch({
+        validTokens: { epicgames: "Epic Games" },
+        pagesByHost: { "www.epicgames.com": { status: 403 } },
+      }),
+    });
+    expect(resolved).toMatchObject({
+      token: "epicgames",
+      method: "domain_guess",
+      companyName: "Epic Games",
+    });
+  });
+
+  it("throws NOT_FOUND when no board can be located", async () => {
+    await expect(
+      resolveGreenhouseSource({
+        url: "https://www.nianticlabs.com/careers",
+        fetchImpl: makeFetch({
+          validTokens: {},
+          pagesByHost: {
+            "www.nianticlabs.com": {
+              status: 200,
+              html: "<html>no board here</html>",
+            },
+          },
+        }),
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("rejects empty and malformed input", async () => {
+    await expect(
+      resolveGreenhouseSource({
+        url: "  ",
+        fetchImpl: makeFetch({ validTokens: {} }),
+      }),
+    ).rejects.toBeInstanceOf(GreenhouseResolutionError);
+    await expect(
+      resolveGreenhouseSource({
+        url: "not a url",
+        fetchImpl: makeFetch({ validTokens: {} }),
+      }),
+    ).rejects.toMatchObject({ code: "INVALID_URL" });
+  });
+});

--- a/career-boards/greenhouse/src/resolve-greenhouse-source.ts
+++ b/career-boards/greenhouse/src/resolve-greenhouse-source.ts
@@ -1,0 +1,223 @@
+import {
+  extractGreenhouseTokenFromHtml,
+  GREENHOUSE_BOARDS_API_ORIGIN,
+  GREENHOUSE_CANONICAL_BOARD_ORIGIN,
+  GREENHOUSE_DEFAULT_USER_AGENT,
+  guessTokensFromHostname,
+  isGreenhouseHost,
+  parseGreenhouseUrl,
+} from "./greenhouse-url";
+
+export type GreenhouseResolutionErrorCode =
+  | "EMPTY_URL"
+  | "INVALID_URL"
+  | "NOT_FOUND";
+
+export type GreenhouseResolutionMethod =
+  | "greenhouse_url"
+  | "page_scrape"
+  | "domain_guess";
+
+export interface ResolvedGreenhouseSource {
+  token: string;
+  canonicalCareersUrl: string;
+  companyName: string | null;
+  method: GreenhouseResolutionMethod;
+}
+
+export interface ResolveGreenhouseSourceOptions {
+  url: string;
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  userAgent?: string;
+}
+
+export class GreenhouseResolutionError extends Error {
+  readonly code: GreenhouseResolutionErrorCode;
+  readonly input: string;
+
+  constructor(
+    code: GreenhouseResolutionErrorCode,
+    message: string,
+    input: string,
+  ) {
+    super(message);
+    this.name = "GreenhouseResolutionError";
+    this.code = code;
+    this.input = input;
+  }
+}
+
+interface GreenhouseBoardInfo {
+  name: string | null;
+}
+
+/**
+ * Resolves an arbitrary user-supplied URL to a Greenhouse board, trying the
+ * cheapest reliable strategy first:
+ *
+ *  1. The URL already points at Greenhouse    -> parse the token directly.
+ *  2. A company careers page                  -> scrape the embedded board token.
+ *  3. Scrape blocked/unhelpful                -> guess the token from the domain.
+ *
+ * Every candidate token is validated against the public board API before being
+ * trusted, so a wrong guess never produces a broken source.
+ */
+export async function resolveGreenhouseSource(
+  options: ResolveGreenhouseSourceOptions,
+): Promise<ResolvedGreenhouseSource> {
+  const input = options.url?.trim() ?? "";
+  if (!input) {
+    throw new GreenhouseResolutionError(
+      "EMPTY_URL",
+      "URL cannot be empty.",
+      options.url ?? "",
+    );
+  }
+
+  const fetchFn = options.fetchImpl ?? globalThis.fetch;
+  if (!fetchFn) {
+    throw new Error(
+      "No fetch implementation available. Pass fetchImpl or use Node 18+.",
+    );
+  }
+  const userAgent = options.userAgent ?? GREENHOUSE_DEFAULT_USER_AGENT;
+
+  // Layer 1: already a Greenhouse URL.
+  if (isGreenhouseUrlSafe(input)) {
+    const token = parseGreenhouseUrl(input).token;
+    const info = await getBoardInfo(token, fetchFn, options.signal, userAgent);
+    if (info) return resolved(token, info, "greenhouse_url");
+    throw notFound(input);
+  }
+
+  const pageUrl = toUrlOrThrow(input);
+
+  // Layer 2: scrape the company careers page for an embedded board token.
+  const html = await tryFetchText(
+    pageUrl.href,
+    fetchFn,
+    options.signal,
+    userAgent,
+  );
+  if (html) {
+    const scraped = extractGreenhouseTokenFromHtml(html);
+    if (scraped) {
+      const info = await getBoardInfo(
+        scraped,
+        fetchFn,
+        options.signal,
+        userAgent,
+      );
+      if (info) return resolved(scraped, info, "page_scrape");
+    }
+  }
+
+  // Layer 3: guess the token from the hostname, validated against the API.
+  for (const candidate of guessTokensFromHostname(pageUrl.hostname)) {
+    const info = await getBoardInfo(
+      candidate,
+      fetchFn,
+      options.signal,
+      userAgent,
+    );
+    if (info) return resolved(candidate, info, "domain_guess");
+  }
+
+  throw notFound(input);
+}
+
+async function getBoardInfo(
+  token: string,
+  fetchFn: typeof fetch,
+  signal: AbortSignal | undefined,
+  userAgent: string,
+): Promise<GreenhouseBoardInfo | null> {
+  const url = `${GREENHOUSE_BOARDS_API_ORIGIN}/v1/boards/${token}`;
+  let response: Response;
+  try {
+    response = await fetchFn(url, {
+      method: "GET",
+      signal,
+      headers: { accept: "application/json", "user-agent": userAgent },
+    });
+  } catch {
+    return null;
+  }
+  if (!response.ok) return null;
+
+  try {
+    const body = (await response.json()) as { name?: unknown };
+    const name =
+      typeof body.name === "string" && body.name.trim()
+        ? body.name.trim()
+        : null;
+    return { name };
+  } catch {
+    return null;
+  }
+}
+
+async function tryFetchText(
+  url: string,
+  fetchFn: typeof fetch,
+  signal: AbortSignal | undefined,
+  userAgent: string,
+): Promise<string | null> {
+  try {
+    const response = await fetchFn(url, {
+      method: "GET",
+      redirect: "follow",
+      signal,
+      headers: {
+        accept: "text/html,application/xhtml+xml",
+        "user-agent": userAgent,
+      },
+    });
+    if (!response.ok) return null;
+    return await response.text();
+  } catch {
+    return null;
+  }
+}
+
+function isGreenhouseUrlSafe(input: string): boolean {
+  try {
+    return isGreenhouseHost(new URL(input).hostname);
+  } catch {
+    return false;
+  }
+}
+
+function toUrlOrThrow(input: string): URL {
+  try {
+    return new URL(input);
+  } catch {
+    throw new GreenhouseResolutionError(
+      "INVALID_URL",
+      `Invalid URL: ${input}`,
+      input,
+    );
+  }
+}
+
+function resolved(
+  token: string,
+  info: GreenhouseBoardInfo,
+  method: GreenhouseResolutionMethod,
+): ResolvedGreenhouseSource {
+  return {
+    token,
+    canonicalCareersUrl: `${GREENHOUSE_CANONICAL_BOARD_ORIGIN}/${token}`,
+    companyName: info.name,
+    method,
+  };
+}
+
+function notFound(input: string): GreenhouseResolutionError {
+  return new GreenhouseResolutionError(
+    "NOT_FOUND",
+    "Could not find a Greenhouse job board for that URL.",
+    input,
+  );
+}

--- a/orchestrator/src/server/api/routes/watchlist.ts
+++ b/orchestrator/src/server/api/routes/watchlist.ts
@@ -350,7 +350,7 @@ watchlistRouter.put(
       }
 
       try {
-        const normalized = adapter.normalizeCustomSelection({
+        const normalized = await adapter.normalizeCustomSelection({
           label: selection.label,
           careersUrl: normalizedUrl,
         });

--- a/orchestrator/src/server/config/career-boards-greenhouse.json
+++ b/orchestrator/src/server/config/career-boards-greenhouse.json
@@ -1,0 +1,10 @@
+[
+  {
+    "label": "Epic Games",
+    "greenhouseUrl": "https://job-boards.greenhouse.io/epicgames"
+  },
+  {
+    "label": "Riot Games",
+    "greenhouseUrl": "https://job-boards.greenhouse.io/riotgames"
+  }
+]

--- a/orchestrator/src/server/services/post-application/ingestion/gmail-api.ts
+++ b/orchestrator/src/server/services/post-application/ingestion/gmail-api.ts
@@ -177,6 +177,16 @@ export function buildGmailQuery(searchDays: number): string {
     "hiring freeze",
     "position on hold",
     "withdrawn",
+    // Interview scheduling / calendar coordination
+    "invitation",
+    "updated invitation",
+    "reschedule",
+    "rescheduled",
+    "next steps",
+    "phone screen",
+    "screening call",
+    "let's chat",
+    "quick chat",
   ];
   const fromTerms = [
     "careers@",
@@ -194,6 +204,25 @@ export function buildGmailQuery(searchDays: number): string {
     "@workdaymail.com",
     "@greenhouse.io",
     "@ashbyhq.com",
+    // Scheduling / calendar providers
+    "@calendly.com",
+    "@savvycal.com",
+    "calendar-notification@google.com",
+  ];
+  // Full-text (subject OR body) terms. Recruiter follow-ups and calendar
+  // invites often carry a plain job-title or "First and Last" subject with no
+  // recruitment keyword and come from an arbitrary company/personal domain, so
+  // the only reliable signal lives in the body (booking links, thank-you
+  // phrasing). Keep these high-precision to avoid flooding busy inboxes.
+  const fullTextTerms = [
+    "thank you for applying",
+    "thanks for applying",
+    "book a time",
+    "book the best time",
+    "schedule a call",
+    "microsoft teams meeting",
+    "calendly.com",
+    "savvycal.com",
   ];
   const excludeSubjectTerms = [
     "newsletter",
@@ -212,11 +241,14 @@ export function buildGmailQuery(searchDays: number): string {
   const fromBlock = fromTerms
     .map((term) => `from:${quoteTerm(term)}`)
     .join(" OR ");
+  const fullTextBlock = fullTextTerms
+    .map((term) => quoteTerm(term))
+    .join(" OR ");
   const excludeClauses = excludeSubjectTerms
     .map((term) => `-subject:${quoteTerm(term)}`)
     .join(" ");
 
-  return `newer_than:${searchDays}d ((${subjectBlock}) OR (${fromBlock})) ${excludeClauses}`.trim();
+  return `newer_than:${searchDays}d ((${subjectBlock}) OR (${fromBlock}) OR (${fullTextBlock})) ${excludeClauses}`.trim();
 }
 
 export async function listMessageIds(

--- a/orchestrator/src/server/watchlist/adapters/greenhouse.ts
+++ b/orchestrator/src/server/watchlist/adapters/greenhouse.ts
@@ -1,0 +1,201 @@
+import {
+  getJobDetails,
+  getJobsFromBoard,
+  greenhouseTokenToLabel,
+  greenhouseTokenToSourceKey,
+  greenhouseUrlToSourceKey,
+  type NormalizedGreenhouseJob,
+  parseGreenhouseUrl,
+  resolveGreenhouseSource,
+} from "@career-boards/greenhouse";
+import type { ManualJobDraft, WatchlistSelectedSource } from "@shared/types";
+import { z } from "zod";
+import type { WatchlistCatalogSourceAdapter } from "./types";
+
+const GREENHOUSE_WATCHLIST_MAX_JOBS = 40;
+
+const greenhouseSourceSchema = z.object({
+  label: z.string().trim().min(1).max(200),
+  greenhouseUrl: z.string().trim().url().max(2000),
+});
+
+export const greenhouseWatchlistAdapter: WatchlistCatalogSourceAdapter = {
+  sourceType: "greenhouse",
+  descriptor: {
+    sourceType: "greenhouse",
+    label: "Greenhouse",
+    catalogLabel: "Greenhouse company",
+    customSourceOptionLabel: "Choose your own Greenhouse company",
+    customSourceSearchText: "custom greenhouse url",
+    customSourceInputLabel: "Company careers page or Greenhouse URL",
+    customSourcePlaceholder: "https://www.company.com/careers",
+    customSourceHelpText:
+      "Paste the company's careers page and we'll find its Greenhouse board " +
+      "automatically. If that fails, paste the board directly: go to " +
+      "job-boards.greenhouse.io/ + the company name (e.g. 'riotgames'), or " +
+      "open a job posting, click Apply, and copy the greenhouse.io link.",
+    emptyCatalogText: "No Greenhouse companies found.",
+    fetchingLabel: "Fetching from Greenhouse...",
+    invalidUrlMessage:
+      "Couldn't find a Greenhouse job board for that URL. Try pasting the " +
+      "board directly, e.g. https://job-boards.greenhouse.io/companyname",
+    supportsCustomSource: true,
+    supportsBranding: false,
+  },
+  catalogSchema: greenhouseSourceSchema,
+  parseCatalogSources(entries) {
+    return z
+      .array(greenhouseSourceSchema)
+      .parse(entries)
+      .map((entry) => {
+        const parsed = parseGreenhouseUrl(entry.greenhouseUrl);
+        return {
+          id: buildSourceId(parsed.token),
+          label: entry.label,
+          sourceType: "greenhouse",
+          careersUrl: parsed.canonicalCareersUrl,
+          cxsJobsUrl: null,
+        };
+      });
+  },
+  hydrateSelectedSource(source) {
+    const parsed = parseGreenhouseUrl(source.careersUrl);
+    return {
+      ...source,
+      label: getHydratedGreenhouseLabel(source, parsed.token),
+      careersUrl: parsed.canonicalCareersUrl,
+      cxsJobsUrl: null,
+    };
+  },
+  async normalizeCustomSelection(input) {
+    const resolved = await resolveGreenhouseSource({ url: input.careersUrl });
+    const trimmedLabel = input.label?.trim();
+    const label =
+      trimmedLabel && trimmedLabel !== input.careersUrl.trim()
+        ? trimmedLabel
+        : (resolved.companyName ?? greenhouseTokenToLabel(resolved.token));
+
+    return {
+      label,
+      careersUrl: resolved.canonicalCareersUrl,
+    };
+  },
+  async fetchJobs(input) {
+    const response = await getJobsFromBoard({
+      careersUrl: input.source.careersUrl,
+      signal: input.signal,
+    });
+    const source = greenhouseUrlToSourceKey(input.source.careersUrl);
+    const jobs = response.jobs
+      .slice(0, GREENHOUSE_WATCHLIST_MAX_JOBS)
+      .map((job) => normalizeGreenhouseJob(input.source, source, job));
+
+    return {
+      total: response.total,
+      fetched: jobs.length,
+      jobs,
+    };
+  },
+  async fetchJobDetails(input) {
+    const details = await getJobDetails({
+      jobRef: input.jobRef,
+      signal: input.signal,
+    });
+    return {
+      jobRef: input.jobRef,
+      jobUrl: details.job.jobUrl,
+      descriptionHtml: details.job.jobDescriptionHtml,
+    };
+  },
+  async prepareImportDraft(input) {
+    const details = await getJobDetails({
+      jobRef: input.jobRef,
+      signal: input.signal,
+    });
+    const source = greenhouseTokenToSourceKey(
+      parseGreenhouseUrl(input.source.careersUrl).token,
+    );
+    const draft = buildManualDraft(input.source, source, details.job);
+
+    return {
+      draft,
+      source: draft.source ?? null,
+      sourceHost:
+        getSourceHost(details.job.jobUrl) ??
+        getSourceHost(input.source.careersUrl),
+    };
+  },
+};
+
+function buildSourceId(token: string): string {
+  return `greenhouse:${token}`;
+}
+
+function getHydratedGreenhouseLabel(
+  source: {
+    sourceType: string;
+    label: string;
+    careersUrl: string;
+  },
+  token: string,
+): string {
+  if (
+    source.sourceType === "greenhouse" &&
+    (!source.label.trim() || source.label.trim() === source.careersUrl.trim())
+  ) {
+    return greenhouseTokenToLabel(token);
+  }
+
+  return source.label;
+}
+
+function normalizeGreenhouseJob(
+  selectedSource: WatchlistSelectedSource,
+  source: string,
+  job: NormalizedGreenhouseJob,
+) {
+  return {
+    jobRef: job.jobApiUrl,
+    source,
+    sourceJobId: job.externalId,
+    sourceType: selectedSource.sourceType,
+    title: job.title,
+    employer: job.company ?? selectedSource.label,
+    jobUrl: job.jobUrl,
+    applicationLink: job.jobUrl,
+    location: job.locationText ?? null,
+    postedAt: job.postedOn ?? null,
+  };
+}
+
+function buildManualDraft(
+  selectedSource: WatchlistSelectedSource,
+  source: string,
+  details: {
+    externalId: string;
+    title: string;
+    company?: string;
+    locationText?: string;
+    jobDescriptionText: string;
+    jobUrl: string;
+  },
+): ManualJobDraft {
+  return {
+    source,
+    sourceJobId: details.externalId,
+    title: details.title,
+    employer: details.company ?? selectedSource.label,
+    jobUrl: details.jobUrl,
+    applicationLink: details.jobUrl,
+    location: details.locationText,
+    jobDescription: details.jobDescriptionText,
+  };
+}
+
+function getSourceHost(value: string): string | null {
+  try {
+    return new URL(value).hostname || null;
+  } catch {
+    return null;
+  }
+}

--- a/orchestrator/src/server/watchlist/adapters/index.ts
+++ b/orchestrator/src/server/watchlist/adapters/index.ts
@@ -1,9 +1,14 @@
 import type { WatchedSourceType } from "@shared/types";
 import { bamboohrWatchlistAdapter } from "./bamboohr";
+import { greenhouseWatchlistAdapter } from "./greenhouse";
 import type { WatchlistCatalogSourceAdapter } from "./types";
 import { workdayWatchlistAdapter } from "./workday";
 
-const adapters = [workdayWatchlistAdapter, bamboohrWatchlistAdapter] as const;
+const adapters = [
+  workdayWatchlistAdapter,
+  bamboohrWatchlistAdapter,
+  greenhouseWatchlistAdapter,
+] as const;
 
 const adaptersByType = new Map<
   WatchedSourceType,

--- a/orchestrator/src/server/watchlist/adapters/types.ts
+++ b/orchestrator/src/server/watchlist/adapters/types.ts
@@ -21,10 +21,15 @@ export interface WatchlistCatalogSourceAdapter {
   normalizeCustomSelection(input: {
     label: string | null | undefined;
     careersUrl: string;
-  }): {
-    label: string;
-    careersUrl: string;
-  };
+  }):
+    | {
+        label: string;
+        careersUrl: string;
+      }
+    | Promise<{
+        label: string;
+        careersUrl: string;
+      }>;
   fetchJobs(input: {
     source: WatchlistSelectedSource;
     signal?: AbortSignal;

--- a/orchestrator/tsconfig.json
+++ b/orchestrator/tsconfig.json
@@ -20,7 +20,9 @@
       "@career-boards/bamboohr": ["../career-boards/bamboohr/src/index.ts"],
       "@career-boards/bamboohr/*": ["../career-boards/bamboohr/src/*"],
       "@career-boards/workday": ["../career-boards/workday/src/index.ts"],
-      "@career-boards/workday/*": ["../career-boards/workday/src/*"]
+      "@career-boards/workday/*": ["../career-boards/workday/src/*"],
+      "@career-boards/greenhouse": ["../career-boards/greenhouse/src/index.ts"],
+      "@career-boards/greenhouse/*": ["../career-boards/greenhouse/src/*"]
     }
   },
   "include": ["src/**/*", "scripts/**/*", "../career-boards/**/*.ts"],

--- a/orchestrator/vite.config.ts
+++ b/orchestrator/vite.config.ts
@@ -69,6 +69,10 @@ export default defineConfig({
         __dirname,
         "../career-boards/workday/src/index.ts",
       ),
+      "@career-boards/greenhouse": path.resolve(
+        __dirname,
+        "../career-boards/greenhouse/src/index.ts",
+      ),
     },
   },
   server: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,10 @@
       "name": "@career-boards/bamboohr",
       "version": "0.0.1"
     },
+    "career-boards/greenhouse": {
+      "name": "@career-boards/greenhouse",
+      "version": "0.0.1"
+    },
     "career-boards/workday": {
       "name": "@career-boards/workday",
       "version": "0.0.1"
@@ -2929,6 +2933,10 @@
     },
     "node_modules/@career-boards/bamboohr": {
       "resolved": "career-boards/bamboohr",
+      "link": true
+    },
+    "node_modules/@career-boards/greenhouse": {
+      "resolved": "career-boards/greenhouse",
       "link": true
     },
     "node_modules/@career-boards/workday": {


### PR DESCRIPTION
## Add Greenhouse career board support to the watchlist

### Summary
Adds Greenhouse as a third watchlist career-board format alongside Workday and
BambooHR, so users can track jobs from any Greenhouse-powered company. This
covers a large share of tech employers with a single adapter.

Previously the watchlist only supported two set formats (Workday, BambooHR). Greenhouse is one of the most widely
used ATSs, and its public board API exposes both job listings and full descriptions. Admittedly however, its less obvious when in use, due to how well it integrates by design with company sites.

### How it works
A new `@career-boards/greenhouse` module talks to the public Greenhouse board
API (`boards-api.greenhouse.io`). For custom sources, the user doesn't need to
know the underlying board token as a hybrid resolver figures it out from
whatever URL they paste, trying the cheapest reliable strategy first:

1. **Greenhouse URL** -> parse the board token directly
2. **Company careers page** -> scrape the embedded board token from the page
3. **Scrape blocked/unhelpful** -> guess the token from the domain, validated
   against the board API before it's trusted
4. **Fall back on user guidance** -> Prompts the user with suggested flows on how to determine the token themselves before progressing.

Every candidate is validated against the API, so a wrong guess never produces a
broken source. In practice this means a user can paste a plain careers page
(e.g. `https://www.epicgames.com/site/careers/jobs`) and it resolves
automatically, even when the page blocks server-side scraping, the
domain-guess fallback usually recovers it.

### Changes
- New `career-boards/greenhouse` workspace: URL parser, hybrid source resolver,
  and board list/detail fetchers (with HTML-entity decoding for descriptions)
- New Greenhouse watchlist adapter, registered in the adapter index
- `normalizeCustomSelection` is now async-capable so adapters can resolve a
  source over the network (Workday/BambooHR unchanged)
- Seeded Riot Games and Epic Games into the Greenhouse catalog
- Added `@career-boards/greenhouse` path aliases to `tsconfig.json` and
  `vite.config.ts`
- Location strings strip Greenhouse's `BLANK` placeholder components
  (e.g. `BLANK,BLANK,Multiple Locations` -> `Multiple Locations`)

### Testing
- 36 unit tests across the new module (URL parsing, token extraction,
  domain-guess, the 4-layer resolver, list/detail normalization, HTML decoding)
- Typecheck and Biome clean; existing watchlist/adapter tests still pass
- Verified end-to-end against the live Greenhouse API and through the full app
  (add custom source → resolver runs in the route → persists → results fetch)

### Notes
- Branding/logos are not enabled for Greenhouse (no reliable per-board logo
  endpoint); the source falls back to no logo.
- The UI required no changes, the source-type picker and custom-URL input are
  descriptor-driven, so Greenhouse appears automatically.