### PR TITLE
Serialize job dates as ISO in JSON output

### DIFF
--- a/extractors/jobspy/scrape_jobs.py
+++ b/extractors/jobspy/scrape_jobs.py
@@ -290,7 +290,7 @@ def main() -> int:
         escapechar="\\",
         index=False,
     )
-    jobs.to_json(output_json, orient="records", force_ascii=False)
+    jobs.to_json(output_json, orient="records", force_ascii=False, date_format="iso")
 
     print(f"Wrote CSV:  {output_csv}")
     print(f"Wrote JSON: {output_json}")


### PR DESCRIPTION
## Summary
- Serialize scraped job dates in ISO format for JSON output
- Improve compatibility with LinkedIn date fields

Effectively, LinkedIn never had the "date posted" being parsed correctly, which means you'd have to click into the link to find out if the post is several weeks old or not. not anymore!