### PR TITLE
Add Requesty as an LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 
 MODEL=google/gemini-3-flash-preview
 
-# LLM provider (optional). Examples: openrouter, openai, gemini, gemini_cli, codex.
+# LLM provider (optional). Examples: openrouter, requesty, openai, gemini, gemini_cli, codex.
 # LLM_PROVIDER=gemini_cli
 # For Gemini (CLI): install @google/gemini-cli, run `gemini` and sign in (OAuth), or set
 # GEMINI_API_KEY in the environment. Optional overrides:

--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -43,7 +43,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 ![Model settings section](/img/features/settings-model-section.png)
 
 - In hosted deployments with platform-managed LLM enabled, this section is hidden because provider, API key, and model selection are managed by the hosted platform.
-- Choose provider (`openrouter`, `lmstudio`, `ollama`, `openai`, `glm`, `gemini`, `gemini_cli`, `codex`)
+- Choose provider (`openrouter`, `requesty`, `lmstudio`, `ollama`, `openai`, `glm`, `gemini`, `gemini_cli`, `codex`)
 - Set provider-specific base URL/API key when required
 - Configure the default model/runtime, plus purpose-specific overrides for:
   - Scoring

--- a/orchestrator/src/client/pages/settings/utils.test.ts
+++ b/orchestrator/src/client/pages/settings/utils.test.ts
@@ -110,6 +110,7 @@ describe("settings utils", () => {
     expect(supportsLlmModelSuggestions("gemini")).toBe(true);
     expect(supportsLlmModelSuggestions("gemini_cli")).toBe(true);
     expect(supportsLlmModelSuggestions("ollama")).toBe(true);
+    expect(supportsLlmModelSuggestions("requesty")).toBe(true);
     expect(supportsLlmModelSuggestions("openrouter")).toBe(false);
   });
 });

--- a/orchestrator/src/client/pages/settings/utils.ts
+++ b/orchestrator/src/client/pages/settings/utils.ts
@@ -42,6 +42,7 @@ export const LLM_MODEL_SUGGESTION_PROVIDERS = [
   "gemini",
   "gemini_cli",
   "ollama",
+  "requesty",
 ] as const;
 
 export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {

--- a/orchestrator/src/client/pages/settings/utils.ts
+++ b/orchestrator/src/client/pages/settings/utils.ts
@@ -22,6 +22,7 @@ export const formatSecretHint = (hint: string | null) =>
 
 export const LLM_PROVIDERS = [
   "openrouter",
+  "requesty",
   "lmstudio",
   "ollama",
   "openai",
@@ -45,6 +46,7 @@ export const LLM_MODEL_SUGGESTION_PROVIDERS = [
 
 export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
   openrouter: "OpenRouter",
+  requesty: "Requesty",
   lmstudio: "LM Studio",
   ollama: "Ollama",
   openai: "OpenAI",
@@ -58,6 +60,7 @@ export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
 
 const PROVIDERS_WITH_API_KEY = new Set<LlmProviderId>([
   "openrouter",
+  "requesty",
   "openai",
   "anthropic",
   "openai_compatible",
@@ -77,6 +80,8 @@ const PROVIDERS_WITH_BASE_URL = new Set<LlmProviderId>([
 const PROVIDER_HINTS: Record<LlmProviderId, string> = {
   openrouter:
     "OpenRouter uses your API key and supports model routing across providers.",
+  requesty:
+    "Requesty uses your API key and routes requests across providers through an OpenAI-compatible endpoint.",
   lmstudio: "LM Studio runs locally via its OpenAI-compatible server.",
   ollama:
     "Ollama typically runs locally. Add an API key only for Ollama-compatible endpoints protected by bearer auth.",
@@ -100,6 +105,10 @@ const PROVIDER_KEY_HELPERS: Record<
   openrouter: {
     text: "Create a key at openrouter.ai",
     href: "https://openrouter.ai/keys",
+  },
+  requesty: {
+    text: "Create a key at app.requesty.ai/api-keys",
+    href: "https://app.requesty.ai/api-keys",
   },
   lmstudio: { text: "No API key required for LM Studio" },
   ollama: {

--- a/orchestrator/src/server/services/llm/credentials.ts
+++ b/orchestrator/src/server/services/llm/credentials.ts
@@ -41,5 +41,12 @@ export function resolveLlmApiKey(options: {
     return toStringOrNull(getOriginalEnvValue("OPENROUTER_API_KEY"));
   }
 
+  if (
+    provider === "requesty" &&
+    toStringOrNull(getOriginalEnvValue("REQUESTY_API_KEY"))
+  ) {
+    return toStringOrNull(getOriginalEnvValue("REQUESTY_API_KEY"));
+  }
+
   return null;
 }

--- a/orchestrator/src/server/services/llm/providers/index.ts
+++ b/orchestrator/src/server/services/llm/providers/index.ts
@@ -9,9 +9,11 @@ import { ollamaStrategy } from "./ollama";
 import { openAiStrategy } from "./openai";
 import { openAiCompatibleStrategy } from "./openai-compatible";
 import { openRouterStrategy } from "./openrouter";
+import { requestyStrategy } from "./requesty";
 
 export const strategies: Record<LlmProvider, ProviderStrategy> = {
   openrouter: openRouterStrategy,
+  requesty: requestyStrategy,
   lmstudio: lmStudioStrategy,
   ollama: ollamaStrategy,
   openai: openAiStrategy,

--- a/orchestrator/src/server/services/llm/providers/providers.test.ts
+++ b/orchestrator/src/server/services/llm/providers/providers.test.ts
@@ -7,6 +7,7 @@ import { ollamaStrategy } from "./ollama";
 import { openAiStrategy } from "./openai";
 import { openAiCompatibleStrategy } from "./openai-compatible";
 import { openRouterStrategy } from "./openrouter";
+import { requestyStrategy } from "./requesty";
 
 const schema = {
   name: "test_schema",
@@ -33,6 +34,18 @@ describe("provider adapters", () => {
           model: "model-a",
         },
         expectedUrl: "https://openrouter.ai/api/v1/chat/completions",
+        expectedResponseFormat: "json_schema",
+      },
+      {
+        name: "requesty-json_schema",
+        strategy: requestyStrategy,
+        args: {
+          mode: "json_schema" as const,
+          baseUrl: "https://router.requesty.ai/v1",
+          apiKey: "x",
+          model: "openai/gpt-4o-mini",
+        },
+        expectedUrl: "https://router.requesty.ai/v1/chat/completions",
         expectedResponseFormat: "json_schema",
       },
       {
@@ -184,6 +197,7 @@ describe("provider adapters", () => {
       choices: [{ message: { content: "ok" } }],
     };
     expect(openRouterStrategy.extractText(response)).toBe("ok");
+    expect(requestyStrategy.extractText(response)).toBe("ok");
     expect(glmStrategy.extractText(response)).toBe("ok");
     expect(lmStudioStrategy.extractText(response)).toBe("ok");
     expect(ollamaStrategy.extractText(response)).toBe("ok");

--- a/orchestrator/src/server/services/llm/providers/requesty.ts
+++ b/orchestrator/src/server/services/llm/providers/requesty.ts
@@ -1,0 +1,22 @@
+import { buildHeaders, joinUrl } from "../utils/http";
+import {
+  buildChatCompletionsBody,
+  createProviderStrategy,
+  extractChatCompletionsText,
+} from "./factory";
+
+export const requestyStrategy = createProviderStrategy({
+  provider: "requesty",
+  defaultBaseUrl: "https://router.requesty.ai/v1",
+  requiresApiKey: true,
+  modes: ["json_schema", "json_object", "text", "none"],
+  validationPaths: ["/models"],
+  buildRequest: ({ mode, baseUrl, apiKey, model, messages, jsonSchema }) => {
+    return {
+      url: joinUrl(baseUrl, "/chat/completions"),
+      headers: buildHeaders({ apiKey, provider: "requesty" }),
+      body: buildChatCompletionsBody({ mode, model, messages, jsonSchema }),
+    };
+  },
+  extractText: extractChatCompletionsText,
+});

--- a/orchestrator/src/server/services/llm/service.test.ts
+++ b/orchestrator/src/server/services/llm/service.test.ts
@@ -166,4 +166,29 @@ describe("LlmService provider normalization", () => {
     expect(models[0]).toBe("google/gemini-3-flash-preview");
     expect(models.length).toBeGreaterThan(1);
   });
+
+  it("lists Requesty models from the /models endpoint", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            { id: "openai/gpt-4o-mini" },
+            { id: "anthropic/claude-sonnet-4-5" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const llm = new LlmService({
+      provider: "requesty",
+      apiKey: "rqsty-sk-test",
+    });
+    const models = await llm.listModels();
+
+    expect(models).toContain("openai/gpt-4o-mini");
+    expect(models).toContain("anthropic/claude-sonnet-4-5");
+    const [requestedUrl] = fetchSpy.mock.calls[0] ?? [];
+    expect(String(requestedUrl)).toBe("https://router.requesty.ai/v1/models");
+  });
 });

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -609,6 +609,7 @@ function normalizeProvider(
   if (normalized === "lmstudio") return "lmstudio";
   if (normalized === "ollama") return "ollama";
   if (normalized === "codex") return "codex";
+  if (normalized === "requesty") return "requesty";
   if (normalized && normalized !== "openrouter") {
     logger.warn("Unknown LLM provider, defaulting to openrouter", {
       normalized,

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -228,7 +228,8 @@ export class LlmService {
       this.provider !== "anthropic" &&
       this.provider !== "glm" &&
       this.provider !== "gemini" &&
-      this.provider !== "ollama"
+      this.provider !== "ollama" &&
+      this.provider !== "requesty"
     ) {
       return [];
     }
@@ -245,6 +246,9 @@ export class LlmService {
       }
       if (this.provider === "glm") {
         return this.listGlmModels();
+      }
+      if (this.provider === "requesty") {
+        return this.listRequestyModels();
       }
       return this.listOllamaModels();
     })();
@@ -559,6 +563,28 @@ export class LlmService {
     return (payload.data ?? [])
       .map((entry) => entry.id?.trim() ?? "")
       .filter(isGlmTextGenerationModel)
+      .filter(Boolean);
+  }
+
+  private async listRequestyModels(): Promise<string[]> {
+    const response = await fetch(joinUrl(this.baseUrl, "/models"), {
+      method: "GET",
+      headers: buildHeaders({
+        apiKey: this.apiKey,
+        provider: this.provider,
+      }),
+    });
+
+    if (!response.ok) {
+      const detail = await getResponseDetail(response);
+      throw new Error(detail || `Requesty returned ${response.status}.`);
+    }
+
+    const payload = (await response.json()) as {
+      data?: Array<{ id?: string | null }>;
+    };
+    return (payload.data ?? [])
+      .map((entry) => entry.id?.trim() ?? "")
       .filter(Boolean);
   }
 

--- a/orchestrator/src/server/services/llm/types.ts
+++ b/orchestrator/src/server/services/llm/types.ts
@@ -1,5 +1,6 @@
 export type LlmProvider =
   | "openrouter"
+  | "requesty"
   | "lmstudio"
   | "ollama"
   | "openai"

--- a/orchestrator/src/server/services/modelSelection.ts
+++ b/orchestrator/src/server/services/modelSelection.ts
@@ -88,6 +88,7 @@ function getDefaultBaseUrlForProvider(
     return "https://generativelanguage.googleapis.com";
   }
   if (normalized === "gemini_cli" || normalized === "codex") return null;
+  if (normalized === "requesty") return "https://router.requesty.ai/v1";
   return "https://openrouter.ai";
 }
 

--- a/orchestrator/src/server/services/settings.ts
+++ b/orchestrator/src/server/services/settings.ts
@@ -53,6 +53,9 @@ function resolveDefaultLlmBaseUrl(provider: string): string {
   if (normalized === "codex") {
     return "";
   }
+  if (normalized === "requesty") {
+    return "https://router.requesty.ai/v1";
+  }
   return "https://openrouter.ai";
 }
 

--- a/shared/src/types/settings.ts
+++ b/shared/src/types/settings.ts
@@ -25,6 +25,7 @@ export interface ResumeProjectsSettings {
 
 export const LLM_PROVIDER_VALUES = [
   "openrouter",
+  "requesty",
   "lmstudio",
   "ollama",
   "openai",


### PR DESCRIPTION
Adds Requesty as an LLM provider, mirroring the existing OpenRouter provider.

Requesty (https://router.requesty.ai/v1) exposes an OpenAI-compatible chat-completions API, so this reuses the existing provider-strategy pattern (`createProviderStrategy`) with a fixed base URL — no new dependency.

Changes:
- New `providers/requesty.ts` strategy: base URL https://router.requesty.ai/v1, `/chat/completions` endpoint, `/models` validation path, bearer auth via the shared header builder.
- Registered `requesty` in the strategies record, the `LlmProvider` union, and `LLM_PROVIDER_VALUES`.
- Settings UI: added label, API-key requirement, hint, and key-helper link (https://app.requesty.ai/api-keys).
- Default base-URL resolution (`settings.ts`, `modelSelection.ts`) and provider normalization (`service.ts`) now recognize requesty.
- Optional `REQUESTY_API_KEY` env fallback, mirroring `OPENROUTER_API_KEY`.
- Added a provider adapter test case and updated `.env.example` and the settings docs.

Not included: the OpenRouter-specific resume-import and ghostwriter image-capability paths (they query OpenRouter's own `/api/v1/models` metadata). Requesty falls through the same graceful path as the other OpenAI-compatible providers there; happy to wire those up if wanted.

Verification:
- `npm --workspace orchestrator run check:types` (tsc --noEmit) — pass.
- `providers.test.ts` — pass (17 tests).
- Live round-trip through the new strategy to https://router.requesty.ai/v1 with `openai/gpt-4o-mini` — HTTP 200, extracted text "ok".

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
