### PR TITLE
Update the Docker image to Codex CLI 0.144.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ENV DATA_DIR=/app/data
 ENV CODEX_HOME=/app/codex-home
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 ENV PATH=/root/.local/bin:${PATH}
-ARG CODEX_CLI_VERSION=0.120.0
+ARG CODEX_CLI_VERSION=0.144.6
 
 # Install runtime dependencies shared by build and production stages.
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary

- Update the Dockerfile’s Codex CLI version from 0.120.0 to 0.144.6

## Testing

- Not run (not requested)