### PR TITLE
Centralize resume project selection across tailoring flows

### DIFF
--- a/docs-site/docs/features/reactive-resume.md
+++ b/docs-site/docs/features/reactive-resume.md
@@ -67,17 +67,20 @@ Each project is identified by:
 
 ### Project selection controls
 
-The Settings UI supports 3 controls:
+The Settings UI supports 4 project modes/controls:
 
-- **Must Include**: always include these projects.
-- **AI Selectable**: pool of projects AI can pick from.
-- **Max Projects**: final cap for included projects.
+- **Must include**: always sent to relevant AI contexts and always shown in tailored resumes.
+- **AI can select**: sent to AI and available for automatic or manual job selection.
+- **Don't include**: never sent to AI and never shown in tailored resumes.
+- **Target**: desired final project count; JobOps keeps it at or above the Must-include count.
 
 At generation time:
 
 1. Must-include projects are added first.
-2. AI picks up to remaining slots from AI-selectable projects.
-3. Final visible projects are applied to the generated resume.
+2. A job's valid AI-selectable choices fill the remaining slots up to the target.
+3. Excluded, deleted, stale, and duplicate IDs are removed.
+
+Automatic selection fills every available slot. Manual selection may use fewer slots, but cannot exceed the target. PDF generation never makes a hidden project-selection AI call; it resolves the saved job choices against the current global policy, so the PDF matches the Tailoring editor.
 
 ## Setup and configuration
 
@@ -131,10 +134,10 @@ After that import, JobOps reads resume context locally by default.
 
 In **Settings → Reactive Resume**:
 
-1. Set `Max projects`.
+1. Set the project `Target`.
 2. Mark projects as **Must Include** where needed.
-3. Mark remaining projects as **AI selectable**.
-4. Save settings.
+3. Mark projects as **AI can select** or **Don't include**.
+4. Save settings. Existing generated PDFs affected by the policy are marked stale and queued for regeneration.
 
 ## Runtime behavior
 
@@ -151,6 +154,8 @@ High-level flow:
    - RxResume export
    - Local LaTeX with `tectonic`
    - Local Typst with `typst`
+
+In the Tailoring editor, Must-include projects are checked and locked, excluded projects are absent, and selectable projects can be toggled until the target is filled. Use **Pick again with AI** to replace only the selectable portion. **Generate all** updates summary, headline, and skills without replacing manual project choices.
 
 ### Resume-data caching
 

--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -175,12 +175,14 @@ Defaults and constraints:
 - JobOps uses the selected RxResume resume as the source of truth for import and project data
 - Invalid Reactive Resume credentials or other `4xx` config failures block the save and stay visible as an inline error
 - Temporary Reactive Resume downtime shows an inline warning, but the save still succeeds
-- Changing PDF-affecting settings (`pdfRenderer`, `typstTheme`, `rxresumeBaseResumeId`, RxResume URL/key) auto-queues regeneration for ready jobs that currently use system-generated PDFs
+- Changing PDF-affecting settings (`pdfRenderer`, `typstTheme`, `rxresumeBaseResumeId`, RxResume URL/key, or resume project policy) auto-queues regeneration for ready jobs that currently use system-generated PDFs
 - Select a template/base resume
 - Configure project selection behavior:
-  - Max projects
-  - Must-include projects
-  - AI-selectable projects
+  - Target project count
+  - **Must include**: always available to AI and always included in tailored resumes
+  - **AI can select**: available to AI and to per-job automatic/manual selection
+  - **Don't include**: excluded from AI prompts and tailored resumes
+- The target cannot be lower than the Must-include count. Automatic selection fills available slots; manual selection may use fewer but cannot exceed the target.
 - JobOps briefly caches successful Reactive Resume resume data to reduce repeated API calls across settings, profile, and PDF flows
 
 ### Tracer Links

--- a/orchestrator/src/client/api/jobs.ts
+++ b/orchestrator/src/client/api/jobs.ts
@@ -308,7 +308,7 @@ export async function summarizeJob(
   id: string,
   options?: {
     force?: boolean;
-    fields?: Array<"summary" | "headline" | "skills">;
+    fields?: Array<"summary" | "headline" | "skills" | "projects">;
   },
 ): Promise<Job> {
   const params = new URLSearchParams();

--- a/orchestrator/src/client/components/ReactiveResumeConfigPanel.tsx
+++ b/orchestrator/src/client/components/ReactiveResumeConfigPanel.tsx
@@ -375,10 +375,10 @@ export const ReactiveResumeConfigPanel: React.FC<
                           Visible in template
                         </TableHead>
                         <TableHead className="text-xs whitespace-wrap sm:whitespace-nowrap">
-                          Must Include
+                          Must include
                         </TableHead>
                         <TableHead className="text-xs whitespace-wrap sm:whitespace-nowrap">
-                          AI selectable
+                          AI can select
                         </TableHead>
                       </TableRow>
                     </TableHeader>

--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.test.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.test.tsx
@@ -101,7 +101,7 @@ describe("DesignResumeListSection", () => {
     );
 
     const maxProjectsInput = screen.getByLabelText(
-      "Maximum projects in Tailored Resumes",
+      "Target projects in tailored resumes",
     );
     expect(maxProjectsInput).toHaveValue(2);
 

--- a/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
+++ b/orchestrator/src/client/components/design-resume/DesignResumeListSection.tsx
@@ -131,10 +131,9 @@ const projectModeOptions: Array<{
 }> = [
   {
     mode: "manual",
-    label: "Don't select",
-    shortLabel: "Don't select",
-    tooltip:
-      "Do not select this project, meaning it'll never show in tailored resumes",
+    label: "Don't include",
+    shortLabel: "Don't include",
+    tooltip: "Never send this project to AI or show it in tailored resumes",
     icon: EyeOff,
     activeClassName: "border-border/70 bg-muted/55 text-muted-foreground",
   },
@@ -148,10 +147,10 @@ const projectModeOptions: Array<{
   },
   {
     mode: "must-include",
-    label: "Always selected",
-    shortLabel: "Always",
+    label: "Must include",
+    shortLabel: "Must include",
     tooltip:
-      "Always include this project in tailored resumes, regardless of the job description",
+      "Always send this project to relevant AI contexts and include it in tailored resumes",
     icon: LockKeyhole,
     activeClassName: "border-amber-200/35 bg-amber-300/12 text-amber-200",
   },
@@ -521,12 +520,12 @@ export function DesignResumeListSectionContent({
                 asChild
                 content={
                   <>
-                    Set the maximum number of projects that Job Tailoring can
-                    include in tailored resumes. <br />
-                    <br /> Always-selected projects count toward this limit.{" "}
+                    Set the desired number of projects in tailored resumes.{" "}
+                    <br />
+                    <br /> Must-include projects count toward this target.{" "}
                     <br />
                     <br /> Setting it to 0 prevents automatic project selection
-                    unless projects are marked Always.
+                    unless projects are marked Must include.
                   </>
                 }
                 contentClassName="max-w-96 text-center"
@@ -535,7 +534,7 @@ export function DesignResumeListSectionContent({
                   htmlFor={maxProjectsInputId}
                   className="text-xs font-medium text-muted-foreground w-full"
                 >
-                  Maximum projects in Tailored Resumes
+                  Target projects in tailored resumes
                 </label>
               </Tip>
 

--- a/orchestrator/src/client/components/discovered-panel/ProjectSelector.test.tsx
+++ b/orchestrator/src/client/components/discovered-panel/ProjectSelector.test.tsx
@@ -1,26 +1,92 @@
+import { resolveResumeProjectSelection } from "@shared/resume-projects";
 import { createResumeProjectCatalogItem } from "@shared/testing/factories.js";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ProjectSelector } from "./ProjectSelector";
 
 describe("ProjectSelector", () => {
   it("renders html project descriptions as plain text", () => {
+    const catalog = [
+      createResumeProjectCatalogItem({
+        id: "project",
+        description:
+          "<ul><li><p><strong>Built analytics</strong> using FastAPI.</p></li></ul>",
+      }),
+    ];
     render(
       <ProjectSelector
-        catalog={[
-          createResumeProjectCatalogItem({
-            description:
-              "<ul><li><p><strong>Built analytics</strong> using FastAPI.</p></li></ul>",
-          }),
-        ]}
-        selectedIds={new Set()}
+        catalog={catalog}
+        resolution={resolveResumeProjectSelection({
+          catalog,
+          resumeProjects: {
+            maxProjects: 3,
+            lockedProjectIds: [],
+            aiSelectableProjectIds: ["project"],
+          },
+        })}
         onToggle={vi.fn()}
-        maxProjects={3}
         disabled={false}
       />,
     );
 
     expect(screen.getByText("Built analytics using FastAPI.")).toBeVisible();
     expect(screen.queryByText(/<strong>/)).not.toBeInTheDocument();
+  });
+
+  it("shows must-include projects as selected and hides excluded projects", () => {
+    const catalog = ["a", "b", "c", "excluded"].map((id) =>
+      createResumeProjectCatalogItem({ id, name: id }),
+    );
+    render(
+      <ProjectSelector
+        catalog={catalog}
+        resolution={resolveResumeProjectSelection({
+          catalog,
+          resumeProjects: {
+            maxProjects: 3,
+            lockedProjectIds: ["a", "b", "c"],
+            aiSelectableProjectIds: [],
+          },
+        })}
+        onToggle={vi.fn()}
+        disabled={false}
+      />,
+    );
+
+    const checkboxes = screen.getAllByRole("checkbox");
+    expect(checkboxes).toHaveLength(3);
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toBeChecked();
+      expect(checkbox).toBeDisabled();
+    }
+    expect(screen.getAllByText("Must include")).toHaveLength(3);
+    expect(screen.queryByText("excluded")).not.toBeInTheDocument();
+  });
+
+  it("blocks another manual choice once the target is filled", () => {
+    const onToggle = vi.fn();
+    const catalog = ["a", "b"].map((id) =>
+      createResumeProjectCatalogItem({ id, name: id }),
+    );
+    render(
+      <ProjectSelector
+        catalog={catalog}
+        resolution={resolveResumeProjectSelection({
+          catalog,
+          resumeProjects: {
+            maxProjects: 1,
+            lockedProjectIds: [],
+            aiSelectableProjectIds: ["a", "b"],
+          },
+          selectedProjectIds: ["a"],
+        })}
+        onToggle={onToggle}
+        disabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /b/i }));
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(screen.getByText("Remove a project first.")).toBeVisible();
   });
 });

--- a/orchestrator/src/client/components/discovered-panel/ProjectSelector.tsx
+++ b/orchestrator/src/client/components/discovered-panel/ProjectSelector.tsx
@@ -1,75 +1,88 @@
+import type { ResumeProjectSelectionResolution } from "@shared/resume-projects";
 import type { ResumeProjectCatalogItem } from "@shared/types.js";
-import { AlertTriangle } from "lucide-react";
 import type React from "react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { cn, stripHtml } from "@/lib/utils";
 
 interface ProjectSelectorProps {
   catalog: ResumeProjectCatalogItem[];
-  selectedIds: Set<string>;
+  resolution: ResumeProjectSelectionResolution;
   onToggle: (id: string) => void;
-  maxProjects: number;
   disabled: boolean;
 }
 
 export const ProjectSelector: React.FC<ProjectSelectorProps> = ({
   catalog,
-  selectedIds,
+  resolution,
   onToggle,
-  maxProjects,
   disabled,
 }) => {
-  const tooManyProjects = selectedIds.size > maxProjects;
+  const mustIncludeIds = new Set(resolution.mustIncludeIds);
+  const aiSelectableIds = new Set(resolution.aiSelectableIds);
+  const selectedIds = new Set(resolution.effectiveSelectedIds);
+  const targetFilled = selectedIds.size >= resolution.targetCount;
+  const projects = catalog.filter(
+    (project) =>
+      mustIncludeIds.has(project.id) || aiSelectableIds.has(project.id),
+  );
 
   return (
     <div className="space-y-2">
-      <div className="flex flex-wrap items-start gap-2 sm:items-center sm:justify-between">
-        {tooManyProjects && (
-          <span className="flex items-center gap-1 text-[10px] text-amber-500 font-medium">
-            <AlertTriangle className="h-3 w-3" />
-            Max {maxProjects} recommended
-          </span>
-        )}
-      </div>
+      <p className="text-[11px] text-muted-foreground">
+        {selectedIds.size} of {resolution.targetCount} projects selected
+      </p>
 
       <div className="space-y-1.5">
-        {catalog.length === 0 ? (
-          <div className="text-xs text-muted-foreground text-center py-4">
-            Loading projects...
-          </div>
-        ) : (
-          catalog.map((project) => {
-            const description = stripHtml(project.description);
+        {projects.map((project) => {
+          const description = stripHtml(project.description);
+          const mustInclude = mustIncludeIds.has(project.id);
+          const selected = selectedIds.has(project.id);
+          const needsRemovalFirst = !selected && targetFilled;
+          const projectDisabled = disabled || mustInclude || needsRemovalFirst;
 
-            return (
-              <label
-                key={project.id}
-                htmlFor={`project-${project.id}`}
-                className={cn(
-                  "flex items-start gap-2.5 rounded-lg border p-2.5 text-xs transition-colors cursor-pointer",
-                  selectedIds.has(project.id)
-                    ? "border-primary/40 bg-primary/5"
-                    : "border-border/40 bg-muted/5 hover:bg-muted/10",
-                  disabled && "opacity-50 cursor-not-allowed",
-                )}
-              >
-                <Checkbox
-                  id={`project-${project.id}`}
-                  checked={selectedIds.has(project.id)}
-                  onCheckedChange={() => onToggle(project.id)}
-                  disabled={disabled}
-                  className="mt-0.5"
-                />
-                <div className="flex-1 min-w-0">
-                  <div className="font-medium truncate">{project.name}</div>
-                  <div className="text-[10px] text-muted-foreground line-clamp-1 mt-0.5">
-                    {description}
-                  </div>
+          return (
+            <label
+              key={project.id}
+              htmlFor={`project-${project.id}`}
+              title={needsRemovalFirst ? "Remove a project first." : undefined}
+              className={cn(
+                "flex items-start gap-2.5 rounded-lg border p-2.5 text-xs transition-colors cursor-pointer",
+                selected
+                  ? "border-primary/40 bg-primary/5"
+                  : "border-border/40 bg-muted/5 hover:bg-muted/10",
+                projectDisabled && "cursor-not-allowed opacity-50",
+              )}
+            >
+              <Checkbox
+                id={`project-${project.id}`}
+                checked={selected}
+                onCheckedChange={() => onToggle(project.id)}
+                disabled={projectDisabled}
+                className="mt-0.5"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between gap-2">
+                  <span className="truncate font-medium">{project.name}</span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground">
+                    {mustInclude
+                      ? "Must include"
+                      : selected
+                        ? "Selected"
+                        : "Available"}
+                  </span>
                 </div>
-              </label>
-            );
-          })
-        )}
+                <div className="text-[10px] text-muted-foreground line-clamp-1 mt-0.5">
+                  {description}
+                </div>
+                {needsRemovalFirst ? (
+                  <div className="mt-1 text-[10px] text-muted-foreground">
+                    Remove a project first.
+                  </div>
+                ) : null}
+              </div>
+            </label>
+          );
+        })}
       </div>
     </div>
   );

--- a/orchestrator/src/client/components/tailoring/TailoringSections.test.ts
+++ b/orchestrator/src/client/components/tailoring/TailoringSections.test.ts
@@ -58,7 +58,7 @@ describe("getNoSelectedProjectsInfo", () => {
     ).toBe("no-project-slots");
   });
 
-  it("explains when must-include projects fill all automatic slots", () => {
+  it("treats must-include projects as selected even when the job selection is empty", () => {
     expect(
       getNoSelectedProjectsInfo({
         catalog,
@@ -69,8 +69,8 @@ describe("getNoSelectedProjectsInfo", () => {
           lockedProjectIds: ["p1", "p2"],
           aiSelectableProjectIds: [],
         }),
-      })?.reason,
-    ).toBe("no-available-slots");
+      }),
+    ).toBeNull();
   });
 
   it("explains when no projects are AI-selectable", () => {
@@ -81,7 +81,7 @@ describe("getNoSelectedProjectsInfo", () => {
         selectedIds: new Set(),
         resumeProjectsSettings: settings({ aiSelectableProjectIds: [] }),
       })?.reason,
-    ).toBe("no-ai-selectable-projects");
+    ).toBe("selection-empty");
   });
 
   it("explains when automatic selection produced no saved selection", () => {

--- a/orchestrator/src/client/components/tailoring/TailoringSections.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringSections.tsx
@@ -1,4 +1,5 @@
 import { TokenizedInput } from "@client/pages/orchestrator/TokenizedInput";
+import { resolveResumeProjectSelection } from "@shared/resume-projects";
 import type {
   ResumeProjectCatalogItem,
   ResumeProjectsSettings,
@@ -15,7 +16,7 @@ import {
   Undo2,
 } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Tip } from "@/client/components/Tip";
 import {
   Accordion,
@@ -44,11 +45,13 @@ interface TailoringSectionsProps {
   tracerEnableBlockedReason: string | null;
   tracerReadinessChecking?: boolean;
   generatingSection: "summary" | "headline" | "skills" | null;
+  isGeneratingProjects: boolean;
   openSkillGroupId: string;
   disableInputs: boolean;
   onGenerateSummary: () => void;
   onGenerateHeadline: () => void;
   onGenerateSkills: () => void;
+  onGenerateProjects: () => void;
   onSummaryChange: (value: string) => void;
   onHeadlineChange: (value: string) => void;
   onUndoSummary: () => void;
@@ -90,10 +93,7 @@ type NoSelectedProjectsReason =
   | "settings-loading"
   | "no-projects"
   | "no-project-slots"
-  | "no-available-slots"
-  | "no-ai-selectable-projects"
-  | "selection-empty"
-  | "unknown";
+  | "selection-empty";
 
 type NoSelectedProjectsInfoCopy = {
   reason: NoSelectedProjectsReason;
@@ -170,8 +170,6 @@ export function getNoSelectedProjectsInfo(args: {
   resumeProjectsSettings?: ResumeProjectsSettings | null;
   isResumeProjectsSettingsLoading?: boolean;
 }): NoSelectedProjectsInfoCopy | null {
-  if (args.selectedIds.size > 0) return null;
-
   if (args.isCatalogLoading) {
     return {
       reason: "projects-loading",
@@ -202,48 +200,25 @@ export function getNoSelectedProjectsInfo(args: {
   const settings = args.resumeProjectsSettings;
   if (!settings) {
     return {
-      reason: "unknown",
-      title: "No projects selected",
-      description:
-        "No projects are saved for this job yet. The generated PDF will not include tailored project choices until you select projects below or run automatic generation again.",
+      reason: "settings-loading",
+      title: "Project settings are still loading",
+      description: "Project choices will appear when settings finish loading.",
     };
   }
 
-  const catalogIds = new Set(args.catalog.map((project) => project.id));
-  const lockedProjectIds = settings.lockedProjectIds.filter((id) =>
-    catalogIds.has(id),
-  );
-  const lockedSet = new Set(lockedProjectIds);
-  const aiSelectableProjectIds = settings.aiSelectableProjectIds
-    .filter((id) => catalogIds.has(id))
-    .filter((id) => !lockedSet.has(id));
-  const maxProjects = Math.max(0, Math.floor(settings.maxProjects));
-  const availableSlots = Math.max(0, maxProjects - lockedProjectIds.length);
+  const resolution = resolveResumeProjectSelection({
+    catalog: args.catalog,
+    resumeProjects: settings,
+    selectedProjectIds: [...args.selectedIds],
+  });
+  if (resolution.effectiveSelectedIds.length > 0) return null;
 
-  if (maxProjects === 0) {
+  if (resolution.targetCount === 0) {
     return {
       reason: "no-project-slots",
       title: "No project slots available",
       description:
-        "Project settings currently allow 0 projects. Increase the max project count or select projects manually before generating the PDF.",
-    };
-  }
-
-  if (availableSlots === 0) {
-    return {
-      reason: "no-available-slots",
-      title: "No AI selection slots available",
-      description:
-        "Your max project count is already filled by must-include projects, so automatic selection cannot add more projects. Select projects manually or adjust the max project count.",
-    };
-  }
-
-  if (aiSelectableProjectIds.length === 0) {
-    return {
-      reason: "no-ai-selectable-projects",
-      title: "No AI-selectable projects",
-      description:
-        "Your resume has projects, but none are available for automatic selection. Select projects manually here, or mark projects as AI-selectable in resume project settings.",
+        "Project settings currently allow 0 projects. Increase the target to include projects.",
     };
   }
 
@@ -251,7 +226,9 @@ export function getNoSelectedProjectsInfo(args: {
     reason: "selection-empty",
     title: "No projects selected",
     description:
-      "Automatic tailoring created the draft, but no projects were selected for this job. Choose the projects to include below before generating the PDF.",
+      resolution.aiSelectableIds.length === 0
+        ? "No projects are marked Must include or AI can select in Settings."
+        : "Choose projects below or use Pick again with AI.",
   };
 }
 
@@ -333,11 +310,13 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
   tracerEnableBlockedReason,
   tracerReadinessChecking = false,
   generatingSection,
+  isGeneratingProjects,
   openSkillGroupId,
   disableInputs,
   onGenerateSummary,
   onGenerateHeadline,
   onGenerateSkills,
+  onGenerateProjects,
   onSummaryChange,
   onHeadlineChange,
   onUndoSummary,
@@ -375,7 +354,21 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
       : skillsDraft.some(skillGroupNeedsReview)
         ? "review"
         : "ready";
-  const projectsState: SectionState = selectedIds.size > 0 ? "ready" : "none";
+  const projectResolution = useMemo(
+    () =>
+      resumeProjectsSettings
+        ? resolveResumeProjectSelection({
+            catalog,
+            resumeProjects: resumeProjectsSettings,
+            selectedProjectIds: [...selectedIds],
+          })
+        : null,
+    [catalog, resumeProjectsSettings, selectedIds],
+  );
+  const selectedProjectCount =
+    projectResolution?.effectiveSelectedIds.length ?? 0;
+  const projectsState: SectionState =
+    selectedProjectCount > 0 ? "ready" : "none";
   const noSelectedProjectsInfo = getNoSelectedProjectsInfo({
     catalog,
     isCatalogLoading,
@@ -710,7 +703,9 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
               title="Selected Projects"
               state={projectsState}
               badgeLabel={
-                selectedIds.size > 0 ? String(selectedIds.size) : undefined
+                selectedProjectCount > 0
+                  ? String(selectedProjectCount)
+                  : undefined
               }
               badgeAdornment={
                 noSelectedProjectsInfo ? (
@@ -720,13 +715,33 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
             />
           </AccordionTrigger>
           <AccordionContent className="px-3 pb-3 pt-3">
-            <ProjectSelector
-              catalog={catalog}
-              selectedIds={selectedIds}
-              onToggle={onToggleProject}
-              maxProjects={3}
-              disabled={disableInputs}
-            />
+            {projectResolution ? (
+              <>
+                <div className="mb-2 flex justify-end">
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className={actionButtonClass}
+                    onClick={onGenerateProjects}
+                    disabled={disableInputs}
+                  >
+                    <Sparkles className="mr-1 h-3.5 w-3.5" />
+                    {isGeneratingProjects ? "Picking..." : "Pick again with AI"}
+                  </Button>
+                </div>
+                <ProjectSelector
+                  catalog={catalog}
+                  resolution={projectResolution}
+                  onToggle={onToggleProject}
+                  disabled={disableInputs}
+                />
+              </>
+            ) : (
+              <p className="py-3 text-xs text-muted-foreground">
+                Project settings are still loading.
+              </p>
+            )}
           </AccordionContent>
         </AccordionItem>
       )}

--- a/orchestrator/src/client/components/tailoring/TailoringWorkspace.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringWorkspace.tsx
@@ -2,6 +2,7 @@ import * as api from "@client/api";
 import { useProfile } from "@client/hooks/useProfile";
 import { useSettings } from "@client/hooks/useSettings";
 import { useTracerReadiness } from "@client/hooks/useTracerReadiness";
+import { resolveResumeProjectSelection } from "@shared/resume-projects";
 import type { Job } from "@shared/types.js";
 import {
   Check,
@@ -56,7 +57,12 @@ interface TailoringBaseline {
 }
 
 type AutosaveStatus = "saved" | "unsaved" | "saving" | "error";
-type TailoringGenerateTarget = "all" | "summary" | "headline" | "skills";
+type TailoringGenerateTarget =
+  | "all"
+  | "summary"
+  | "headline"
+  | "skills"
+  | "projects";
 
 const AutosaveStatusIcon: React.FC<{ status: AutosaveStatus }> = ({
   status,
@@ -142,7 +148,7 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
     applyIncomingDraft,
     markSavedSnapshot,
     markSavedJob,
-    handleToggleProject,
+    replaceSelectedProjects,
     handleAddSkillGroup,
     handleUpdateSkillGroup,
     handleRemoveSkillGroup,
@@ -374,7 +380,8 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
 
         const updatedJob = await api.summarizeJob(props.job.id, {
           force: true,
-          fields: target === "all" ? undefined : [target],
+          fields:
+            target === "all" ? ["summary", "headline", "skills"] : [target],
         });
         applyIncomingDraft(updatedJob);
         setAiBaseline(toBaselineFromJob(updatedJob));
@@ -408,6 +415,39 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
   const handleGenerateSkills = useCallback(async () => {
     await handleGenerateTailoring("skills");
   }, [handleGenerateTailoring]);
+
+  const handleGenerateProjects = useCallback(async () => {
+    await handleGenerateTailoring("projects");
+  }, [handleGenerateTailoring]);
+
+  const handleToggleProject = useCallback(
+    (id: string) => {
+      const resumeProjects = settings?.resumeProjects.value;
+      if (!resumeProjects) return;
+      const resolution = resolveResumeProjectSelection({
+        catalog,
+        resumeProjects,
+        selectedProjectIds: [...selectedIds],
+      });
+      if (!resolution.aiSelectableIds.includes(id)) return;
+
+      const mustIncludeSet = new Set(resolution.mustIncludeIds);
+      const next = resolution.effectiveSelectedIds.filter(
+        (projectId) => !mustIncludeSet.has(projectId),
+      );
+      const index = next.indexOf(id);
+      if (index >= 0) next.splice(index, 1);
+      else if (resolution.effectiveSelectedIds.length < resolution.targetCount)
+        next.push(id);
+      replaceSelectedProjects(next);
+    },
+    [
+      catalog,
+      replaceSelectedProjects,
+      selectedIds,
+      settings?.resumeProjects.value,
+    ],
+  );
 
   const handleGeneratePdf = useCallback(async () => {
     try {
@@ -485,11 +525,13 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
         generateTarget === "skills"
           ? generateTarget
           : null,
+      isGeneratingProjects: generateTarget === "projects",
       openSkillGroupId,
       disableInputs,
       onGenerateSummary: handleGenerateSummary,
       onGenerateHeadline: handleGenerateHeadline,
       onGenerateSkills: handleGenerateSkills,
+      onGenerateProjects: handleGenerateProjects,
       onSummaryChange: setSummary,
       onHeadlineChange: setHeadline,
       onUndoSummary: handleUndoSummary,
@@ -538,6 +580,7 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
       handleGenerateSummary,
       handleGenerateHeadline,
       handleGenerateSkills,
+      handleGenerateProjects,
       setSummary,
       setHeadline,
       handleUndoSummary,

--- a/orchestrator/src/client/components/tailoring/useTailoringDraft.ts
+++ b/orchestrator/src/client/components/tailoring/useTailoringDraft.ts
@@ -270,6 +270,10 @@ export function useTailoringDraft({
     });
   }, []);
 
+  const replaceSelectedProjects = useCallback((ids: Iterable<string>) => {
+    setSelectedIds(new Set(ids));
+  }, []);
+
   const handleAddSkillGroup = useCallback(() => {
     const nextId = createTailoredSkillDraftId();
     setSkillsDraft((prev) => [
@@ -318,6 +322,7 @@ export function useTailoringDraft({
     markSavedSnapshot,
     markSavedJob,
     handleToggleProject,
+    replaceSelectedProjects,
     handleAddSkillGroup,
     handleUpdateSkillGroup,
     handleRemoveSkillGroup,

--- a/orchestrator/src/server/api/routes/jobs/documents.ts
+++ b/orchestrator/src/server/api/routes/jobs/documents.ts
@@ -31,7 +31,12 @@ import {
 
 export const jobsDocumentsRouter = Router();
 
-const tailoringGenerateFields = ["summary", "headline", "skills"] as const;
+const tailoringGenerateFields = [
+  "summary",
+  "headline",
+  "skills",
+  "projects",
+] as const;
 type TailoringGenerateField = (typeof tailoringGenerateFields)[number];
 
 function encodeContentDispositionFileName(value: string): string {

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -14,6 +14,7 @@ import { trackServerProductEvent } from "@infra/product-analytics";
 import { runWithRequestContext } from "@infra/request-context";
 import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import { createLocationIntentFromLegacyInputs } from "@shared/location-domain.js";
+import { resolveResumeProjectSelection } from "@shared/resume-projects";
 import type {
   JobStatus,
   PipelineConfig,
@@ -618,7 +619,7 @@ export async function runPipeline(
 
 export type ProcessJobOptions = {
   force?: boolean;
-  fields?: Array<"summary" | "headline" | "skills">;
+  fields?: Array<"summary" | "headline" | "skills" | "projects">;
   requestOrigin?: string | null;
   analyticsOrigin?:
     | "move_to_ready"
@@ -680,6 +681,8 @@ export async function summarizeJob(
         shouldUpdateAllTailoring || requestedFields.includes("headline");
       const shouldUpdateSkills =
         shouldUpdateAllTailoring || requestedFields.includes("skills");
+      const shouldUpdateProjects =
+        shouldUpdateAllTailoring || requestedFields.includes("projects");
       const shouldGenerateTailoring =
         shouldUpdateSummary || shouldUpdateHeadline || shouldUpdateSkills;
 
@@ -719,7 +722,7 @@ export async function summarizeJob(
 
       // 2. Suggest Projects
       let selectedProjectIds = job.selectedProjectIds;
-      if (shouldUpdateAllTailoring) {
+      if (shouldUpdateProjects) {
         try {
           const existingSelectedProjectIds =
             parseProjectIdsCsv(selectedProjectIds);
@@ -732,46 +735,47 @@ export async function summarizeJob(
             overrideRaw: overrideResumeProjectsRaw,
           });
 
-          const locked = resumeProjects.lockedProjectIds;
-          const desiredCount = Math.max(
-            0,
-            resumeProjects.maxProjects - locked.length,
+          const currentSelection = resolveResumeProjectSelection({
+            catalog,
+            resumeProjects,
+            selectedProjectIds: existingSelectedProjectIds,
+          });
+          const mustIncludeSet = new Set(currentSelection.mustIncludeIds);
+          const currentAiIds = currentSelection.effectiveSelectedIds.filter(
+            (id) => !mustIncludeSet.has(id),
           );
-          const eligibleSet = new Set(resumeProjects.aiSelectableProjectIds);
+          const storedSelectionIsValid =
+            existingSelectedProjectIds.length > 0 &&
+            existingSelectedProjectIds.length === currentAiIds.length &&
+            existingSelectedProjectIds.every(
+              (id, index) => id === currentAiIds[index],
+            );
+          const emptySelection = resolveResumeProjectSelection({
+            catalog,
+            resumeProjects,
+          });
+          const eligibleSet = new Set(emptySelection.aiSelectableIds);
           const eligibleProjects = selectionItems.filter((p) =>
             eligibleSet.has(p.id),
           );
-          const allowedProjectIds = new Set([
-            ...locked,
-            ...eligibleProjects.map((project) => project.id),
-          ]);
-          const missingLockedProjectIds = locked.filter(
-            (id) => !existingSelectedProjectIds.includes(id),
-          );
-          const disallowedExistingProjectIds =
-            existingSelectedProjectIds.filter(
-              (id) => !allowedProjectIds.has(id),
-            );
-          const existingSelectionExceedsMax =
-            existingSelectedProjectIds.length > resumeProjects.maxProjects;
-          const existingSelectionValid =
-            existingSelectedProjectIds.length > 0 &&
-            disallowedExistingProjectIds.length === 0 &&
-            missingLockedProjectIds.length === 0 &&
-            !existingSelectionExceedsMax;
-
-          if (existingSelectionValid && !options?.force) {
-            selectedProjectIds = existingSelectedProjectIds.join(",");
+          if (storedSelectionIsValid && !options?.force) {
+            selectedProjectIds = currentAiIds.join(",");
           } else {
-            await reserveTailoringUsage();
-            const picked = await pickProjectIdsForJob({
-              jobDescription: job.jobDescription || "",
-              eligibleProjects,
-              desiredCount,
-            });
-
-            tailoringUsageSucceeded = true;
-            selectedProjectIds = [...locked, ...picked].join(",");
+            if (
+              emptySelection.remainingSlots > 0 &&
+              eligibleProjects.length > 0
+            ) {
+              await reserveTailoringUsage();
+              const picked = await pickProjectIdsForJob({
+                jobDescription: job.jobDescription || "",
+                eligibleProjects,
+                desiredCount: emptySelection.remainingSlots,
+              });
+              tailoringUsageSucceeded = true;
+              selectedProjectIds = picked.join(",");
+            } else {
+              selectedProjectIds = "";
+            }
           }
         } catch (error) {
           jobLogger.warn("Failed to suggest projects", { error });
@@ -788,7 +792,7 @@ export async function summarizeJob(
         ...(shouldUpdateSkills
           ? { tailoredSkills: tailoredSkills ?? undefined }
           : {}),
-        ...(shouldUpdateAllTailoring
+        ...(shouldUpdateProjects
           ? { selectedProjectIds: selectedProjectIds ?? undefined }
           : {}),
       });

--- a/orchestrator/src/server/pipeline/project-selection.test.ts
+++ b/orchestrator/src/server/pipeline/project-selection.test.ts
@@ -146,4 +146,37 @@ describe("summarizeJob project selection", () => {
       }),
     );
   });
+
+  it("does not call the selection model when must-include projects fill the target", async () => {
+    vi.mocked(jobsRepo.getJobById).mockResolvedValue({
+      id: "job-1",
+      jobDescription: "Data acquisition engineer role.",
+      tailoredSummary: "Existing summary.",
+      tailoredHeadline: "Existing headline.",
+      tailoredSkills: JSON.stringify(["TypeScript"]),
+      selectedProjectIds: null,
+    } as any);
+    vi.mocked(settingsRepo.getSetting).mockResolvedValue(
+      JSON.stringify({
+        maxProjects: 3,
+        lockedProjectIds: ["mumtaz-urdu", "jobops", "indus-marine"],
+        aiSelectableProjectIds: [],
+      }),
+    );
+
+    expect(await summarizeJob("job-1")).toEqual({ success: true });
+    expect(pickProjectIdsForJob).not.toHaveBeenCalled();
+    expect(jobsRepo.updateJob).toHaveBeenCalledWith(
+      "job-1",
+      expect.objectContaining({ selectedProjectIds: "" }),
+    );
+  });
+
+  it("replaces only projects when projects are explicitly requested", async () => {
+    await summarizeJob("job-1", { force: true, fields: ["projects"] });
+
+    expect(jobsRepo.updateJob).toHaveBeenCalledWith("job-1", {
+      selectedProjectIds: "mumtaz-urdu",
+    });
+  });
 });

--- a/orchestrator/src/server/services/ai-resilience.test.ts
+++ b/orchestrator/src/server/services/ai-resilience.test.ts
@@ -249,8 +249,41 @@ describe("AI Service Resilience", () => {
         desiredCount: 2,
       });
 
-      // Should strip p999 and only return p1
-      expect(result).toEqual(["p1"]);
+      // Invalid IDs are removed and deterministic fallback fills the slot.
+      expect(result).toEqual(["p1", "p2"]);
+    });
+
+    it("tops up a short AI ranking deterministically", async () => {
+      vi.mocked(global.fetch).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify({ selectedProjectIds: ["p2"] }),
+              },
+            },
+          ],
+        }),
+      } as any);
+
+      const result = await pickProjectIdsForJob({
+        jobDescription: "React dev",
+        eligibleProjects: [
+          ...mockProjects,
+          {
+            id: "p3",
+            name: "Project 3",
+            description: "Other",
+            summaryText: "Other",
+            date: "2024",
+            isVisibleInBase: false,
+          },
+        ],
+        desiredCount: 3,
+      });
+
+      expect(result).toEqual(["p2", "p1", "p3"]);
     });
   });
 });

--- a/orchestrator/src/server/services/auto-pdf-regeneration.test.ts
+++ b/orchestrator/src/server/services/auto-pdf-regeneration.test.ts
@@ -45,6 +45,11 @@ vi.mock("./pdf-fingerprint", () => ({
     pdfRenderer: "latex",
     typstTheme: "classic",
     rxresumeBaseResumeId: null,
+    resumeProjects: {
+      maxProjects: 3,
+      lockedProjectIds: [],
+      aiSelectableProjectIds: [],
+    },
   }),
   getJobPdfFreshness: vi.fn((job: { pdfFingerprint?: string | null }) =>
     job.pdfFingerprint === "fresh" ? "current" : "stale",
@@ -85,6 +90,11 @@ describe("auto PDF regeneration", () => {
       pdfRenderer: "latex",
       typstTheme: "classic",
       rxresumeBaseResumeId: null,
+      resumeProjects: {
+        maxProjects: 3,
+        lockedProjectIds: [],
+        aiSelectableProjectIds: [],
+      },
     });
   });
 
@@ -149,6 +159,25 @@ describe("auto PDF regeneration", () => {
       }),
       { dedupeKey: "tenant-test:tenant:job-2" },
     );
+  });
+
+  it("invalidates generated PDFs when resume project policy changes", async () => {
+    mocks.getReadyJobsWithGeneratedPdfs.mockResolvedValue([
+      createJob({
+        id: "job-project-policy",
+        status: "ready",
+        pdfPath: "data/pdfs/job-project-policy.pdf",
+        pdfSource: "generated",
+        pdfFingerprint: "stale",
+      }),
+    ]);
+
+    expect(
+      await enqueueAutoPdfRegenerationForSettingsChanges({
+        updatedSettingKeys: ["resumeProjects"],
+        requestedBy: "user",
+      }),
+    ).toBe(1);
   });
 
   it("carries hosted user ownership into queued regeneration jobs", async () => {
@@ -237,6 +266,11 @@ describe("auto PDF regeneration", () => {
       pdfRenderer: "typst",
       typstTheme: "compact",
       rxresumeBaseResumeId: null,
+      resumeProjects: {
+        maxProjects: 3,
+        lockedProjectIds: [],
+        aiSelectableProjectIds: [],
+      },
     });
     mocks.getReadyJobsWithGeneratedPdfs.mockResolvedValue([
       createJob({

--- a/orchestrator/src/server/services/auto-pdf-regeneration.ts
+++ b/orchestrator/src/server/services/auto-pdf-regeneration.ts
@@ -21,6 +21,7 @@ const SETTINGS_INVALIDATION_KEYS = new Set<SettingKey>([
   "rxresumeBaseResumeId",
   "rxresumeUrl",
   "rxresumeApiKey",
+  "resumeProjects",
 ]);
 
 function onlyInvalidatesTypstTheme(

--- a/orchestrator/src/server/services/demo-simulator.ts
+++ b/orchestrator/src/server/services/demo-simulator.ts
@@ -14,7 +14,7 @@ import type {
 
 type ProcessOptions = {
   force?: boolean;
-  fields?: Array<"summary" | "headline" | "skills">;
+  fields?: Array<"summary" | "headline" | "skills" | "projects">;
 };
 
 function scoreFromJob(job: Job): number {
@@ -131,7 +131,9 @@ export async function simulateSummarizeJob(
     ...(updateAll || requestedFields.includes("skills")
       ? { tailoredSkills: makeDemoTailoredSkills() }
       : {}),
-    ...(updateAll ? { selectedProjectIds: ensureProjectIds(job) } : {}),
+    ...(updateAll || requestedFields.includes("projects")
+      ? { selectedProjectIds: ensureProjectIds(job) }
+      : {}),
   });
   return { success: true };
 }

--- a/orchestrator/src/server/services/ghostwriter-context.test.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.test.ts
@@ -196,6 +196,40 @@ describe("buildJobChatPromptContext", () => {
     expect(context.profileSnapshot).toContain("Skills:");
   });
 
+  it("omits globally excluded projects from Ghostwriter context", async () => {
+    const job = createJob({ id: "job-project-policy" });
+    vi.mocked(getJobById).mockResolvedValue(job);
+    vi.mocked(getSetting).mockImplementation(async (key) =>
+      key === "resumeProjects"
+        ? JSON.stringify({
+            maxProjects: 1,
+            lockedProjectIds: ["included"],
+            aiSelectableProjectIds: [],
+          })
+        : null,
+    );
+    vi.mocked(getProfile).mockResolvedValue({
+      sections: {
+        projects: {
+          items: ["included", "excluded"].map((id) => ({
+            id,
+            name: `${id} project`,
+            description: id,
+            summary: id,
+            date: "2026",
+            visible: false,
+          })),
+        },
+      },
+    });
+
+    const context = await buildJobChatPromptContext(job.id);
+
+    expect(context.profileSnapshot).toContain("included project");
+    expect(context.profileSnapshot).not.toContain("excluded project");
+    expect(context.systemPrompt).not.toContain("excluded project");
+  });
+
   it("falls back to empty profile snapshot when profile loading fails", async () => {
     const job = createJob({ id: "job-ctx-2" });
     vi.mocked(getJobById).mockResolvedValue(job);

--- a/orchestrator/src/server/services/ghostwriter-context.ts
+++ b/orchestrator/src/server/services/ghostwriter-context.ts
@@ -36,6 +36,7 @@ import {
   getEffectivePromptTemplate,
   renderPromptTemplate,
 } from "./prompt-templates";
+import { filterProfileProjectsForAi } from "./resumeProjects";
 import {
   getWritingStyle,
   stripLanguageDirectivesFromConstraints,
@@ -392,7 +393,7 @@ export async function buildJobChatPromptContext(
 
   let profile: ResumeProfile = {};
   try {
-    profile = await getProfile();
+    profile = await filterProfileProjectsForAi(await getProfile());
   } catch (error) {
     logger.warn("Failed to load profile for job chat context", {
       jobId,

--- a/orchestrator/src/server/services/pdf-fingerprint.test.ts
+++ b/orchestrator/src/server/services/pdf-fingerprint.test.ts
@@ -11,6 +11,11 @@ const context: PdfFingerprintContext = {
   pdfRenderer: "latex",
   typstTheme: "classic",
   rxresumeBaseResumeId: "rxresume-base-1",
+  resumeProjects: {
+    maxProjects: 3,
+    lockedProjectIds: ["must"],
+    aiSelectableProjectIds: ["selectable"],
+  },
 };
 
 describe("PDF freshness", () => {
@@ -102,6 +107,17 @@ describe("PDF freshness", () => {
         ...context,
         pdfRenderer: "typst",
         typstTheme: "compact",
+      }),
+    );
+  });
+
+  it("includes resume project policy changes", () => {
+    const job = createJob({ tailoredSummary: "Summary" });
+
+    expect(createJobPdfFingerprint(job, context)).not.toBe(
+      createJobPdfFingerprint(job, {
+        ...context,
+        resumeProjects: { ...context.resumeProjects, maxProjects: 4 },
       }),
     );
   });

--- a/orchestrator/src/server/services/pdf-fingerprint.ts
+++ b/orchestrator/src/server/services/pdf-fingerprint.ts
@@ -5,6 +5,7 @@ import type {
   Job,
   JobPdfFreshness,
   PdfRenderer,
+  ResumeProjectsSettings,
   TypstTheme,
 } from "@shared/types";
 import { getCurrentDesignResumeOrNullOnLegacy } from "./design-resume";
@@ -33,16 +34,23 @@ export interface PdfFingerprintContext {
   pdfRenderer: PdfRenderer;
   typstTheme: TypstTheme;
   rxresumeBaseResumeId: string | null;
+  resumeProjects: ResumeProjectsSettings;
 }
 
 export async function resolvePdfFingerprintContext(): Promise<PdfFingerprintContext> {
-  const [designResume, rawRenderer, rawTypstTheme, configuredBaseResume] =
-    await Promise.all([
-      getCurrentDesignResumeOrNullOnLegacy(),
-      settingsRepo.getSetting("pdfRenderer"),
-      settingsRepo.getSetting("typstTheme"),
-      getConfiguredRxResumeBaseResumeId(),
-    ]);
+  const [
+    designResume,
+    rawRenderer,
+    rawTypstTheme,
+    rawResumeProjects,
+    configuredBaseResume,
+  ] = await Promise.all([
+    getCurrentDesignResumeOrNullOnLegacy(),
+    settingsRepo.getSetting("pdfRenderer"),
+    settingsRepo.getSetting("typstTheme"),
+    settingsRepo.getSetting("resumeProjects"),
+    getConfiguredRxResumeBaseResumeId(),
+  ]);
 
   const parsedRenderer = settingsRegistry.pdfRenderer.parse(
     rawRenderer ?? undefined,
@@ -59,6 +67,9 @@ export async function resolvePdfFingerprintContext(): Promise<PdfFingerprintCont
     pdfRenderer: parsedRenderer ?? settingsRegistry.pdfRenderer.default(),
     typstTheme: parsedTypstTheme ?? settingsRegistry.typstTheme.default(),
     rxresumeBaseResumeId: configuredBaseResume.resumeId ?? null,
+    resumeProjects:
+      settingsRegistry.resumeProjects.parse(rawResumeProjects ?? undefined) ??
+      settingsRegistry.resumeProjects.default(),
   };
 }
 
@@ -73,6 +84,7 @@ export function createJobPdfFingerprint(
       ? { typstTheme: context.typstTheme }
       : {}),
     rxresumeBaseResumeId: context.rxresumeBaseResumeId,
+    resumeProjects: context.resumeProjects,
     designResumeDocumentId: context.designResumeDocumentId,
     designResumeRevision: context.designResumeRevision,
     designResumeUpdatedAt: context.designResumeUpdatedAt,

--- a/orchestrator/src/server/services/pdf-tailoring.test.ts
+++ b/orchestrator/src/server/services/pdf-tailoring.test.ts
@@ -368,7 +368,6 @@ vi.mock("./design-resume", () => ({
 
 vi.mock("./rxresume", async () => {
   const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
-  const projectSelectionModule = await import("./projectSelection");
   return {
     importResume: vi.fn().mockResolvedValue("temp-resume-id"),
     exportResumePdf: vi.fn().mockResolvedValue({
@@ -394,21 +393,13 @@ vi.mock("./rxresume", async () => {
           data.basics.headline = args.tailoredContent.headline;
         }
 
-        let selected = (args.selectedProjectIds as string | null | undefined)
-          ?.split(",")
+        const selected = (
+          (args.selectedProjectIds as string | null | undefined) ?? ""
+        )
+          .split(",")
           .map((s) => s.trim())
-          .filter(Boolean);
-        if (!selected) {
-          selected = await projectSelectionModule.pickProjectIdsForJob({
-            jobDescription: args.jobDescription,
-            eligibleProjects: [
-              { id: "p1", name: "Project 1" },
-              { id: "p2", name: "Project 2" },
-            ],
-            desiredCount: 3,
-          } as any);
-        }
-        const selectedSet = new Set(selected);
+          .filter((id) => id === "p2");
+        const selectedSet = new Set(["p1", ...selected]);
         for (const item of data.sections?.projects?.items ?? []) {
           item.hidden = !selectedSet.has(item.id);
         }
@@ -494,7 +485,7 @@ describe("PDF Service Tailoring Logic", () => {
     const p2 = projects.find((p: any) => p.id === "p2");
 
     expect(p2.hidden).toBe(false);
-    expect(p1.hidden).toBe(true);
+    expect(p1.hidden).toBe(false);
 
     // 3. Verify Summary Update
     const summary = savedResumeJson.summary.content;
@@ -519,18 +510,15 @@ describe("PDF Service Tailoring Logic", () => {
     const savedResumeJson = mockResumeRenderer.getLastResumeJson();
     const projects = savedResumeJson.sections.projects.items;
 
-    expect(projects.find((p: any) => p.id === "p1").hidden).toBe(true);
+    expect(projects.find((p: any) => p.id === "p1").hidden).toBe(false);
     expect(projects.find((p: any) => p.id === "p2").hidden).toBe(true);
     expect(savedResumeJson.sections.projects.hidden).toBe(false);
   });
 
-  it("should fall back to AI selection if selectedProjectIds is null/undefined", async () => {
-    // Setup AI selection mock for this test
-    vi.mocked(projectSelection.pickProjectIdsForJob).mockResolvedValue(["p1"]);
-
+  it("resolves must-include projects without AI when selection is absent", async () => {
     await generatePdf("job-3", {}, "desc", "base.json", undefined);
 
-    expect(projectSelection.pickProjectIdsForJob).toHaveBeenCalled();
+    expect(projectSelection.pickProjectIdsForJob).not.toHaveBeenCalled();
 
     expect(mockResumeRenderer.renderResumePdf).toHaveBeenCalled();
     const savedResumeJson = mockResumeRenderer.getLastResumeJson();

--- a/orchestrator/src/server/services/projectSelection.ts
+++ b/orchestrator/src/server/services/projectSelection.ts
@@ -39,36 +39,39 @@ export async function pickProjectIdsForJob(args: {
     return [];
   }
 
-  const model = await resolveLlmModel("projectSelection");
   const jobDescription = stripHtmlTags(args.jobDescription);
-
-  const prompt = buildProjectSelectionPrompt({
-    jobDescription,
-    projects: args.eligibleProjects,
-    desiredCount,
-  });
-
-  const llm = await createConfiguredLlmService("projectSelection");
-  const result = await llm.callJson<{ selectedProjectIds: string[] }>({
-    model,
-    messages: [{ role: "user", content: prompt }],
-    jsonSchema: PROJECT_SELECTION_SCHEMA,
-  });
-
-  if (!result.success) {
-    const fallback = fallbackPickProjectIds(
+  let selectedProjectIds: unknown[] = [];
+  try {
+    const [model, llm] = await Promise.all([
+      resolveLlmModel("projectSelection"),
+      createConfiguredLlmService("projectSelection"),
+    ]);
+    const result = await llm.callJson<{ selectedProjectIds: string[] }>({
+      model,
+      messages: [
+        {
+          role: "user",
+          content: buildProjectSelectionPrompt({
+            jobDescription,
+            projects: args.eligibleProjects,
+            desiredCount,
+          }),
+        },
+      ],
+      jsonSchema: PROJECT_SELECTION_SCHEMA,
+    });
+    selectedProjectIds =
+      result.success && Array.isArray(result.data?.selectedProjectIds)
+        ? result.data.selectedProjectIds
+        : [];
+  } catch {
+    return fallbackPickProjectIds(
       jobDescription,
       args.eligibleProjects,
       desiredCount,
     );
-    return fallback;
   }
 
-  const selectedProjectIds = Array.isArray(result.data?.selectedProjectIds)
-    ? result.data.selectedProjectIds
-    : [];
-
-  // Validate and dedupe the returned IDs
   const unique: string[] = [];
   const seen = new Set<string>();
   for (const id of selectedProjectIds) {
@@ -82,13 +85,13 @@ export async function pickProjectIdsForJob(args: {
     if (unique.length >= desiredCount) break;
   }
 
-  if (unique.length === 0) {
-    const fallback = fallbackPickProjectIds(
-      jobDescription,
-      args.eligibleProjects,
-      desiredCount,
-    );
-    return fallback;
+  for (const id of fallbackPickProjectIds(
+    jobDescription,
+    args.eligibleProjects,
+    desiredCount,
+  )) {
+    if (!seen.has(id)) unique.push(id);
+    if (unique.length >= desiredCount) break;
   }
 
   return unique;
@@ -111,7 +114,7 @@ function buildProjectSelectionPrompt(args: {
 You are selecting which projects to include on a resume for a specific job.
 
 Rules:
-- Choose up to ${args.desiredCount} project IDs.
+- Rank the best ${args.desiredCount} project IDs.
 - Only choose IDs from the provided list.
 - Prefer projects that strongly match the job description keywords/tech stack.
 - Prefer projects that signal impact and real-world engineering.

--- a/orchestrator/src/server/services/resumeProjects.test.ts
+++ b/orchestrator/src/server/services/resumeProjects.test.ts
@@ -1,6 +1,9 @@
 import type { ResumeProjectCatalogItem } from "@shared/types";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import * as rp from "./resumeProjects";
+
+const settingsMocks = vi.hoisted(() => ({ getSetting: vi.fn() }));
+vi.mock("@server/repositories/settings", () => settingsMocks);
 
 describe("Resume Projects Logic", () => {
   describe("stripHtml", () => {
@@ -192,5 +195,49 @@ describe("Resume Projects Logic", () => {
       expect(result.overrideResumeProjects).toBeNull();
       expect(result.resumeProjects.lockedProjectIds).toEqual(["p1"]);
     });
+  });
+
+  it("keeps project exclusions scoped to the current workspace settings", async () => {
+    const profile = {
+      sections: {
+        projects: {
+          items: ["shared", "tenant-a-only", "tenant-b-only"].map((id) => ({
+            id,
+            name: id,
+            description: "",
+            summary: "",
+            date: "",
+            visible: true,
+          })),
+        },
+      },
+    };
+    settingsMocks.getSetting
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          maxProjects: 2,
+          lockedProjectIds: ["shared"],
+          aiSelectableProjectIds: ["tenant-a-only"],
+        }),
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          maxProjects: 2,
+          lockedProjectIds: ["shared"],
+          aiSelectableProjectIds: ["tenant-b-only"],
+        }),
+      );
+
+    const tenantA = await rp.filterProfileProjectsForAi(profile);
+    const tenantB = await rp.filterProfileProjectsForAi(profile);
+
+    expect(tenantA.sections?.projects?.items?.map(({ id }) => id)).toEqual([
+      "shared",
+      "tenant-a-only",
+    ]);
+    expect(tenantB.sections?.projects?.items?.map(({ id }) => id)).toEqual([
+      "shared",
+      "tenant-b-only",
+    ]);
   });
 });

--- a/orchestrator/src/server/services/resumeProjects.ts
+++ b/orchestrator/src/server/services/resumeProjects.ts
@@ -1,3 +1,5 @@
+import { getSetting } from "@server/repositories/settings";
+import { resolveResumeProjectSelection } from "@shared/resume-projects";
 import type {
   ResumeProfile,
   ResumeProjectCatalogItem,
@@ -153,6 +155,40 @@ export function resolveResumeProjectsSettings(args: {
     defaultResumeProjects,
     overrideResumeProjects,
     resumeProjects,
+  };
+}
+
+export async function filterProfileProjectsForAi(
+  profile: ResumeProfile,
+): Promise<ResumeProfile> {
+  const items = profile.sections?.projects?.items;
+  if (!items?.length) return profile;
+
+  const { catalog } = extractProjectsFromProfile(profile);
+  const { resumeProjects } = resolveResumeProjectsSettings({
+    catalog,
+    overrideRaw: await getSetting("resumeProjects"),
+  });
+  const resolution = resolveResumeProjectSelection({
+    catalog,
+    resumeProjects,
+  });
+  const allowedIds = new Set([
+    ...resolution.mustIncludeIds,
+    ...resolution.aiSelectableIds,
+  ]);
+
+  return {
+    ...profile,
+    sections: {
+      ...profile.sections,
+      projects: {
+        ...profile.sections?.projects,
+        items: items
+          .filter((item) => allowedIds.has(item.id))
+          .map((item) => ({ ...item, hidden: false, visible: true })),
+      },
+    },
   };
 }
 

--- a/orchestrator/src/server/services/rxresume/index.ts
+++ b/orchestrator/src/server/services/rxresume/index.ts
@@ -1,13 +1,13 @@
 import { createHash } from "node:crypto";
 import { getSetting } from "@server/repositories/settings";
 import { getOriginalEnvValue } from "@server/services/envSettings";
-import { pickProjectIdsForJob } from "@server/services/projectSelection";
 import { resolveResumeProjectsSettings } from "@server/services/resumeProjects";
 import {
   resolveTracerPublicBaseUrl,
   rewriteResumeLinksWithTracer,
 } from "@server/services/tracer-links";
 import { getActiveTenantId } from "@server/tenancy/context";
+import { resolveResumeProjectSelection } from "@shared/resume-projects";
 import type { ResumeProjectCatalogItem } from "@shared/types";
 import {
   getResumeSchemaValidationMessage,
@@ -355,15 +355,6 @@ export async function validateResumeSchema(
   };
 }
 
-function parseSelectedProjectIds(selectedProjectIds?: string | null): string[] {
-  if (selectedProjectIds === null || selectedProjectIds === undefined)
-    return [];
-  return selectedProjectIds
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
 export function extractProjectsFromResume(resumeData: unknown): {
   mode: "v5";
   catalog: ResumeProjectCatalogItem[];
@@ -406,36 +397,16 @@ export async function prepareTailoredResumeForPdf(args: {
     tailoredContent: args.tailoredContent,
   });
 
-  const { catalog, selectionItems } = extractProjectsFromResumeV5(workingCopy);
-
-  let selectedIds = parseSelectedProjectIds(args.selectedProjectIds);
-
-  if (
-    args.selectedProjectIds === null ||
-    args.selectedProjectIds === undefined
-  ) {
-    const overrideResumeProjectsRaw = await getSetting("resumeProjects");
-    const { resumeProjects } = resolveResumeProjectsSettings({
-      catalog,
-      overrideRaw: overrideResumeProjectsRaw,
-    });
-
-    const locked = resumeProjects.lockedProjectIds;
-    const desiredCount = Math.max(
-      0,
-      resumeProjects.maxProjects - locked.length,
-    );
-    const eligibleSet = new Set(resumeProjects.aiSelectableProjectIds);
-    const eligibleProjects = selectionItems.filter((p) =>
-      eligibleSet.has(p.id),
-    );
-    const picked = await pickProjectIdsForJob({
-      jobDescription: args.jobDescription,
-      eligibleProjects,
-      desiredCount,
-    });
-    selectedIds = [...locked, ...picked];
-  }
+  const { catalog } = extractProjectsFromResumeV5(workingCopy);
+  const { resumeProjects } = resolveResumeProjectsSettings({
+    catalog,
+    overrideRaw: await getSetting("resumeProjects"),
+  });
+  const selectedIds = resolveResumeProjectSelection({
+    catalog,
+    resumeProjects,
+    selectedProjectIds: args.selectedProjectIds,
+  }).effectiveSelectedIds;
 
   applyProjectVisibility({
     resumeData: workingCopy,

--- a/orchestrator/src/server/services/scorer.test.ts
+++ b/orchestrator/src/server/services/scorer.test.ts
@@ -371,6 +371,43 @@ describe("salary penalty", () => {
   });
 
   describe("profile prompt sanitization", () => {
+    it("omits globally excluded projects from scoring", async () => {
+      const { scoreJobSuitability } = await import("./scorer");
+      getEffectiveSettingsMock.mockResolvedValue({
+        penalizeMissingSalary: { value: false, default: false, override: null },
+        missingSalaryPenalty: { value: 10, default: 10, override: null },
+        scoringInstructions: { value: "", default: "", override: null },
+        rxresumeBaseResumeId: "base-resume-123",
+      } as any);
+      getSettingMock.mockImplementation(async (key) =>
+        key === "resumeProjects"
+          ? JSON.stringify({
+              maxProjects: 1,
+              lockedProjectIds: ["included"],
+              aiSelectableProjectIds: [],
+            })
+          : null,
+      );
+
+      await scoreJobSuitability(createJob({ id: "project-policy-score" }), {
+        sections: {
+          projects: {
+            items: ["included", "excluded"].map((id) => ({
+              id,
+              name: `${id} project`,
+              description: id,
+              summary: id,
+              date: "2026",
+              visible: false,
+            })),
+          },
+        },
+      });
+
+      expect(getScoringPrompt()).toContain("included project");
+      expect(getScoringPrompt()).not.toContain("excluded project");
+    });
+
     it("includes top-level education and the full top-level CV content", async () => {
       const { scoreJobSuitability } = await import("./scorer");
       getEffectiveSettingsMock.mockResolvedValue({

--- a/orchestrator/src/server/services/scorer.ts
+++ b/orchestrator/src/server/services/scorer.ts
@@ -15,6 +15,7 @@ import type { JsonSchemaDefinition } from "./llm/types";
 import { stripMarkdownCodeFences } from "./llm/utils/json";
 import { createConfiguredLlmService, resolveLlmModel } from "./modelSelection";
 import { renderPromptTemplate } from "./prompt-templates";
+import { filterProfileProjectsForAi } from "./resumeProjects";
 import { getEffectiveSettings } from "./settings";
 
 export class LlmNotConfiguredError extends Error {
@@ -250,15 +251,16 @@ export async function scoreJobSuitability(
   profile: Record<string, unknown>,
   options: { scoringInstructions?: string } = {},
 ): Promise<SuitabilityResult> {
-  const [model, settings] = await Promise.all([
+  const [model, settings, aiProfile] = await Promise.all([
     resolveLlmModel("scoring"),
     getEffectiveSettings(),
+    filterProfileProjectsForAi(profile),
   ]);
   const scoringInstructions = Object.hasOwn(options, "scoringInstructions")
     ? (options.scoringInstructions ?? "")
     : (settings.scoringInstructions?.value ?? "");
 
-  const prompt = buildScoringPrompt(job, sanitizeProfileForPrompt(profile), {
+  const prompt = buildScoringPrompt(job, sanitizeProfileForPrompt(aiProfile), {
     instructions: scoringInstructions,
     promptTemplate:
       settings.scoringPromptTemplate?.value ??

--- a/orchestrator/src/server/services/summary.test.ts
+++ b/orchestrator/src/server/services/summary.test.ts
@@ -110,6 +110,37 @@ describe("generateTailoring", () => {
     );
   });
 
+  it("omits globally excluded projects from the tailoring prompt", async () => {
+    vi.mocked(getSetting).mockImplementation(async (key) =>
+      key === "resumeProjects"
+        ? JSON.stringify({
+            maxProjects: 1,
+            lockedProjectIds: ["included"],
+            aiSelectableProjectIds: [],
+          })
+        : null,
+    );
+
+    await generateTailoring("Build APIs", {
+      sections: {
+        projects: {
+          items: ["included", "excluded"].map((id) => ({
+            id,
+            name: `${id} project`,
+            description: id,
+            summary: id,
+            date: "2026",
+            visible: true,
+          })),
+        },
+      },
+    });
+
+    const prompt = callJsonMock.mock.calls.at(-1)?.[0]?.messages?.[0]?.content;
+    expect(prompt).toContain("included project");
+    expect(prompt).not.toContain("excluded project");
+  });
+
   it("removes language directives from constraints so explicit language settings win", async () => {
     vi.mocked(getWritingStyle).mockResolvedValue({
       tone: "friendly",

--- a/orchestrator/src/server/services/summary.ts
+++ b/orchestrator/src/server/services/summary.ts
@@ -15,6 +15,7 @@ import {
   getEffectivePromptTemplate,
   renderPromptTemplate,
 } from "./prompt-templates";
+import { filterProfileProjectsForAi } from "./resumeProjects";
 import {
   getWritingStyle,
   stripKeywordLimitFromConstraints,
@@ -81,12 +82,13 @@ export async function generateTailoring(
   jobDescription: string,
   profile: ResumeProfile,
 ): Promise<TailoringResult> {
-  const [model, writingStyle] = await Promise.all([
+  const [model, writingStyle, aiProfile] = await Promise.all([
     resolveLlmModel("tailoring"),
     getWritingStyle(),
+    filterProfileProjectsForAi(profile),
   ]);
   const prompt = await buildTailoringPrompt(
-    profile,
+    aiProfile,
     jobDescription,
     writingStyle,
   );

--- a/orchestrator/src/server/tailoring-flow.test.ts
+++ b/orchestrator/src/server/tailoring-flow.test.ts
@@ -38,6 +38,11 @@ describe("Tailoring Flow", () => {
       pdfRenderer: "latex",
       typstTheme: "classic",
       rxresumeBaseResumeId: null,
+      resumeProjects: {
+        maxProjects: 3,
+        lockedProjectIds: [],
+        aiSelectableProjectIds: [],
+      },
     });
     vi.mocked(jobsRepo.finalizeGeneratedPdfIfCurrent).mockResolvedValue(
       {} as any,

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -7,5 +7,6 @@ export * from "./ghostwriter-note-context";
 export * from "./job-document-classification";
 export * from "./language-detection";
 export * from "./location-support";
+export * from "./resume-projects";
 export * from "./types";
 export * from "./utils/type-conversion";

--- a/shared/src/resume-projects.test.ts
+++ b/shared/src/resume-projects.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { resolveResumeProjectSelection } from "./resume-projects";
+import type { ResumeProjectCatalogItem } from "./types";
+
+const catalog = (ids: string[]): ResumeProjectCatalogItem[] =>
+  ids.map((id) => ({
+    id,
+    name: id,
+    description: "",
+    date: "",
+    isVisibleInBase: false,
+  }));
+
+describe("resolveResumeProjectSelection", () => {
+  it.each([
+    {
+      name: "drops stale, duplicate, and excluded job IDs",
+      catalogIds: ["must", "excluded", "ai-1", "ai-2"],
+      settings: {
+        maxProjects: 3,
+        lockedProjectIds: ["must", "must", "deleted"],
+        aiSelectableProjectIds: ["ai-1", "ai-2", "must", "deleted"],
+      },
+      selected: "excluded,ai-2,ai-2,deleted",
+      effective: ["must", "ai-2"],
+      excluded: ["excluded"],
+      target: 3,
+      remaining: 1,
+    },
+    {
+      name: "raises a low target to the must-include count",
+      catalogIds: ["a", "b", "c", "d"],
+      settings: {
+        maxProjects: 1,
+        lockedProjectIds: ["a", "b", "c"],
+        aiSelectableProjectIds: ["d"],
+      },
+      selected: "d",
+      effective: ["a", "b", "c"],
+      excluded: [],
+      target: 3,
+      remaining: 0,
+    },
+    {
+      name: "keeps fewer projects when the catalog is insufficient",
+      catalogIds: ["a", "b", "c"],
+      settings: {
+        maxProjects: 5,
+        lockedProjectIds: [],
+        aiSelectableProjectIds: ["a", "b", "c"],
+      },
+      selected: "a,b,c",
+      effective: ["a", "b", "c"],
+      excluded: [],
+      target: 5,
+      remaining: 2,
+    },
+    {
+      name: "caps a job selection at the target",
+      catalogIds: ["a", "b", "c", "d", "e"],
+      settings: {
+        maxProjects: 3,
+        lockedProjectIds: ["a"],
+        aiSelectableProjectIds: ["b", "c", "d", "e"],
+      },
+      selected: "b,c,d,e",
+      effective: ["a", "b", "c"],
+      excluded: [],
+      target: 3,
+      remaining: 0,
+    },
+  ])("$name", ({
+    catalogIds,
+    settings,
+    selected,
+    effective,
+    excluded,
+    target,
+    remaining,
+  }) => {
+    expect(
+      resolveResumeProjectSelection({
+        catalog: catalog(catalogIds),
+        resumeProjects: settings,
+        selectedProjectIds: selected,
+      }),
+    ).toMatchObject({
+      effectiveSelectedIds: effective,
+      excludedIds: excluded,
+      targetCount: target,
+      remainingSlots: remaining,
+    });
+  });
+});

--- a/shared/src/resume-projects.ts
+++ b/shared/src/resume-projects.ts
@@ -1,0 +1,60 @@
+import type { ResumeProjectCatalogItem, ResumeProjectsSettings } from "./types";
+
+export interface ResumeProjectSelectionResolution {
+  mustIncludeIds: string[];
+  aiSelectableIds: string[];
+  excludedIds: string[];
+  effectiveSelectedIds: string[];
+  targetCount: number;
+  remainingSlots: number;
+}
+
+export function resolveResumeProjectSelection(args: {
+  catalog: ResumeProjectCatalogItem[];
+  resumeProjects: ResumeProjectsSettings;
+  selectedProjectIds?: string | readonly string[] | null;
+}): ResumeProjectSelectionResolution {
+  const catalogIds = unique(args.catalog.map((project) => project.id));
+  const catalogSet = new Set(catalogIds);
+  const mustIncludeIds = unique(args.resumeProjects.lockedProjectIds).filter(
+    (id) => catalogSet.has(id),
+  );
+  const mustIncludeSet = new Set(mustIncludeIds);
+  const aiSelectableIds = unique(
+    args.resumeProjects.aiSelectableProjectIds,
+  ).filter((id) => catalogSet.has(id) && !mustIncludeSet.has(id));
+  const aiSelectableSet = new Set(aiSelectableIds);
+  const excludedIds = catalogIds.filter(
+    (id) => !mustIncludeSet.has(id) && !aiSelectableSet.has(id),
+  );
+  const targetCount = Math.max(
+    mustIncludeIds.length,
+    Number.isFinite(args.resumeProjects.maxProjects)
+      ? Math.max(0, Math.floor(args.resumeProjects.maxProjects))
+      : 0,
+  );
+  const selected =
+    typeof args.selectedProjectIds === "string"
+      ? args.selectedProjectIds.split(",")
+      : (args.selectedProjectIds ?? []);
+  const selectedAiIds = unique(selected).filter((id) =>
+    aiSelectableSet.has(id),
+  );
+  const effectiveSelectedIds = [
+    ...mustIncludeIds,
+    ...selectedAiIds.slice(0, targetCount - mustIncludeIds.length),
+  ];
+
+  return {
+    mustIncludeIds,
+    aiSelectableIds,
+    excludedIds,
+    effectiveSelectedIds,
+    targetCount,
+    remainingSlots: Math.max(0, targetCount - effectiveSelectedIds.length),
+  };
+}
+
+function unique(values: readonly string[]): string[] {
+  return [...new Set(values.map((value) => value.trim()).filter(Boolean))];
+}


### PR DESCRIPTION
## Summary
- Centralize resume project selection rules across client and server flows
- Align tailoring, scoring, PDF generation, Ghostwriter, and Reactive Resume behavior
- Update documentation and add regression coverage for project selection and related services

## Testing
- Not run (not requested)