### PR TITLE
fix(client): stop treating recoverable API errors as fatal client crashes

### DIFF
--- a/orchestrator/src/client/components/AppErrorBoundary.test.tsx
+++ b/orchestrator/src/client/components/AppErrorBoundary.test.tsx
@@ -1,6 +1,7 @@
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiClientError } from "@/client/api/core";
 import {
   AppErrorBoundary,
   buildFatalIssueUrl,
@@ -128,6 +129,26 @@ describe("AppErrorBoundary", () => {
     fireEvent.click(screen.getByText("Technical details"));
     expect(screen.getByText(/token=\[redacted\]/)).toBeInTheDocument();
     expect(screen.queryByText(/abc123/)).not.toBeInTheDocument();
+  });
+
+  it("keeps the app alive and shows a toast for recoverable API errors", async () => {
+    renderBoundary(<div>Healthy app</div>, "/jobs/ready");
+    const event = new Event("unhandledrejection", {
+      cancelable: true,
+    }) as PromiseRejectionEvent;
+    Object.defineProperty(event, "reason", {
+      value: new ApiClientError("API request failed", { status: 500 }),
+    });
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(screen.getByText("Healthy app")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Something went wrong" }),
+    ).not.toBeInTheDocument();
+    expect(event.defaultPrevented).toBe(true);
   });
 
   it("normalizes non-Error promise rejections safely", async () => {

--- a/orchestrator/src/client/components/AppErrorBoundary.tsx
+++ b/orchestrator/src/client/components/AppErrorBoundary.tsx
@@ -1,6 +1,8 @@
 import { AlertTriangle, ExternalLink, Home, RotateCcw } from "lucide-react";
 import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
+import { ApiClientError } from "@/client/api/core";
+import { showErrorToast } from "@/client/lib/error-toast";
 import { Button } from "@/components/ui/button";
 import { GITHUB_REPO, getCurrentAppVersion } from "../lib/version";
 
@@ -269,6 +271,15 @@ class ReactCrashBoundary extends React.Component<
   }
 }
 
+function isRecoverableApiError(reason: unknown): boolean {
+  return (
+    reason instanceof ApiClientError ||
+    (typeof reason === "object" &&
+      reason !== null &&
+      (reason as { name?: unknown }).name === "ApiClientError")
+  );
+}
+
 export function AppErrorBoundary({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const route = `${location.pathname}${location.search}${location.hash}`;
@@ -281,17 +292,29 @@ export function AppErrorBoundary({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const handleError = (event: ErrorEvent) => {
+      const reason = event.error ?? event.message;
+      if (isRecoverableApiError(reason)) {
+        event.preventDefault();
+        showErrorToast(reason, "API request failed");
+        return;
+      }
       event.preventDefault();
       setGlobalSnapshot(
-        createFatalErrorSnapshot(event.error ?? event.message, "runtime", {
+        createFatalErrorSnapshot(reason, "runtime", {
           route,
         }),
       );
     };
     const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
+      const reason = event.reason;
+      if (isRecoverableApiError(reason)) {
+        event.preventDefault();
+        showErrorToast(reason, "API request failed");
+        return;
+      }
       event.preventDefault();
       setGlobalSnapshot(
-        createFatalErrorSnapshot(event.reason, "unhandledrejection", {
+        createFatalErrorSnapshot(reason, "unhandledrejection", {
           route,
         }),
       );


### PR DESCRIPTION
## Summary

Fixes #586. Multiple users (Danalisao, nikhil-reddy05, Rometheman) hit a full-screen
"Something went wrong" crash immediately after starting a job search, with an
auto-filed crash report showing `ApiClientError: API request failed` from an
`unhandledrejection` on `/jobs/ready` (Rometheman had to restart the Docker
container to recover).

The crash screen is produced by the global `error` / `unhandledrejection` listeners
in `orchestrator/src/client/components/AppErrorBoundary.tsx`. They escalate *any*
uncaught rejection to the fatal, app-unmounting `FatalErrorScreen`. But the reason in
these reports is an `ApiClientError` (`orchestrator/src/client/api/core.ts`) - a
classified, recoverable backend error carrying `status`/`code`/`requestId`, thrown by
`fetchApi` whenever the backend returns a non-OK envelope (e.g. a failed pipeline run).
Most call sites already catch these and show a toast, but it only takes one
un-awaited/uncaught promise in the search path for the rejection to reach the global
handler, where a routine, retryable failure gets mislabelled as a fatal client crash
and takes down the whole app.

This change guards both global handlers: if the reason is an `ApiClientError`, it calls
`preventDefault()` and shows an error toast instead of the fatal screen, keeping the
board usable. Every other reason still hits the fatal path unchanged, so genuine
programming errors are unaffected.

## Why this matters

A transient, recoverable API failure should not destroy the app or force a container
restart, and it should not auto-file a "Client crash" report. Guarding at the boundary
is robust: it holds no matter which specific call site forgets to `await` or wrap a
fetch, rather than depending on chasing down one un-awaited promise that any future
change could reintroduce.

Scope is limited to `AppErrorBoundary.tsx` plus its test. A new test asserts that an
uncaught `ApiClientError` leaves the app rendered (no "Something went wrong" heading)
with `defaultPrevented === true`, while the existing tests confirm plain `Error` and
non-Error rejections still show the fatal screen.

`tsc --noEmit` and `vitest run src/client/components/AppErrorBoundary.test.tsx` (8/8) pass.

Closes #586
