### PR TITLE
Show selected job summaries while loading full details

### DIFF
--- a/docs-site/docs/features/orchestrator.md
+++ b/docs-site/docs/features/orchestrator.md
@@ -56,6 +56,11 @@ It exists to ensure:
    2. Top jobs above threshold are auto-processed.
    3. Jobs move directly to `ready` with generated PDFs.
 
+When you select a job, the detail panel shows the available title, employer,
+status, and listing information immediately. A loading skeleton fills the
+remaining detail area until the full job arrives. If that request fails, use
+**Retry** in the panel; actions that require full details stay unavailable.
+
 ### Using the Filters panel
 
 The main jobs page has a `Filters` button on the top-right next to `Search`.

--- a/orchestrator/src/client/components/JobHeader.test.tsx
+++ b/orchestrator/src/client/components/JobHeader.test.tsx
@@ -1,4 +1,5 @@
 import { createJob } from "@shared/testing/factories.js";
+import type { JobListItem } from "@shared/types.js";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import type React from "react";
 import { MemoryRouter } from "react-router-dom";
@@ -60,6 +61,22 @@ describe("JobHeader", () => {
     expect(screen.getByText("Tech Corp")).toBeInTheDocument();
     expect(screen.getByText("London")).toBeInTheDocument();
     expect(screen.getByText("£60,000")).toBeInTheDocument();
+  });
+
+  it("renders lightweight list data without full-detail indicators", () => {
+    const {
+      isRemote: _isRemote,
+      sponsorMatchNames: _sponsorMatchNames,
+      suitabilityReason: _suitabilityReason,
+      tracerLinksEnabled: _tracerLinksEnabled,
+      ...summary
+    } = mockJob;
+
+    renderWithRouter(<JobHeader job={summary as JobListItem} />);
+
+    expect(screen.getByText("Software Engineer")).toBeInTheDocument();
+    expect(screen.getByText("Tech Corp")).toBeInTheDocument();
+    expect(screen.queryByText("Tracer links off")).not.toBeInTheDocument();
   });
 
   it("links the title to the job page", () => {

--- a/orchestrator/src/client/components/JobHeader.tsx
+++ b/orchestrator/src/client/components/JobHeader.tsx
@@ -1,5 +1,5 @@
 import { isAwaitingAiScore, ScoreRing } from "@client/components";
-import type { AppliedDuplicateMatch, Job } from "@shared/types.js";
+import type { AppliedDuplicateMatch, Job, JobListItem } from "@shared/types.js";
 import { Calendar, DollarSign, Loader2, MapPin, Search } from "lucide-react";
 import type React from "react";
 import { useMemo, useState } from "react";
@@ -17,7 +17,7 @@ import {
 import { Tip } from "./Tip";
 
 interface JobHeaderProps {
-  job: Job;
+  job: Job | JobListItem;
   className?: string;
   onCheckSponsor?: () => Promise<void>;
   jobCTA?: React.ReactNode;
@@ -167,7 +167,10 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
   jobCTA,
 }) => {
   const jobStatus = getJobStatusIndicator(job.status);
-  const tracerStatus = getTracerStatusIndicator(job.tracerLinksEnabled);
+  const fullJob = "tracerLinksEnabled" in job ? job : null;
+  const tracerStatus = fullJob
+    ? getTracerStatusIndicator(fullJob.tracerLinksEnabled)
+    : null;
   const { showSponsorInfo } = useSettings();
   const location = useLocation();
   const { pathname } = location;
@@ -183,12 +186,13 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
     ) : job.status === "ready" ? (
       <p className="text-xs">Tailored and ready to apply.</p>
     ) : undefined;
-  const tracerStatusTooltip = !job.tracerLinksEnabled ? (
-    <p className="text-xs">
-      Tracer links are turned off for this job, so click tracking will not be
-      recorded.
-    </p>
-  ) : undefined;
+  const tracerStatusTooltip =
+    fullJob && !fullJob.tracerLinksEnabled ? (
+      <p className="text-xs">
+        Tracer links are turned off for this job, so click tracking will not be
+        recorded.
+      </p>
+    ) : undefined;
   return (
     <div
       className={cn(
@@ -210,11 +214,11 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
           <span>{job.employer}</span>
 
           <div className="flex flex-wrap items-center gap-x-3 text-sm text-muted-foreground/70 mt-1">
-            {(job.location || job.isRemote) && (
+            {(job.location || fullJob?.isRemote) && (
               <span className="flex items-center gap-1">
                 <MapPin className="size-4" />
                 {job.location?.trim()}
-                {job.isRemote && ", Remote"}
+                {fullJob?.isRemote && ", Remote"}
               </span>
             )}
             {deadline && (
@@ -238,7 +242,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
               score={job.suitabilityScore}
               size="sm"
               isAwaitingAi={isAwaitingAiScore(job)}
-              suitabilityReason={job.suitabilityReason}
+              suitabilityReason={fullJob?.suitabilityReason}
               jobId={job.id}
             />
           </div>
@@ -256,13 +260,15 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
             tooltipClassName="max-w-xs"
             className={jobStatusTooltip ? "cursor-help" : undefined}
           />
-          <StatusIndicator
-            dotColor={tracerStatus.dotColor}
-            label={tracerStatus.label}
-            tooltip={tracerStatusTooltip}
-            tooltipClassName="max-w-xs"
-            className={tracerStatusTooltip ? "cursor-help" : undefined}
-          />
+          {tracerStatus && (
+            <StatusIndicator
+              dotColor={tracerStatus.dotColor}
+              label={tracerStatus.label}
+              tooltip={tracerStatusTooltip}
+              tooltipClassName="max-w-xs"
+              className={tracerStatusTooltip ? "cursor-help" : undefined}
+            />
+          )}
 
           <AppliedDuplicatePill match={job.appliedDuplicateMatch} />
 
@@ -286,7 +292,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
             />
           )}
 
-          {job.isRemote === true && (
+          {fullJob?.isRemote === true && (
             <StatusIndicator
               variant="emerald"
               label="Remote"
@@ -298,7 +304,7 @@ export const JobHeader: React.FC<JobHeaderProps> = ({
           {showSponsorInfo && (
             <SponsorPill
               score={job.sponsorMatchScore}
-              names={job.sponsorMatchNames}
+              names={fullJob?.sponsorMatchNames ?? null}
               onCheck={onCheckSponsor}
             />
           )}

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -135,6 +135,9 @@ vi.mock("./orchestrator/useOrchestratorData", () => ({
   useOrchestratorData: () => ({
     jobs: mockJobs,
     selectedJob: mockSelectedJob,
+    selectedJobListItem: mockSelectedJob,
+    selectedJobLoadState: "idle",
+    retrySelectedJob: vi.fn(),
     stats: {
       discovered: 1,
       processing: 1,

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -119,6 +119,8 @@ const processingJob = createJob({
 
 let mockJobs = [jobFixture, job2, processingJob];
 let mockSelectedJob: Job | null = jobFixture;
+let mockSelectedJobListItemOverride: Job | null | undefined;
+let mockSelectedJobLoadState: "idle" | "loading" | "error" = "idle";
 
 const createMatchMedia = (matches: boolean | Record<string, boolean>) =>
   vi.fn().mockImplementation((query: string) => ({
@@ -135,8 +137,11 @@ vi.mock("./orchestrator/useOrchestratorData", () => ({
   useOrchestratorData: () => ({
     jobs: mockJobs,
     selectedJob: mockSelectedJob,
-    selectedJobListItem: mockSelectedJob,
-    selectedJobLoadState: "idle",
+    selectedJobListItem:
+      mockSelectedJobListItemOverride === undefined
+        ? mockSelectedJob
+        : mockSelectedJobListItemOverride,
+    selectedJobLoadState: mockSelectedJobLoadState,
     retrySelectedJob: vi.fn(),
     stats: {
       discovered: 1,
@@ -536,6 +541,8 @@ describe("OrchestratorPage", () => {
     mockPipelineSources = ["linkedin"];
     mockJobs = [jobFixture, job2, processingJob];
     mockSelectedJob = jobFixture;
+    mockSelectedJobListItemOverride = undefined;
+    mockSelectedJobLoadState = "idle";
     mockLoadJobs = vi.fn().mockResolvedValue(undefined);
     mockAutomaticRunValues = {
       topN: 12,
@@ -1590,6 +1597,35 @@ describe("OrchestratorPage", () => {
     await waitFor(() => {
       expect(locationText()).toContain("/all");
     });
+  });
+
+  it("opens the listing from summary data while full job details load", () => {
+    window.matchMedia = createMatchMedia(
+      true,
+    ) as unknown as typeof window.matchMedia;
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    mockSelectedJob = null;
+    mockSelectedJobListItemOverride = job2;
+    mockSelectedJobLoadState = "loading";
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/discovered/job-2"]}>
+        <Routes>
+          <Route path="/jobs/:tab/:jobId" element={<OrchestratorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    pressKey("o");
+
+    expect(openSpy).toHaveBeenCalledWith(
+      job2.applicationLink,
+      "_blank",
+      "noopener,noreferrer",
+    );
+    pressKey("r");
+    expect(api.processJob).not.toHaveBeenCalled();
+    openSpy.mockRestore();
   });
 
   it("triggers skip, mark applied, and move-to-ready actions from shortcuts", async () => {

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -28,6 +28,9 @@ export const OrchestratorPage: React.FC = () => {
   const {
     jobs,
     selectedJob,
+    selectedJobListItem,
+    selectedJobLoadState,
+    retrySelectedJob,
     stats,
     isLoading,
     isPipelineRunning,
@@ -147,6 +150,9 @@ export const OrchestratorPage: React.FC = () => {
           <OrchestratorJobWorkspaceContainer
             jobs={jobs}
             selectedJob={selectedJob}
+            selectedJobListItem={selectedJobListItem}
+            selectedJobLoadState={selectedJobLoadState}
+            retrySelectedJob={retrySelectedJob}
             stats={stats}
             isLoading={isLoading}
             isPipelineRunning={isPipelineRunning}

--- a/orchestrator/src/client/pages/orchestrator/JobDetailPanel.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobDetailPanel.test.tsx
@@ -62,8 +62,12 @@ vi.mock("@client/components", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@client/components")>();
   return {
     ...actual,
-    JobHeader: ({ jobCTA }: { jobCTA?: React.ReactNode }) => (
-      <div data-testid="job-header">{jobCTA}</div>
+    JobHeader: ({ job, jobCTA }: { job: Job; jobCTA?: React.ReactNode }) => (
+      <div data-testid="job-header">
+        <span>{job.title}</span>
+        <span>{job.employer}</span>
+        {jobCTA}
+      </div>
     ),
     JobBriefPane: () => <div data-testid="job-brief-pane" />,
     TailoredSummary: () => <div data-testid="tailored-summary" />,
@@ -151,10 +155,26 @@ vi.mock("sonner", () => ({
   },
 }));
 
-const renderJobDetailPanel = async (
-  props: React.ComponentProps<typeof JobDetailPanel>,
-) => {
-  const rendered = render(<JobDetailPanel {...props} />);
+type JobDetailPanelTestProps = Omit<
+  React.ComponentProps<typeof JobDetailPanel>,
+  "selectedJobListItem" | "selectedJobLoadState" | "onRetrySelectedJob"
+> &
+  Partial<
+    Pick<
+      React.ComponentProps<typeof JobDetailPanel>,
+      "selectedJobListItem" | "selectedJobLoadState" | "onRetrySelectedJob"
+    >
+  >;
+
+const renderJobDetailPanel = async (props: JobDetailPanelTestProps) => {
+  const rendered = render(
+    <JobDetailPanel
+      selectedJobListItem={props.selectedJob}
+      selectedJobLoadState="idle"
+      onRetrySelectedJob={vi.fn()}
+      {...props}
+    />,
+  );
   await act(async () => {
     await Promise.resolve();
   });
@@ -169,6 +189,69 @@ describe("JobDetailPanel", () => {
     mockSettings.settings = null;
     mockSettings.renderMarkdownInJobDescriptions = true;
     vi.mocked(api.getProfile).mockResolvedValue({});
+  });
+
+  it("shows the selected job summary and safe links while full details load", async () => {
+    const summary = createJob({
+      id: "job-2",
+      title: "Platform Engineer",
+      employer: "Example Ltd",
+      status: "discovered",
+      applicationLink: "https://example.com/apply/job-2",
+    });
+
+    await renderJobDetailPanel({
+      activeTab: "discovered",
+      activeJobs: [summary],
+      selectedJob: null,
+      selectedJobListItem: summary,
+      selectedJobLoadState: "loading",
+      onSelectJobId: vi.fn(),
+      onJobUpdated: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(screen.getByText("Platform Engineer")).toBeInTheDocument();
+    expect(screen.getByText("Example Ltd")).toBeInTheDocument();
+    expect(screen.getByTestId("job-detail-skeleton")).toBeInTheDocument();
+    expect(screen.getByText("Loading full job details…")).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /open job listing/i }),
+    ).toHaveAttribute("href", "https://example.com/apply/job-2");
+    expect(screen.getByRole("tab", { name: /brief/i })).toBeDisabled();
+    expect(screen.queryByText("Start Tailoring")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /more actions/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the summary and offers retry when detail loading fails", async () => {
+    const onRetrySelectedJob = vi.fn();
+    const summary = createJob({
+      id: "job-2",
+      title: "Platform Engineer",
+      employer: "Example Ltd",
+      status: "discovered",
+    });
+
+    await renderJobDetailPanel({
+      activeTab: "discovered",
+      activeJobs: [summary],
+      selectedJob: null,
+      selectedJobListItem: summary,
+      selectedJobLoadState: "error",
+      onSelectJobId: vi.fn(),
+      onJobUpdated: vi.fn().mockResolvedValue(undefined),
+      onRetrySelectedJob,
+    });
+
+    expect(screen.getByText("Platform Engineer")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Couldn't load job details",
+    );
+    expect(screen.queryByTestId("job-detail-skeleton")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetrySelectedJob).toHaveBeenCalledTimes(1);
   });
 
   it("renders discovered jobs in the unified inspector", async () => {

--- a/orchestrator/src/client/pages/orchestrator/JobDetailPanel.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobDetailPanel.tsx
@@ -58,6 +58,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { parseJobBrief } from "@/client/components/JobBriefPane";
 import { showErrorToast } from "@/client/lib/error-toast";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -66,6 +67,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { trackProductEvent } from "@/lib/analytics";
 import {
@@ -75,14 +77,18 @@ import {
   safeFilenamePart,
 } from "@/lib/utils";
 import type { FilterTab } from "./constants";
+import type { SelectedJobLoadState } from "./useOrchestratorData";
 
 interface JobDetailPanelProps {
   activeTab: FilterTab;
   activeJobs: JobListItem[];
   selectedJob: Job | null;
+  selectedJobListItem: JobListItem | null;
+  selectedJobLoadState: SelectedJobLoadState;
   onSelectJobId: (jobId: string | null) => void;
   onJobUpdated: () => Promise<void>;
   onPauseRefreshChange?: (paused: boolean) => void;
+  onRetrySelectedJob: () => void;
 }
 
 type InspectorTab = "brief" | "tailoring" | "apply";
@@ -116,6 +122,42 @@ const tabCopy: Record<
       "!border-emerald-400/65 !bg-emerald-500/20 !text-emerald-100",
   },
 };
+
+const InspectorTabsList: React.FC<{
+  inspectorTab: InspectorTab;
+  disabled?: boolean;
+}> = ({ inspectorTab, disabled = false }) => (
+  <TabsList className="mb-4 grid h-auto grid-cols-3 gap-1 rounded-lg bg-muted/90 text-sm">
+    {Object.entries(tabCopy).map(([value, copy]) => {
+      const isSelected = inspectorTab === value;
+      const trigger = (
+        <TabsTrigger
+          key={value}
+          value={value}
+          disabled={disabled}
+          className={cn(
+            "flex flex-1 items-center gap-1.5 lg:flex-none",
+            isSelected && copy.selectedClassName,
+          )}
+        >
+          <span className={cn("size-1.5 rounded-full", copy.dotClassName)} />
+          <span className="text-sm">{copy.label}</span>
+        </TabsTrigger>
+      );
+
+      return (
+        <Tip
+          key={value}
+          asChild
+          content={<p>{copy.description}</p>}
+          contentClassName="max-w-xs text-center"
+        >
+          {trigger}
+        </Tip>
+      );
+    })}
+  </TabsList>
+);
 
 const statusTone: Record<
   Job["status"],
@@ -177,7 +219,7 @@ const getPrimaryAction = (job: Job): string => {
 };
 
 const getDefaultInspectorTab = (
-  job: Job | null,
+  job: Pick<Job, "status"> | null,
   activeTab: FilterTab,
 ): InspectorTab => {
   if (!job) return "brief";
@@ -240,9 +282,12 @@ export const JobDetailPanel: React.FC<JobDetailPanelProps> = ({
   activeTab,
   activeJobs,
   selectedJob,
+  selectedJobListItem,
+  selectedJobLoadState,
   onSelectJobId,
   onJobUpdated,
   onPauseRefreshChange,
+  onRetrySelectedJob,
 }) => {
   const [inspectorTab, setInspectorTab] = useState<InspectorTab>("brief");
   const [isProcessing, setIsProcessing] = useState(false);
@@ -308,14 +353,15 @@ export const JobDetailPanel: React.FC<JobDetailPanelProps> = ({
   }, [loadCatalog]);
 
   useEffect(() => {
-    const currentJobId = selectedJob?.id ?? null;
+    const selection = selectedJob ?? selectedJobListItem;
+    const currentJobId = selection?.id ?? null;
     const currentSelectionKey = `${activeTab}:${currentJobId ?? ""}`;
     if (previousSelectionKeyRef.current === currentSelectionKey) return;
     previousSelectionKeyRef.current = currentSelectionKey;
-    setInspectorTab(getDefaultInspectorTab(selectedJob, activeTab));
+    setInspectorTab(getDefaultInspectorTab(selection, activeTab));
     setIsEditDetailsOpen(false);
     onPauseRefreshChange?.(false);
-  }, [activeTab, selectedJob, onPauseRefreshChange]);
+  }, [activeTab, selectedJob, selectedJobListItem, onPauseRefreshChange]);
 
   useEffect(() => {
     return () => onPauseRefreshChange?.(false);
@@ -507,6 +553,105 @@ export const JobDetailPanel: React.FC<JobDetailPanelProps> = ({
   );
 
   if (!selectedJob) {
+    if (selectedJobListItem) {
+      const isLoadingDetails = selectedJobLoadState !== "error";
+      const listingUrl =
+        selectedJobListItem.applicationLink || selectedJobListItem.jobUrl;
+      const summaryPdfMessage = isPdfRegenerating(selectedJobListItem)
+        ? PDF_REGENERATING_MESSAGE
+        : isPdfStale(selectedJobListItem)
+          ? STALE_PDF_MESSAGE
+          : null;
+
+      return (
+        <Tabs
+          value={inspectorTab}
+          aria-busy={isLoadingDetails}
+          className="flex min-h-0 min-w-0 flex-1 flex-col p-1 lg:sticky lg:top-24 lg:max-h-[calc(100vh-8rem)] lg:self-start lg:overflow-y-auto"
+        >
+          <InspectorTabsList inspectorTab={inspectorTab} disabled />
+          <JobHeader
+            job={selectedJobListItem}
+            jobCTA={
+              listingUrl ? (
+                <OpenJobListingButton href={listingUrl} />
+              ) : undefined
+            }
+          />
+
+          <div className="flex min-w-0 flex-col gap-4 rounded-lg rounded-t-none border border-t-0 border-border/50 bg-card p-4">
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Stat
+                label="Location"
+                value={selectedJobListItem.location}
+                tone="blue"
+              />
+              <Stat
+                label="Salary"
+                value={selectedJobListItem.salary}
+                tone="green"
+              />
+              <Stat label="Function" value={selectedJobListItem.jobFunction} />
+              <Stat label="Type" value={selectedJobListItem.jobType} />
+            </div>
+
+            {summaryPdfMessage ? (
+              <p className="text-xs text-muted-foreground">
+                {summaryPdfMessage}
+              </p>
+            ) : null}
+
+            {selectedJobLoadState === "error" ? (
+              <Alert>
+                <CircleAlert />
+                <AlertTitle>Couldn&apos;t load job details</AlertTitle>
+                <AlertDescription className="flex flex-col items-start gap-3">
+                  <p>
+                    The summary is still available. Try loading the details
+                    again.
+                  </p>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    onClick={onRetrySelectedJob}
+                  >
+                    Retry
+                  </Button>
+                </AlertDescription>
+              </Alert>
+            ) : (
+              <>
+                <output
+                  className="flex items-center gap-2 text-xs text-muted-foreground"
+                  aria-live="polite"
+                >
+                  <Loader2 className="size-3.5 animate-spin motion-reduce:animate-none" />
+                  Loading full job details…
+                </output>
+                <div
+                  className="flex flex-col gap-4"
+                  aria-hidden="true"
+                  data-testid="job-detail-skeleton"
+                >
+                  <div className="flex flex-col gap-2">
+                    <Skeleton className="h-4 w-32" />
+                    <Skeleton className="h-4 w-full" />
+                    <Skeleton className="h-4 w-11/12" />
+                  </div>
+                  <Skeleton className="h-24 w-full" />
+                  <div className="grid gap-2 sm:grid-cols-2">
+                    <Skeleton className="h-12 w-full" />
+                    <Skeleton className="h-12 w-full" />
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </Tabs>
+      );
+    }
+
     return (
       <div className="min-w-0 rounded-xl border border-border bg-card p-4 shadow-sm">
         <div className="flex h-full min-h-[260px] flex-col items-center justify-center gap-2 text-center">
@@ -551,37 +696,7 @@ export const JobDetailPanel: React.FC<JobDetailPanelProps> = ({
       onValueChange={(value) => setInspectorTab(value as InspectorTab)}
       className="flex min-h-0 min-w-0 flex-1 flex-col lg:sticky lg:top-24 lg:self-start lg:max-h-[calc(100vh-8rem)] lg:overflow-y-auto p-1"
     >
-      <TabsList className="grid h-auto grid-cols-3 gap-1 rounded-lg text-sm bg-muted/90 mb-4">
-        {Object.entries(tabCopy).map(([value, copy]) => {
-          const isSelected = inspectorTab === value;
-          const trigger = (
-            <TabsTrigger
-              key={value}
-              value={value}
-              className={cn(
-                "flex-1 flex items-center lg:flex-none gap-1.5",
-                isSelected && copy.selectedClassName,
-              )}
-            >
-              <span
-                className={cn("h-1.5 w-1.5 rounded-full", copy.dotClassName)}
-              />
-              <span className="text-sm">{copy.label}</span>
-            </TabsTrigger>
-          );
-
-          return (
-            <Tip
-              key={value}
-              asChild
-              content={<p>{copy.description}</p>}
-              contentClassName="max-w-xs text-center"
-            >
-              {trigger}
-            </Tip>
-          );
-        })}
-      </TabsList>
+      <InspectorTabsList inspectorTab={inspectorTab} />
       <JobHeader
         job={selectedJob}
         onCheckSponsor={async () => {

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorJobWorkspaceContainer.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorJobWorkspaceContainer.tsx
@@ -13,6 +13,7 @@ import type { RunMode } from "./run-mode";
 import { useFilteredJobs } from "./useFilteredJobs";
 import { useJobSelectionActions } from "./useJobSelectionActions";
 import { useKeyboardShortcuts } from "./useKeyboardShortcuts";
+import type { SelectedJobLoadState } from "./useOrchestratorData";
 import type { useOrchestratorFilters } from "./useOrchestratorFilters";
 import type { useOrchestratorNavigation } from "./useOrchestratorNavigation";
 import type { useOrchestratorUiState } from "./useOrchestratorUiState";
@@ -22,6 +23,9 @@ import { getJobCounts, getSourcesWithJobs } from "./utils";
 interface OrchestratorJobWorkspaceContainerProps {
   jobs: JobListItem[];
   selectedJob: Job | null;
+  selectedJobListItem: JobListItem | null;
+  selectedJobLoadState: SelectedJobLoadState;
+  retrySelectedJob: () => void;
   stats: Record<JobStatus, number>;
   isLoading: boolean;
   isPipelineRunning: boolean;
@@ -38,6 +42,9 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
 > = ({
   jobs,
   selectedJob,
+  selectedJobListItem,
+  selectedJobLoadState,
+  retrySelectedJob,
   stats,
   isLoading,
   isPipelineRunning,
@@ -73,6 +80,14 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
     if (!tabDef || tabDef.statuses.length === 0) return selectedJob;
     return tabDef.statuses.includes(selectedJob.status) ? selectedJob : null;
   }, [navigation.activeTab, selectedJob]);
+  const visibleSelectedJobListItem = useMemo(() => {
+    if (!selectedJobListItem) return null;
+    const tabDef = tabs.find((tab) => tab.id === navigation.activeTab);
+    if (!tabDef || tabDef.statuses.length === 0) return selectedJobListItem;
+    return tabDef.statuses.includes(selectedJobListItem.status)
+      ? selectedJobListItem
+      : null;
+  }, [navigation.activeTab, selectedJobListItem]);
 
   const {
     selectedJobIds,
@@ -208,6 +223,10 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
           jobs={jobs}
           activeJobs={activeJobs}
           selectedJob={visibleSelectedJob}
+          selectedJobListItem={visibleSelectedJobListItem}
+          selectedJobLoadState={
+            visibleSelectedJobListItem ? selectedJobLoadState : "idle"
+          }
           selectedJobId={navigation.selectedJobId}
           selectedJobIds={selectedJobIds}
           activeTab={navigation.activeTab}
@@ -250,6 +269,7 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
           onSelectJobId={navigation.handleSelectJobId}
           onJobUpdated={loadJobs}
           onPauseRefreshChange={setIsRefreshPaused}
+          onRetrySelectedJob={retrySelectedJob}
         />
       </div>
 
@@ -271,10 +291,15 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
           activeTab={navigation.activeTab}
           activeJobs={activeJobs}
           selectedJob={visibleSelectedJob}
+          selectedJobListItem={visibleSelectedJobListItem}
+          selectedJobLoadState={
+            visibleSelectedJobListItem ? selectedJobLoadState : "idle"
+          }
           onOpenChange={ui.onDetailDrawerOpenChange}
           onSelectJobId={navigation.handleSelectJobId}
           onJobUpdated={loadJobs}
           onPauseRefreshChange={setIsRefreshPaused}
+          onRetrySelectedJob={retrySelectedJob}
         />
       )}
 

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorJobWorkspaceContainer.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorJobWorkspaceContainer.tsx
@@ -137,6 +137,7 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
     activeJobs,
     selectedJobId: navigation.selectedJobId,
     selectedJob: visibleSelectedJob,
+    selectedJobSummary: visibleSelectedJobListItem,
     selectedJobIds,
     isDesktop: ui.isDesktop,
     handleSelectJobId: navigation.handleSelectJobId,

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorJobsWorkspace.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorJobsWorkspace.tsx
@@ -14,6 +14,7 @@ import { JobDetailPanel } from "./JobDetailPanel";
 import { JobListPanel } from "./JobListPanel";
 import { OrchestratorFilters } from "./OrchestratorFilters";
 import { OrchestratorSummary } from "./OrchestratorSummary";
+import type { SelectedJobLoadState } from "./useOrchestratorData";
 
 interface EmptyStateAction {
   label: string;
@@ -26,6 +27,8 @@ interface OrchestratorJobsWorkspaceProps {
   jobs: JobListItem[];
   activeJobs: JobListItem[];
   selectedJob: Job | null;
+  selectedJobListItem: JobListItem | null;
+  selectedJobLoadState: SelectedJobLoadState;
   selectedJobId: string | null;
   selectedJobIds: Set<string>;
   activeTab: FilterTab;
@@ -68,6 +71,7 @@ interface OrchestratorJobsWorkspaceProps {
   onSelectJobId: (jobId: string | null) => void;
   onJobUpdated: () => Promise<void>;
   onPauseRefreshChange: (paused: boolean) => void;
+  onRetrySelectedJob: () => void;
 }
 
 export const OrchestratorJobsWorkspace: React.FC<
@@ -78,6 +82,8 @@ export const OrchestratorJobsWorkspace: React.FC<
   jobs,
   activeJobs,
   selectedJob,
+  selectedJobListItem,
+  selectedJobLoadState,
   selectedJobId,
   selectedJobIds,
   activeTab,
@@ -120,6 +126,7 @@ export const OrchestratorJobsWorkspace: React.FC<
   onSelectJobId,
   onJobUpdated,
   onPauseRefreshChange,
+  onRetrySelectedJob,
 }) => (
   <>
     <OrchestratorSummary stats={stats} isPipelineRunning={isPipelineRunning} />
@@ -182,9 +189,12 @@ export const OrchestratorJobsWorkspace: React.FC<
             activeTab={activeTab}
             activeJobs={activeJobs}
             selectedJob={selectedJob}
+            selectedJobListItem={selectedJobListItem}
+            selectedJobLoadState={selectedJobLoadState}
             onSelectJobId={onSelectJobId}
             onJobUpdated={onJobUpdated}
             onPauseRefreshChange={onPauseRefreshChange}
+            onRetrySelectedJob={onRetrySelectedJob}
           />
         )}
       </div>

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorMobileJobDrawer.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorMobileJobDrawer.tsx
@@ -4,16 +4,20 @@ import { Button } from "@/components/ui/button";
 import { Drawer, DrawerClose, DrawerContent } from "@/components/ui/drawer";
 import type { FilterTab } from "./constants";
 import { JobDetailPanel } from "./JobDetailPanel";
+import type { SelectedJobLoadState } from "./useOrchestratorData";
 
 interface OrchestratorMobileJobDrawerProps {
   open: boolean;
   activeTab: FilterTab;
   activeJobs: JobListItem[];
   selectedJob: Job | null;
+  selectedJobListItem: JobListItem | null;
+  selectedJobLoadState: SelectedJobLoadState;
   onOpenChange: (open: boolean) => void;
   onSelectJobId: (jobId: string | null) => void;
   onJobUpdated: () => Promise<void>;
   onPauseRefreshChange: (paused: boolean) => void;
+  onRetrySelectedJob: () => void;
 }
 
 export const OrchestratorMobileJobDrawer: React.FC<
@@ -23,10 +27,13 @@ export const OrchestratorMobileJobDrawer: React.FC<
   activeTab,
   activeJobs,
   selectedJob,
+  selectedJobListItem,
+  selectedJobLoadState,
   onOpenChange,
   onSelectJobId,
   onJobUpdated,
   onPauseRefreshChange,
+  onRetrySelectedJob,
 }) => (
   <Drawer open={open} onOpenChange={onOpenChange}>
     <DrawerContent className="max-h-[90vh]">
@@ -45,9 +52,12 @@ export const OrchestratorMobileJobDrawer: React.FC<
           activeTab={activeTab}
           activeJobs={activeJobs}
           selectedJob={selectedJob}
+          selectedJobListItem={selectedJobListItem}
+          selectedJobLoadState={selectedJobLoadState}
           onSelectJobId={onSelectJobId}
           onJobUpdated={onJobUpdated}
           onPauseRefreshChange={onPauseRefreshChange}
+          onRetrySelectedJob={onRetrySelectedJob}
         />
       </div>
     </DrawerContent>

--- a/orchestrator/src/client/pages/orchestrator/useKeyboardShortcuts.ts
+++ b/orchestrator/src/client/pages/orchestrator/useKeyboardShortcuts.ts
@@ -25,6 +25,7 @@ type UseKeyboardShortcutsArgs = {
   activeJobs: JobListItem[];
   selectedJobId: string | null;
   selectedJob: JobListItem | null;
+  selectedJobSummary: JobListItem | null;
   selectedJobIds: Set<string>;
   isDesktop: boolean;
   handleSelectJobId: (id: string | null) => void;
@@ -47,6 +48,7 @@ export function useKeyboardShortcuts(args: UseKeyboardShortcutsArgs): void {
     activeJobs,
     selectedJobId,
     selectedJob,
+    selectedJobSummary,
     selectedJobIds,
     isDesktop: _isDesktop,
     handleSelectJobId,
@@ -253,8 +255,9 @@ export function useKeyboardShortcuts(args: UseKeyboardShortcutsArgs): void {
       },
 
       [SHORTCUTS.openListing.key]: () => {
-        if (!selectedJob) return;
-        const link = selectedJob.applicationLink || selectedJob.jobUrl;
+        const listingJob = selectedJob ?? selectedJobSummary;
+        if (!listingJob) return;
+        const link = listingJob.applicationLink || listingJob.jobUrl;
         if (link) window.open(link, "_blank", "noopener,noreferrer");
       },
 

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorData.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorData.test.ts
@@ -1,5 +1,6 @@
 import * as api from "@client/api";
 import { renderHookWithQueryClient } from "@client/test/renderWithQueryClient";
+import { createJob } from "@shared/testing/factories.js";
 import { act, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useOrchestratorData } from "./useOrchestratorData";
@@ -55,17 +56,35 @@ const makeResponse = (jobId: string, revision = `rev-${jobId}`) => ({
   revision,
 });
 
+const makeJobsResponse = (jobs: ReturnType<typeof createJob>[]) => ({
+  jobs,
+  total: jobs.length,
+  byStatus: {
+    discovered: jobs.filter((job) => job.status === "discovered").length,
+    processing: jobs.filter((job) => job.status === "processing").length,
+    ready: jobs.filter((job) => job.status === "ready").length,
+    applied: jobs.filter((job) => job.status === "applied").length,
+    in_progress: jobs.filter((job) => job.status === "in_progress").length,
+    skipped: jobs.filter((job) => job.status === "skipped").length,
+    expired: jobs.filter((job) => job.status === "expired").length,
+  },
+  revision: jobs.map((job) => `${job.id}:${job.updatedAt}`).join("|"),
+});
+
 type Deferred<T> = {
   promise: Promise<T>;
   resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
 };
 
 const deferred = <T>(): Deferred<T> => {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((res) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 };
 
 describe("useOrchestratorData", () => {
@@ -691,6 +710,118 @@ describe("useOrchestratorData", () => {
     await waitFor(() => {
       expect(api.getJob).toHaveBeenCalledWith("job-1");
       expect((result.current.selectedJob as any)?.id).toBe("job-1");
+    });
+  });
+
+  it("exposes the new summary and hides the previous full job while details load", async () => {
+    const job1 = createJob({
+      id: "job-1",
+      title: "First role",
+      status: "discovered",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const job2 = createJob({
+      id: "job-2",
+      title: "Second role",
+      status: "discovered",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    const job2Request = deferred<typeof job2>();
+    vi.mocked(api.getJobs).mockResolvedValue(makeJobsResponse([job1, job2]));
+    vi.mocked(api.getJob).mockImplementation((jobId) =>
+      jobId === job1.id ? Promise.resolve(job1) : job2Request.promise,
+    );
+
+    let selectedJobId: string | null = job1.id;
+    const { result, rerender } = renderHook(() =>
+      useOrchestratorData(selectedJobId),
+    );
+
+    await waitFor(() => expect(result.current.selectedJob?.id).toBe(job1.id));
+
+    selectedJobId = job2.id;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.selectedJobListItem?.id).toBe(job2.id);
+      expect(result.current.selectedJob).toBeNull();
+      expect(result.current.selectedJobLoadState).toBe("loading");
+    });
+
+    await act(async () => {
+      job2Request.resolve(job2);
+      await job2Request.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.selectedJob?.id).toBe(job2.id);
+      expect(result.current.selectedJobLoadState).toBe("idle");
+    });
+
+    selectedJobId = job1.id;
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current.selectedJob?.id).toBe(job1.id);
+      expect(result.current.selectedJobLoadState).toBe("idle");
+    });
+    expect(api.getJob).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a detail response that arrives after deselection", async () => {
+    const job = createJob({
+      id: "job-1",
+      status: "discovered",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const request = deferred<typeof job>();
+    vi.mocked(api.getJobs).mockResolvedValue(makeJobsResponse([job]));
+    vi.mocked(api.getJob).mockReturnValue(request.promise);
+
+    let selectedJobId: string | null = job.id;
+    const { result, rerender } = renderHook(() =>
+      useOrchestratorData(selectedJobId),
+    );
+
+    await waitFor(() =>
+      expect(result.current.selectedJobLoadState).toBe("loading"),
+    );
+
+    selectedJobId = null;
+    rerender();
+    await act(async () => {
+      request.resolve(job);
+      await request.promise;
+    });
+
+    expect(result.current.selectedJob).toBeNull();
+    expect(result.current.selectedJobListItem).toBeNull();
+    expect(result.current.selectedJobLoadState).toBe("idle");
+  });
+
+  it("retries a failed selected job detail request", async () => {
+    const job = createJob({
+      id: "job-1",
+      status: "discovered",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    vi.mocked(api.getJobs).mockResolvedValue(makeJobsResponse([job]));
+    vi.mocked(api.getJob)
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(job);
+
+    const { result } = renderHook(() => useOrchestratorData(job.id));
+
+    await waitFor(() =>
+      expect(result.current.selectedJobLoadState).toBe("error"),
+    );
+
+    act(() => result.current.retrySelectedJob());
+
+    await waitFor(() => {
+      expect(api.getJob).toHaveBeenCalledTimes(2);
+      expect(result.current.selectedJob?.id).toBe(job.id);
+      expect(result.current.selectedJobLoadState).toBe("idle");
     });
   });
 });

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
@@ -45,6 +45,8 @@ type PipelineTerminalSnapshot = {
   signature: string;
 };
 
+export type SelectedJobLoadState = "idle" | "loading" | "error";
+
 const ACTIVE_PIPELINE_STEPS: ReadonlySet<PipelineProgressStep> = new Set([
   "crawling",
   "challenge_required",
@@ -80,6 +82,10 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
   const queryClient = useQueryClient();
   const [jobListItems, setJobListItems] = useState<JobListItem[]>([]);
   const [selectedJob, setSelectedJob] = useState<Job | null>(null);
+  const [selectedJobRequestState, setSelectedJobRequestState] = useState<{
+    jobId: string;
+    status: Exclude<SelectedJobLoadState, "idle">;
+  } | null>(null);
   const [stats, setStats] = useState<Record<JobStatus, number>>(initialStats);
   const [isLoading, setIsLoading] = useState(true);
   const [isPipelineRunning, setIsPipelineRunning] = useState(false);
@@ -162,8 +168,7 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
   );
 
   const loadSelectedJob = useCallback(
-    async (jobId: string) => {
-      const seq = ++selectedJobRequestSeqRef.current;
+    async (jobId: string, seq: number) => {
       try {
         const fullJob = await queryClient.fetchQuery({
           queryKey: queryKeys.jobs.detail(jobId),
@@ -171,17 +176,18 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
           staleTime: 0,
         });
         selectedJobCacheRef.current.set(jobId, fullJob);
-        if (
-          selectedJobId === jobId &&
-          seq === selectedJobRequestSeqRef.current
-        ) {
+        if (seq === selectedJobRequestSeqRef.current) {
           setSelectedJob(fullJob);
+          setSelectedJobRequestState(null);
         }
       } catch (error) {
-        showErrorToast(error, "Failed to load selected job details");
+        if (seq === selectedJobRequestSeqRef.current) {
+          setSelectedJobRequestState({ jobId, status: "error" });
+          showErrorToast(error, "Failed to load selected job details");
+        }
       }
     },
-    [queryClient, selectedJobId],
+    [queryClient],
   );
 
   const loadJobs = useCallback(async () => {
@@ -406,6 +412,9 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
   }, [checkPipelineStatus, isPipelineSseConnected, isRefreshPaused]);
 
   useEffect(() => {
+    const seq = ++selectedJobRequestSeqRef.current;
+    setSelectedJobRequestState(null);
+
     if (!selectedJobId) {
       setSelectedJob(null);
       return;
@@ -425,12 +434,44 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
       return;
     }
 
-    void loadSelectedJob(selectedJobId);
+    setSelectedJob(null);
+    setSelectedJobRequestState({ jobId: selectedJobId, status: "loading" });
+    void loadSelectedJob(selectedJobId, seq);
   }, [jobListItems, loadSelectedJob, selectedJobId]);
+
+  const selectedJobListItem = selectedJobId
+    ? (jobListItems.find((job) => job.id === selectedJobId) ?? null)
+    : null;
+  const cachedSelectedJob = selectedJobId
+    ? selectedJobCacheRef.current.get(selectedJobId)
+    : null;
+  const matchingSelectedJob =
+    selectedJob?.id === selectedJobId
+      ? selectedJob
+      : cachedSelectedJob &&
+          cachedSelectedJob.updatedAt === selectedJobListItem?.updatedAt
+        ? cachedSelectedJob
+        : null;
+  const selectedJobLoadState: SelectedJobLoadState =
+    selectedJobListItem && !matchingSelectedJob
+      ? selectedJobRequestState?.jobId === selectedJobId
+        ? selectedJobRequestState.status
+        : "loading"
+      : "idle";
+  const retrySelectedJob = useCallback(() => {
+    if (!selectedJobId || !selectedJobListItem) return;
+    const seq = ++selectedJobRequestSeqRef.current;
+    setSelectedJob(null);
+    setSelectedJobRequestState({ jobId: selectedJobId, status: "loading" });
+    void loadSelectedJob(selectedJobId, seq);
+  }, [loadSelectedJob, selectedJobId, selectedJobListItem]);
 
   return {
     jobs: jobListItems,
-    selectedJob,
+    selectedJob: matchingSelectedJob,
+    selectedJobListItem,
+    selectedJobLoadState,
+    retrySelectedJob,
     stats,
     isLoading,
     isPipelineRunning,

--- a/orchestrator/src/components/ui/skeleton.tsx
+++ b/orchestrator/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn(
+        "animate-pulse rounded-md bg-muted motion-reduce:animate-none",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };


### PR DESCRIPTION
## Summary
- Display available job summary data immediately when a job is selected.
- Add loading skeletons and disable detail-dependent actions until full details load.
- Preserve summaries and provide retry handling when detail requests fail.
- Add component and hook coverage plus user-facing documentation.

## Testing
- Added unit tests for summary rendering, loading/error states, retry behavior, and stale response handling.

<img width="892" height="622" alt="image" src="https://github.com/user-attachments/assets/e1d39839-8d49-4c99-98ff-a5f0ccd5e24f" />
