### PR TITLE
fix: keep tailoring autosave from reverting newer edits

### DIFF
--- a/orchestrator/src/client/components/tailoring/TailoringWorkspace.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringWorkspace.tsx
@@ -41,7 +41,7 @@ interface TailoringWorkspaceBaseProps {
 
 interface TailoringWorkspaceEditorProps extends TailoringWorkspaceBaseProps {
   mode: "editor";
-  onUpdate: () => void | Promise<void>;
+  onUpdate: (job?: Job) => void | Promise<void>;
   onRegisterSave?: (save: () => Promise<void>) => void;
   onBeforeGenerate?: () => boolean | Promise<boolean>;
 }
@@ -231,20 +231,21 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
     persistedPayloadKeyRef.current = savedPayloadKey;
   }, [savedPayloadKey]);
 
-  useEffect(() => {
-    return () => {
-      isMountedRef.current = false;
-      if (autosaveTimerRef.current) {
-        clearTimeout(autosaveTimerRef.current);
-      }
-    };
-  }, []);
+  const flushAutosaveRef = useRef<() => Promise<void>>(async () => {});
 
   const runAutosaveLoop = useCallback(async () => {
-    if (saveInFlightRef.current) {
+    const inFlight = saveInFlightRef.current;
+    if (inFlight) {
       saveAgainRef.current = true;
-      await saveInFlightRef.current;
-      return;
+      await inFlight;
+      if (saveInFlightRef.current) return;
+      if (
+        !latestPayloadRef.current ||
+        getTailoringSavePayloadKey(latestPayloadRef.current) ===
+          persistedPayloadKeyRef.current
+      ) {
+        return;
+      }
     }
 
     const savePromise = (async () => {
@@ -265,6 +266,8 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
           if (isMountedRef.current) setAutosaveStatus("saving");
           const snapshotKey = getTailoringSavePayloadKey(snapshot);
           const updatedJob = await api.updateJob(props.job.id, snapshot);
+          // Keep parent/cache in sync even if this editor already unmounted.
+          void props.onUpdate(updatedJob);
           if (!isMountedRef.current) return;
           const updatedPayload = toSavePayloadFromJob(updatedJob);
 
@@ -308,7 +311,7 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
 
     saveInFlightRef.current = savePromise;
     await savePromise;
-  }, [markSavedJob, markSavedSnapshot, props.job.id]);
+  }, [markSavedJob, markSavedSnapshot, props.job.id, props.onUpdate]);
 
   const flushAutosave = useCallback(async () => {
     if (autosaveTimerRef.current) {
@@ -328,6 +331,15 @@ export const TailoringWorkspace: React.FC<TailoringWorkspaceProps> = (
       await runAutosaveLoop();
     }
   }, [runAutosaveLoop]);
+
+  flushAutosaveRef.current = flushAutosave;
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      void flushAutosaveRef.current();
+    };
+  }, []);
 
   useEffect(() => {
     if (autosaveTimerRef.current) {

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -157,6 +157,7 @@ vi.mock("./orchestrator/useOrchestratorData", () => ({
     pipelineTerminalEvent: mockPipelineTerminalEvent,
     setIsRefreshPaused: vi.fn(),
     loadJobs: mockLoadJobs,
+    applySelectedJobUpdate: vi.fn(),
   }),
 }));
 

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -1,5 +1,6 @@
 import { ManualImportSheet } from "@client/components/ManualImportSheet";
 import { useSettings } from "@client/hooks/useSettings";
+import type { Job } from "@shared/types.js";
 import type React from "react";
 import { useCallback, useMemo, useState } from "react";
 import { OrchestratorHeader } from "./orchestrator/OrchestratorHeader";
@@ -38,7 +39,19 @@ export const OrchestratorPage: React.FC = () => {
     pipelineTerminalEvent,
     setIsRefreshPaused,
     loadJobs,
+    applySelectedJobUpdate,
   } = useOrchestratorData(navigation.selectedJobId);
+
+  const handleJobUpdated = useCallback(
+    async (job?: Job) => {
+      if (job) {
+        applySelectedJobUpdate(job);
+        return;
+      }
+      await loadJobs();
+    },
+    [applySelectedJobUpdate, loadJobs],
+  );
 
   useNavigationRefresh(loadJobs);
 
@@ -156,7 +169,7 @@ export const OrchestratorPage: React.FC = () => {
             stats={stats}
             isLoading={isLoading}
             isPipelineRunning={isPipelineRunning}
-            loadJobs={loadJobs}
+            loadJobs={handleJobUpdated}
             setIsRefreshPaused={setIsRefreshPaused}
             filters={filters}
             navigation={navigation}

--- a/orchestrator/src/client/pages/orchestrator/JobDetailPanel.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobDetailPanel.tsx
@@ -86,7 +86,7 @@ interface JobDetailPanelProps {
   selectedJobListItem: JobListItem | null;
   selectedJobLoadState: SelectedJobLoadState;
   onSelectJobId: (jobId: string | null) => void;
-  onJobUpdated: () => Promise<void>;
+  onJobUpdated: (job?: Job) => Promise<void>;
   onPauseRefreshChange?: (paused: boolean) => void;
   onRetrySelectedJob: () => void;
 }

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorJobWorkspaceContainer.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorJobWorkspaceContainer.tsx
@@ -29,7 +29,7 @@ interface OrchestratorJobWorkspaceContainerProps {
   stats: Record<JobStatus, number>;
   isLoading: boolean;
   isPipelineRunning: boolean;
-  loadJobs: () => Promise<void>;
+  loadJobs: (job?: Job) => Promise<void>;
   setIsRefreshPaused: (paused: boolean) => void;
   filters: ReturnType<typeof useOrchestratorFilters>;
   navigation: ReturnType<typeof useOrchestratorNavigation>;

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorJobsWorkspace.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorJobsWorkspace.tsx
@@ -69,7 +69,7 @@ interface OrchestratorJobsWorkspaceProps {
   onToggleSelectJob: (jobId: string) => void;
   onToggleSelectAll: (checked: boolean) => void;
   onSelectJobId: (jobId: string | null) => void;
-  onJobUpdated: () => Promise<void>;
+  onJobUpdated: (job?: Job) => Promise<void>;
   onPauseRefreshChange: (paused: boolean) => void;
   onRetrySelectedJob: () => void;
 }

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorMobileJobDrawer.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorMobileJobDrawer.tsx
@@ -15,7 +15,7 @@ interface OrchestratorMobileJobDrawerProps {
   selectedJobLoadState: SelectedJobLoadState;
   onOpenChange: (open: boolean) => void;
   onSelectJobId: (jobId: string | null) => void;
-  onJobUpdated: () => Promise<void>;
+  onJobUpdated: (job?: Job) => Promise<void>;
   onPauseRefreshChange: (paused: boolean) => void;
   onRetrySelectedJob: () => void;
 }

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorData.ts
@@ -167,6 +167,24 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
     [publishPipelineTerminal],
   );
 
+  const applySelectedJobUpdate = useCallback(
+    (job: Job): Job => {
+      const cached = selectedJobCacheRef.current.get(job.id);
+      if (cached && cached.updatedAt > job.updatedAt) {
+        return cached;
+      }
+      selectedJobCacheRef.current.set(job.id, job);
+      queryClient.setQueryData(queryKeys.jobs.detail(job.id), job);
+      setSelectedJob((current) => {
+        if (!current || current.id !== job.id) return current;
+        if (current.updatedAt > job.updatedAt) return current;
+        return job;
+      });
+      return job;
+    },
+    [queryClient],
+  );
+
   const loadSelectedJob = useCallback(
     async (jobId: string, seq: number) => {
       try {
@@ -175,9 +193,17 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
           queryFn: () => api.getJob(jobId),
           staleTime: 0,
         });
-        selectedJobCacheRef.current.set(jobId, fullJob);
+        const applied = applySelectedJobUpdate(fullJob);
         if (seq === selectedJobRequestSeqRef.current) {
-          setSelectedJob(fullJob);
+          setSelectedJob((current) => {
+            if (
+              current?.id === jobId &&
+              current.updatedAt > applied.updatedAt
+            ) {
+              return current;
+            }
+            return applied;
+          });
           setSelectedJobRequestState(null);
         }
       } catch (error) {
@@ -187,7 +213,7 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
         }
       }
     },
-    [queryClient],
+    [applySelectedJobUpdate, queryClient],
   );
 
   const loadJobs = useCallback(async () => {
@@ -482,6 +508,7 @@ export const useOrchestratorData = (selectedJobId: string | null) => {
     isRefreshPaused,
     setIsRefreshPaused,
     loadJobs,
+    applySelectedJobUpdate,
     checkForJobChanges,
     checkPipelineStatus,
   };


### PR DESCRIPTION
## Summary
Tailoring edits could show “Saved” and then revert to an older value when leaving the panel or after a slow job reload.

- Flush pending tailoring autosave when the editor unmounts
- Push the saved job into the selected-job cache instead of waiting on a reload
- Ignore stale job reloads so newer cache/state can’t overwrite what just saved

## Testing
- Local CI-parity: biome, types, client build, full vitest (1901 passed / 3 skipped)
- Manually reproduced the revert while editing summary, then confirmed edits stick after save / navigate away