### PR TITLE
feat(visa-sponsors): Canada provider (ESDC positive LMIA employers)

### DIFF
--- a/docs-site/docs/features/visa-sponsors.md
+++ b/docs-site/docs/features/visa-sponsors.md
@@ -11,6 +11,13 @@ The Visa Sponsors page lets you search official licensed sponsor registers from 
 
 Each provider corresponds to a country's official register and is auto-discovered at startup from the `visa-sponsor-providers/` directory.
 
+Available providers:
+
+| Country | Source | What it lists |
+|---------|--------|---------------|
+| United Kingdom (`uk`) | [GOV.UK register of licensed sponsors](https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers) | Worker and Temporary Worker licensed sponsors, with routes and type/rating |
+| Canada (`ca`) | [ESDC positive LMIA employers list](https://open.canada.ca/data/en/dataset/90fed587-1364-4f33-a9ee-208181dc0b97) | Employers issued a positive Labour Market Impact Assessment in the latest published quarter, with program stream and approved positions |
+
 For each company, it shows:
 
 - Match score against your query

--- a/orchestrator/package.json
+++ b/orchestrator/package.json
@@ -65,6 +65,7 @@
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.38.2",
     "express": "^4.22.2",
+    "fflate": "^0.8.3",
     "framer-motion": "^12.40.0",
     "html-to-text": "^9.0.5",
     "jsdom": "^25.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16060,9 +16060,9 @@
       }
     },
     "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
     "node_modules/figlet": {
@@ -30242,6 +30242,7 @@
         "dotenv": "^17.4.2",
         "drizzle-orm": "^0.38.2",
         "express": "^4.22.2",
+        "fflate": "^0.8.3",
         "framer-motion": "^12.40.0",
         "html-to-text": "^9.0.5",
         "jsdom": "^25.0.1",

--- a/shared/src/visa-sponsor-providers/index.ts
+++ b/shared/src/visa-sponsor-providers/index.ts
@@ -1,4 +1,4 @@
-export const VISA_SPONSOR_PROVIDER_IDS = ["uk"] as const;
+export const VISA_SPONSOR_PROVIDER_IDS = ["uk", "ca"] as const;
 
 export type VisaSponsorProviderId = (typeof VISA_SPONSOR_PROVIDER_IDS)[number];
 
@@ -14,6 +14,10 @@ export const VISA_SPONSOR_PROVIDER_METADATA: Record<
   uk: {
     label: "United Kingdom",
     countryKey: "united kingdom",
+  },
+  ca: {
+    label: "Canada",
+    countryKey: "canada",
   },
 };
 

--- a/visa-sponsor-providers/ca/manifest.test.ts
+++ b/visa-sponsor-providers/ca/manifest.test.ts
@@ -1,0 +1,156 @@
+import { strToU8, zipSync } from "fflate";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import manifest, { parseLmiaRows, pickLatestQuarterResource } from "./manifest";
+import { extractRows } from "./xlsx";
+
+// CKAN payload mirroring the real dataset: quarters as XLSX in en/fr,
+// legacy CSVs, and statistical tables that must be ignored.
+const ckanPayload = {
+  result: {
+    resources: [
+      {
+        name: "2020Q3-Employers Who Were Issued a Positive Labour Market Impact Assessment",
+        format: "CSV",
+        language: ["en"],
+        url: "https://x/2020q3.csv",
+      },
+      {
+        name: "2025Q3-Employers Who Were Issued a Positive Labour Market Impact Assessment",
+        format: "XLSX",
+        language: ["en"],
+        url: "https://x/2025q3_en.xlsx",
+      },
+      {
+        name: "2025Q4-Employers Who Were Issued a Positive Labour Market Impact Assessment",
+        format: "XLSX",
+        language: ["fr"],
+        url: "https://x/2025q4_fr.xlsx",
+      },
+      {
+        name: "2025Q4-Employers Who Were Issued a Positive Labour Market Impact Assessment",
+        format: "XLSX",
+        language: ["en"],
+        url: "https://x/2025q4_en.xlsx",
+      },
+    ],
+  },
+};
+
+// A tiny real XLSX built in-memory with the ESDC sheet shape: two title rows,
+// the header row, then data rows (shared strings + inline numbers).
+function buildWorkbook(): Uint8Array {
+  const strings = [
+    "Employers who were issued a positive LMIA", // 0 title
+    "Province/Territory", // 1
+    "Program Stream", // 2
+    "Employer", // 3
+    "Address", // 4
+    "Occupation", // 5
+    "Approved Positions", // 6
+    "Ontario", // 7
+    "    High Wage", // 8
+    "ACME Robotics Ltd", // 9
+    "Toronto, ON M5V 2T6", // 10
+    "21231-Software engineers", // 11
+    "Ampersand & Co", // 12
+    "Waterloo, ON N2L 3G1", // 13
+  ];
+  const sharedStrings = `<?xml version="1.0"?><sst>${strings
+    .map(
+      (s) => `<si><t xml:space="preserve">${s.replace(/&/g, "&amp;")}</t></si>`,
+    )
+    .join("")}</sst>`;
+
+  const s = (ref: string, idx: number) =>
+    `<c r="${ref}" t="s"><v>${idx}</v></c>`;
+  const n = (ref: string, value: number) => `<c r="${ref}"><v>${value}</v></c>`;
+  const sheet = `<?xml version="1.0"?><worksheet><sheetData>
+    <row r="1">${s("A1", 0)}</row>
+    <row r="2"/>
+    <row r="3">${s("A3", 1)}${s("B3", 2)}${s("C3", 3)}${s("D3", 4)}${s("E3", 5)}${s("F3", 6)}</row>
+    <row r="4">${s("A4", 7)}${s("B4", 8)}${s("C4", 9)}${s("D4", 10)}${s("E4", 11)}${n("F4", 3)}</row>
+    <row r="5">${s("A5", 7)}${s("B5", 8)}${s("C5", 12)}${s("D5", 13)}${s("E5", 11)}${n("F5", 1)}</row>
+  </sheetData></worksheet>`;
+
+  return zipSync({
+    "xl/worksheets/sheet1.xml": strToU8(sheet),
+    "xl/sharedStrings.xml": strToU8(sharedStrings),
+  });
+}
+
+describe("CA visa sponsor provider manifest", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("picks the newest English positive-LMIA XLSX quarter from CKAN", () => {
+    expect(pickLatestQuarterResource(ckanPayload)).toEqual({
+      url: "https://x/2025q4_en.xlsx",
+      quarter: "2025Q4",
+    });
+  });
+
+  it("returns null when the dataset has no matching resource", () => {
+    expect(pickLatestQuarterResource({ result: { resources: [] } })).toBeNull();
+    expect(pickLatestQuarterResource(null)).toBeNull();
+  });
+
+  it("extracts rows from the workbook, resolving shared strings and entities", () => {
+    const rows = extractRows(buildWorkbook());
+
+    // Self-closing empty rows are dropped by the extractor; the provider
+    // locates the header by content, so alignment is irrelevant.
+    expect(rows[1][2]).toBe("Employer");
+    expect(rows[3][2]).toBe("Ampersand & Co");
+  });
+
+  it("parses sponsors from the sheet, mapping columns by header name", () => {
+    const sponsors = parseLmiaRows(extractRows(buildWorkbook()), "2025Q4");
+
+    expect(sponsors).toHaveLength(2);
+    expect(sponsors[0]).toEqual({
+      organisationName: "ACME Robotics Ltd",
+      townCity: "Toronto",
+      county: "Ontario",
+      typeRating: "LMIA positive employer (2025Q4: 3 approved positions)",
+      route: "High Wage",
+    });
+  });
+
+  it("fetches CKAN, downloads the newest quarter and parses it end to end", async () => {
+    const workbook = buildWorkbook();
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("package_show")) {
+        return Promise.resolve(Response.json(ckanPayload));
+      }
+      return Promise.resolve(
+        new Response(workbook.slice().buffer as ArrayBuffer),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const sponsors = await manifest.fetchSponsors();
+
+    expect(sponsors).toHaveLength(2);
+    expect(fetchMock.mock.calls[1][0]).toBe("https://x/2025q4_en.xlsx");
+  });
+
+  it("throws an actionable error when the sheet has no employer header", async () => {
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("package_show")) {
+        return Promise.resolve(Response.json(ckanPayload));
+      }
+      const empty = zipSync({
+        "xl/worksheets/sheet1.xml": strToU8(
+          "<worksheet><sheetData/></worksheet>",
+        ),
+      });
+      return Promise.resolve(new Response(empty.slice().buffer as ArrayBuffer));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(manifest.fetchSponsors()).rejects.toThrow(
+      "Canada LMIA list appears empty or invalid",
+    );
+  });
+});

--- a/visa-sponsor-providers/ca/manifest.ts
+++ b/visa-sponsor-providers/ca/manifest.ts
@@ -1,0 +1,135 @@
+import type {
+  VisaSponsor,
+  VisaSponsorProviderManifest,
+} from "@shared/types/visa-sponsors";
+import { extractRows } from "./xlsx";
+
+// ESDC quarterly list of employers issued a positive Labour Market Impact
+// Assessment (LMIA) — the public signal that an employer hires temporary
+// foreign workers in Canada. Quarters are published as XLSX resources on the
+// open.canada.ca dataset; the newest English quarter is resolved via the CKAN
+// API instead of hardcoding a download URL.
+const CKAN_PACKAGE_URL =
+  "https://open.canada.ca/data/api/action/package_show?id=90fed587-1364-4f33-a9ee-208181dc0b97";
+
+const QUARTER_PATTERN = /^(\d{4})Q(\d)/;
+
+const NO_RESOURCE_MESSAGE =
+  "Could not find a positive-LMIA XLSX resource on the open.canada.ca dataset";
+const EMPTY_LIST_MESSAGE = "Canada LMIA list appears empty or invalid";
+
+interface CkanResource {
+  name?: string;
+  url?: string;
+  format?: string;
+  language?: string[];
+}
+
+export function pickLatestQuarterResource(
+  payload: unknown,
+): { url: string; quarter: string } | null {
+  const resources = (
+    payload as { result?: { resources?: CkanResource[] } } | null
+  )?.result?.resources;
+  if (!Array.isArray(resources)) return null;
+
+  let best: { url: string; quarter: string; rank: number } | null = null;
+  for (const resource of resources) {
+    const name = resource?.name ?? "";
+    const match = QUARTER_PATTERN.exec(name);
+    if (!match) continue;
+    if ((resource.format ?? "").toUpperCase() !== "XLSX") continue;
+    if (resource.language && !resource.language.includes("en")) continue;
+    if (!/positive/i.test(name)) continue;
+    if (!resource.url) continue;
+
+    const rank = Number(match[1]) * 10 + Number(match[2]);
+    if (!best || rank > best.rank) {
+      best = { url: resource.url, quarter: `${match[1]}Q${match[2]}`, rank };
+    }
+  }
+
+  return best ? { url: best.url, quarter: best.quarter } : null;
+}
+
+export function parseLmiaRows(
+  rows: string[][],
+  quarter: string,
+): VisaSponsor[] {
+  // The sheet has title rows before the header; locate the header by its
+  // "Employer" column, then map columns by name (layout drifted across years).
+  const headerIndex = rows.findIndex((row) =>
+    row.some((cell) => /^employer$/i.test(cell)),
+  );
+  if (headerIndex === -1) return [];
+
+  const header = rows[headerIndex].map((cell) => cell.toLowerCase());
+  const col = (pattern: RegExp) =>
+    header.findIndex((cell) => pattern.test(cell));
+  const employerCol = col(/^employer$/);
+  const provinceCol = col(/province/);
+  const streamCol = col(/stream/);
+  const addressCol = col(/address/);
+  const positionsCol = col(/positions/);
+
+  const sponsors: VisaSponsor[] = [];
+  for (const row of rows.slice(headerIndex + 1)) {
+    const organisationName = row[employerCol] ?? "";
+    if (!organisationName) continue;
+
+    // Addresses read "City, PROV postal"; the city is the leading segment.
+    const address = addressCol >= 0 ? (row[addressCol] ?? "") : "";
+    const townCity = address.split(",")[0]?.trim() ?? "";
+    const positions = positionsCol >= 0 ? Number(row[positionsCol]) || 0 : 0;
+
+    sponsors.push({
+      organisationName,
+      townCity,
+      county: provinceCol >= 0 ? (row[provinceCol] ?? "") : "",
+      typeRating: positions
+        ? `LMIA positive employer (${quarter}: ${positions} approved positions)`
+        : `LMIA positive employer (${quarter})`,
+      route: streamCol >= 0 && row[streamCol] ? row[streamCol].trim() : "TFWP",
+    });
+  }
+
+  return sponsors;
+}
+
+export const manifest: VisaSponsorProviderManifest = {
+  id: "ca",
+  displayName: "Canada",
+  countryKey: "canada",
+  scheduledUpdateHour: 5,
+
+  async fetchSponsors(): Promise<VisaSponsor[]> {
+    const packageResponse = await fetch(CKAN_PACKAGE_URL);
+    if (!packageResponse.ok) {
+      throw new Error(
+        `Failed to query open.canada.ca: ${packageResponse.status} ${packageResponse.statusText}`,
+      );
+    }
+
+    const resource = pickLatestQuarterResource(await packageResponse.json());
+    if (!resource) {
+      throw new Error(NO_RESOURCE_MESSAGE);
+    }
+
+    const fileResponse = await fetch(resource.url);
+    if (!fileResponse.ok) {
+      throw new Error(
+        `Failed to download LMIA list (${resource.quarter}): ${fileResponse.status} ${fileResponse.statusText}`,
+      );
+    }
+
+    const rows = extractRows(new Uint8Array(await fileResponse.arrayBuffer()));
+    const sponsors = parseLmiaRows(rows, resource.quarter);
+    if (sponsors.length === 0) {
+      throw new Error(EMPTY_LIST_MESSAGE);
+    }
+
+    return sponsors;
+  },
+};
+
+export default manifest;

--- a/visa-sponsor-providers/ca/xlsx.ts
+++ b/visa-sponsor-providers/ca/xlsx.ts
@@ -1,0 +1,73 @@
+import { unzipSync } from "fflate";
+
+// Minimal XLSX row extractor — just enough for the flat, single-sheet
+// spreadsheets ESDC publishes (no formulas, no dates, shared strings +
+// inline numbers). Returns rows as arrays of trimmed cell strings.
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replace(/&amp;/g, "&");
+}
+
+function parseSharedStrings(xml: string): string[] {
+  const strings: string[] = [];
+  for (const si of xml.matchAll(/<si>([\s\S]*?)<\/si>/g)) {
+    // Concatenate every text run so rich-text cells come out whole.
+    const text = [...si[1].matchAll(/<t[^>]*>([\s\S]*?)<\/t>/g)]
+      .map((t) => decodeXmlEntities(t[1]))
+      .join("");
+    strings.push(text);
+  }
+  return strings;
+}
+
+function columnIndex(cellRef: string): number {
+  let index = 0;
+  for (const char of cellRef) {
+    if (char < "A" || char > "Z") break;
+    index = index * 26 + (char.charCodeAt(0) - 64);
+  }
+  return index - 1;
+}
+
+export function extractRows(workbook: Uint8Array): string[][] {
+  const files = unzipSync(workbook);
+  const sheet = files["xl/worksheets/sheet1.xml"];
+  if (!sheet) {
+    throw new Error("XLSX has no xl/worksheets/sheet1.xml");
+  }
+
+  const decoder = new TextDecoder();
+  const sharedStrings = files["xl/sharedStrings.xml"]
+    ? parseSharedStrings(decoder.decode(files["xl/sharedStrings.xml"]))
+    : [];
+
+  const rows: string[][] = [];
+  for (const row of decoder
+    .decode(sheet)
+    .matchAll(/<row[^>]*>([\s\S]*?)<\/row>/g)) {
+    const cells: string[] = [];
+    for (const cell of row[1].matchAll(
+      /<c(?<attrs>[^>]*)>(?:[\s\S]*?<(?:v|t)[^>]*>(?<value>[\s\S]*?)<\/(?:v|t)>)?[\s\S]*?<\/c>|<c(?<attrsEmpty>[^>]*)\/>/g,
+    )) {
+      const attrs = cell.groups?.attrs ?? cell.groups?.attrsEmpty ?? "";
+      const ref = /r="([A-Z]+)\d+"/.exec(attrs)?.[1] ?? "";
+      const type = /t="([^"]+)"/.exec(attrs)?.[1];
+      const raw = cell.groups?.value ?? "";
+      const value =
+        type === "s" && raw !== ""
+          ? (sharedStrings[Number(raw)] ?? "")
+          : decodeXmlEntities(raw);
+      const index = ref ? columnIndex(ref) : cells.length;
+      cells[index] = value.trim();
+    }
+    rows.push(Array.from(cells, (c) => c ?? ""));
+  }
+
+  return rows;
+}


### PR DESCRIPTION
## What

Adds a `ca` visa-sponsor provider backed by ESDC's [positive LMIA employers list](https://open.canada.ca/data/en/dataset/90fed587-1364-4f33-a9ee-208181dc0b97) — employers issued a positive Labour Market Impact Assessment, i.e. cleared to hire temporary foreign workers.

- Latest quarter resolved via the **CKAN API** (`package_show`), never a hardcoded URL: newest English `YYYYQn…Positive…` resource wins. Note: quarters have shipped as **XLSX** since 2021 (the CSVs on the dataset stop at 2020Q3), so a minimal sheet extractor (shared strings + inline values, ~70 lines) was added on top of `fflate` — promoted from transitive to a direct orchestrator dependency (0 new packages in the lockfile).
- Columns mapped **by header name** (Province, Stream, Employer, Address, Approved Positions) so the provider survives the layout drift this dataset historically shows.
- `route` = program stream (High Wage / Low Wage / etc.), `typeRating` = "LMIA positive employer (2025Q4: N approved positions)", city parsed from the address, province in the county field.
- Catalog + docs table updated.

## Evidence

- Live run: **9,737 employers** parsed from the real 2025Q4 workbook in ~4.6s (sanity: Shopify Inc., Ottawa, Ontario, High Wage)
- 6 unit tests, including an in-memory XLSX built with fflate that mirrors the ESDC sheet shape (title rows before header, shared strings, entity decoding, empty-header error path)

## Checks

`biome ci .` clean · shared + orchestrator typechecks · provider tests 6/6 · same 5 pre-existing client test files fail on clean main in my env (locale/timing), unrelated. Docs table conflicts trivially with #662/#663 — happy to rebase whichever lands last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)