### PR TITLE
fix(visa-sponsors/uk): resolve CSV via GOV.UK Content API with HTML fallback

### DIFF
--- a/visa-sponsor-providers/uk/manifest.test.ts
+++ b/visa-sponsor-providers/uk/manifest.test.ts
@@ -1,8 +1,29 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import manifest, { extractWorkerTemporaryWorkerCsvUrl } from "./manifest";
+import manifest, {
+  extractWorkerTemporaryWorkerCsvUrl,
+  pickWorkerTemporaryWorkerCsvAttachment,
+} from "./manifest";
 
 const currentWorkerCsvUrl =
   "https://assets.publishing.service.gov.uk/media/6a43a38a1a04d4dae8b814a9/SP_-_Worker_and_Temporary_Worker_Web_Register_-_2026-06-30.csv";
+
+// Shape mirrors the real GOV.UK Content API response for this publication.
+const contentApiPayload = {
+  details: {
+    attachments: [
+      {
+        title: "Register of Worker and Temporary Worker licensed sponsors",
+        url: currentWorkerCsvUrl,
+        content_type: "text/csv",
+      },
+    ],
+  },
+};
+
+const sponsorCsv = [
+  "Organisation Name,Town/City,County,Type & Rating,Route",
+  'ACME Robotics Ltd,London,Greater London,"Worker (A rating)",Skilled Worker',
+].join("\n");
 
 describe("UK visa sponsor provider manifest", () => {
   afterEach(() => {
@@ -24,10 +45,88 @@ describe("UK visa sponsor provider manifest", () => {
     expect(extractWorkerTemporaryWorkerCsvUrl(html)).toBeNull();
   });
 
-  it("keeps the existing failure path when the matching CSV link is missing", async () => {
+  it("picks the Worker and Temporary Worker CSV attachment from the Content API payload", () => {
+    expect(pickWorkerTemporaryWorkerCsvAttachment(contentApiPayload)).toBe(
+      currentWorkerCsvUrl,
+    );
+  });
+
+  it("ignores non-CSV and unrelated Content API attachments", () => {
+    expect(
+      pickWorkerTemporaryWorkerCsvAttachment({
+        details: {
+          attachments: [
+            {
+              title: "Sponsor guidance",
+              url: "https://x/guide.pdf",
+              content_type: "application/pdf",
+            },
+            {
+              title: "Register of student sponsors",
+              url: "https://x/students.csv",
+              content_type: "text/csv",
+            },
+          ],
+        },
+      }),
+    ).toBeNull();
+    expect(pickWorkerTemporaryWorkerCsvAttachment(null)).toBeNull();
+    expect(pickWorkerTemporaryWorkerCsvAttachment({})).toBeNull();
+  });
+
+  it("resolves the CSV via the Content API without touching the HTML page", async () => {
     const fetchMock = vi
       .fn()
-      .mockResolvedValue(
+      .mockResolvedValueOnce(Response.json(contentApiPayload))
+      .mockResolvedValueOnce(new Response(sponsorCsv));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sponsors = await manifest.fetchSponsors();
+
+    expect(sponsors).toHaveLength(1);
+    expect(sponsors[0].organisationName).toBe("ACME Robotics Ltd");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe(currentWorkerCsvUrl);
+  });
+
+  it("falls back to the HTML scrape when the Content API fails", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("upstream error", { status: 500 }))
+      .mockResolvedValueOnce(
+        new Response(
+          `<a href="${currentWorkerCsvUrl}">Register of Worker and Temporary Worker licensed sponsors</a>`,
+        ),
+      )
+      .mockResolvedValueOnce(new Response(sponsorCsv));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sponsors = await manifest.fetchSponsors();
+
+    expect(sponsors).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back when the Content API returns invalid JSON", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("<html>not json</html>"))
+      .mockResolvedValueOnce(
+        new Response(
+          `<a href="${currentWorkerCsvUrl}">Register of Worker and Temporary Worker licensed sponsors</a>`,
+        ),
+      )
+      .mockResolvedValueOnce(new Response(sponsorCsv));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(manifest.fetchSponsors()).resolves.toHaveLength(1);
+  });
+
+  it("keeps the existing failure path when both sources miss the CSV link", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ details: { attachments: [] } }))
+      .mockResolvedValueOnce(
         new Response(
           '<a href="https://assets.publishing.service.gov.uk/media/123/Student_Sponsor_Register.csv">Student sponsors</a>',
         ),
@@ -37,6 +136,6 @@ describe("UK visa sponsor provider manifest", () => {
     await expect(manifest.fetchSponsors()).rejects.toThrow(
       "Could not find Worker and Temporary Worker CSV link on gov.uk page",
     );
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/visa-sponsor-providers/uk/manifest.ts
+++ b/visa-sponsor-providers/uk/manifest.ts
@@ -7,6 +7,12 @@ import { parseVisaSponsorsCsv } from "@shared/visa-sponsors/csv";
 const GOV_UK_PAGE_URL =
   "https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers";
 
+// Same publication, served as structured JSON. The HTML page intermittently
+// renders without the direct CSV href, so the Content API is the primary
+// source and the HTML scrape below is kept as a fallback.
+const GOV_UK_CONTENT_API_URL =
+  "https://www.gov.uk/api/content/government/publications/register-of-licensed-sponsors-workers";
+
 const GOV_UK_ASSET_PREFIX = "https://assets.publishing.service.gov.uk/media/";
 const CSV_HREF_PATTERN = /href=(["'])([^"']+\.csv(?:\?[^"']*)?)\1/gi;
 const CSV_LINK_NOT_FOUND_MESSAGE =
@@ -48,7 +54,66 @@ export function extractWorkerTemporaryWorkerCsvUrl(
   return null;
 }
 
+function isWorkerTemporaryWorkerLabel(label: string): boolean {
+  const normalized = label.toLowerCase();
+  const withoutTemporaryWorker = normalized.replace(/temporary worker/g, "");
+  return (
+    normalized.includes("temporary worker") &&
+    withoutTemporaryWorker.includes("worker")
+  );
+}
+
+export function pickWorkerTemporaryWorkerCsvAttachment(
+  payload: unknown,
+): string | null {
+  const attachments = (
+    payload as { details?: { attachments?: unknown } } | null
+  )?.details?.attachments;
+  if (!Array.isArray(attachments)) return null;
+
+  for (const attachment of attachments) {
+    const {
+      url,
+      title,
+      content_type: contentType,
+    } = (attachment ?? {}) as {
+      url?: unknown;
+      title?: unknown;
+      content_type?: unknown;
+    };
+    if (typeof url !== "string" || url.length === 0) continue;
+
+    const isCsv =
+      contentType === "text/csv" || url.toLowerCase().endsWith(".csv");
+    if (!isCsv) continue;
+
+    const label = typeof title === "string" ? title : "";
+    if (
+      isWorkerTemporaryWorkerLabel(label) ||
+      isWorkerTemporaryWorkerLabel(normalizeCsvUrl(url))
+    ) {
+      return url;
+    }
+  }
+
+  return null;
+}
+
+async function fetchCsvUrlFromContentApi(): Promise<string | null> {
+  try {
+    const response = await fetch(GOV_UK_CONTENT_API_URL);
+    if (!response.ok) return null;
+    return pickWorkerTemporaryWorkerCsvAttachment(await response.json());
+  } catch {
+    // Any Content API failure falls through to the HTML scrape.
+    return null;
+  }
+}
+
 async function extractCsvUrl(): Promise<string> {
+  const apiCsvUrl = await fetchCsvUrlFromContentApi();
+  if (apiCsvUrl) return apiCsvUrl;
+
   const response = await fetch(GOV_UK_PAGE_URL);
   if (!response.ok) {
     throw new Error(


### PR DESCRIPTION
## Problem

The UK visa-sponsor provider scrapes the publication's HTML page for the CSV href. gov.uk intermittently serves that page **without** the direct `assets.publishing.service.gov.uk/media/…` link (verified by fetching the same URL repeatedly — the href comes and goes), so the daily refresh fails with:

```
❌ Failed to download sponsors for provider uk: Could not find Worker and Temporary Worker CSV link on gov.uk page
```

…and the on-disk register silently goes stale. Reproduced on a fresh self-hosted install (ghcr latest).

## Fix

Use the [GOV.UK Content API](https://www.gov.uk/api/content/government/publications/register-of-licensed-sponsors-workers) for the same publication as the **primary** source — it returns the attachment list as structured JSON (`details.attachments[]`, `content_type: text/csv`), no scraping. The existing HTML scrape is kept intact as a **fallback**, and the existing error message is preserved when both sources miss (log compatibility).

## Evidence

- Live run after the fix: **142,364 sponsors** fetched in ~5.5s via the Content API path.
- 8 unit tests (3 existing kept, 5 new): Content API happy path, non-CSV/unrelated attachments ignored, fallback on 500, fallback on invalid JSON, both-sources-miss keeps the original error.

## Checks

- `biome ci .` clean · `check:types:shared` · orchestrator + extractor typechecks · `build:client` OK
- `test:all`: 259 files pass; 5 client test files fail **identically on clean main** in my environment (locale/timing-dependent: charts stress tests, date-age labels, salary formatting on a pt-BR machine) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)