### PR TITLE
Fix pipeline progress tracking and resume scoring after configuration

### DIFF
--- a/orchestrator/src/client/components/PipelineProgress.test.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 type SseHandlers = {
@@ -14,6 +14,7 @@ const sseMock = vi.hoisted(() => ({
 const apiMock = vi.hoisted(() => ({
   getPipelineProgressSnapshot: vi.fn(),
   prepareChallengeViewer: vi.fn(),
+  resumePipelineScoring: vi.fn(),
   solvePipelineChallenge: vi.fn(),
 }));
 
@@ -78,6 +79,8 @@ describe("PipelineProgress", () => {
     apiMock.getPipelineProgressSnapshot.mockReset();
     apiMock.getPipelineProgressSnapshot.mockResolvedValue(baseProgress);
     apiMock.prepareChallengeViewer.mockReset();
+    apiMock.resumePipelineScoring.mockReset();
+    apiMock.resumePipelineScoring.mockResolvedValue({ resolved: true });
     apiMock.solvePipelineChallenge.mockReset();
   });
 
@@ -147,6 +150,21 @@ describe("PipelineProgress", () => {
     expect(
       screen.queryByText("Searching glassdoor for “backend” in leeds"),
     ).toBeNull();
+  });
+
+  it("resumes scoring after LLM configuration is added", () => {
+    render(<PipelineProgress isRunning />);
+    act(() =>
+      sseMock.handlers?.onMessage({
+        ...baseProgress,
+        step: "configuration_required",
+        error: "Add an API key.",
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Restart scoring" }));
+
+    expect(apiMock.resumePipelineScoring).toHaveBeenCalledOnce();
   });
 
   it("renders browser challenges from live progress", () => {

--- a/orchestrator/src/client/components/PipelineProgress.test.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.test.tsx
@@ -152,19 +152,28 @@ describe("PipelineProgress", () => {
     ).toBeNull();
   });
 
-  it("resumes scoring after LLM configuration is added", () => {
-    render(<PipelineProgress isRunning />);
-    act(() =>
-      sseMock.handlers?.onMessage({
+  it("keeps polling after LLM configuration is added", async () => {
+    apiMock.getPipelineProgressSnapshot
+      .mockResolvedValueOnce({
         ...baseProgress,
         step: "configuration_required",
         error: "Add an API key.",
-      }),
-    );
+      })
+      .mockResolvedValueOnce({
+        ...baseProgress,
+        step: "scoring",
+        message: "Scoring jobs...",
+      });
+    render(<PipelineProgress isRunning />);
+
+    await act(async () => vi.advanceTimersByTimeAsync(1500));
 
     fireEvent.click(screen.getByRole("button", { name: "Restart scoring" }));
+    await act(async () => vi.advanceTimersByTimeAsync(2000));
 
     expect(apiMock.resumePipelineScoring).toHaveBeenCalledOnce();
+    expect(apiMock.getPipelineProgressSnapshot).toHaveBeenCalledTimes(2);
+    expect(screen.getByText("Scoring matches")).toBeInTheDocument();
   });
 
   it("renders browser challenges from live progress", () => {

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -1,6 +1,7 @@
 import {
   getPipelineProgressSnapshot,
   prepareChallengeViewer,
+  resumePipelineScoring,
   solvePipelineChallenge,
 } from "@client/api";
 import type {
@@ -52,6 +53,7 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
 }) => {
   const [progress, setProgress] = useState<PipelineProgressState | null>(null);
   const [solvingExtractor, setSolvingExtractor] = useState<string | null>(null);
+  const [resumingScoring, setResumingScoring] = useState(false);
   const [now, setNow] = useState(() => Date.now());
 
   const handleSolveChallenge = useCallback(async (extractorId: string) => {
@@ -73,6 +75,16 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
       showErrorToast(error, "Failed to solve challenge");
     } finally {
       setSolvingExtractor(null);
+    }
+  }, []);
+
+  const handleResumeScoring = useCallback(async () => {
+    setResumingScoring(true);
+    try {
+      await resumePipelineScoring();
+    } catch (error) {
+      setResumingScoring(false);
+      showErrorToast(error, "Failed to restart scoring");
     }
   }, []);
 
@@ -158,11 +170,16 @@ export const PipelineProgress: React.FC<PipelineProgressProps> = ({
     ? Math.max(0, Math.floor((now - startedAt) / 1000))
     : 0;
 
-  if (progress.step === "scoring") {
+  if (
+    progress.step === "scoring" ||
+    progress.step === "configuration_required"
+  ) {
     return (
       <PipelineProgressCard
         progress={progress}
         elapsedSeconds={elapsedSeconds}
+        resumingScoring={resumingScoring}
+        onResumeScoring={handleResumeScoring}
       />
     );
   }

--- a/orchestrator/src/client/components/PipelineProgress.tsx
+++ b/orchestrator/src/client/components/PipelineProgress.tsx
@@ -25,7 +25,6 @@ const TERMINAL_STEPS: ReadonlySet<PipelineProgressState["step"]> = new Set([
   "completed",
   "cancelled",
   "failed",
-  "configuration_required",
 ]);
 
 const getCurrentCombination = (

--- a/orchestrator/src/server/pipeline/progress.test.ts
+++ b/orchestrator/src/server/pipeline/progress.test.ts
@@ -11,7 +11,10 @@ describe("pipeline fanout progress", () => {
       resetProgress();
       progressHelpers.initializeFanout({
         roles: ["Backend", "Platform"],
-        taskIds: ["jobspy", "gradcracker"],
+        tasks: [
+          { id: "jobspy", unitsPerRole: 9 },
+          { id: "gradcracker", unitsPerRole: 3 },
+        ],
         locations: ["Manchester", "London", "Leeds"],
         sources: ["indeed", "linkedin", "glassdoor", "gradcracker"],
         locationCount: 3,
@@ -19,7 +22,7 @@ describe("pipeline fanout progress", () => {
         capacity: 3,
       });
       progressHelpers.startFanoutTask("jobspy");
-      progressHelpers.updateFanoutTaskTerms("jobspy", 1);
+      progressHelpers.updateFanoutTaskTerms("jobspy", 1, 6);
       progressHelpers.settleFanoutTask("gradcracker", "check");
       progressHelpers.updateFanoutResults(12, 9);
 
@@ -29,13 +32,13 @@ describe("pipeline fanout progress", () => {
         sourceCount: 4,
         locations: ["Manchester", "London", "Leeds"],
         sources: ["indeed", "linkedin", "glassdoor", "gradcracker"],
-        total: 4,
+        total: 24,
         capacity: 3,
         results: 12,
         unique: 9,
         roles: [
-          { role: "Backend", complete: 1, running: 0, queued: 0, check: 1 },
-          { role: "Platform", complete: 0, running: 1, queued: 0, check: 1 },
+          { role: "Backend", complete: 3, running: 3, queued: 3, check: 3 },
+          { role: "Platform", complete: 0, running: 0, queued: 9, check: 3 },
         ],
       });
     });
@@ -46,7 +49,7 @@ describe("pipeline fanout progress", () => {
       resetProgress();
       progressHelpers.initializeFanout({
         roles: ["Backend"],
-        taskIds: ["jobspy"],
+        tasks: [{ id: "jobspy", unitsPerRole: 3 }],
         locations: ["Manchester"],
         sources: ["indeed", "linkedin", "glassdoor"],
         locationCount: 1,

--- a/orchestrator/src/server/pipeline/progress.test.ts
+++ b/orchestrator/src/server/pipeline/progress.test.ts
@@ -22,7 +22,10 @@ describe("pipeline fanout progress", () => {
         capacity: 3,
       });
       progressHelpers.startFanoutTask("jobspy");
-      progressHelpers.updateFanoutTaskTerms("jobspy", 1, 6);
+      progressHelpers.updateFanoutTaskTerms("jobspy", "Backend", 0, 6);
+      progressHelpers.updateFanoutTaskTerms("jobspy", "Backend", 0, 6);
+      progressHelpers.updateFanoutTaskTerms("jobspy", "Backend", 1, 6);
+      progressHelpers.updateFanoutTaskTerms("jobspy", "Platform", 1, 6);
       progressHelpers.settleFanoutTask("gradcracker", "check");
       progressHelpers.updateFanoutResults(12, 9);
 
@@ -37,8 +40,8 @@ describe("pipeline fanout progress", () => {
         results: 12,
         unique: 9,
         roles: [
-          { role: "Backend", complete: 3, running: 3, queued: 3, check: 3 },
-          { role: "Platform", complete: 0, running: 0, queued: 9, check: 3 },
+          { role: "Backend", complete: 3, running: 0, queued: 6, check: 3 },
+          { role: "Platform", complete: 0, running: 3, queued: 6, check: 3 },
         ],
       });
     });

--- a/orchestrator/src/server/pipeline/progress.ts
+++ b/orchestrator/src/server/pipeline/progress.ts
@@ -55,9 +55,13 @@ const currentSourceStatsByTenant = new Map<
 >();
 
 type FanoutUnitState = "queued" | "running" | "complete" | "check";
+type FanoutTask = {
+  states: FanoutUnitState[];
+  unitsPerRole: number;
+};
 type FanoutTracker = {
   roles: string[];
-  tasks: Map<string, FanoutUnitState[]>;
+  tasks: Map<string, FanoutTask>;
   locations: string[];
   sources: string[];
   locationCount: number;
@@ -183,7 +187,12 @@ function aggregateCrawlingStats(tenantId = getProgressScopeKey()) {
 
 function buildFanoutProgress(tracker: FanoutTracker): PipelineFanoutProgress {
   const roles = tracker.roles.map((role, index) => {
-    const states = [...tracker.tasks.values()].map((task) => task[index]);
+    const states = [...tracker.tasks.values()].flatMap((task) =>
+      task.states.slice(
+        index * task.unitsPerRole,
+        (index + 1) * task.unitsPerRole,
+      ),
+    );
     return {
       role,
       complete: states.filter((state) => state === "complete").length,
@@ -198,7 +207,11 @@ function buildFanoutProgress(tracker: FanoutTracker): PipelineFanoutProgress {
     sourceCount: tracker.sourceCount,
     locations: tracker.locations,
     sources: tracker.sources,
-    total: tracker.roles.length * tracker.tasks.size,
+    total: roles.reduce(
+      (sum, role) =>
+        sum + role.complete + role.running + role.queued + role.check,
+      0,
+    ),
     capacity: tracker.capacity,
     results: tracker.results,
     unique: tracker.unique,
@@ -274,7 +287,7 @@ export function resetProgress(): void {
 export const progressHelpers = {
   initializeFanout: (options: {
     roles: string[];
-    taskIds: string[];
+    tasks: Array<{ id: string; unitsPerRole: number }>;
     locations: string[];
     sources: string[];
     locationCount: number;
@@ -284,9 +297,15 @@ export const progressHelpers = {
     const tracker: FanoutTracker = {
       roles: options.roles,
       tasks: new Map(
-        options.taskIds.map((taskId) => [
-          taskId,
-          options.roles.map(() => "queued" as const),
+        options.tasks.map((task) => [
+          task.id,
+          {
+            unitsPerRole: task.unitsPerRole,
+            states: Array.from(
+              { length: options.roles.length * task.unitsPerRole },
+              () => "queued" as const,
+            ),
+          },
         ]),
       ),
       locations: options.locations,
@@ -303,22 +322,31 @@ export const progressHelpers = {
 
   startFanoutTask: (taskId: string) => {
     const tracker = getFanoutTracker();
-    const states = tracker?.tasks.get(taskId);
-    if (!tracker || !states) return;
-    states.fill("running");
+    const task = tracker?.tasks.get(taskId);
+    if (!tracker || !task) return;
+    task.states.fill("running");
     emitFanout(tracker);
   },
 
-  updateFanoutTaskTerms: (taskId: string, termsProcessed: number) => {
+  updateFanoutTaskTerms: (
+    taskId: string,
+    termsProcessed: number,
+    termsTotal?: number,
+  ) => {
     const tracker = getFanoutTracker();
-    const states = tracker?.tasks.get(taskId);
-    if (!tracker || !states) return;
-    const processed = Math.max(0, Math.min(states.length, termsProcessed));
-    for (let index = 0; index < states.length; index += 1) {
-      states[index] =
-        index < processed
+    const task = tracker?.tasks.get(taskId);
+    if (!tracker || !task) return;
+    const total = Math.max(1, termsTotal ?? tracker.roles.length);
+    const processed = Math.max(0, Math.min(total, termsProcessed));
+    const completeUnits = Math.round((processed / total) * task.states.length);
+    const runningUnits = Math.round(
+      (Math.min(total, processed + 1) / total) * task.states.length,
+    );
+    for (let index = 0; index < task.states.length; index += 1) {
+      task.states[index] =
+        index < completeUnits
           ? "complete"
-          : index === processed
+          : index < runningUnits
             ? "running"
             : "queued";
     }
@@ -327,9 +355,9 @@ export const progressHelpers = {
 
   settleFanoutTask: (taskId: string, state: "complete" | "check") => {
     const tracker = getFanoutTracker();
-    const states = tracker?.tasks.get(taskId);
-    if (!tracker || !states) return;
-    states.fill(state);
+    const task = tracker?.tasks.get(taskId);
+    if (!tracker || !task) return;
+    task.states.fill(state);
     emitFanout(tracker);
   },
 

--- a/orchestrator/src/server/pipeline/progress.ts
+++ b/orchestrator/src/server/pipeline/progress.ts
@@ -58,6 +58,8 @@ type FanoutUnitState = "queued" | "running" | "complete" | "check";
 type FanoutTask = {
   states: FanoutUnitState[];
   unitsPerRole: number;
+  completedTerms: number;
+  termProgressStarted: boolean;
 };
 type FanoutTracker = {
   roles: string[];
@@ -301,6 +303,8 @@ export const progressHelpers = {
           task.id,
           {
             unitsPerRole: task.unitsPerRole,
+            completedTerms: 0,
+            termProgressStarted: false,
             states: Array.from(
               { length: options.roles.length * task.unitsPerRole },
               () => "queued" as const,
@@ -330,25 +334,51 @@ export const progressHelpers = {
 
   updateFanoutTaskTerms: (
     taskId: string,
+    role: string,
     termsProcessed: number,
     termsTotal?: number,
   ) => {
     const tracker = getFanoutTracker();
     const task = tracker?.tasks.get(taskId);
     if (!tracker || !task) return;
+    const roleIndex = tracker.roles.indexOf(role);
+    if (roleIndex < 0) return;
+    if (!task.termProgressStarted) {
+      task.states.fill("queued");
+      task.termProgressStarted = true;
+    }
     const total = Math.max(1, termsTotal ?? tracker.roles.length);
     const processed = Math.max(0, Math.min(total, termsProcessed));
-    const completeUnits = Math.round((processed / total) * task.states.length);
-    const runningUnits = Math.round(
-      (Math.min(total, processed + 1) / total) * task.states.length,
-    );
-    for (let index = 0; index < task.states.length; index += 1) {
-      task.states[index] =
-        index < completeUnits
-          ? "complete"
-          : index < runningUnits
-            ? "running"
-            : "queued";
+    const unitsPerTerm = Math.max(1, Math.round(task.states.length / total));
+    const roleStart = roleIndex * task.unitsPerRole;
+    const roleEnd = roleStart + task.unitsPerRole;
+    const roleStates = task.states.slice(roleStart, roleEnd);
+    if (processed > task.completedTerms) {
+      let remaining = (processed - task.completedTerms) * unitsPerTerm;
+      for (
+        let index = 0;
+        index < roleStates.length && remaining > 0;
+        index += 1
+      ) {
+        if (roleStates[index] === "complete") continue;
+        task.states[roleStart + index] = "complete";
+        remaining -= 1;
+      }
+      task.completedTerms = processed;
+    } else if (
+      processed === task.completedTerms &&
+      !roleStates.includes("running")
+    ) {
+      let remaining = unitsPerTerm;
+      for (
+        let index = 0;
+        index < roleStates.length && remaining > 0;
+        index += 1
+      ) {
+        if (roleStates[index] !== "queued") continue;
+        task.states[roleStart + index] = "running";
+        remaining -= 1;
+      }
     }
     emitFanout(tracker);
   },

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -111,6 +111,7 @@ describe("discoverJobsStep", () => {
     expect(getProgress().fanout).toMatchObject({
       locations: ["United Kingdom"],
       sources: ["indeed", "linkedin", "ukvisajobs"],
+      total: 3,
     });
     expect(result.sourceErrors).toEqual([
       "UK Visa Jobs: login failed (sources: ukvisajobs)",

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -319,6 +319,7 @@ export async function discoverJobsStep(args: {
               progressHelpers.updateFanoutTaskTerms(
                 manifest.id,
                 event.termsProcessed,
+                event.termsTotal,
               );
             }
             progressHelpers.crawlingUpdate({
@@ -421,11 +422,19 @@ export async function discoverJobsStep(args: {
 
   progressHelpers.startCrawling(totalSources, args.preserveFanout);
   if (!args.preserveFanout) {
+    const locationCount = Math.max(1, locationIntent.cityLocations.length);
     progressHelpers.initializeFanout({
       roles: searchTerms,
-      taskIds: [
-        ...sourceTasks.map((task) => task.source),
-        ...(watchlistSelectedSources.length > 0 ? ["watchlist"] : []),
+      tasks: [
+        ...sourceTasks.map((task) => ({
+          id: task.source,
+          unitsPerRole:
+            (groupedByManifest.get(task.source)?.sources.length ?? 1) *
+            locationCount,
+        })),
+        ...(watchlistSelectedSources.length > 0
+          ? [{ id: "watchlist", unitsPerRole: locationCount }]
+          : []),
       ],
       locations:
         locationIntent.cityLocations.length > 0
@@ -435,7 +444,7 @@ export async function discoverJobsStep(args: {
         ...compatibleSources,
         ...(watchlistSelectedSources.length > 0 ? ["watchlist"] : []),
       ],
-      locationCount: Math.max(1, locationIntent.cityLocations.length),
+      locationCount,
       sourceCount:
         compatibleSources.length +
         (watchlistSelectedSources.length > 0 ? 1 : 0),

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -315,9 +315,15 @@ export async function discoverJobsStep(args: {
           getExistingJobUrls,
           shouldCancel: args.shouldCancel,
           onProgress: (event) => {
-            if (event.termsProcessed !== undefined) {
+            const role =
+              searchTerms.find((term) => event.currentUrl === term) ??
+              searchTerms.find((term) =>
+                event.currentUrl?.startsWith(`${term} @`),
+              );
+            if (event.termsProcessed !== undefined && role) {
               progressHelpers.updateFanoutTaskTerms(
                 manifest.id,
+                role,
                 event.termsProcessed,
                 event.termsTotal,
               );


### PR DESCRIPTION
## Summary

- Keep pipeline progress polling active while LLM configuration is required.
- Add a restart-scoring action after configuration is added.
- Track fanout progress per role, source, and location with accurate totals.
- Update discovery progress handling and related tests.

## Testing

- Not run (not requested).