### PR TITLE
feat(visa-sponsors): Netherlands provider (IND public register)

### DIFF
--- a/docs-site/docs/features/visa-sponsors.md
+++ b/docs-site/docs/features/visa-sponsors.md
@@ -11,6 +11,13 @@ The Visa Sponsors page lets you search official licensed sponsor registers from 
 
 Each provider corresponds to a country's official register and is auto-discovered at startup from the `visa-sponsor-providers/` directory.
 
+Available providers:
+
+| Country | Source | What it lists |
+|---------|--------|---------------|
+| United Kingdom (`uk`) | [GOV.UK register of licensed sponsors](https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers) | Worker and Temporary Worker licensed sponsors, with routes and type/rating |
+| Netherlands (`nl`) | [IND public register of recognised sponsors](https://ind.nl/en/public-register-recognised-sponsors/public-register-work) | Recognised sponsors for the residence purposes work and highly skilled migrant, with KvK number |
+
 For each company, it shows:
 
 - Match score against your query

--- a/shared/src/visa-sponsor-providers/index.ts
+++ b/shared/src/visa-sponsor-providers/index.ts
@@ -1,4 +1,4 @@
-export const VISA_SPONSOR_PROVIDER_IDS = ["uk"] as const;
+export const VISA_SPONSOR_PROVIDER_IDS = ["uk", "nl"] as const;
 
 export type VisaSponsorProviderId = (typeof VISA_SPONSOR_PROVIDER_IDS)[number];
 
@@ -14,6 +14,10 @@ export const VISA_SPONSOR_PROVIDER_METADATA: Record<
   uk: {
     label: "United Kingdom",
     countryKey: "united kingdom",
+  },
+  nl: {
+    label: "Netherlands",
+    countryKey: "netherlands",
   },
 };
 

--- a/visa-sponsor-providers/nl/manifest.test.ts
+++ b/visa-sponsor-providers/nl/manifest.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import manifest, { parseIndRegisterHtml } from "./manifest";
+
+// Mirrors the real IND register table markup (verified 2026-07-11).
+const registerHtml = `
+  <table>
+    <thead>
+      <tr>
+        <th scope="col">Organisation</th>
+        <th scope="col">KvK number</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th scope="row">Machinefabriek en Staalbouw Nederland B.V.</th>
+        <td>16051874</td>
+      </tr>
+      <tr>
+        <th scope="row">@EasePay B.V.</th>
+        <td>83892869</td>
+      </tr>
+      <tr>
+        <th scope="row">Adyen N.V.</th>
+        <td>34259528</td>
+      </tr>
+      <tr>
+        <th scope="row">Ampersand &amp; Co</th>
+        <td></td>
+      </tr>
+    </tbody>
+  </table>
+`;
+
+describe("NL visa sponsor provider manifest", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("parses organisation rows from the IND register table", () => {
+    const sponsors = parseIndRegisterHtml(registerHtml);
+
+    expect(sponsors).toHaveLength(4);
+    expect(sponsors[0]).toEqual({
+      organisationName: "Machinefabriek en Staalbouw Nederland B.V.",
+      townCity: "",
+      county: "",
+      typeRating: "Recognised sponsor (KvK 16051874)",
+      route: "Work / Highly skilled migrant",
+    });
+    expect(sponsors[2].organisationName).toBe("Adyen N.V.");
+  });
+
+  it("decodes HTML entities and tolerates a missing KvK number", () => {
+    const sponsors = parseIndRegisterHtml(registerHtml);
+
+    expect(sponsors[3].organisationName).toBe("Ampersand & Co");
+    expect(sponsors[3].typeRating).toBe("Recognised sponsor");
+  });
+
+  it("ignores header rows and non-row markup", () => {
+    const sponsors = parseIndRegisterHtml(
+      '<th scope="col">Organisation</th><td>ignored</td>',
+    );
+
+    expect(sponsors).toHaveLength(0);
+  });
+
+  it("fetches and parses the register page", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(registerHtml));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sponsors = await manifest.fetchSponsors();
+
+    expect(sponsors).toHaveLength(4);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws an actionable error when the page yields no sponsors", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("<html><body>maintenance</body></html>"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(manifest.fetchSponsors()).rejects.toThrow(
+      "Could not find any recognised sponsors in the IND register page",
+    );
+  });
+
+  it("throws when the register page is unreachable", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("gone", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(manifest.fetchSponsors()).rejects.toThrow(
+      "Failed to fetch IND register page: 503",
+    );
+  });
+});

--- a/visa-sponsor-providers/nl/manifest.ts
+++ b/visa-sponsor-providers/nl/manifest.ts
@@ -1,0 +1,82 @@
+import type {
+  VisaSponsor,
+  VisaSponsorProviderManifest,
+} from "@shared/types/visa-sponsors";
+
+// IND public register of recognised sponsors for the residence purpose
+// "work" and "highly skilled migrant". Single HTML page, one table:
+// <th scope="row">Organisation</th><td>KvK number</td> (~12k rows).
+const IND_REGISTER_URL =
+  "https://ind.nl/en/public-register-recognised-sponsors/public-register-work";
+
+const SPONSOR_ROW_PATTERN =
+  /<th[^>]*scope=(["'])row\1[^>]*>([\s\S]*?)<\/th>\s*<td[^>]*>([\s\S]*?)<\/td>/gi;
+
+const NO_SPONSORS_MESSAGE =
+  "Could not find any recognised sponsors in the IND register page";
+
+function decodeHtmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#0?39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ");
+}
+
+function cleanCellText(cell: string): string {
+  return decodeHtmlEntities(cell.replace(/<[^>]*>/g, ""))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export function parseIndRegisterHtml(html: string): VisaSponsor[] {
+  const sponsors: VisaSponsor[] = [];
+
+  for (const match of html.matchAll(SPONSOR_ROW_PATTERN)) {
+    const organisationName = cleanCellText(match[2]);
+    const kvkNumber = cleanCellText(match[3]);
+    if (!organisationName) continue;
+
+    sponsors.push({
+      organisationName,
+      townCity: "",
+      county: "",
+      // The register lists recognition, not location; the KvK number is the
+      // only other public field and is kept for disambiguation.
+      typeRating: kvkNumber
+        ? `Recognised sponsor (KvK ${kvkNumber})`
+        : "Recognised sponsor",
+      route: "Work / Highly skilled migrant",
+    });
+  }
+
+  return sponsors;
+}
+
+export const manifest: VisaSponsorProviderManifest = {
+  id: "nl",
+  displayName: "Netherlands",
+  countryKey: "netherlands",
+  scheduledUpdateHour: 3,
+
+  async fetchSponsors(): Promise<VisaSponsor[]> {
+    const response = await fetch(IND_REGISTER_URL);
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch IND register page: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const sponsors = parseIndRegisterHtml(await response.text());
+    if (sponsors.length === 0) {
+      throw new Error(NO_SPONSORS_MESSAGE);
+    }
+
+    return sponsors;
+  },
+};
+
+export default manifest;


### PR DESCRIPTION
## What

Adds a `nl` visa-sponsor provider backed by the [IND public register of recognised sponsors](https://ind.nl/en/public-register-recognised-sponsors/public-register-work) (residence purposes **work** and **highly skilled migrant**) — the Dutch equivalent of the UK licensed-sponsor register.

- Single HTML table (`<th scope="row">Organisation</th><td>KvK</td>`, ~12,900 rows), parsed with entity decoding and tag stripping
- `route: "Work / Highly skilled migrant"`; KvK number kept in `typeRating` for disambiguation (the register publishes no location)
- Catalog entries added to `VISA_SPONSOR_PROVIDER_IDS` / `VISA_SPONSOR_PROVIDER_METADATA`
- Docs: provider table added to the Visa Sponsors feature page

## Evidence

- Live run: **12,887 sponsors** parsed from the real register (Adyen N.V. present, KvK 34259528)
- 6 unit tests: parsing (entities, missing KvK, header rows ignored), fetch happy path, empty-page and non-OK error paths

## Checks

`biome ci .` clean · shared + orchestrator typechecks · `build:client` · docs build OK · `test:all` 260 passed (same 5 client files fail identically on clean main in my env — locale/timing, unrelated)

Follow-ups planned in the same shape if welcome: US (H-1B Employer Data Hub) and Canada (LMIA positive employers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)