### PR TITLE
feat(visa-sponsors): United States provider (USCIS H-1B Employer Data Hub)

### DIFF
--- a/docs-site/docs/features/visa-sponsors.md
+++ b/docs-site/docs/features/visa-sponsors.md
@@ -11,6 +11,13 @@ The Visa Sponsors page lets you search official licensed sponsor registers from 
 
 Each provider corresponds to a country's official register and is auto-discovered at startup from the `visa-sponsor-providers/` directory.
 
+Available providers:
+
+| Country | Source | What it lists |
+|---------|--------|---------------|
+| United Kingdom (`uk`) | [GOV.UK register of licensed sponsors](https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers) | Worker and Temporary Worker licensed sponsors, with routes and type/rating |
+| United States (`us`) | [USCIS H-1B Employer Data Hub](https://www.uscis.gov/tools/reports-and-studies/h-1b-employer-data-hub) | Employers with H-1B approvals in the latest published fiscal year (sponsorship history signal) |
+
 For each company, it shows:
 
 - Match score against your query

--- a/shared/src/visa-sponsor-providers/index.ts
+++ b/shared/src/visa-sponsor-providers/index.ts
@@ -1,4 +1,4 @@
-export const VISA_SPONSOR_PROVIDER_IDS = ["uk"] as const;
+export const VISA_SPONSOR_PROVIDER_IDS = ["uk", "us"] as const;
 
 export type VisaSponsorProviderId = (typeof VISA_SPONSOR_PROVIDER_IDS)[number];
 
@@ -14,6 +14,10 @@ export const VISA_SPONSOR_PROVIDER_METADATA: Record<
   uk: {
     label: "United Kingdom",
     countryKey: "united kingdom",
+  },
+  us: {
+    label: "United States",
+    countryKey: "united states",
   },
 };
 

--- a/visa-sponsor-providers/us/manifest.test.ts
+++ b/visa-sponsor-providers/us/manifest.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import manifest, { parseH1bExport } from "./manifest";
+
+// Mirrors the real USCIS Data Hub export header and quirks (verified
+// 2026-07-11): rows with an empty employer, one row per NAICS code for the
+// same employer, quoted names.
+const exportCsv = [
+  '"Fiscal Year",Employer,"Initial Approval","Initial Denial","Continuing Approval","Continuing Denial",NAICS,"Tax ID",State,City,ZIP',
+  "2023,,1,0,0,0,51,8070,DE,WILMINGTON,19801",
+  '2023,"ACME ROBOTICS INC",2,0,3,1,51,1234,WA,SEATTLE,98101',
+  '2023,"ACME ROBOTICS INC",1,0,0,0,54,1234,WA,SEATTLE,98101',
+  '2023,"DENIED ONLY LLC",0,2,0,1,51,9999,TX,AUSTIN,78701',
+  '2023,"1 800 CONTACTS INC",0,0,1,0,42,1643,,,',
+].join("\n");
+
+describe("US visa sponsor provider manifest", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("aggregates approvals per employer across NAICS rows", () => {
+    const sponsors = parseH1bExport(exportCsv, 2023);
+    const acme = sponsors.find(
+      (s) => s.organisationName === "ACME ROBOTICS INC",
+    );
+
+    expect(acme).toEqual({
+      organisationName: "ACME ROBOTICS INC",
+      townCity: "SEATTLE",
+      county: "WA",
+      typeRating: "H-1B employer (FY2023: 6 approvals)",
+      route: "H-1B",
+    });
+  });
+
+  it("skips empty-employer rows and employers with zero approvals", () => {
+    const sponsors = parseH1bExport(exportCsv, 2023);
+    const names = sponsors.map((s) => s.organisationName);
+
+    expect(names).toEqual(["ACME ROBOTICS INC", "1 800 CONTACTS INC"]);
+  });
+
+  it("tolerates rows with missing location fields", () => {
+    const sponsors = parseH1bExport(exportCsv, 2023);
+    const contacts = sponsors.find(
+      (s) => s.organisationName === "1 800 CONTACTS INC",
+    );
+
+    expect(contacts?.townCity).toBe("");
+    expect(contacts?.county).toBe("");
+  });
+
+  it("downloads the newest available fiscal year and falls back on 404", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("2023")) {
+        return Promise.resolve(new Response(exportCsv));
+      }
+      return Promise.resolve(new Response("not found", { status: 404 }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sponsors = await manifest.fetchSponsors();
+
+    expect(sponsors.length).toBeGreaterThan(0);
+    expect(sponsors[0].typeRating).toContain("FY2023");
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(urls[urls.length - 1]).toContain("h1b_datahubexport-2023.csv");
+  });
+
+  it("throws an actionable error when no year is available", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response("nope", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(manifest.fetchSponsors()).rejects.toThrow(
+      "Failed to download US H-1B export",
+    );
+  });
+});

--- a/visa-sponsor-providers/us/manifest.ts
+++ b/visa-sponsor-providers/us/manifest.ts
@@ -1,0 +1,146 @@
+import type {
+  VisaSponsor,
+  VisaSponsorProviderManifest,
+} from "@shared/types/visa-sponsors";
+
+// USCIS H-1B Employer Data Hub yearly export. Employers that petitioned for
+// H-1B workers, with approval counts — the closest public equivalent of a
+// "sponsor register" for the US. Files are published per fiscal year at a
+// stable path; the latest available year is discovered by probing downwards.
+const DATA_URL = (fiscalYear: number) =>
+  `https://www.uscis.gov/sites/default/files/document/data/h1b_datahubexport-${fiscalYear}.csv`;
+
+const OLDEST_FISCAL_YEAR = 2019;
+
+const EMPTY_EXPORT_MESSAGE = "US H-1B export appears empty or invalid";
+
+// Header: "Fiscal Year",Employer,"Initial Approval","Initial Denial",
+// "Continuing Approval","Continuing Denial",NAICS,"Tax ID",State,City,ZIP
+const COLUMNS = {
+  employer: 1,
+  initialApproval: 2,
+  continuingApproval: 4,
+  state: 8,
+  city: 9,
+} as const;
+
+function parseCsvLine(line: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    const nextChar = line[i + 1];
+
+    if (char === '"' && !inQuotes) {
+      inQuotes = true;
+    } else if (char === '"' && inQuotes) {
+      if (nextChar === '"') {
+        current += '"';
+        i++;
+      } else {
+        inQuotes = false;
+      }
+    } else if (char === "," && !inQuotes) {
+      fields.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+
+  fields.push(current.trim());
+  return fields;
+}
+
+export function parseH1bExport(
+  content: string,
+  fiscalYear: number,
+): VisaSponsor[] {
+  const lines = content.replace(/^﻿/, "").split(/\r?\n/);
+  // Employers appear once per NAICS code; aggregate approvals per employer.
+  const byEmployer = new Map<
+    string,
+    { approvals: number; city: string; state: string }
+  >();
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    const fields = parseCsvLine(line);
+    const employer = fields[COLUMNS.employer] ?? "";
+    if (!employer) continue;
+
+    const approvals =
+      (Number(fields[COLUMNS.initialApproval]) || 0) +
+      (Number(fields[COLUMNS.continuingApproval]) || 0);
+
+    const existing = byEmployer.get(employer);
+    if (existing) {
+      existing.approvals += approvals;
+      if (!existing.city) existing.city = fields[COLUMNS.city] ?? "";
+      if (!existing.state) existing.state = fields[COLUMNS.state] ?? "";
+    } else {
+      byEmployer.set(employer, {
+        approvals,
+        city: fields[COLUMNS.city] ?? "",
+        state: fields[COLUMNS.state] ?? "",
+      });
+    }
+  }
+
+  const sponsors: VisaSponsor[] = [];
+  for (const [organisationName, data] of byEmployer) {
+    if (data.approvals === 0) continue;
+
+    sponsors.push({
+      organisationName,
+      townCity: data.city,
+      county: data.state,
+      typeRating: `H-1B employer (FY${fiscalYear}: ${data.approvals} approvals)`,
+      route: "H-1B",
+    });
+  }
+
+  return sponsors;
+}
+
+async function fetchLatestExport(): Promise<{
+  content: string;
+  fiscalYear: number;
+}> {
+  const currentYear = new Date().getFullYear();
+  let lastError = `no export found between FY${OLDEST_FISCAL_YEAR} and FY${currentYear + 1}`;
+
+  for (let year = currentYear + 1; year >= OLDEST_FISCAL_YEAR; year--) {
+    const response = await fetch(DATA_URL(year));
+    if (!response.ok) {
+      lastError = `FY${year}: ${response.status} ${response.statusText}`;
+      continue;
+    }
+    return { content: await response.text(), fiscalYear: year };
+  }
+
+  throw new Error(`Failed to download US H-1B export: ${lastError}`);
+}
+
+export const manifest: VisaSponsorProviderManifest = {
+  id: "us",
+  displayName: "United States",
+  countryKey: "united states",
+  scheduledUpdateHour: 4,
+
+  async fetchSponsors(): Promise<VisaSponsor[]> {
+    const { content, fiscalYear } = await fetchLatestExport();
+    const sponsors = parseH1bExport(content, fiscalYear);
+    if (sponsors.length === 0) {
+      throw new Error(EMPTY_EXPORT_MESSAGE);
+    }
+
+    return sponsors;
+  },
+};
+
+export default manifest;


### PR DESCRIPTION
## What

Adds a `us` visa-sponsor provider backed by the [USCIS H-1B Employer Data Hub](https://www.uscis.gov/tools/reports-and-studies/h-1b-employer-data-hub) yearly export — employers with H-1B petition approvals, the closest public equivalent of a sponsor register for the US.

- Latest fiscal year discovered by probing `h1b_datahubexport-<year>.csv` downwards from next year (FY2023 is the newest published today; FY2024+ gets picked up automatically)
- One row per employer×NAICS in the source → aggregated per employer, initial+continuing approvals summed; zero-approval and empty-employer rows dropped
- `route: "H-1B"`, `typeRating: "H-1B employer (FY2023: N approvals)"`, city/state mapped to the location fields
- Catalog + docs table updated

## Evidence

- Live run: **27,146 employers** parsed from the FY2023 export in ~5s (sanity: GOOGLE LLC, Mountain View CA, 2,460 approvals)
- 5 unit tests: NAICS aggregation, empty-employer and zero-approval filtering, missing-location tolerance, year-probing fallback, no-year-available error

## Notes

- This lists sponsorship *history* (approvals in the last published FY), which is the practical signal a candidate needs; the JD-facing register the UK has doesn't exist for the US.
- Docs table will conflict trivially with #662 (NL) — happy to rebase whichever lands second.

## Checks

`biome ci .` clean · shared + orchestrator typechecks · provider tests 5/5 · same 5 pre-existing client test files fail on clean main in my env (locale/timing), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)