### PR TITLE
Keep the selected job mounted during same-job refetch

### DIFF
--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorData.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorData.test.ts
@@ -713,6 +713,45 @@ describe("useOrchestratorData", () => {
     });
   });
 
+  it("keeps the selected job mounted during a same-job refetch", async () => {
+    const staleJob = createJob({
+      id: "job-1",
+      title: "Stale role",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const freshJob = createJob({
+      id: staleJob.id,
+      title: "Fresh role",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+    const freshJobRequest = deferred<typeof freshJob>();
+    vi.mocked(api.getJobs)
+      .mockResolvedValueOnce(makeJobsResponse([staleJob]))
+      .mockResolvedValueOnce(makeJobsResponse([freshJob]));
+    vi.mocked(api.getJob)
+      .mockResolvedValueOnce(staleJob)
+      .mockReturnValueOnce(freshJobRequest.promise);
+
+    const { result } = renderHook(() => useOrchestratorData(staleJob.id));
+
+    await waitFor(() => expect(result.current.selectedJob).toEqual(staleJob));
+
+    await act(async () => {
+      await result.current.loadJobs();
+    });
+
+    await waitFor(() => expect(api.getJob).toHaveBeenCalledTimes(2));
+    expect(result.current.selectedJob).toEqual(staleJob);
+    expect(result.current.selectedJobLoadState).toBe("idle");
+
+    await act(async () => {
+      freshJobRequest.resolve(freshJob);
+      await freshJobRequest.promise;
+    });
+
+    await waitFor(() => expect(result.current.selectedJob).toEqual(freshJob));
+  });
+
   it("exposes the new summary and hides the previous full job while details load", async () => {
     const job1 = createJob({
       id: "job-1",

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
@@ -434,10 +434,12 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
       return;
     }
 
-    setSelectedJob(null);
-    setSelectedJobRequestState({ jobId: selectedJobId, status: "loading" });
+    if (selectedJob?.id !== selectedJobId) {
+      setSelectedJob(null);
+      setSelectedJobRequestState({ jobId: selectedJobId, status: "loading" });
+    }
     void loadSelectedJob(selectedJobId, seq);
-  }, [jobListItems, loadSelectedJob, selectedJobId]);
+  }, [jobListItems, loadSelectedJob, selectedJob?.id, selectedJobId]);
 
   const selectedJobListItem = selectedJobId
     ? (jobListItems.find((job) => job.id === selectedJobId) ?? null)


### PR DESCRIPTION
## Summary
- Preserve the selected job while refreshing the same job.
- Add unit coverage for stale-to-fresh job updates during refetch.

## Testing
- Not run (not requested)