### PR TITLE
fix(docker): copy greenhouse career-board into the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ COPY docs-site/package*.json ./docs-site/
 COPY shared/package*.json ./shared/
 COPY orchestrator/package*.json ./orchestrator/
 COPY career-boards/bamboohr/package*.json ./career-boards/bamboohr/
+COPY career-boards/greenhouse/package*.json ./career-boards/greenhouse/
 COPY career-boards/workday/package*.json ./career-boards/workday/
 COPY extractors/adzuna/package*.json ./extractors/adzuna/
 COPY extractors/hiringcafe/package*.json ./extractors/hiringcafe/
@@ -103,6 +104,7 @@ COPY shared ./shared
 COPY docs-site ./docs-site
 COPY orchestrator ./orchestrator
 COPY career-boards/bamboohr ./career-boards/bamboohr
+COPY career-boards/greenhouse ./career-boards/greenhouse
 COPY career-boards/workday ./career-boards/workday
 COPY visa-sponsor-providers ./visa-sponsor-providers
 COPY extractors/adzuna ./extractors/adzuna
@@ -151,6 +153,7 @@ COPY docs-site/package*.json ./docs-site/
 COPY shared/package*.json ./shared/
 COPY orchestrator/package*.json ./orchestrator/
 COPY career-boards/bamboohr/package*.json ./career-boards/bamboohr/
+COPY career-boards/greenhouse/package*.json ./career-boards/greenhouse/
 COPY career-boards/workday/package*.json ./career-boards/workday/
 COPY extractors/adzuna/package*.json ./extractors/adzuna/
 COPY extractors/hiringcafe/package*.json ./extractors/hiringcafe/
@@ -243,6 +246,7 @@ COPY --from=docs-build /app/docs-site/build ./orchestrator/dist/docs
 COPY shared ./shared
 COPY orchestrator ./orchestrator
 COPY career-boards/bamboohr ./career-boards/bamboohr
+COPY career-boards/greenhouse ./career-boards/greenhouse
 COPY career-boards/workday ./career-boards/workday
 COPY visa-sponsor-providers ./visa-sponsor-providers
 COPY extractors/adzuna ./extractors/adzuna


### PR DESCRIPTION
`career-boards/greenhouse` (added in #659) is imported by the orchestrator (`watchlist/adapters/greenhouse.ts`) but is never copied into the Docker image the way `bamboohr` and `workday` are. Images built from current `main` build fine but crash on boot:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@career-boards/greenhouse'
```

**Fix:** copy `career-boards/greenhouse` in the same four Dockerfile stages that already copy the other career-boards (+4 lines, no app code changes).

**Verified:** built the image from this branch and started it — the container reaches `healthy` and `/health` returns `200`, where `main` crash-loops on the error above.

_The published `:latest` image predates #659, so quickstart users pull a pre-greenhouse image and never hit this — only builds from current source are affected._
