### PR TITLE
Fix onboarding migration and run budgets

### DIFF
--- a/orchestrator/src/client/components/OnboardingGate.test.tsx
+++ b/orchestrator/src/client/components/OnboardingGate.test.tsx
@@ -113,6 +113,29 @@ describe("OnboardingGate", () => {
     expect(screen.queryByText("onboarding")).not.toBeInTheDocument();
   });
 
+  it("allows Resume Studio only while the resume step is next", async () => {
+    vi.mocked(useOnboardingStatus).mockReturnValue({
+      checking: false,
+      complete: false,
+      nextRequirementId: "resume",
+    } as any);
+
+    render(
+      <MemoryRouter initialEntries={["/design-resume"]}>
+        <OnboardingGate />
+        <Routes>
+          <Route path="/design-resume" element={<div>resume studio</div>} />
+          <Route path="/onboarding" element={<div>onboarding</div>} />
+        </Routes>
+      </MemoryRouter>,
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(useOnboardingStatus).toHaveBeenCalled());
+    expect(screen.getByText("resume studio")).toBeInTheDocument();
+    expect(screen.queryByText("onboarding")).not.toBeInTheDocument();
+  });
+
   it("sends brand-new installs to onboarding before auth redirects", async () => {
     const { getAuthBootstrapStatus } = await import("@client/api");
     vi.mocked(getAuthBootstrapStatus).mockResolvedValueOnce({

--- a/orchestrator/src/client/components/OnboardingGate.tsx
+++ b/orchestrator/src/client/components/OnboardingGate.tsx
@@ -65,12 +65,12 @@ export const OnboardingGate: React.FC = () => {
     return <Navigate to="/onboarding" replace />;
   }
 
-  return <OnboardingRedirect />;
+  return <OnboardingRedirect pathname={location.pathname} />;
 };
 
-const OnboardingRedirect: React.FC = () => {
+const OnboardingRedirect: React.FC<{ pathname: string }> = ({ pathname }) => {
   const { error } = useSettings();
-  const { checking, complete } = useOnboardingStatus();
+  const { checking, complete, nextRequirementId } = useOnboardingStatus();
 
   if (error) {
     if (!navigator.onLine) {
@@ -80,6 +80,13 @@ const OnboardingRedirect: React.FC = () => {
   }
 
   if (checking || complete) {
+    return null;
+  }
+
+  if (
+    nextRequirementId === "resume" &&
+    (pathname === "/design-resume" || pathname.startsWith("/design-resume/"))
+  ) {
     return null;
   }
 

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -9,13 +9,23 @@ import { renderWithQueryClient } from "../test/renderWithQueryClient";
 import { OnboardingPage } from "./OnboardingPage";
 import { useOnboardingFlow } from "./onboarding/useOnboardingFlow";
 
+const analyticsMocks = vi.hoisted(() => ({
+  trackProductEvent: vi.fn(),
+}));
+
 vi.mock("@/client/api", () => ({
   confirmOnboardingResume: vi.fn(),
   getAppStatus: vi.fn(),
   getAuthBootstrapStatus: vi.fn(),
+  hasAuthenticatedSession: vi.fn(() => true),
   getProfile: vi.fn(),
   saveOnboardingProfile: vi.fn(),
   setupFirstAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/analytics")>()),
+  trackProductEvent: analyticsMocks.trackProductEvent,
 }));
 
 vi.mock("@client/hooks/useOnboardingStatus", () => ({
@@ -156,7 +166,6 @@ function mockFlow() {
     handleSaveRxresume: vi.fn(),
     handleTemplateResumeChange: vi.fn(),
     isBusy: false,
-    isGeneratingSearchTerms: false,
     isImportingResume: false,
     importingResumeFileName: null,
     isRxResumeSelfHosted: false,
@@ -244,6 +253,12 @@ describe("OnboardingPage", () => {
         password: "password123",
       }),
     );
+    expect(analyticsMocks.trackProductEvent).toHaveBeenCalledWith(
+      "onboarding_account_create_submitted",
+      expect.objectContaining({
+        username_length_bucket: "4_10",
+      }),
+    );
   });
 
   it("saves location preferences and advances from the returned server status", async () => {
@@ -259,18 +274,40 @@ describe("OnboardingPage", () => {
     vi.mocked(api.saveOnboardingProfile).mockResolvedValue(resumeStatus);
 
     await renderPage();
-    fireEvent.change(await screen.findByPlaceholderText("United Kingdom"), {
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Select country" }),
+    );
+    const countrySearch = screen.getByPlaceholderText("Search country...");
+    fireEvent.change(countrySearch, {
       target: { value: "United Kingdom" },
     });
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("option", { name: "Afghanistan" }),
+      ).not.toBeInTheDocument(),
+    );
+    fireEvent.keyDown(countrySearch, { key: "Enter" });
     fireEvent.click(screen.getByRole("button", { name: /save and continue/i }));
 
     await waitFor(() =>
       expect(api.saveOnboardingProfile).toHaveBeenCalledWith(
         expect.objectContaining({
-          country: "United Kingdom",
+          country: "united kingdom",
           cities: [],
         }),
       ),
+    );
+    expect(analyticsMocks.trackProductEvent).toHaveBeenCalledWith(
+      "onboarding_profile_save_submitted",
+      expect.objectContaining({
+        has_country: true,
+        city_count: 0,
+        requires_visa_sponsorship: false,
+      }),
+    );
+    expect(analyticsMocks.trackProductEvent).toHaveBeenCalledWith(
+      "onboarding_profile_save_completed",
+      { result: "success" },
     );
     expect(await screen.findByText("Resume importer")).toBeInTheDocument();
   });
@@ -317,6 +354,10 @@ describe("OnboardingPage", () => {
     vi.mocked(api.confirmOnboardingResume).mockResolvedValue(completeStatus);
 
     await renderPage();
+
+    expect(
+      screen.getByRole("link", { name: /edit in resume studio/i }),
+    ).toHaveAttribute("href", "/design-resume");
     expect(await screen.findByText("Sam")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /use this resume/i }));
 
@@ -324,6 +365,14 @@ describe("OnboardingPage", () => {
       expect(api.confirmOnboardingResume).toHaveBeenCalledWith("local:doc-1"),
     );
     expect(api.confirmOnboardingResume).toHaveBeenCalledTimes(1);
+    expect(analyticsMocks.trackProductEvent).toHaveBeenCalledWith(
+      "onboarding_resume_confirm_completed",
+      { result: "success", source: "local" },
+    );
+    expect(analyticsMocks.trackProductEvent).toHaveBeenCalledWith(
+      "onboarding_completed",
+      expect.objectContaining({ completed_steps: 3 }),
+    );
   });
 
   it("reconciles onboarding when the shared Codex control disconnects", async () => {

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -1,6 +1,10 @@
 import { PageHeader, PageMain } from "@client/components/layout";
 import { useDesignResume } from "@client/hooks/useDesignResume";
 import { useOnboardingStatus } from "@client/hooks/useOnboardingStatus";
+import {
+  formatCountryLabel,
+  SUPPORTED_COUNTRY_KEYS,
+} from "@shared/location-support.js";
 import type {
   OnboardingRequirement,
   OnboardingRequirementId,
@@ -17,12 +21,11 @@ import {
   EyeOff,
   FileCheck2,
   MapPin,
-  RefreshCw,
   Sparkles,
   UserPlus,
 } from "lucide-react";
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router-dom";
 import * as api from "@/client/api";
 import { queryKeys } from "@/client/lib/queryKeys";
@@ -31,14 +34,27 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SearchableDropdown } from "@/components/ui/searchable-dropdown";
+import { bucketDurationMs, trackProductEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { showErrorToast } from "../lib/error-toast";
+import {
+  getErrorCategory,
+  getHttpStatusBucket,
+  getTextLengthBucket,
+} from "./onboarding/analytics";
 import { BaseResumeStep } from "./onboarding/components/BaseResumeStep";
 import { LlmConnectionStep } from "./onboarding/components/LlmConnectionStep";
 import type { ValidationState } from "./onboarding/types";
 import { useOnboardingFlow } from "./onboarding/useOnboardingFlow";
 
 const STEP_ORDER: OnboardingRequirementId[] = ["profile", "model", "resume"];
+const COUNTRY_OPTIONS = SUPPORTED_COUNTRY_KEYS.filter(
+  (country) => country !== "usa/ca",
+).map((country) => ({
+  value: country,
+  label: formatCountryLabel(country),
+}));
 
 function getRequirement(
   status: OnboardingStatusResponse | null,
@@ -66,10 +82,36 @@ function stepTitle(id: OnboardingRequirementId): string {
   return "Your resume";
 }
 
+function getRequirementAnalyticsStatus(
+  requirement: OnboardingRequirement | null,
+) {
+  return requirement?.status ?? "missing";
+}
+
 export const OnboardingPage: React.FC = () => {
   const [bootstrapState, setBootstrapState] = useState<
     "checking" | "account" | "launch" | "error"
   >("checking");
+  const analyticsStartedAtRef = useRef(Date.now());
+  const analyticsStartedRef = useRef(false);
+
+  const trackStarted = useCallback(
+    (
+      entryState: "account_required" | "launch",
+      nextStep: "account" | OnboardingRequirementId | "none",
+      demoMode: boolean,
+    ) => {
+      if (analyticsStartedRef.current) return;
+      analyticsStartedRef.current = true;
+      trackProductEvent("onboarding_started", {
+        entry_state: entryState,
+        next_step: nextStep,
+        has_session: api.hasAuthenticatedSession(),
+        demo_mode: demoMode,
+      });
+    },
+    [],
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -87,6 +129,12 @@ export const OnboardingPage: React.FC = () => {
     };
   }, []);
 
+  useEffect(() => {
+    if (bootstrapState === "account") {
+      trackStarted("account_required", "account", false);
+    }
+  }, [bootstrapState, trackStarted]);
+
   if (bootstrapState === "checking") {
     return <LoadingState message="Preparing your workspace…" />;
   }
@@ -98,7 +146,14 @@ export const OnboardingPage: React.FC = () => {
   if (bootstrapState === "account") {
     return <AccountSetup onComplete={() => setBootstrapState("launch")} />;
   }
-  return <LaunchSetup />;
+  return (
+    <LaunchSetup
+      analyticsStartedAt={analyticsStartedAtRef.current}
+      onStarted={(nextStep, demoMode) =>
+        trackStarted("launch", nextStep, demoMode)
+      }
+    />
+  );
 };
 
 function LoadingState({ message }: { message: string }) {
@@ -124,15 +179,28 @@ function AccountSetup({ onComplete }: { onComplete: () => void }) {
 
   const submit = async (event: React.FormEvent) => {
     event.preventDefault();
+    const normalizedUsername = username.trim();
+    trackProductEvent("onboarding_account_create_submitted", {
+      username_length_bucket: getTextLengthBucket(normalizedUsername),
+    });
     try {
       setBusy(true);
       await api.setupFirstAdmin({
-        username: username.trim(),
+        username: normalizedUsername,
         password,
-        displayName: username.trim(),
+        displayName: normalizedUsername,
+      });
+      trackProductEvent("onboarding_account_create_completed", {
+        result: "success",
+        credential_length_bucket: getTextLengthBucket(password),
       });
       onComplete();
     } catch (error) {
+      trackProductEvent("onboarding_account_create_completed", {
+        result: "error",
+        credential_length_bucket: getTextLengthBucket(password),
+        error_category: getErrorCategory(error),
+      });
       showErrorToast(error, "Could not create the workspace account");
     } finally {
       setBusy(false);
@@ -218,7 +286,16 @@ function Field({
   );
 }
 
-function LaunchSetup() {
+function LaunchSetup({
+  analyticsStartedAt,
+  onStarted,
+}: {
+  analyticsStartedAt: number;
+  onStarted: (
+    nextStep: OnboardingRequirementId | "none",
+    demoMode: boolean,
+  ) => void;
+}) {
   const queryClient = useQueryClient();
   const onboarding = useOnboardingStatus();
   const flow = useOnboardingFlow();
@@ -246,6 +323,9 @@ function LaunchSetup() {
     Array<"remote" | "hybrid" | "onsite">
   >(["remote", "hybrid"]);
   const [requiresVisaSponsorship, setRequiresVisaSponsorship] = useState(false);
+  const completionTrackedRef = useRef(false);
+  const lastStepViewRef = useRef<string | null>(null);
+  const lastStatusCheckRef = useRef<string | null>(null);
 
   const showModel =
     appStatus.data?.capabilities.userEditableLlmSettings ?? true;
@@ -254,8 +334,78 @@ function LaunchSetup() {
     : STEP_ORDER.filter((step) => step !== "model");
   const status = onboarding.status;
   const activeStep = selectedStep ?? status?.nextRequirementId ?? "profile";
+  const profileRequirement = getRequirement(status, "profile");
+  const modelRequirement = getRequirement(status, "model");
+  const resumeRequirement = getRequirement(status, "resume");
+  const activeRequirement = getRequirement(status, activeStep);
+
+  useEffect(() => {
+    if (!status || onboarding.checking || appStatus.isLoading) return;
+    onStarted(status.nextRequirementId ?? "none", flow.demoMode);
+  }, [
+    appStatus.isLoading,
+    flow.demoMode,
+    onboarding.checking,
+    onStarted,
+    status,
+  ]);
+
+  useEffect(() => {
+    if (!status || onboarding.checking || appStatus.isLoading) return;
+    const key = `${activeStep}:${getRequirementAnalyticsStatus(activeRequirement)}`;
+    if (lastStepViewRef.current === key) return;
+    lastStepViewRef.current = key;
+    trackProductEvent("onboarding_step_viewed", {
+      step: activeStep,
+      step_index: visibleSteps.indexOf(activeStep) + 1,
+      requirement_status: getRequirementAnalyticsStatus(activeRequirement),
+    });
+  }, [
+    activeRequirement,
+    activeStep,
+    appStatus.isLoading,
+    onboarding.checking,
+    status,
+    visibleSteps,
+  ]);
+
+  useEffect(() => {
+    if (!status || onboarding.checking || appStatus.isLoading) return;
+    const key = JSON.stringify([
+      status.complete,
+      status.nextRequirementId,
+      profileRequirement?.status,
+      modelRequirement?.status,
+      resumeRequirement?.status,
+    ]);
+    if (lastStatusCheckRef.current === key) return;
+    lastStatusCheckRef.current = key;
+    trackProductEvent("onboarding_status_checked", {
+      complete: status.complete,
+      next_step: status.nextRequirementId ?? "none",
+      profile_status: getRequirementAnalyticsStatus(profileRequirement),
+      model_status: getRequirementAnalyticsStatus(modelRequirement),
+      resume_status: getRequirementAnalyticsStatus(resumeRequirement),
+    });
+  }, [
+    appStatus.isLoading,
+    modelRequirement,
+    onboarding.checking,
+    profileRequirement,
+    resumeRequirement,
+    status,
+  ]);
 
   const applyStatus = (next: OnboardingStatusResponse) => {
+    if (next.complete && !completionTrackedRef.current) {
+      completionTrackedRef.current = true;
+      trackProductEvent("onboarding_completed", {
+        duration_bucket: bucketDurationMs(Date.now() - analyticsStartedAt),
+        completed_steps: next.requirements.filter(
+          (requirement) => requirement.status === "ready",
+        ).length,
+      });
+    }
     queryClient.setQueryData(queryKeys.onboarding.status(), next);
     setSelectedStep(next.nextRequirementId);
   };
@@ -267,8 +417,6 @@ function LaunchSetup() {
     return <LoadingState message="Loading your setup…" />;
   }
 
-  const modelRequirement = getRequirement(status, "model");
-  const resumeRequirement = getRequirement(status, "resume");
   const resumeSource =
     typeof resumeRequirement?.details?.confirmationSource === "string"
       ? resumeRequirement.details.confirmationSource
@@ -281,6 +429,12 @@ function LaunchSetup() {
       .split(/[\n,]/)
       .map((city) => city.trim())
       .filter(Boolean);
+    trackProductEvent("onboarding_profile_save_submitted", {
+      has_country: Boolean(country.trim()),
+      city_count: parsedCities.length,
+      workplace_type_count: workplaceTypes.length,
+      requires_visa_sponsorship: requiresVisaSponsorship,
+    });
     try {
       setProfileBusy(true);
       applyStatus(
@@ -291,7 +445,15 @@ function LaunchSetup() {
           requiresVisaSponsorship,
         }),
       );
+      trackProductEvent("onboarding_profile_save_completed", {
+        result: "success",
+      });
     } catch (error) {
+      trackProductEvent("onboarding_profile_save_completed", {
+        result: "error",
+        error_category: getErrorCategory(error),
+        http_status_bucket: getHttpStatusBucket(error),
+      });
       showErrorToast(error, "Could not save search preferences");
     } finally {
       setProfileBusy(false);
@@ -305,10 +467,22 @@ function LaunchSetup() {
 
   const confirmResume = async () => {
     if (!resumeSource) return;
+    const source = resumeSource.startsWith("rxresume:") ? "rxresume" : "local";
+    trackProductEvent("onboarding_resume_confirm_submitted", { source });
     try {
       setConfirmBusy(true);
       applyStatus(await api.confirmOnboardingResume(resumeSource));
+      trackProductEvent("onboarding_resume_confirm_completed", {
+        result: "success",
+        source,
+      });
     } catch (error) {
+      trackProductEvent("onboarding_resume_confirm_completed", {
+        result: "error",
+        source,
+        error_category: getErrorCategory(error),
+        http_status_bucket: getHttpStatusBucket(error),
+      });
       showErrorToast(error, "Could not confirm this resume");
     } finally {
       setConfirmBusy(false);
@@ -445,7 +619,6 @@ function LaunchSetup() {
                     setSelectedStep(showModel ? "model" : "profile")
                   }
                   onConfirm={confirmResume}
-                  onRefresh={() => void profileQuery.refetch()}
                 />
               )}
             </CardContent>
@@ -540,10 +713,20 @@ function ProfileStep(props: {
     >
       <div className="grid gap-5 sm:grid-cols-2">
         <Field label="Country or market">
-          <Input
+          <SearchableDropdown
             value={props.country}
-            onChange={(event) => props.onCountryChange(event.target.value)}
-            placeholder="United Kingdom"
+            options={COUNTRY_OPTIONS}
+            onValueChange={props.onCountryChange}
+            placeholder="Select country"
+            searchPlaceholder="Search country..."
+            emptyText="No matching countries."
+            triggerClassName="h-10 w-full"
+            ariaLabel={
+              props.country
+                ? formatCountryLabel(props.country)
+                : "Select country"
+            }
+            allowCustomValue={false}
           />
         </Field>
         <Field label="Preferred cities or regions (optional)">
@@ -609,7 +792,6 @@ function ResumeStep({
   busy,
   onBack,
   onConfirm,
-  onRefresh,
 }: {
   flow: ReturnType<typeof useOnboardingFlow>;
   requirement: OnboardingRequirement | null;
@@ -618,7 +800,6 @@ function ResumeStep({
   busy: boolean;
   onBack: () => void;
   onConfirm: () => void;
-  onRefresh: () => void;
 }) {
   const experience = profile?.sections?.experience?.items ?? [];
   if (!hasResume) {
@@ -716,17 +897,8 @@ function ResumeStep({
               {experience.length === 1 ? "entry" : "entries"}
             </div>
           </div>
-          <Button
-            type="button"
-            variant="outline"
-            className="w-full"
-            onClick={onRefresh}
-          >
-            <RefreshCw className="h-4 w-4" />
-            Refresh preview
-          </Button>
           <Button type="button" variant="outline" className="w-full" asChild>
-            <a href="/resume/design">
+            <a href="/design-resume">
               <BriefcaseBusiness className="h-4 w-4" />
               Edit in Resume Studio
             </a>

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -5,12 +5,7 @@ import { useRxResumeConfigState } from "@client/hooks/useRxResumeConfigState";
 import { useSettings } from "@client/hooks/useSettings";
 import { queryKeys } from "@client/lib/queryKeys";
 import { normalizeLlmProvider } from "@client/pages/settings/utils";
-import type {
-  AppSettings,
-  OnboardingStatusResponse,
-  SearchTermsSuggestionResponse,
-} from "@shared/types";
-import { normalizeSearchTerms } from "@shared/utils/search-terms";
+import type { AppSettings, OnboardingStatusResponse } from "@shared/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -36,11 +31,6 @@ export function useOnboardingFlow() {
   const demoMode = demoInfo?.demoMode ?? false;
 
   const [isSaving, setIsSaving] = useState(false);
-  const [isGeneratingSearchTerms, setIsGeneratingSearchTerms] = useState(false);
-  const [preparedSearchTerms, setPreparedSearchTerms] = useState<string[]>([]);
-  const [searchTermsSource, setSearchTermsSource] = useState<
-    SearchTermsSuggestionResponse["source"] | null
-  >(null);
   const [isImportingResume, setIsImportingResume] = useState(false);
   const [importingResumeFileName, setImportingResumeFileName] = useState<
     string | null
@@ -56,7 +46,7 @@ export function useOnboardingFlow() {
       llmBaseUrl: "",
       llmApiKey: "",
       model: "",
-      pdfRenderer: "latex",
+      pdfRenderer: "typst",
       rxresumeUrl: "",
       rxresumeApiKey: "",
       rxresumeBaseResumeId: null,
@@ -92,7 +82,7 @@ export function useOnboardingFlow() {
       llmBaseUrl: settings.llmBaseUrl?.value || "",
       llmApiKey: "",
       model: settings.model?.override ?? "",
-      pdfRenderer: selectedId ? "rxresume" : "latex",
+      pdfRenderer: selectedId ? "rxresume" : "typst",
       rxresumeUrl: settings.rxresumeUrl ?? "",
       rxresumeApiKey: "",
       rxresumeBaseResumeId: selectedId,
@@ -246,12 +236,12 @@ export function useOnboardingFlow() {
           updatedAt: document.updatedAt,
         });
 
-        if (settings?.pdfRenderer?.value !== "latex") {
+        if (settings?.pdfRenderer?.value !== "typst") {
           const nextSettings = await api.updateSettings({
-            pdfRenderer: "latex",
+            pdfRenderer: "typst",
           });
           syncSettingsCache(nextSettings);
-          setValue("pdfRenderer", "latex");
+          setValue("pdfRenderer", "typst");
         }
 
         await refreshOnboardingState();
@@ -268,9 +258,9 @@ export function useOnboardingFlow() {
         });
         toast.success("Resume uploaded", {
           description:
-            settings?.pdfRenderer?.value === "latex"
+            settings?.pdfRenderer?.value === "typst"
               ? "Your local Resume Studio document is ready."
-              : "Your local Resume Studio document is ready and PDF rendering was switched to LaTeX.",
+              : "Your local Resume Studio document is ready and PDF rendering was switched to Typst.",
         });
       } catch (error) {
         trackProductEvent("onboarding_resume_upload_completed", {
@@ -330,70 +320,16 @@ export function useOnboardingFlow() {
     [getValues, refreshOnboardingState, setBaseResumeId, setValue],
   );
 
-  const savedSearchTerms = normalizeSearchTerms(
-    settings?.searchTerms?.override ?? preparedSearchTerms,
-  );
-  const hasSavedSearchTerms = savedSearchTerms.length > 0;
-
-  const ensureSearchTerms = useCallback(
-    async (options?: { force?: boolean; trigger?: "auto" | "manual" }) => {
-      if (!options?.force && hasSavedSearchTerms) {
-        return true;
-      }
-
-      try {
-        trackProductEvent("onboarding_search_terms_started", {
-          trigger: options?.trigger ?? "manual",
-          had_existing_terms: hasSavedSearchTerms,
-        });
-        setIsGeneratingSearchTerms(true);
-        const suggestion = await api.suggestOnboardingSearchTerms();
-        const terms = normalizeSearchTerms(suggestion.terms);
-        if (terms.length === 0) {
-          throw new Error("No usable search terms were generated.");
-        }
-
-        const nextSettings = await api.updateSettings({ searchTerms: terms });
-        syncSettingsCache(nextSettings);
-        setPreparedSearchTerms(terms);
-        setSearchTermsSource(suggestion.source);
-        trackProductEvent("onboarding_search_terms_completed", {
-          result: "success",
-          source: suggestion.source,
-          terms_count: terms.length,
-        });
-        toast.success("Search terms prepared", {
-          description: `${terms.length} resume-based title${
-            terms.length === 1 ? "" : "s"
-          } saved for job discovery.`,
-        });
-        return true;
-      } catch (error) {
-        trackProductEvent("onboarding_search_terms_completed", {
-          result: "error",
-          error_category: getErrorCategory(error),
-        });
-        showErrorToast(error, "Failed to prepare search terms");
-        return false;
-      } finally {
-        setIsGeneratingSearchTerms(false);
-      }
-    },
-    [hasSavedSearchTerms, syncSettingsCache],
-  );
-
   const isBusy = isSaving || settingsLoading || isImportingResume;
 
   return {
     demoMode,
-    ensureSearchTerms,
     handleImportResumeFile,
     handleRxresumeSelfHostedChange,
     handleSaveModel,
     handleSaveRxresume,
     handleTemplateResumeChange,
     isBusy,
-    isGeneratingSearchTerms,
     isImportingResume,
     importingResumeFileName,
     isRxResumeSelfHosted,
@@ -403,9 +339,6 @@ export function useOnboardingFlow() {
     selectedProvider,
     settings,
     settingsLoading,
-    hasSavedSearchTerms,
-    savedSearchTerms,
-    searchTermsSource,
     setResumeSetupMode: handleResumeSetupModeChange,
     setValue,
     watch,

--- a/orchestrator/src/client/pages/orchestrator/automatic-run.ts
+++ b/orchestrator/src/client/pages/orchestrator/automatic-run.ts
@@ -9,7 +9,11 @@ import {
   parseSearchCitiesSetting,
   serializeSearchCitiesSetting,
 } from "@shared/search-cities.js";
-import { type JobSource, normalizePipelineRunBudget } from "@shared/types";
+import {
+  deriveExtractorLimits,
+  type JobSource,
+  normalizePipelineRunBudget,
+} from "@shared/types";
 import { getAuthScopedStorageKey } from "@/client/api/client";
 
 export type AutomaticPresetId = "fast" | "balanced" | "detailed";
@@ -162,18 +166,6 @@ export function normalizeWorkplaceTypes(
   return out.length > 0 ? out : [...WORKPLACE_TYPE_OPTIONS];
 }
 
-export interface ExtractorLimits {
-  jobspyResultsWanted: number;
-  gradcrackerMaxJobsPerTerm: number;
-  ukvisajobsMaxJobs: number;
-  adzunaMaxJobsPerTerm: number;
-  startupjobsMaxJobsPerTerm: number;
-  workingnomadsMaxJobsPerTerm: number;
-  jobindexMaxJobsPerTerm: number;
-  seekMaxJobsPerTerm: number;
-  naukriMaxJobsPerTerm: number;
-}
-
 export function inferAutomaticPresetSelection(args: {
   topN: number;
   minSuitabilityScore: number;
@@ -210,69 +202,7 @@ export function inferAutomaticPresetSelection(args: {
   return "custom";
 }
 
-export function deriveExtractorLimits(args: {
-  budget: number;
-  searchTerms: string[];
-  sources: JobSource[];
-}): ExtractorLimits {
-  const budget = normalizePipelineRunBudget(args.budget);
-  const termCount = Math.max(1, args.searchTerms.length);
-  const includesIndeed = args.sources.includes("indeed");
-  const includesLinkedIn = args.sources.includes("linkedin");
-  const includesGlassdoor = args.sources.includes("glassdoor");
-  const includesGradcracker = args.sources.includes("gradcracker");
-  const includesUkVisaJobs = args.sources.includes("ukvisajobs");
-  const includesAdzuna = args.sources.includes("adzuna");
-  const includesHiringCafe = args.sources.includes("hiringcafe");
-  const includesStartupJobs = args.sources.includes("startupjobs");
-  const includesWorkingNomads = args.sources.includes("workingnomads");
-  const includesJobindex = args.sources.includes("jobindex");
-  const includesSeek = args.sources.includes("seek");
-  const includesNaukri = args.sources.includes("naukri");
-
-  const weightedContributors =
-    (includesIndeed ? termCount : 0) +
-    (includesLinkedIn ? termCount : 0) +
-    (includesGlassdoor ? termCount : 0) +
-    (includesGradcracker ? termCount : 0) +
-    (includesUkVisaJobs ? 1 : 0) +
-    (includesAdzuna ? termCount : 0) +
-    (includesHiringCafe ? termCount : 0) +
-    (includesStartupJobs ? termCount : 0) +
-    (includesWorkingNomads ? termCount : 0) +
-    (includesJobindex ? termCount : 0) +
-    (includesSeek ? termCount : 0) +
-    (includesNaukri ? termCount : 0);
-
-  if (weightedContributors <= 0) {
-    return {
-      jobspyResultsWanted: budget,
-      gradcrackerMaxJobsPerTerm: budget,
-      ukvisajobsMaxJobs: budget,
-      adzunaMaxJobsPerTerm: budget,
-      startupjobsMaxJobsPerTerm: budget,
-      workingnomadsMaxJobsPerTerm: budget,
-      jobindexMaxJobsPerTerm: budget,
-      seekMaxJobsPerTerm: budget,
-      naukriMaxJobsPerTerm: budget,
-    };
-  }
-
-  const perUnit = Math.max(1, Math.floor(budget / weightedContributors));
-  const remainder = Math.max(0, budget - perUnit * weightedContributors);
-
-  return {
-    jobspyResultsWanted: perUnit,
-    gradcrackerMaxJobsPerTerm: perUnit,
-    ukvisajobsMaxJobs: Math.min(budget, perUnit + remainder),
-    adzunaMaxJobsPerTerm: perUnit,
-    startupjobsMaxJobsPerTerm: perUnit,
-    workingnomadsMaxJobsPerTerm: perUnit,
-    jobindexMaxJobsPerTerm: perUnit,
-    seekMaxJobsPerTerm: perUnit,
-    naukriMaxJobsPerTerm: perUnit,
-  };
-}
+export { deriveExtractorLimits };
 
 export function parseSearchTermsInput(input: string): string[] {
   return input

--- a/orchestrator/src/lib/analytics.ts
+++ b/orchestrator/src/lib/analytics.ts
@@ -272,23 +272,21 @@ type ProductEventMap = {
   };
   onboarding_started: {
     entry_state: "account_required" | "launch";
-    next_step: "account" | "model" | "resume" | "first_run" | "none";
+    next_step: "account" | "profile" | "model" | "resume" | "none";
     has_session: boolean;
     demo_mode: boolean;
   };
   onboarding_step_viewed: {
-    step: "account" | "model" | "resume" | "first_run";
+    step: "profile" | "model" | "resume";
     step_index: number;
     requirement_status:
       | "ready"
       | "needs_action"
       | "invalid"
       | "checking_unavailable"
-      | "complete"
-      | "not_applicable";
+      | "missing";
   };
   onboarding_account_create_submitted: {
-    has_display_name: boolean;
     username_length_bucket: string;
   };
   onboarding_account_create_completed: {
@@ -296,12 +294,16 @@ type ProductEventMap = {
     error_category?: string;
     credential_length_bucket: string;
   };
-  onboarding_model_config_changed: {
-    provider: string;
-    changed_field: "provider" | "endpoint" | "api_key" | "model";
-    endpoint_mode: "default" | "custom" | "blank";
-    has_saved_key: boolean;
-    model_source: "default" | "custom" | "blank";
+  onboarding_profile_save_submitted: {
+    has_country: boolean;
+    city_count: number;
+    workplace_type_count: number;
+    requires_visa_sponsorship: boolean;
+  };
+  onboarding_profile_save_completed: {
+    result: "success" | "error";
+    error_category?: string;
+    http_status_bucket?: string;
   };
   onboarding_model_verify_submitted: {
     provider: string;
@@ -348,7 +350,13 @@ type ProductEventMap = {
   };
   onboarding_status_checked: {
     complete: boolean;
-    next_step: "model" | "resume" | "first_run" | "none";
+    next_step: "profile" | "model" | "resume" | "none";
+    profile_status:
+      | "ready"
+      | "needs_action"
+      | "invalid"
+      | "checking_unavailable"
+      | "missing";
     model_status:
       | "ready"
       | "needs_action"
@@ -362,47 +370,18 @@ type ProductEventMap = {
       | "checking_unavailable"
       | "missing";
   };
-  onboarding_search_terms_started: {
-    trigger: "auto" | "manual";
-    had_existing_terms: boolean;
-  };
-  onboarding_search_terms_completed: {
+  onboarding_resume_confirm_completed: {
     result: "success" | "error";
-    source?: "ai" | "fallback";
-    terms_count?: number;
+    source: "local" | "rxresume";
     error_category?: string;
+    http_status_bucket?: string;
+  };
+  onboarding_resume_confirm_submitted: {
+    source: "local" | "rxresume";
   };
   onboarding_completed: {
     duration_bucket: string;
     completed_steps: number;
-    search_terms_source: "ai" | "fallback" | "existing" | "unknown";
-  };
-  onboarding_exited: {
-    last_step: "account" | "model" | "resume" | "first_run";
-    last_requirement_status:
-      | "ready"
-      | "needs_action"
-      | "invalid"
-      | "checking_unavailable"
-      | "complete"
-      | "not_applicable";
-    duration_bucket: string;
-    exit_type: "route_change" | "tab_hidden" | "unload";
-  };
-  onboarding_inactive: {
-    last_step: "account" | "model" | "resume" | "first_run";
-    idle_bucket: "2m" | "5m" | "10m";
-    had_error_visible: boolean;
-  };
-  onboarding_error_shown: {
-    step: "account" | "model" | "resume" | "first_run";
-    error_category: string;
-    http_status_bucket?: string;
-  };
-  onboarding_coach_interacted: {
-    action: "replay" | "skip" | "done" | "start";
-    scope: "account" | "launch";
-    step: "account" | "model" | "resume" | "first_run";
   };
 };
 

--- a/orchestrator/src/server/api/routes/pipeline.test.ts
+++ b/orchestrator/src/server/api/routes/pipeline.test.ts
@@ -676,6 +676,7 @@ describe.sequential("Pipeline API routes", () => {
         minSuitabilityScore: 65,
         sources: ["gradcracker"],
         scoringInstructions: "Prefer backend API roles above GBP 60k.",
+        runBudget: 300,
         locationIntent: expect.objectContaining({
           selectedCountry: "united kingdom",
           country: "united kingdom",

--- a/orchestrator/src/server/api/routes/pipeline.ts
+++ b/orchestrator/src/server/api/routes/pipeline.ts
@@ -554,6 +554,7 @@ pipelineRouter.post("/run", async (req: Request, res: Response) => {
           minSuitabilityScore: config.minSuitabilityScore,
           sources: config.sources,
           scoringInstructions: config.scoringInstructions,
+          runBudget: config.runBudget,
           locationIntent,
           watchlistSelectedSourceIds: config.watchlistSelectedSourceIds,
         },

--- a/orchestrator/src/server/db/migrate.test.ts
+++ b/orchestrator/src/server/db/migrate.test.ts
@@ -99,6 +99,48 @@ describe.sequential("database migrations", () => {
     );
   });
 
+  it("marks only existing workspaces for legacy onboarding migration", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-migrate-"));
+    const script = `
+      import { join } from "node:path";
+      import { pathToFileURL } from "node:url";
+      import Database from "better-sqlite3";
+
+      const dbPath = join(process.env.DATA_DIR, "jobs.db");
+      const sqlite = new Database(dbPath);
+      sqlite.exec(\`
+        CREATE TABLE settings (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO settings(key, value) VALUES ('llmProvider', 'openrouter');
+      \`);
+      sqlite.close();
+
+      await import(pathToFileURL(join(process.cwd(), "src/server/db/migrate.ts")).href);
+
+      const migratedDb = new Database(dbPath, { readonly: true });
+      const pending = migratedDb.prepare(
+        "SELECT value FROM settings WHERE key = 'onboardingLegacyMigrationPending'",
+      ).get();
+      if (pending?.value !== "1") {
+        throw new Error("Existing workspace was not marked for onboarding migration");
+      }
+      migratedDb.close();
+    `;
+
+    execFileSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", script],
+      {
+        env: { ...process.env, DATA_DIR: tempDir },
+        stdio: "pipe",
+      },
+    );
+  });
+
   it("creates hosted usage tables with user-scoped foreign keys and indexes", async () => {
     tempDir = await mkdtemp(join(tmpdir(), "job-ops-migrate-"));
     const script = `

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -1677,12 +1677,50 @@ function seedLegacyOwnerFromBasicAuth(): void {
   sqlite.exec("DELETE FROM auth_sessions");
 }
 
+function seedLegacyOnboardingMigration(): void {
+  sqlite.exec(`CREATE TABLE IF NOT EXISTS app_data_migrations (
+    id TEXT PRIMARY KEY,
+    applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`);
+
+  const migrationId = "onboarding-markers-v1";
+  const applied = sqlite
+    .prepare("SELECT 1 FROM app_data_migrations WHERE id = ?")
+    .get(migrationId);
+  if (applied) return;
+
+  sqlite.exec(`INSERT OR IGNORE INTO settings(
+    tenant_id, user_id, key, value, created_at, updated_at
+  )
+  SELECT scopes.tenant_id, scopes.user_id, 'onboardingLegacyMigrationPending', '1', datetime('now'), datetime('now')
+  FROM (
+    SELECT tenant_id, user_id FROM settings WHERE key NOT LIKE 'onboarding%'
+    UNION
+    SELECT tenant_id, user_id FROM design_resume_documents
+  ) AS scopes
+  WHERE NOT EXISTS (
+    SELECT 1 FROM settings existing
+    WHERE existing.tenant_id = scopes.tenant_id
+      AND coalesce(existing.user_id, '') = coalesce(scopes.user_id, '')
+      AND existing.key IN (
+        'onboardingProfileCompleted',
+        'onboardingLlmCompleted',
+        'onboardingResumeConfirmedSource',
+        'onboardingLegacyMigrationPending'
+      )
+  )`);
+  sqlite
+    .prepare("INSERT INTO app_data_migrations(id) VALUES (?)")
+    .run(migrationId);
+}
+
 console.log("🔐 Applying tenancy compatibility migrations...");
 ensureTenantColumns();
 seedLegacyOwnerFromBasicAuth();
 ensurePrivateUserColumns();
 rebuildPostApplicationPrivateTables();
 rebuildSettingsTable();
+seedLegacyOnboardingMigration();
 ensureTracerLinksUniqueIndex();
 sqlite.exec("DROP INDEX IF EXISTS idx_settings_tenant_key_unique");
 sqlite.exec("DROP INDEX IF EXISTS idx_settings_tenant_user_key_unique");

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -438,6 +438,7 @@ export async function runPipeline(
         ({ unprocessedJobs, scoredJobs } = await scoreJobsStep({
           profile,
           scoringInstructions: mergedConfig.scoringInstructions,
+          visaSponsorCountryKey: mergedConfig.locationIntent?.selectedCountry,
           shouldCancel: () =>
             getPipelineState(scopeKey).cancelRequestedAt !== null,
         }));
@@ -459,6 +460,7 @@ export async function runPipeline(
           ({ unprocessedJobs, scoredJobs } = await scoreJobsStep({
             profile,
             scoringInstructions: mergedConfig.scoringInstructions,
+            visaSponsorCountryKey: mergedConfig.locationIntent?.selectedCountry,
             shouldCancel: () =>
               getPipelineState(scopeKey).cancelRequestedAt !== null,
           }));

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -116,6 +116,44 @@ describe("discoverJobsStep", () => {
     );
   });
 
+  it("overrides persisted extractor limits with the normalized run budget", async () => {
+    const settingsRepo = await import("@server/repositories/settings");
+    const registryModule = await import("@server/extractors/registry");
+    const jobspyManifest = {
+      id: "jobspy",
+      displayName: "JobSpy",
+      providesSources: ["indeed", "linkedin", "glassdoor"],
+      run: vi.fn().mockResolvedValue({ success: true, jobs: [] }),
+    };
+
+    vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+      searchTerms: JSON.stringify(["engineer"]),
+      jobspyResultsWanted: "25",
+    } as any);
+    vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+      manifests: new Map([["jobspy", jobspyManifest as any]]),
+      manifestBySource: new Map([
+        ["indeed", jobspyManifest as any],
+        ["linkedin", jobspyManifest as any],
+      ]),
+      availableSources: ["indeed", "linkedin"],
+    } as any);
+
+    await discoverJobsStep({
+      mergedConfig: {
+        ...baseConfig,
+        sources: ["indeed", "linkedin"],
+        runBudget: 50,
+      },
+    });
+
+    expect(jobspyManifest.run).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: expect.objectContaining({ jobspyResultsWanted: "150" }),
+      }),
+    );
+  });
+
   it("streams extractor progress detail while discovery is still running", async () => {
     const settingsRepo = await import("@server/repositories/settings");
     const registryModule = await import("@server/extractors/registry");

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -17,7 +17,11 @@ import {
 } from "@shared/location-domain.js";
 import { formatCountryLabel } from "@shared/location-support.js";
 import { normalizeStringArray } from "@shared/normalize-string-array.js";
-import type { CreateJobInput, PipelineConfig } from "@shared/types";
+import {
+  type CreateJobInput,
+  deriveExtractorLimits,
+  type PipelineConfig,
+} from "@shared/types";
 import {
   type CrawlSource,
   type PendingChallenge,
@@ -179,6 +183,18 @@ export async function discoverJobsStep(args: {
   const compatibleSources = sourcePlans
     .filter(({ plan }) => plan.canRun)
     .map(({ source }) => source);
+  const runSettings =
+    args.mergedConfig.runBudget !== undefined
+      ? Object.fromEntries(
+          Object.entries(
+            deriveExtractorLimits({
+              budget: args.mergedConfig.runBudget,
+              searchTerms,
+              sources: compatibleSources,
+            }),
+          ).map(([key, value]) => [key, String(value)]),
+        )
+      : {};
   let existingJobUrlsPromise: Promise<string[]> | null = null;
   const getExistingJobUrls = (): Promise<string[]> => {
     if (!existingJobUrlsPromise) {
@@ -247,7 +263,7 @@ export async function discoverJobsStep(args: {
           : grouped.detail,
       run: async () => {
         const filteredSettings = Object.fromEntries(
-          Object.entries(settings).filter(
+          Object.entries({ ...settings, ...runSettings }).filter(
             ([, value]) =>
               typeof value === "string" || typeof value === "undefined",
           ),

--- a/orchestrator/src/server/pipeline/steps/score-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/score-jobs.test.ts
@@ -99,6 +99,21 @@ describe("scoreJobsStep auto-skip behavior", () => {
     );
   });
 
+  it("uses the selected run country for visa sponsor matching", async () => {
+    const visaSponsors = await import("@server/services/visa-sponsors/index");
+
+    await scoreJobsStep({
+      profile: {},
+      visaSponsorCountryKey: "united kingdom",
+    });
+
+    expect(visaSponsors.searchSponsors).toHaveBeenCalledWith("Acme Corp", {
+      limit: 10,
+      minScore: 50,
+      countryKey: "united kingdom",
+    });
+  });
+
   it("passes per-run scoring instructions to the scorer", async () => {
     const scorer = await import("@server/services/scorer");
 

--- a/orchestrator/src/server/pipeline/steps/score-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/score-jobs.ts
@@ -14,6 +14,7 @@ const SCORING_CONCURRENCY = 4;
 export async function scoreJobsStep(args: {
   profile: Record<string, unknown>;
   scoringInstructions?: string;
+  visaSponsorCountryKey?: string | null;
   shouldCancel?: () => boolean;
 }): Promise<{ unprocessedJobs: Job[]; scoredJobs: ScoredJob[] }> {
   logger.info("Running scoring step");
@@ -82,6 +83,7 @@ export async function scoreJobsStep(args: {
         const sponsorResults = await visaSponsors.searchSponsors(job.employer, {
           limit: 10,
           minScore: 50,
+          countryKey: args.visaSponsorCountryKey ?? undefined,
         });
 
         const summary =

--- a/orchestrator/src/server/services/onboarding-status.test.ts
+++ b/orchestrator/src/server/services/onboarding-status.test.ts
@@ -164,6 +164,55 @@ describe("onboarding status engine", () => {
       status: "needs_action",
       primaryAction: "connect_model",
     });
+    expect(mocks.applySettingsUpdates).not.toHaveBeenCalled();
+  });
+
+  it("validates and persists legacy onboarding state once", async () => {
+    const values: Record<string, string | null> = {
+      llmApiKey: "sk-test",
+      llmProvider: "openrouter",
+      llmBaseUrl: "",
+      model: "gpt-4o",
+      onboardingLegacyMigrationPending: "1",
+      onboardingProfileCompleted: null,
+      onboardingLlmCompleted: null,
+      onboardingResumeConfirmedSource: null,
+    };
+    mocks.getSetting.mockImplementation(async (key: string) =>
+      Object.hasOwn(values, key) ? values[key] : null,
+    );
+    mocks.applySettingsUpdates.mockImplementation(async (update) => {
+      if (update.onboardingProfileCompleted !== undefined) {
+        values.onboardingProfileCompleted = update.onboardingProfileCompleted
+          ? "1"
+          : "0";
+      }
+      if (update.onboardingLlmCompleted !== undefined) {
+        values.onboardingLlmCompleted = update.onboardingLlmCompleted
+          ? "1"
+          : "0";
+      }
+      if (update.onboardingResumeConfirmedSource !== undefined) {
+        values.onboardingResumeConfirmedSource =
+          update.onboardingResumeConfirmedSource;
+      }
+      values.onboardingLegacyMigrationPending = "0";
+      return {
+        shouldRefreshBackupScheduler: false,
+        shouldClearRxResumeCaches: false,
+        updatedSettingKeys: [],
+      };
+    });
+
+    const status = await getOnboardingStatus();
+
+    expect(mocks.applySettingsUpdates).toHaveBeenCalledWith({
+      onboardingProfileCompleted: true,
+      onboardingLegacyMigrationPending: false,
+      onboardingLlmCompleted: true,
+      onboardingResumeConfirmedSource: "local:doc-1",
+    });
+    expect(status.complete).toBe(true);
   });
 
   it("does not trust a completed Codex marker when refreshed auth is invalid", async () => {

--- a/orchestrator/src/server/services/onboarding-status.ts
+++ b/orchestrator/src/server/services/onboarding-status.ts
@@ -531,6 +531,48 @@ async function buildHostedResumeRequirement(): Promise<OnboardingRequirement> {
   });
 }
 
+async function migrateLegacyOnboardingState(args: {
+  hostedMode: boolean;
+  userEditableLlmSettings: boolean;
+}): Promise<void> {
+  if ((await getSetting("onboardingLegacyMigrationPending")) !== "1") return;
+
+  const update: UpdateSettingsInput = {
+    onboardingProfileCompleted: true,
+    onboardingLegacyMigrationPending: false,
+  };
+
+  if (args.userEditableLlmSettings) {
+    const [provider, model, validation] = await Promise.all([
+      getSetting("llmProvider"),
+      getSetting("model"),
+      validateLlm({}),
+    ]);
+    const normalizedProvider = normalizeLlmProviderValue(provider);
+    update.onboardingLlmCompleted =
+      validation.valid && !(normalizedProvider === "ollama" && !model?.trim());
+  }
+
+  if (!args.hostedMode) {
+    const localStatus = await getDesignResumeStatus();
+    if (localStatus.exists && localStatus.documentId) {
+      update.onboardingResumeConfirmedSource = `local:${localStatus.documentId}`;
+    } else {
+      const { resumeId } = await getConfiguredRxResumeBaseResumeId();
+      if (resumeId && (await validateResumeConfig()).valid) {
+        update.onboardingResumeConfirmedSource = `rxresume:${resumeId}`;
+      }
+    }
+  }
+
+  await applySettingsUpdates(update);
+  logger.info("Migrated legacy onboarding state", {
+    requestId: getRequestId() ?? null,
+    modelReady: update.onboardingLlmCompleted ?? null,
+    resumeReady: Boolean(update.onboardingResumeConfirmedSource),
+  });
+}
+
 export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {
   const appStatus = getJobOpsAppStatus();
   const userEditableLlmSettings =
@@ -567,6 +609,11 @@ export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {
     ];
     return { complete: true, nextRequirementId: null, requirements };
   }
+
+  await migrateLegacyOnboardingState({
+    hostedMode,
+    userEditableLlmSettings,
+  });
 
   const profileCompleted = await getSetting("onboardingProfileCompleted");
   const profileRequirement = buildRequirement({

--- a/shared/src/settings-registry.ts
+++ b/shared/src/settings-registry.ts
@@ -551,6 +551,13 @@ export const settingsRegistry = {
     serialize: (value: string | null | undefined): string | null =>
       value ?? null,
   },
+  onboardingLegacyMigrationPending: {
+    kind: "typed" as const,
+    schema: z.boolean(),
+    default: (): boolean => false,
+    parse: parseBitBoolOrNull,
+    serialize: serializeBitBool,
+  },
   blockedCompanyKeywords: {
     kind: "typed" as const,
     schema: z.array(z.string().trim().min(1).max(200)).max(200),

--- a/shared/src/testing/factories.ts
+++ b/shared/src/testing/factories.ts
@@ -202,6 +202,11 @@ export const createAppSettings = (
     default: "",
     override: null,
   },
+  onboardingLegacyMigrationPending: {
+    value: false,
+    default: false,
+    override: null,
+  },
   blockedCompanyKeywords: {
     value: [],
     default: [],

--- a/shared/src/types/pipeline.ts
+++ b/shared/src/types/pipeline.ts
@@ -17,6 +17,73 @@ export function normalizePipelineRunBudget(value: number): number {
   );
 }
 
+export interface ExtractorLimits {
+  jobspyResultsWanted: number;
+  gradcrackerMaxJobsPerTerm: number;
+  ukvisajobsMaxJobs: number;
+  adzunaMaxJobsPerTerm: number;
+  startupjobsMaxJobsPerTerm: number;
+  workingnomadsMaxJobsPerTerm: number;
+  jobindexMaxJobsPerTerm: number;
+  seekMaxJobsPerTerm: number;
+  naukriMaxJobsPerTerm: number;
+}
+
+export function deriveExtractorLimits(args: {
+  budget: number;
+  searchTerms: string[];
+  sources: readonly string[];
+}): ExtractorLimits {
+  const budget = normalizePipelineRunBudget(args.budget);
+  const termCount = Math.max(1, args.searchTerms.length);
+  const perTermSources = [
+    "indeed",
+    "linkedin",
+    "glassdoor",
+    "gradcracker",
+    "adzuna",
+    "hiringcafe",
+    "startupjobs",
+    "workingnomads",
+    "jobindex",
+    "seek",
+    "naukri",
+  ] as const;
+  const weightedContributors =
+    perTermSources.filter((source) => args.sources.includes(source)).length *
+      termCount +
+    (args.sources.includes("ukvisajobs") ? 1 : 0);
+
+  if (weightedContributors <= 0) {
+    return {
+      jobspyResultsWanted: budget,
+      gradcrackerMaxJobsPerTerm: budget,
+      ukvisajobsMaxJobs: budget,
+      adzunaMaxJobsPerTerm: budget,
+      startupjobsMaxJobsPerTerm: budget,
+      workingnomadsMaxJobsPerTerm: budget,
+      jobindexMaxJobsPerTerm: budget,
+      seekMaxJobsPerTerm: budget,
+      naukriMaxJobsPerTerm: budget,
+    };
+  }
+
+  const perUnit = Math.max(1, Math.floor(budget / weightedContributors));
+  const remainder = Math.max(0, budget - perUnit * weightedContributors);
+
+  return {
+    jobspyResultsWanted: perUnit,
+    gradcrackerMaxJobsPerTerm: perUnit,
+    ukvisajobsMaxJobs: Math.min(budget, perUnit + remainder),
+    adzunaMaxJobsPerTerm: perUnit,
+    startupjobsMaxJobsPerTerm: perUnit,
+    workingnomadsMaxJobsPerTerm: perUnit,
+    jobindexMaxJobsPerTerm: perUnit,
+    seekMaxJobsPerTerm: perUnit,
+    naukriMaxJobsPerTerm: perUnit,
+  };
+}
+
 export interface PipelineConfig {
   topN: number; // Number of top jobs to process
   minSuitabilityScore: number; // Minimum score to auto-process
@@ -24,6 +91,7 @@ export interface PipelineConfig {
   outputDir: string; // Directory for generated PDFs
   locationIntent?: LocationIntent;
   scoringInstructions?: string;
+  runBudget?: number;
   enableCrawling?: boolean;
   enableScoring?: boolean;
   enableImporting?: boolean;

--- a/shared/src/types/settings.ts
+++ b/shared/src/types/settings.ts
@@ -257,6 +257,7 @@ export interface AppSettings {
   onboardingProfileCompleted: Resolved<boolean>;
   onboardingLlmCompleted: Resolved<boolean>;
   onboardingResumeConfirmedSource: Resolved<string>;
+  onboardingLegacyMigrationPending: Resolved<boolean>;
   blockedCompanyKeywords: Resolved<string[]>;
   scoringInstructions: Resolved<string>;
   ghostwriterSystemPromptTemplate: Resolved<string>;


### PR DESCRIPTION
## What changed

- Migrates existing workspaces into the new durable onboarding completion markers without treating fresh installs as complete.
- Applies the normalized 300-job minimum to the extractor settings used by each server-side pipeline run.
- Reuses the searchable manual-run country selector during onboarding.
- Uses the selected run country to choose the matching visa sponsor provider during scoring.
- Lets the resume step open the real Resume Studio route without the onboarding gate immediately redirecting back.
- Defaults uploaded local Resume Studio documents to the Typst renderer instead of LaTeX.
- Updates onboarding analytics for profile/model/resume lifecycle and removes obsolete first-run/search-term telemetry.

## Why

The onboarding refactor could redirect upgraded users back through setup, while direct pipeline API calls could still discover below the normalized minimum because persisted extractor limits won. Sponsor matching also searched every registered country instead of the country selected during onboarding/run setup. The resume edit action additionally targeted a nonexistent route, while the onboarding gate blocked the real Resume Studio route.

## Validation

- `./orchestrator/node_modules/.bin/biome ci .`
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run` — 268 files passed, 1,844 tests passed, 3 skipped
