### PR TITLE
feat: auto-resize tailoring summary textarea with word/char count

### DIFF
--- a/orchestrator/src/client/components/tailoring/TailoringSections.summary.test.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringSections.summary.test.tsx
@@ -1,0 +1,195 @@
+import {
+  mockElementMeasurement,
+  triggerElementResize,
+} from "@client/test/dom-measurement";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  TAILOR_TEXTAREA_MAX_HEIGHT_PX,
+  TAILOR_TEXTAREA_MIN_HEIGHT_PX,
+} from "./summary-text-metrics";
+import { TailoringSections } from "./TailoringSections";
+
+type Props = React.ComponentProps<typeof TailoringSections>;
+
+const renderSections = (summary: string) => {
+  const props: Props = {
+    catalog: [],
+    isCatalogLoading: false,
+    summary,
+    headline: "",
+    jobDescription: "",
+    skillsDraft: [],
+    selectedIds: new Set(),
+    tracerLinksEnabled: false,
+    tracerEnableBlocked: false,
+    tracerEnableBlockedReason: null,
+    generatingSection: null,
+    openSkillGroupId: "",
+    disableInputs: false,
+    onGenerateSummary: vi.fn(),
+    onGenerateHeadline: vi.fn(),
+    onGenerateSkills: vi.fn(),
+    onSummaryChange: vi.fn(),
+    onHeadlineChange: vi.fn(),
+    onUndoSummary: vi.fn(),
+    onUndoHeadline: vi.fn(),
+    onUndoSkills: vi.fn(),
+    onRedoSummary: vi.fn(),
+    onRedoHeadline: vi.fn(),
+    onRedoSkills: vi.fn(),
+    canUndoSummary: false,
+    canUndoHeadline: false,
+    canUndoSkills: false,
+    canRedoSummary: false,
+    canRedoHeadline: false,
+    canRedoSkills: false,
+    onDescriptionChange: vi.fn(),
+    onSkillGroupOpenChange: vi.fn(),
+    onAddSkillGroup: vi.fn(),
+    onUpdateSkillGroup: vi.fn(),
+    onRemoveSkillGroup: vi.fn(),
+    onToggleProject: vi.fn(),
+    onTracerLinksEnabledChange: vi.fn(),
+  };
+
+  const view = render(<TailoringSections {...props} />);
+
+  // The Summary section starts collapsed, so its textarea is not mounted yet.
+  fireEvent.click(screen.getByRole("button", { name: "Summary" }));
+
+  return {
+    getTextarea: () =>
+      screen.getByLabelText("Tailored Summary") as HTMLTextAreaElement,
+    setSummary: (next: string) =>
+      view.rerender(<TailoringSections {...props} summary={next} />),
+    toggleSummary: () =>
+      fireEvent.click(screen.getByRole("button", { name: "Summary" })),
+  };
+};
+
+describe("TailoringSections summary field", () => {
+  it("shows a word count that toggles to characters and back on click", () => {
+    renderSections("Tailored resume summary");
+
+    fireEvent.click(screen.getByRole("button", { name: "3 words" }));
+    expect(
+      screen.getByRole("button", { name: "23 characters" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "23 characters" }));
+    expect(screen.getByRole("button", { name: "3 words" })).toBeInTheDocument();
+  });
+
+  it("shows zero words for an empty summary", () => {
+    renderSections("");
+    expect(screen.getByRole("button", { name: "0 words" })).toBeInTheDocument();
+  });
+
+  it("grows the textarea to fit content and caps it at the shared maximum", () => {
+    const { getTextarea, setSummary } = renderSections("short");
+    const textarea = getTextarea();
+
+    mockElementMeasurement(textarea, { width: 400, height: 180 });
+    setSummary("a somewhat longer summary");
+    expect(textarea.style.height).toBe("180px");
+
+    mockElementMeasurement(textarea, { width: 400, height: 900 });
+    setSummary("a very long summary that overflows the cap");
+    expect(textarea.style.height).toBe(`${TAILOR_TEXTAREA_MAX_HEIGHT_PX}px`);
+  });
+
+  it("never shrinks the textarea below the shared minimum", () => {
+    const { getTextarea, setSummary } = renderSections("short");
+    const textarea = getTextarea();
+
+    mockElementMeasurement(textarea, { width: 400, height: 20 });
+    setSummary("s");
+    expect(textarea.style.height).toBe(`${TAILOR_TEXTAREA_MIN_HEIGHT_PX}px`);
+  });
+
+  it("adds border height so the last line is not clipped", () => {
+    const { getTextarea, setSummary } = renderSections("short");
+    const textarea = getTextarea();
+
+    mockElementMeasurement(textarea, { width: 400, height: 180 });
+    // scrollHeight covers content and padding only; borders add 2px here.
+    Object.defineProperty(textarea, "clientHeight", {
+      configurable: true,
+      get: () => 178,
+    });
+    setSummary("a somewhat longer summary");
+
+    expect(textarea.style.height).toBe("182px");
+  });
+
+  it("keeps a manual drag-resize instead of snapping back to the auto height", () => {
+    const { getTextarea, setSummary } = renderSections("short");
+    const textarea = getTextarea();
+
+    textarea.style.height = "600px";
+    mockElementMeasurement(textarea, { width: 400, height: 180 });
+    setSummary("edited after the manual resize");
+
+    expect(textarea.style.height).toBe("600px");
+  });
+
+  it("keeps any manual nudge until returned to the minimum height", () => {
+    const { getTextarea, setSummary } = renderSections("short");
+    const textarea = getTextarea();
+
+    mockElementMeasurement(textarea, { width: 400, height: 180 });
+    setSummary("a somewhat longer summary");
+    expect(textarea.style.height).toBe("180px");
+
+    textarea.style.height = "181px";
+    mockElementMeasurement(textarea, { width: 400, height: 210 });
+    setSummary("a longer summary after the nudge");
+    expect(textarea.style.height).toBe("181px");
+
+    textarea.style.height = `${TAILOR_TEXTAREA_MIN_HEIGHT_PX}px`;
+    mockElementMeasurement(textarea, { width: 400, height: 220 });
+    setSummary("a longer summary after returning to the minimum");
+    expect(textarea.style.height).toBe("220px");
+  });
+
+  it("returns to auto height after the Summary field remounts", () => {
+    const { getTextarea, setSummary, toggleSummary } = renderSections("short");
+    const textarea = getTextarea();
+
+    mockElementMeasurement(textarea, { width: 400, height: 180 });
+    setSummary("a somewhat longer summary");
+    expect(textarea.style.height).toBe("180px");
+
+    toggleSummary();
+    toggleSummary();
+
+    const remountedTextarea = getTextarea();
+    mockElementMeasurement(remountedTextarea, { width: 400, height: 210 });
+    setSummary("a longer summary after reopening");
+    expect(remountedTextarea.style.height).toBe("210px");
+  });
+
+  it("shrinks trailing blank-line space after blur", () => {
+    const { getTextarea, setSummary } = renderSections("short");
+    const textarea = getTextarea();
+
+    fireEvent.focus(textarea);
+    mockElementMeasurement(textarea, { width: 400, height: 220 });
+    setSummary("hello\n\n\n\n");
+    expect(textarea.style.height).toBe("220px");
+
+    mockElementMeasurement(textarea, { width: 400, height: 140 });
+    fireEvent.blur(textarea);
+    expect(textarea.style.height).toBe("140px");
+  });
+
+  it("remeasures the auto height when the field width changes", () => {
+    const { getTextarea } = renderSections("short");
+    const textarea = getTextarea();
+
+    triggerElementResize(textarea, { width: 240, height: 200 });
+
+    expect(textarea.style.height).toBe("200px");
+  });
+});

--- a/orchestrator/src/client/components/tailoring/TailoringSections.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringSections.tsx
@@ -15,7 +15,7 @@ import {
   Undo2,
 } from "lucide-react";
 import type React from "react";
-import { useState } from "react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { Tip } from "@/client/components/Tip";
 import {
   Accordion,
@@ -28,6 +28,13 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { cn } from "@/lib/utils";
 import { ProjectSelector } from "../discovered-panel/ProjectSelector";
 import type { EditableSkillGroup } from "../tailoring-utils";
+import {
+  applySummaryTextareaHeight,
+  formatTextCount,
+  shouldPreserveManualHeight,
+  TAILOR_TEXTAREA_MIN_HEIGHT_PX,
+  type TextCountMode,
+} from "./summary-text-metrics";
 
 interface TailoringSectionsProps {
   catalog: ResumeProjectCatalogItem[];
@@ -364,6 +371,12 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
   const [keywordDrafts, setKeywordDrafts] = useState<Record<string, string>>(
     {},
   );
+  const [summaryCountMode, setSummaryCountMode] =
+    useState<TextCountMode>("words");
+  const summaryFocusedRef = useRef(false);
+  const summaryTextareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const summaryAutoHeightRef = useRef<number | null>(null);
+  const summaryResizeObserverRef = useRef<ResizeObserver | null>(null);
   const tracerToggleDisabled =
     disableInputs || (!tracerLinksEnabled && tracerEnableBlocked);
   const generateTooltip = "Generate";
@@ -383,6 +396,51 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
     resumeProjectsSettings,
     isResumeProjectsSettingsLoading,
   });
+  const syncSummaryTextareaHeight = useCallback(() => {
+    const textarea = summaryTextareaRef.current;
+    if (!textarea) return;
+    if (
+      summaryAutoHeightRef.current !== null &&
+      shouldPreserveManualHeight(
+        summaryAutoHeightRef.current,
+        Number.parseFloat(textarea.style.height),
+      )
+    ) {
+      return;
+    }
+    // While focused, keep trailing blank lines so Enter can grow the box.
+    summaryAutoHeightRef.current = applySummaryTextareaHeight(
+      textarea,
+      !summaryFocusedRef.current,
+    );
+  }, []);
+
+  const setSummaryTextareaRef = useCallback(
+    (node: HTMLTextAreaElement | null) => {
+      summaryResizeObserverRef.current?.disconnect();
+      summaryResizeObserverRef.current = null;
+      summaryTextareaRef.current = node;
+      summaryAutoHeightRef.current = null;
+      if (!node) return;
+      // Accordion remounts the field without changing `summary`, so measure here.
+      syncSummaryTextareaHeight();
+      if (typeof ResizeObserver === "undefined") return;
+      let lastWidth = node.clientWidth;
+      const observer = new ResizeObserver(() => {
+        if (node.clientWidth === lastWidth) return;
+        lastWidth = node.clientWidth;
+        syncSummaryTextareaHeight();
+      });
+      observer.observe(node);
+      summaryResizeObserverRef.current = observer;
+    },
+    [syncSummaryTextareaHeight],
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: summary is the intentional trigger
+  useLayoutEffect(() => {
+    syncSummaryTextareaHeight();
+  }, [summary, syncSummaryTextareaHeight]);
 
   return (
     <Accordion type="multiple" className="space-y-2">
@@ -443,17 +501,55 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
               </Button>
             </Tip>
           </div>
-          <label htmlFor="tailor-summary-edit" className="sr-only">
-            Tailored Summary
-          </label>
-          <textarea
-            id="tailor-summary-edit"
-            className={`${inputClass} min-h-[120px]`}
-            value={summary}
-            onChange={(event) => onSummaryChange(event.target.value)}
-            placeholder="Write a tailored summary for this role, or generate with AI..."
-            disabled={disableInputs}
-          />
+          <div className="relative">
+            <Tip
+              asChild
+              clickBehavior="none"
+              content={
+                summaryCountMode === "words"
+                  ? "Toggle to characters"
+                  : "Toggle to words"
+              }
+            >
+              <Button
+                type="button"
+                size="sm"
+                variant="ghost"
+                className={cn(
+                  actionButtonClass,
+                  "absolute right-1.5 top-1.5 z-10 h-auto border-0 bg-background/80 px-1 py-0.5 tabular-nums shadow-none underline-offset-2 hover:underline",
+                )}
+                onClick={() =>
+                  setSummaryCountMode((current) =>
+                    current === "words" ? "characters" : "words",
+                  )
+                }
+              >
+                {formatTextCount(summary, summaryCountMode)}
+              </Button>
+            </Tip>
+            <label htmlFor="tailor-summary-edit" className="sr-only">
+              Tailored Summary
+            </label>
+            <textarea
+              id="tailor-summary-edit"
+              ref={setSummaryTextareaRef}
+              className={`${inputClass} resize-y overflow-y-auto pt-7`}
+              style={{ minHeight: TAILOR_TEXTAREA_MIN_HEIGHT_PX }}
+              value={summary}
+              onChange={(event) => onSummaryChange(event.target.value)}
+              onFocus={() => {
+                summaryFocusedRef.current = true;
+                syncSummaryTextareaHeight();
+              }}
+              onBlur={() => {
+                summaryFocusedRef.current = false;
+                syncSummaryTextareaHeight();
+              }}
+              placeholder="Write a tailored summary for this role, or generate with AI..."
+              disabled={disableInputs}
+            />
+          </div>
         </AccordionContent>
       </AccordionItem>
 

--- a/orchestrator/src/client/components/tailoring/summary-text-metrics.test.ts
+++ b/orchestrator/src/client/components/tailoring/summary-text-metrics.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import {
+  applySummaryTextareaHeight,
+  collapseTrailingBlankLines,
+  formatTextCount,
+  measureTailorTextareaHeight,
+  shouldPreserveManualHeight,
+  TAILOR_TEXTAREA_MAX_HEIGHT_PX,
+  TAILOR_TEXTAREA_MIN_HEIGHT_PX,
+} from "./summary-text-metrics";
+
+describe("summary-text-metrics", () => {
+  it("formats word and character counts including empty and emoji text", () => {
+    expect(formatTextCount("", "words")).toBe("0 words");
+    expect(formatTextCount("   ", "words")).toBe("0 words");
+    expect(formatTextCount("hi", "words")).toBe("1 word");
+    expect(formatTextCount("  one  two\nthree  ", "words")).toBe("3 words");
+    expect(formatTextCount("", "characters")).toBe("0 characters");
+    expect(formatTextCount("a", "characters")).toBe("1 character");
+    expect(formatTextCount("a b", "characters")).toBe("3 characters");
+    expect(formatTextCount("hi👋", "characters")).toBe("3 characters");
+  });
+
+  it("clamps tailoring textarea height between min and max", () => {
+    expect(measureTailorTextareaHeight(40)).toBe(TAILOR_TEXTAREA_MIN_HEIGHT_PX);
+    expect(measureTailorTextareaHeight(180)).toBe(180);
+    expect(measureTailorTextareaHeight(400)).toBe(
+      TAILOR_TEXTAREA_MAX_HEIGHT_PX,
+    );
+  });
+
+  it("collapses trailing blank lines for height measurement", () => {
+    expect(collapseTrailingBlankLines("hello\n\n\n")).toBe("hello");
+    expect(collapseTrailingBlankLines("hello\nworld\n")).toBe("hello\nworld");
+    expect(collapseTrailingBlankLines("\n\n")).toBe("");
+  });
+
+  it("measures shorter when collapsing trailing blank lines", () => {
+    const textarea = document.createElement("textarea");
+    Object.defineProperty(textarea, "offsetHeight", {
+      configurable: true,
+      get: () => Number.parseFloat(textarea.style.height || "0") || 140,
+    });
+    Object.defineProperty(textarea, "clientHeight", {
+      configurable: true,
+      get: () => Number.parseFloat(textarea.style.height || "0") || 140,
+    });
+    Object.defineProperty(textarea, "scrollHeight", {
+      configurable: true,
+      get: () => (textarea.value.match(/\n/g)?.length ?? 0) * 20 + 40,
+    });
+
+    textarea.value = "hello\n\n\n\n\n";
+    const withBlanks = applySummaryTextareaHeight(textarea);
+    const collapsed = applySummaryTextareaHeight(textarea, true);
+
+    expect(collapsed).toBeLessThan(withBlanks);
+    expect(textarea.value).toBe("hello\n\n\n\n\n");
+  });
+
+  it("preserves any manual height until returned to the minimum", () => {
+    expect(shouldPreserveManualHeight(180, 180)).toBe(false);
+    expect(shouldPreserveManualHeight(180, 181)).toBe(true);
+    expect(shouldPreserveManualHeight(180, 600)).toBe(true);
+    expect(shouldPreserveManualHeight(180, TAILOR_TEXTAREA_MIN_HEIGHT_PX)).toBe(
+      false,
+    );
+  });
+});

--- a/orchestrator/src/client/components/tailoring/summary-text-metrics.ts
+++ b/orchestrator/src/client/components/tailoring/summary-text-metrics.ts
@@ -1,0 +1,90 @@
+export type TextCountMode = "words" | "characters";
+
+const graphemeSegmenter =
+  typeof Intl !== "undefined" && "Segmenter" in Intl
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+function countCharacters(text: string): number {
+  if (graphemeSegmenter) {
+    let count = 0;
+    for (const _ of graphemeSegmenter.segment(text)) {
+      count += 1;
+    }
+    return count;
+  }
+  return Array.from(text).length;
+}
+
+export function formatTextCount(text: string, mode: TextCountMode): string {
+  if (mode === "words") {
+    const count = countWords(text);
+    return `${count} ${count === 1 ? "word" : "words"}`;
+  }
+
+  const count = countCharacters(text);
+  return `${count} ${count === 1 ? "character" : "characters"}`;
+}
+
+export const TAILOR_TEXTAREA_MIN_HEIGHT_PX = 120;
+export const TAILOR_TEXTAREA_MAX_HEIGHT_PX = 250;
+
+/** Strip trailing blank lines so empty space does not inflate auto-height. */
+export function collapseTrailingBlankLines(text: string): string {
+  return text.replace(/\n+$/, "");
+}
+
+export function measureTailorTextareaHeight(contentHeight: number): number {
+  return Math.min(
+    TAILOR_TEXTAREA_MAX_HEIGHT_PX,
+    Math.max(TAILOR_TEXTAREA_MIN_HEIGHT_PX, contentHeight),
+  );
+}
+
+export function applySummaryTextareaHeight(
+  textarea: HTMLTextAreaElement,
+  collapseTrailing = false,
+): number {
+  const originalValue = textarea.value;
+  const measureValue = collapseTrailing
+    ? collapseTrailingBlankLines(originalValue)
+    : originalValue;
+
+  try {
+    if (measureValue !== originalValue) {
+      textarea.value = measureValue;
+    }
+
+    textarea.style.height = "auto";
+    // scrollHeight omits borders, which still count toward a border-box height.
+    const borderHeight = textarea.offsetHeight - textarea.clientHeight;
+    const height = measureTailorTextareaHeight(
+      textarea.scrollHeight + borderHeight,
+    );
+    textarea.style.height = `${height}px`;
+    return height;
+  } finally {
+    if (measureValue !== originalValue) {
+      textarea.value = originalValue;
+    }
+  }
+}
+
+export function shouldPreserveManualHeight(
+  autoHeightPx: number,
+  currentHeightPx: number,
+): boolean {
+  if (!Number.isFinite(autoHeightPx) || !Number.isFinite(currentHeightPx)) {
+    return true;
+  }
+  return (
+    currentHeightPx > TAILOR_TEXTAREA_MIN_HEIGHT_PX &&
+    currentHeightPx !== autoHeightPx
+  );
+}


### PR DESCRIPTION
## Summary
Summary in Tailoring stays a fixed-height box, so longer text is awkward.

- Auto-resize the Summary field between a 120px minimum and 250px maximum, then scroll when content exceeds the cap
- Preserve a manual drag-resize until the box is dragged back to the minimum height (or the section remounts)
- Add a clickable word/character count (grapheme-aware) in the top-right of the field

Closes #696

## Testing
- Local CI-parity: biome, types, client build, full vitest (1916 passed / 3 skipped)
- Manual check in Docker: grow/shrink, count toggle, manual resize reset, trailing blank lines on blur

## Demo


https://github.com/user-attachments/assets/1885f3be-e256-493e-8cd0-08db6a6250b4



