### PR TITLE
Fix country code location matching

### DIFF
--- a/extractors/hiringcafe/src/country-map.ts
+++ b/extractors/hiringcafe/src/country-map.ts
@@ -1,11 +1,7 @@
-export function normalizeCountryKey(value: string | null | undefined): string {
-  const normalized = value?.trim().toLowerCase() ?? "";
-  if (normalized === "uk") return "united kingdom";
-  if (normalized === "us" || normalized === "usa") return "united states";
-  if (normalized === "türkiye") return "turkey";
-  if (normalized === "czech republic") return "czechia";
-  return normalized;
-}
+import {
+  getCountryIso2Code,
+  normalizeCountryKey,
+} from "@shared/location-support.js";
 
 export interface HiringCafeCountryLocation {
   formatted_address: string;
@@ -38,50 +34,10 @@ const COUNTRY_NAME_OVERRIDES: Record<string, string> = {
   turkey: "Turkey",
 };
 
-const ISO2_ALIASES: Record<string, string> = {
-  "united states": "US",
-  "united kingdom": "GB",
-  "united arab emirates": "AE",
-  "new zealand": "NZ",
-  "south korea": "KR",
-  "south africa": "ZA",
-  "costa rica": "CR",
-  "saudi arabia": "SA",
-  "hong kong": "HK",
-  czechia: "CZ",
-  türkiye: "TR",
-  turkey: "TR",
-};
-
-const regionNameMap = buildRegionNameMap();
-
-function buildRegionNameMap(): Map<string, string> {
-  const names = new Intl.DisplayNames(["en"], { type: "region" });
-  const map = new Map<string, string>();
-
-  for (let i = 65; i <= 90; i += 1) {
-    for (let j = 65; j <= 90; j += 1) {
-      const iso2 = String.fromCharCode(i, j);
-      const displayName = names.of(iso2);
-      if (!displayName || displayName === iso2) continue;
-      map.set(normalizeCountryKey(displayName), iso2);
-    }
-  }
-
-  return map;
-}
-
 function toCountryLabel(countryKey: string): string {
   const override = COUNTRY_NAME_OVERRIDES[countryKey];
   if (override) return override;
   return countryKey.replace(/\b\w/g, (char) => char.toUpperCase());
-}
-
-function toIso2(countryKey: string): string | null {
-  if (ISO2_ALIASES[countryKey]) {
-    return ISO2_ALIASES[countryKey];
-  }
-  return regionNameMap.get(countryKey) ?? null;
 }
 
 export function shouldUseGlobalLocation(countryInput?: string | null): boolean {
@@ -95,7 +51,7 @@ export function resolveHiringCafeCountryLocation(
   const countryKey = normalizeCountryKey(countryInput);
   if (!countryKey || GLOBAL_SEARCH_KEYS.has(countryKey)) return null;
 
-  const iso2 = toIso2(countryKey);
+  const iso2 = getCountryIso2Code(countryKey);
   if (!iso2) return null;
 
   const longName = toCountryLabel(countryKey);

--- a/shared/src/location-domain.test.ts
+++ b/shared/src/location-domain.test.ts
@@ -181,6 +181,27 @@ describe("location-domain", () => {
     });
   });
 
+  it("matches structured country evidence using codes and localized names", () => {
+    const intent = {
+      selectedCountry: "netherlands",
+      cityLocations: [],
+      workplaceTypes: ["onsite"],
+      searchScope: "selected_only",
+      matchStrictness: "exact_only",
+    } as const;
+
+    expect(matchLocationIntent(intent, { country: "NL" })).toMatchObject({
+      matched: true,
+      countryMatched: true,
+    });
+    expect(matchLocationIntent(intent, { country: "Nederland" })).toMatchObject(
+      {
+        matched: true,
+        countryMatched: true,
+      },
+    );
+  });
+
   it("keeps flexible city matching available after country matches", () => {
     expect(
       matchLocationIntent(

--- a/shared/src/location-domain.ts
+++ b/shared/src/location-domain.ts
@@ -704,10 +704,10 @@ export function matchLocationIntent(
     };
   }
 
-  const countryMatched =
-    normalizedEvidence.country !== null
-      ? normalizeCountryKey(normalizedEvidence.country) === selectedCountry
-      : matchesRequestedCountry(evidenceLocation, selectedCountry);
+  const countryMatched = matchesRequestedCountry(
+    normalizedEvidence.country ?? evidenceLocation,
+    selectedCountry,
+  );
 
   if (countryMatched) {
     if (requestedCities.length === 0) {

--- a/shared/src/location-support.test.ts
+++ b/shared/src/location-support.test.ts
@@ -3,6 +3,8 @@ import {
   formatCountryLabel,
   getAdzunaCountryCode,
   getCompatibleSourcesForCountry,
+  getCountryIso2Code,
+  getCountryNameVariants,
   isGlassdoorCountry,
   isSourceAllowedForCountry,
   isUkCountry,
@@ -16,6 +18,18 @@ describe("location-support", () => {
     expect(normalizeCountryKey("us")).toBe("united states");
     expect(normalizeCountryKey("usa")).toBe("united states");
     expect(normalizeCountryKey("czech republic")).toBe("czechia");
+    expect(normalizeCountryKey("the netherlands")).toBe("netherlands");
+    expect(normalizeCountryKey("netherland")).toBe("netherlands");
+  });
+
+  it("resolves ISO-2 codes and localized country names", () => {
+    expect(getCountryIso2Code("netherlands")).toBe("NL");
+    expect(getCountryIso2Code("NL")).toBe("NL");
+    expect(getCountryIso2Code("united kingdom")).toBe("GB");
+    expect(getCountryIso2Code("USA")).toBe("US");
+    expect(getCountryNameVariants("netherlands")).toContain("Nederland");
+    expect(getCountryNameVariants("germany")).toContain("Deutschland");
+    expect(getCountryNameVariants("spain")).toContain("España");
   });
 
   it("formats country labels", () => {

--- a/shared/src/location-support.ts
+++ b/shared/src/location-support.ts
@@ -1,15 +1,26 @@
 import type { JobSource } from "./types";
 
 const COUNTRY_ALIASES: Record<string, string> = {
+  britain: "united kingdom",
   "czech republic": "czechia",
   eg: "egypt",
+  england: "united kingdom",
+  "great britain": "united kingdom",
   "korea, republic of": "south korea",
+  netherland: "netherlands",
+  "northern ireland": "united kingdom",
   "republic of korea": "south korea",
   "russian federation": "russia",
+  scotland: "united kingdom",
+  "the netherlands": "netherlands",
+  turkiye: "turkey",
   uk: "united kingdom",
+  uae: "united arab emirates",
+  "united states of america": "united states",
   us: "united states",
   usa: "united states",
   türkiye: "turkey",
+  wales: "united kingdom",
 };
 
 const COUNTRY_LABELS: Record<string, string> = {
@@ -366,6 +377,78 @@ export function sourceRequiresCityLocations(source: JobSource): boolean {
 export function normalizeCountryKey(value: string | null | undefined): string {
   const normalized = value?.trim().toLowerCase() ?? "";
   return COUNTRY_ALIASES[normalized] ?? normalized;
+}
+
+const ISO2_ALIASES: Record<string, string> = {
+  czechia: "CZ",
+  "hong kong": "HK",
+  "south korea": "KR",
+  turkey: "TR",
+  "united arab emirates": "AE",
+  "united kingdom": "GB",
+  "united states": "US",
+};
+
+const COUNTRY_NAME_LOCALES = ["en", "de", "es", "fr", "it", "nl", "pt", "tr"];
+const regionNameMap = buildRegionNameMap();
+const validRegionCodes = new Set(regionNameMap.values());
+const localizedRegionNames = COUNTRY_NAME_LOCALES.map(
+  (locale) => new Intl.DisplayNames([locale], { type: "region" }),
+);
+const countryNameVariantCache = new Map<string, string[]>();
+
+function buildRegionNameMap(): Map<string, string> {
+  const names = new Intl.DisplayNames(["en"], { type: "region" });
+  const map = new Map<string, string>();
+
+  for (let first = 65; first <= 90; first += 1) {
+    for (let second = 65; second <= 90; second += 1) {
+      const iso2 = String.fromCharCode(first, second);
+      const displayName = names.of(iso2);
+      if (!displayName || displayName === iso2) continue;
+      map.set(normalizeCountryKey(displayName), iso2);
+    }
+  }
+
+  return map;
+}
+
+export function getCountryIso2Code(
+  country: string | null | undefined,
+): string | null {
+  const countryKey = normalizeCountryKey(country);
+  const code = countryKey.toUpperCase();
+  if (/^[A-Z]{2}$/.test(code) && validRegionCodes.has(code)) return code;
+  return ISO2_ALIASES[countryKey] ?? regionNameMap.get(countryKey) ?? null;
+}
+
+export function getCountryNameVariants(
+  country: string | null | undefined,
+): string[] {
+  const countryKey = normalizeCountryKey(country);
+  if (!countryKey) return [];
+
+  const cached = countryNameVariantCache.get(countryKey);
+  if (cached) return cached;
+
+  const iso2 = getCountryIso2Code(countryKey);
+  const variants = new Set([
+    countryKey,
+    ...Object.entries(COUNTRY_ALIASES)
+      .filter(([, canonical]) => canonical === countryKey)
+      .map(([alias]) => alias),
+  ]);
+
+  if (iso2) {
+    for (const names of localizedRegionNames) {
+      const displayName = names.of(iso2);
+      if (displayName && displayName !== iso2) variants.add(displayName);
+    }
+  }
+
+  const result = [...variants];
+  countryNameVariantCache.set(countryKey, result);
+  return result;
 }
 
 export function formatCountryLabel(value: string): string {

--- a/shared/src/search-cities.test.ts
+++ b/shared/src/search-cities.test.ts
@@ -95,4 +95,30 @@ describe("search-cities", () => {
     expect(matchesRequestedCountry("Bengaluru, India", "croatia")).toBe(false);
     expect(matchesRequestedCountry(undefined, "croatia")).toBe(false);
   });
+
+  it("matches ISO-2 codes and localized country names", () => {
+    expect(
+      matchesRequestedCountry("Amsterdam Zuid, NH, NL", "netherlands"),
+    ).toBe(true);
+    expect(matchesRequestedCountry("Berlin, DE", "germany")).toBe(false);
+    expect(matchesRequestedCountry("Amsterdam, Netherlands", "NL")).toBe(true);
+    expect(matchesRequestedCountry("Berlin, BE, DE", "germany")).toBe(true);
+    expect(matchesRequestedCountry("Amsterdam, Nederland", "netherlands")).toBe(
+      true,
+    );
+    expect(matchesRequestedCountry("Berlin, Deutschland", "germany")).toBe(
+      true,
+    );
+    expect(matchesRequestedCountry("Madrid, España", "spain")).toBe(true);
+    expect(matchesRequestedCountry("İstanbul, Türkiye", "turkey")).toBe(true);
+  });
+
+  it("does not confuse country codes with subdivision abbreviations", () => {
+    expect(matchesRequestedCountry("San Francisco, CA", "canada")).toBe(false);
+    expect(matchesRequestedCountry("San Francisco, CA, US", "canada")).toBe(
+      false,
+    );
+    expect(matchesRequestedCountry("Indianapolis, IN", "india")).toBe(false);
+    expect(matchesRequestedCountry("IN", "india")).toBe(true);
+  });
 });

--- a/shared/src/search-cities.ts
+++ b/shared/src/search-cities.ts
@@ -1,22 +1,13 @@
-import { normalizeCountryKey } from "./location-support.js";
+import {
+  getCountryIso2Code,
+  getCountryNameVariants,
+  normalizeCountryKey,
+} from "./location-support.js";
 
 const LOCATION_ALIASES: Record<string, string> = {
   uk: "united kingdom",
   us: "united states",
   usa: "united states",
-};
-
-const COUNTRY_LOCATION_VARIANTS: Record<string, string[]> = {
-  "united kingdom": [
-    "uk",
-    "great britain",
-    "britain",
-    "england",
-    "scotland",
-    "wales",
-    "northern ireland",
-  ],
-  "united states": ["us", "usa", "united states of america"],
 };
 
 export function normalizeLocationToken(
@@ -107,10 +98,10 @@ function matchesRequestedLocationTokens(
   requestedLocation: string,
 ): boolean {
   const normalizedJobLocation = normalizeLocationToken(jobLocation)
-    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
     .trim();
   const normalizedRequestedLocation = normalizeLocationToken(requestedLocation)
-    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
     .trim();
   if (!normalizedJobLocation || !normalizedRequestedLocation) return false;
 
@@ -132,6 +123,21 @@ function matchesRequestedLocationTokens(
   return false;
 }
 
+function matchesRequestedCountryCode(
+  jobLocation: string | undefined,
+  countryCode: string,
+): boolean {
+  const parts = (jobLocation ?? "")
+    .split(",")
+    .map((part) => normalizeLocationToken(part))
+    .filter(Boolean);
+  const normalizedCode = countryCode.toLowerCase();
+
+  // A two-part location is ambiguous: city/country and city/subdivision use
+  // the same shape (Berlin, DE vs Wilmington, DE).
+  return parts.length !== 2 && parts.at(-1) === normalizedCode;
+}
+
 export function matchesRequestedCountry(
   jobLocation: string | undefined,
   requestedCountry: string,
@@ -139,12 +145,10 @@ export function matchesRequestedCountry(
   const normalizedCountry = normalizeCountryKey(requestedCountry);
   if (!normalizedCountry) return false;
 
-  const candidates = [
-    normalizedCountry,
-    ...(COUNTRY_LOCATION_VARIANTS[normalizedCountry] ?? []),
-  ];
+  const iso2 = getCountryIso2Code(normalizedCountry);
+  if (iso2 && matchesRequestedCountryCode(jobLocation, iso2)) return true;
 
-  return candidates.some((candidate) =>
+  return getCountryNameVariants(normalizedCountry).some((candidate) =>
     matchesRequestedLocationTokens(jobLocation, candidate),
   );
 }


### PR DESCRIPTION
## Summary

- match ISO-2 country codes such as `NL`, `DE`, `GB`, and `US` in job locations
- support existing aliases, conservative explicit variants, and localized country names across eight languages
- route structured country evidence through the same shared matcher
- reuse the shared ISO resolver in the HiringCafe extractor

## Root cause

Country filtering only matched canonical country names and a small UK/US alias list. JobSpy can return locations with ISO-2 country suffixes, such as `Amsterdam Zuid, NH, NL`, so valid Indeed results were treated as outside the selected country and dropped.

ISO codes are accepted as standalone structured country evidence or as the final component of locations with at least three comma-separated parts. Ambiguous two-part locations such as `San Francisco, CA` and `Indianapolis, IN` are rejected.

## Impact

Valid country-code and localized-country results now survive location filtering without adding a country-data dependency. Existing UK/US aliases remain supported.

## Validation

- `./orchestrator/node_modules/.bin/biome ci .`
- shared, orchestrator, Gradcracker, UK Visa Jobs, and HiringCafe type checks
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run` — 268 files passed, 1,849 tests passed, 3 skipped

Closes #657
