### PR TITLE
feat: add source-linked full resume tailoring

### DIFF
--- a/docs-site/docs/features/reactive-resume.md
+++ b/docs-site/docs/features/reactive-resume.md
@@ -142,8 +142,8 @@ In **Settings → Reactive Resume**:
 
 High-level flow:
 
-1. Load the local Resume Studio document.
-2. Apply tailored summary/headline/skills.
+1. Load and clone the local Resume Studio document.
+2. Apply tailored summary, headline, skills, experience bullets, and project bullets.
 3. Compute final visible projects from your selection rules.
 4. Optionally rewrite outbound links to tracer links (per-job toggle).
 5. Normalize the tailored resume data into JobOps' renderer document model.
@@ -177,12 +177,20 @@ Important:
 
 ### What JobOps changes with AI
 
-Current AI-driven edits are intentionally scoped:
+AI tailoring can change:
 
 - `summary`
 - `headline/title`
 - `skills` and keywords
+- experience bullets linked to their source experience ID
+- project bullets linked to their source project ID
 - project **visibility** (enable/disable per project)
+
+Rewritten bullets may only use evidence from the same source item. JobOps rejects unknown or duplicate IDs and bullets containing numbers absent from that source item.
+
+### Tailoring artifact freshness
+
+JobOps stores experience and project rewrites in a version 1 per-job JSON artifact. The artifact contains hashes of the relevant source resume and job description. Missing, malformed, or hash-mismatched artifacts are regenerated during tailoring and are never applied to PDFs. The artifact is also part of PDF freshness checks, so changing it regenerates system-generated PDFs while uploaded PDFs remain untouched.
 
 ### Local renderer dependency
 

--- a/orchestrator/src/client/components/tailoring/TailoringSections.tsx
+++ b/orchestrator/src/client/components/tailoring/TailoringSections.tsx
@@ -724,7 +724,7 @@ export const TailoringSections: React.FC<TailoringSectionsProps> = ({
               catalog={catalog}
               selectedIds={selectedIds}
               onToggle={onToggleProject}
-              maxProjects={3}
+              maxProjects={resumeProjectsSettings?.maxProjects ?? 3}
               disabled={disableInputs}
             />
           </AccordionContent>

--- a/orchestrator/src/server/db/migrate.test.ts
+++ b/orchestrator/src/server/db/migrate.test.ts
@@ -324,6 +324,62 @@ describe.sequential("database migrations", () => {
     );
   });
 
+  it("preserves jobs and tailored artifacts across idempotent migration", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-migrate-"));
+    const script = `
+      import { join } from "node:path";
+      import { pathToFileURL } from "node:url";
+      import Database from "better-sqlite3";
+
+      const dbPath = join(process.env.DATA_DIR, "jobs.db");
+      const migrationUrl = pathToFileURL(join(process.cwd(), "src/server/db/migrate.ts")).href;
+      await import(\`\${migrationUrl}?run=initial\`);
+
+      const sqlite = new Database(dbPath);
+      const artifact = JSON.stringify({ version: 1, sourceHash: "a", jobDescriptionHash: "b" });
+      sqlite.prepare("INSERT INTO jobs(id, title, employer, job_url, tailored_resume) VALUES (?, ?, ?, ?, ?)").run(
+        "job-with-artifact",
+        "Engineer",
+        "Example Labs",
+        "https://example.com/job-with-artifact",
+        artifact,
+      );
+      sqlite.prepare("INSERT INTO jobs(id, title, employer, job_url) VALUES (?, ?, ?, ?)").run(
+        "job-without-artifact",
+        "Developer",
+        "Example Works",
+        "https://example.com/job-without-artifact",
+      );
+      sqlite.close();
+
+      await import(\`\${migrationUrl}?run=repeat\`);
+
+      const migratedDb = new Database(dbPath, { readonly: true });
+      const count = migratedDb.prepare("SELECT count(*) AS count FROM jobs").get();
+      if (count.count !== 2) {
+        throw new Error(\`Expected 2 jobs after migration, got \${count.count}\`);
+      }
+      const row = migratedDb.prepare("SELECT tailored_resume FROM jobs WHERE id = ?").get("job-with-artifact");
+      if (row?.tailored_resume !== artifact) {
+        throw new Error("tailored_resume was not preserved");
+      }
+      const integrity = migratedDb.prepare("PRAGMA integrity_check").pluck().get();
+      if (integrity !== "ok") {
+        throw new Error(\`SQLite integrity check failed: \${integrity}\`);
+      }
+      migratedDb.close();
+    `;
+
+    execFileSync(
+      process.execPath,
+      ["--import", "tsx", "--input-type=module", "-e", script],
+      {
+        env: { ...process.env, DATA_DIR: tempDir },
+        stdio: "pipe",
+      },
+    );
+  });
+
   it("enforces private unique indexes when user_id is null", async () => {
     tempDir = await mkdtemp(join(tmpdir(), "job-ops-migrate-"));
     const script = `

--- a/orchestrator/src/server/db/migrate.ts
+++ b/orchestrator/src/server/db/migrate.ts
@@ -137,6 +137,7 @@ const pipelineRunsHasConfigSnapshot = tableHasColumn(
 const pipelineRunsHasTenantId = tableHasColumn("pipeline_runs", "tenant_id");
 const jobsHasPdfRegenerating = tableHasColumn("jobs", "pdf_regenerating");
 const jobsHasJobBrief = tableHasColumn("jobs", "job_brief");
+const jobsHasTailoredResume = tableHasColumn("jobs", "tailored_resume");
 const watchlistJobStatesHasUserId = tableHasColumn(
   "watchlist_job_states",
   "user_id",
@@ -264,6 +265,7 @@ const migrations = [
     tailored_summary TEXT,
     tailored_headline TEXT,
     tailored_skills TEXT,
+    tailored_resume TEXT,
     selected_project_ids TEXT,
     pdf_path TEXT,
     pdf_source TEXT CHECK(pdf_source IN ('generated', 'uploaded')),
@@ -775,6 +777,7 @@ const migrations = [
   `ALTER TABLE jobs ADD COLUMN selected_project_ids TEXT`,
   `ALTER TABLE jobs ADD COLUMN tailored_headline TEXT`,
   `ALTER TABLE jobs ADD COLUMN tailored_skills TEXT`,
+  `ALTER TABLE jobs ADD COLUMN tailored_resume TEXT`,
   `ALTER TABLE jobs ADD COLUMN tracer_links_enabled INTEGER NOT NULL DEFAULT 0`,
   `ALTER TABLE jobs ADD COLUMN pdf_source TEXT CHECK(pdf_source IN ('generated', 'uploaded'))`,
   `ALTER TABLE jobs ADD COLUMN pdf_regenerating INTEGER NOT NULL DEFAULT 0`,
@@ -906,6 +909,7 @@ const migrations = [
     tailored_summary TEXT,
     tailored_headline TEXT,
     tailored_skills TEXT,
+    tailored_resume TEXT,
     selected_project_ids TEXT,
     pdf_path TEXT,
     pdf_source TEXT CHECK(pdf_source IN ('generated', 'uploaded')),
@@ -930,7 +934,7 @@ const migrations = [
     company_revenue, company_description, skills, experience_range, company_rating, company_reviews_count,
     vacancy_count, work_from_home_type, title, employer, employer_url, job_url, application_link, disciplines,
     deadline, salary, location, location_evidence, degree_required, starting, job_description, status, outcome, closed_at,
-    suitability_score, suitability_reason, job_brief, tailored_summary, tailored_headline, tailored_skills,
+    suitability_score, suitability_reason, job_brief, tailored_summary, tailored_headline, tailored_skills, tailored_resume,
     selected_project_ids, pdf_path, pdf_source, pdf_regenerating, pdf_fingerprint, pdf_generated_at, tracer_links_enabled, sponsor_match_score, sponsor_match_names, discovered_at, processed_at,
     ready_at,
     applied_at, created_at, updated_at
@@ -942,7 +946,7 @@ const migrations = [
     company_revenue, company_description, skills, experience_range, company_rating, company_reviews_count,
     vacancy_count, work_from_home_type, title, employer, employer_url, job_url, application_link, disciplines,
     deadline, salary, location, location_evidence, degree_required, starting, job_description, status, outcome, closed_at,
-    suitability_score, suitability_reason, ${jobsHasJobBrief ? "job_brief" : "NULL"}, tailored_summary, tailored_headline, tailored_skills,
+    suitability_score, suitability_reason, ${jobsHasJobBrief ? "job_brief" : "NULL"}, tailored_summary, tailored_headline, tailored_skills, ${jobsHasTailoredResume ? "tailored_resume" : "NULL"},
     selected_project_ids, pdf_path, pdf_source, ${jobsHasPdfRegenerating ? "pdf_regenerating" : "0"}, pdf_fingerprint, pdf_generated_at, tracer_links_enabled, sponsor_match_score, sponsor_match_names, discovered_at, processed_at,
     ready_at,
     applied_at, created_at, updated_at

--- a/orchestrator/src/server/db/schema.ts
+++ b/orchestrator/src/server/db/schema.ts
@@ -237,6 +237,7 @@ export const jobs = sqliteTable(
     tailoredSummary: text("tailored_summary"),
     tailoredHeadline: text("tailored_headline"),
     tailoredSkills: text("tailored_skills"),
+    tailoredResume: text("tailored_resume"),
     selectedProjectIds: text("selected_project_ids"),
     pdfPath: text("pdf_path"),
     pdfSource: text("pdf_source", { enum: ["generated", "uploaded"] }),

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -42,6 +42,10 @@ import {
 import { LlmNotConfiguredError } from "../services/scorer";
 import { generateTailoring } from "../services/summary";
 import {
+  createTailoredResumeArtifact,
+  parseValidTailoredResumeArtifact,
+} from "../services/tailored-resume";
+import {
   type PendingChallenge,
   progressHelpers,
   resetProgress,
@@ -672,6 +676,15 @@ export async function summarizeJob(
       let tailoredSummary = job.tailoredSummary;
       let tailoredHeadline = job.tailoredHeadline;
       let tailoredSkills = job.tailoredSkills;
+      let generatedTailoredResume: string | undefined;
+      const jobDescription = job.jobDescription || "";
+      const hasCurrentTailoredResume = Boolean(
+        parseValidTailoredResumeArtifact(
+          job.tailoredResume,
+          profile,
+          jobDescription,
+        ),
+      );
       const requestedFields = options?.fields;
       const shouldUpdateAllTailoring = !requestedFields?.length;
       const shouldUpdateSummary =
@@ -683,14 +696,21 @@ export async function summarizeJob(
       const shouldGenerateTailoring =
         shouldUpdateSummary || shouldUpdateHeadline || shouldUpdateSkills;
 
+      const isRequestedTailoringMissing =
+        (shouldUpdateSummary && !tailoredSummary) ||
+        (shouldUpdateHeadline && !tailoredHeadline) ||
+        (shouldUpdateSkills && !tailoredSkills);
+
       if (
         shouldGenerateTailoring &&
-        (!tailoredSummary || !tailoredHeadline || options?.force)
+        (isRequestedTailoringMissing ||
+          !hasCurrentTailoredResume ||
+          options?.force)
       ) {
         jobLogger.info("Generating tailoring content");
         await reserveTailoringUsage();
         const tailoringResult = await generateTailoring(
-          job.jobDescription || "",
+          jobDescription,
           profile,
         );
         if (tailoringResult.success && tailoringResult.data) {
@@ -704,10 +724,17 @@ export async function summarizeJob(
           if (shouldUpdateSkills) {
             tailoredSkills = JSON.stringify(tailoringResult.data.skills);
           }
+          generatedTailoredResume = JSON.stringify(
+            createTailoredResumeArtifact(
+              tailoringResult.data,
+              profile,
+              jobDescription,
+            ),
+          );
         } else if (
           options?.force ||
-          (shouldUpdateSummary && !tailoredSummary) ||
-          (shouldUpdateHeadline && !tailoredHeadline)
+          isRequestedTailoringMissing ||
+          !hasCurrentTailoredResume
         ) {
           await settleTailoringUsage();
           return {
@@ -787,6 +814,9 @@ export async function summarizeJob(
           : {}),
         ...(shouldUpdateSkills
           ? { tailoredSkills: tailoredSkills ?? undefined }
+          : {}),
+        ...(generatedTailoredResume
+          ? { tailoredResume: generatedTailoredResume }
           : {}),
         ...(shouldUpdateAllTailoring
           ? { selectedProjectIds: selectedProjectIds ?? undefined }
@@ -871,6 +901,7 @@ export async function generateFinalPdf(
           summary: job.tailoredSummary || "",
           headline: job.tailoredHeadline || "",
           skills: job.tailoredSkills ? JSON.parse(job.tailoredSkills) : [],
+          tailoredResume: job.tailoredResume,
         },
         job.jobDescription || "",
         undefined, // deprecated baseResumePath parameter

--- a/orchestrator/src/server/pipeline/project-selection.test.ts
+++ b/orchestrator/src/server/pipeline/project-selection.test.ts
@@ -3,6 +3,8 @@ import * as jobsRepo from "../repositories/jobs";
 import * as settingsRepo from "../repositories/settings";
 import { getProfile } from "../services/profile";
 import { pickProjectIdsForJob } from "../services/projectSelection";
+import { generateTailoring } from "../services/summary";
+import { createTailoredResumeArtifact } from "../services/tailored-resume";
 import { summarizeJob } from "./orchestrator";
 
 vi.mock("@infra/logger", () => {
@@ -71,25 +73,25 @@ const profileWithProjects = {
     projects: {
       items: [
         {
-          id: "mumtaz-urdu",
-          name: "Mumtaz Urdu",
-          summary: "Next.js education platform.",
+          id: "project-a",
+          name: "Project A",
+          summary: "Education platform.",
           description: "",
           date: "",
           visible: false,
         },
         {
-          id: "jobops",
-          name: "JobOps",
-          summary: "Job search automation app.",
+          id: "project-b",
+          name: "Project B",
+          summary: "Workflow application.",
           description: "",
           date: "",
           visible: false,
         },
         {
-          id: "indus-marine",
-          name: "Indus Marine Services",
-          summary: "Induction platform.",
+          id: "project-c",
+          name: "Project C",
+          summary: "Data collection service.",
           description: "",
           date: "",
           visible: false,
@@ -108,19 +110,29 @@ describe("summarizeJob project selection", () => {
       tailoredSummary: "Existing summary.",
       tailoredHeadline: "Existing headline.",
       tailoredSkills: JSON.stringify(["TypeScript"]),
-      selectedProjectIds: "mumtaz-urdu,jobops,indus-marine",
+      selectedProjectIds: "project-a,project-b,project-c",
     } as any);
     vi.mocked(jobsRepo.updateJob).mockResolvedValue(undefined as any);
     vi.mocked(getProfile).mockResolvedValue(profileWithProjects as any);
+    vi.mocked(generateTailoring).mockResolvedValue({
+      success: true,
+      data: {
+        headline: "Existing headline.",
+        summary: "Existing summary.",
+        skills: [{ name: "Backend", keywords: ["TypeScript"] }],
+        experience: [],
+        projects: [{ id: "project-a", bullets: ["Education platform."] }],
+      },
+    });
     vi.mocked(settingsRepo.getSetting).mockImplementation(async (key) => {
       if (key !== "resumeProjects") return null;
       return JSON.stringify({
         maxProjects: 3,
         lockedProjectIds: [],
-        aiSelectableProjectIds: ["mumtaz-urdu"],
+        aiSelectableProjectIds: ["project-a"],
       });
     });
-    vi.mocked(pickProjectIdsForJob).mockResolvedValue(["mumtaz-urdu"]);
+    vi.mocked(pickProjectIdsForJob).mockResolvedValue(["project-a"]);
   });
 
   it("reselects stale saved projects using only the AI-selectable pool", async () => {
@@ -133,17 +145,85 @@ describe("summarizeJob project selection", () => {
         desiredCount: 3,
         eligibleProjects: [
           expect.objectContaining({
-            id: "mumtaz-urdu",
-            name: "Mumtaz Urdu",
+            id: "project-a",
+            name: "Project A",
           }),
         ],
       }),
     );
+    expect(generateTailoring).toHaveBeenCalledTimes(1);
     expect(jobsRepo.updateJob).toHaveBeenCalledWith(
       "job-1",
       expect.objectContaining({
-        selectedProjectIds: "mumtaz-urdu",
+        selectedProjectIds: "project-a",
+        tailoredResume: expect.any(String),
       }),
     );
+  });
+
+  it.each([
+    ["malformed", "{"],
+    [
+      "stale",
+      JSON.stringify(
+        createTailoredResumeArtifact(
+          {
+            headline: "Existing headline.",
+            summary: "Existing summary.",
+            skills: [{ name: "Backend", keywords: ["TypeScript"] }],
+            experience: [],
+            projects: [],
+          },
+          profileWithProjects,
+          "Old job description",
+        ),
+      ),
+    ],
+  ])("regenerates %s full-tailoring artifacts", async (_kind, artifact) => {
+    vi.mocked(jobsRepo.getJobById).mockResolvedValue({
+      id: "job-1",
+      jobDescription: "Data acquisition engineer role.",
+      tailoredSummary: "Existing summary.",
+      tailoredHeadline: "Existing headline.",
+      tailoredSkills: JSON.stringify(["TypeScript"]),
+      tailoredResume: artifact,
+      selectedProjectIds: "project-a",
+    } as any);
+
+    expect(await summarizeJob("job-1")).toEqual({ success: true });
+    expect(generateTailoring).toHaveBeenCalledTimes(1);
+  });
+
+  it("reuses a current artifact unless tailoring is forced", async () => {
+    const artifact = JSON.stringify(
+      createTailoredResumeArtifact(
+        {
+          headline: "Existing headline.",
+          summary: "Existing summary.",
+          skills: [{ name: "Backend", keywords: ["TypeScript"] }],
+          experience: [],
+          projects: [],
+        },
+        profileWithProjects,
+        "Data acquisition engineer role.",
+      ),
+    );
+    vi.mocked(jobsRepo.getJobById).mockResolvedValue({
+      id: "job-1",
+      jobDescription: "Data acquisition engineer role.",
+      tailoredSummary: "Existing summary.",
+      tailoredHeadline: "Existing headline.",
+      tailoredSkills: JSON.stringify(["TypeScript"]),
+      tailoredResume: artifact,
+      selectedProjectIds: "project-a",
+    } as any);
+
+    expect(await summarizeJob("job-1")).toEqual({ success: true });
+    expect(generateTailoring).not.toHaveBeenCalled();
+
+    expect(await summarizeJob("job-1", { force: true })).toEqual({
+      success: true,
+    });
+    expect(generateTailoring).toHaveBeenCalledTimes(1);
   });
 });

--- a/orchestrator/src/server/repositories/jobs.ts
+++ b/orchestrator/src/server/repositories/jobs.ts
@@ -67,6 +67,7 @@ export type JobListItemWithPdfFreshnessInput = JobListItem &
     | "tailoredSummary"
     | "tailoredHeadline"
     | "tailoredSkills"
+    | "tailoredResume"
     | "selectedProjectIds"
     | "jobDescription"
     | "jobBrief"
@@ -156,6 +157,7 @@ export async function getJobListItems(
     tailoredSummary: jobs.tailoredSummary,
     tailoredHeadline: jobs.tailoredHeadline,
     tailoredSkills: jobs.tailoredSkills,
+    tailoredResume: jobs.tailoredResume,
     selectedProjectIds: jobs.selectedProjectIds,
     jobDescription: jobs.jobDescription,
     jobBrief: jobs.jobBrief,
@@ -868,6 +870,7 @@ function mapRowToJob(row: typeof jobs.$inferSelect): Job {
     tailoredSummary: row.tailoredSummary,
     tailoredHeadline: row.tailoredHeadline ?? null,
     tailoredSkills: row.tailoredSkills ?? null,
+    tailoredResume: row.tailoredResume ?? null,
     selectedProjectIds: row.selectedProjectIds ?? null,
     pdfPath: row.pdfPath,
     pdfSource: row.pdfSource ?? null,

--- a/orchestrator/src/server/services/auto-pdf-regeneration.test.ts
+++ b/orchestrator/src/server/services/auto-pdf-regeneration.test.ts
@@ -278,6 +278,23 @@ describe("auto PDF regeneration", () => {
     );
   });
 
+  it("regenerates generated PDFs when the full tailoring artifact changes", () => {
+    const previous = createJob({
+      status: "ready",
+      pdfSource: "generated",
+      tailoredResume: '{"version":1,"value":"before"}',
+    });
+    const next = createJob({
+      status: "ready",
+      pdfSource: "generated",
+      tailoredResume: '{"version":1,"value":"after"}',
+    });
+
+    expect(shouldEnqueueTailoringAutoPdfRegeneration(previous, next)).toBe(
+      true,
+    );
+  });
+
   it("ignores jobs that are not backed by generated PDFs", () => {
     const previous = createJob({
       status: "ready",

--- a/orchestrator/src/server/services/auto-pdf-regeneration.ts
+++ b/orchestrator/src/server/services/auto-pdf-regeneration.ts
@@ -6,7 +6,7 @@ import * as jobsRepo from "@server/repositories/jobs";
 import type { SettingKey } from "@server/repositories/settings";
 import { getPrivateDataScope } from "@server/tenancy/private-scope";
 import type { Job } from "@shared/types";
-import { generateFinalPdf } from "../pipeline";
+import { generateFinalPdf, summarizeJob } from "../pipeline";
 import {
   getJobPdfFreshness,
   resolvePdfFingerprintContext,
@@ -198,6 +198,13 @@ async function processQueuedAutoPdfRegeneration(input: {
         return "processed";
       }
 
+      const tailoringResult = await summarizeJob(job.id);
+      if (!tailoringResult.success) {
+        throw new Error(
+          tailoringResult.error ?? "Automatic resume tailoring failed.",
+        );
+      }
+
       const result = await generateFinalPdf(job.id, {
         analyticsOrigin: "auto_pdf_regeneration",
       });
@@ -301,6 +308,7 @@ export function shouldEnqueueTailoringAutoPdfRegeneration(
     previousJob.tailoredSummary !== nextJob.tailoredSummary ||
     previousJob.tailoredHeadline !== nextJob.tailoredHeadline ||
     previousJob.tailoredSkills !== nextJob.tailoredSkills ||
+    previousJob.tailoredResume !== nextJob.tailoredResume ||
     previousJob.selectedProjectIds !== nextJob.selectedProjectIds ||
     previousJob.jobDescription !== nextJob.jobDescription ||
     previousJob.tracerLinksEnabled !== nextJob.tracerLinksEnabled ||

--- a/orchestrator/src/server/services/design-resume/index.ts
+++ b/orchestrator/src/server/services/design-resume/index.ts
@@ -1205,6 +1205,14 @@ export async function designResumeToProfile(
             date: toText(record.period),
             summary: toText(record.description),
             visible: !toBoolean(record.hidden, false),
+            roles: asArray(record.roles).map((role) => {
+              const roleRecord = asRecord(role) ?? {};
+              return {
+                position: toText(roleRecord.position),
+                period: toText(roleRecord.period),
+                description: toText(roleRecord.description),
+              };
+            }),
           };
         }),
       },

--- a/orchestrator/src/server/services/pdf-fingerprint.test.ts
+++ b/orchestrator/src/server/services/pdf-fingerprint.test.ts
@@ -106,6 +106,17 @@ describe("PDF freshness", () => {
     );
   });
 
+  it("changes when the full tailoring artifact changes", () => {
+    const job = createJob({ tailoredResume: '{"version":1,"value":"before"}' });
+
+    expect(createJobPdfFingerprint(job, context)).not.toBe(
+      createJobPdfFingerprint(
+        { ...job, tailoredResume: '{"version":1,"value":"after"}' },
+        context,
+      ),
+    );
+  });
+
   it("treats legacy PDFs without a source as generated for freshness", () => {
     expect(
       getJobPdfFreshness(

--- a/orchestrator/src/server/services/pdf-fingerprint.ts
+++ b/orchestrator/src/server/services/pdf-fingerprint.ts
@@ -16,6 +16,7 @@ type JobPdfFingerprintInput = Pick<
   | "tailoredSummary"
   | "tailoredHeadline"
   | "tailoredSkills"
+  | "tailoredResume"
   | "selectedProjectIds"
   | "jobDescription"
   | "tracerLinksEnabled"
@@ -80,6 +81,7 @@ export function createJobPdfFingerprint(
       tailoredSummary: job.tailoredSummary ?? null,
       tailoredHeadline: job.tailoredHeadline ?? null,
       tailoredSkills: job.tailoredSkills ?? null,
+      tailoredResume: job.tailoredResume ?? null,
       selectedProjectIds: job.selectedProjectIds ?? null,
       jobDescription: job.jobDescription ?? null,
       tracerLinksEnabled: Boolean(job.tracerLinksEnabled),

--- a/orchestrator/src/server/services/pdf.ts
+++ b/orchestrator/src/server/services/pdf.ts
@@ -48,6 +48,7 @@ export interface TailoredPdfContent {
   summary?: string | null;
   headline?: string | null;
   skills?: Array<{ name: string; keywords: string[] }> | null;
+  tailoredResume?: string | null;
 }
 
 export interface GeneratePdfOptions {

--- a/orchestrator/src/server/services/resumeProjects.ts
+++ b/orchestrator/src/server/services/resumeProjects.ts
@@ -4,6 +4,7 @@ import type {
   ResumeProjectsSettings,
 } from "@shared/types";
 import { stripHtmlTags } from "@shared/utils/string";
+import { extractTailoringSource } from "./tailored-resume";
 
 type ResumeProjectSelectionItem = ResumeProjectCatalogItem & {
   summaryText: string;
@@ -12,34 +13,19 @@ export function extractProjectsFromProfile(profile: ResumeProfile): {
   catalog: ResumeProjectCatalogItem[];
   selectionItems: ResumeProjectSelectionItem[];
 } {
-  const items = profile?.sections?.projects?.items;
-  if (!Array.isArray(items)) return { catalog: [], selectionItems: [] };
-
   const catalog: ResumeProjectCatalogItem[] = [];
   const selectionItems: ResumeProjectSelectionItem[] = [];
 
-  for (const item of items) {
-    if (!item || typeof item !== "object") continue;
-
-    const id = item.id || "";
-    if (!id) continue;
-
-    const name = item.name || "";
-    const description = stripHtml(item.description || "");
-    const date = item.date || "";
-    const isVisibleInBase = Boolean(item.visible);
-    const summary = item.summary || "";
-    const summaryText = stripHtml(summary);
-
+  for (const item of extractTailoringSource(profile).projects) {
     const base: ResumeProjectCatalogItem = {
-      id,
-      name,
-      description,
-      date,
-      isVisibleInBase,
+      id: item.id,
+      name: typeof item.name === "string" ? item.name : "",
+      description: item.description,
+      date: typeof item.period === "string" ? item.period : "",
+      isVisibleInBase: item.visible !== false,
     };
     catalog.push(base);
-    selectionItems.push({ ...base, summaryText });
+    selectionItems.push({ ...base, summaryText: item.description });
   }
 
   return { catalog, selectionItems };

--- a/orchestrator/src/server/services/rxresume/index.test.ts
+++ b/orchestrator/src/server/services/rxresume/index.test.ts
@@ -1,14 +1,17 @@
 import { getSetting } from "@server/repositories/settings";
 import { getActiveTenantId } from "@server/tenancy/context";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createTailoredResumeArtifact } from "../tailored-resume";
 import {
   clearRxResumeResumeCache,
   exportResumePdf,
   getResume,
   importResume,
   listResumes,
+  prepareTailoredResumeForPdf,
   validateCredentials,
 } from "./index";
+import { defaultV5ResumeData } from "./schema/v5";
 import * as v5 from "./v5";
 
 vi.mock("@server/repositories/settings", () => ({
@@ -274,5 +277,129 @@ describe("RxResume Service (index.ts)", () => {
         message: expect.stringContaining("API key is not configured"),
       });
     });
+  });
+});
+
+function tailoringResume() {
+  const resume = structuredClone(defaultV5ResumeData);
+  resume.sections.experience.items = [
+    {
+      id: "experience-1",
+      hidden: false,
+      options: { showLinkInTitle: false },
+      company: "Example Labs",
+      position: "Engineer",
+      location: "Remote",
+      period: "2022 - 2024",
+      website: { url: "", label: "" },
+      description: "Contributed to an API pilot used by 25 teams.",
+      roles: [],
+    },
+  ];
+  resume.sections.projects.items = ["p1", "p2", "p3"].map((id, index) => ({
+    id,
+    hidden: id !== "p1",
+    options: { showLinkInTitle: false },
+    name: `Project ${index + 1}`,
+    period: "2024",
+    website: { url: "", label: "" },
+    description: `Built project ${index + 1}`,
+  }));
+  return resume;
+}
+
+describe("full RxResume tailoring", () => {
+  beforeEach(() => {
+    vi.mocked(getSetting).mockImplementation(async (key) => {
+      if (key === "resumeProjects") {
+        return JSON.stringify({
+          maxProjects: 2,
+          lockedProjectIds: ["p1", "unknown-locked"],
+          aiSelectableProjectIds: ["p2", "p3", "p3", "unknown-selectable"],
+        });
+      }
+      if (key === "rxresumeApiKey") return "test-api-key";
+      if (key === "rxresumeUrl") return "https://rxresu.me";
+      return null;
+    });
+  });
+
+  it("applies source-linked bullets to a clone by stable ID", async () => {
+    const resume = tailoringResume();
+    const data = {
+      headline: "Platform Engineer",
+      summary: "Tailored summary",
+      skills: [],
+      experience: [
+        {
+          id: "experience-1",
+          bullets: ["Contributed to the API pilot used by 25 teams."],
+        },
+      ],
+      projects: [{ id: "p2", bullets: ["Built project 2"] }],
+    };
+    const artifact = createTailoredResumeArtifact(
+      data,
+      resume,
+      "Build APIs",
+      "2026-01-01T00:00:00.000Z",
+    );
+
+    const prepared = await prepareTailoredResumeForPdf({
+      resumeData: resume,
+      tailoredContent: { tailoredResume: JSON.stringify(artifact) },
+      jobDescription: "Build APIs",
+      selectedProjectIds: "p2",
+    });
+
+    expect(resume.sections.experience.items[0].description).toContain(
+      "API pilot used by 25 teams",
+    );
+    expect(prepared.data.sections).toEqual(expect.any(Object));
+    const sections = prepared.data.sections as typeof resume.sections;
+    expect(sections.experience.items[0].description).toBe(
+      "<ul><li>Contributed to the API pilot used by 25 teams.</li></ul>",
+    );
+    expect(sections.projects.items[1].description).toBe(
+      "<ul><li>Built project 2</li></ul>",
+    );
+  });
+
+  it("ignores stale artifacts and caps explicit project IDs", async () => {
+    const resume = tailoringResume();
+    const artifact = createTailoredResumeArtifact(
+      {
+        headline: "Platform Engineer",
+        summary: "Tailored summary",
+        skills: [],
+        experience: [
+          {
+            id: "experience-1",
+            bullets: ["Contributed to the API pilot used by 25 teams."],
+          },
+        ],
+        projects: [],
+      },
+      resume,
+      "Old job description",
+    );
+
+    const prepared = await prepareTailoredResumeForPdf({
+      resumeData: resume,
+      tailoredContent: { tailoredResume: JSON.stringify(artifact) },
+      jobDescription: "New job description",
+      selectedProjectIds: "p2,p2,unknown,p3,p1",
+    });
+    const sections = prepared.data.sections as typeof resume.sections;
+
+    expect(sections.experience.items[0].description).toBe(
+      "Contributed to an API pilot used by 25 teams.",
+    );
+    expect(prepared.selectedProjectIds).toEqual(["p1", "p2"]);
+    expect(sections.projects.items.map((project) => project.hidden)).toEqual([
+      false,
+      false,
+      true,
+    ]);
   });
 });

--- a/orchestrator/src/server/services/rxresume/index.ts
+++ b/orchestrator/src/server/services/rxresume/index.ts
@@ -10,6 +10,10 @@ import {
 import { getActiveTenantId } from "@server/tenancy/context";
 import type { ResumeProjectCatalogItem } from "@shared/types";
 import {
+  applyTailoredResumeArtifact,
+  parseValidTailoredResumeArtifact,
+} from "../tailored-resume";
+import {
   getResumeSchemaValidationMessage,
   safeParseV5ResumeData,
 } from "./schema";
@@ -358,10 +362,14 @@ export async function validateResumeSchema(
 function parseSelectedProjectIds(selectedProjectIds?: string | null): string[] {
   if (selectedProjectIds === null || selectedProjectIds === undefined)
     return [];
-  return selectedProjectIds
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  return [
+    ...new Set(
+      selectedProjectIds
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean),
+    ),
+  ];
 }
 
 export function extractProjectsFromResume(resumeData: unknown): {
@@ -384,6 +392,7 @@ export async function prepareTailoredResumeForPdf(args: {
     summary?: string | null;
     headline?: string | null;
     skills?: TailoredSkillsInput;
+    tailoredResume?: string | null;
   };
   jobDescription: string;
   selectedProjectIds?: string | null;
@@ -400,34 +409,40 @@ export async function prepareTailoredResumeForPdf(args: {
     throw new Error(getResumeSchemaValidationMessage(parsed.error));
   }
 
-  const workingCopy = cloneResumeData(parsed.data as Record<string, unknown>);
+  const baseData = parsed.data as Record<string, unknown>;
+  const tailoredResume = parseValidTailoredResumeArtifact(
+    args.tailoredContent.tailoredResume,
+    baseData,
+    args.jobDescription,
+  );
+  const workingCopy = cloneResumeData(baseData);
   applyTailoredChunks({
     resumeData: workingCopy,
     tailoredContent: args.tailoredContent,
   });
+  if (tailoredResume) {
+    applyTailoredResumeArtifact(workingCopy, tailoredResume);
+  }
 
   const { catalog, selectionItems } = extractProjectsFromResumeV5(workingCopy);
-
-  let selectedIds = parseSelectedProjectIds(args.selectedProjectIds);
+  const { resumeProjects } = resolveResumeProjectsSettings({
+    catalog,
+    overrideRaw: await getSetting("resumeProjects"),
+  });
+  const locked = resumeProjects.lockedProjectIds;
+  const selectable = new Set(resumeProjects.aiSelectableProjectIds);
+  let selectedIds: string[];
 
   if (
     args.selectedProjectIds === null ||
     args.selectedProjectIds === undefined
   ) {
-    const overrideResumeProjectsRaw = await getSetting("resumeProjects");
-    const { resumeProjects } = resolveResumeProjectsSettings({
-      catalog,
-      overrideRaw: overrideResumeProjectsRaw,
-    });
-
-    const locked = resumeProjects.lockedProjectIds;
     const desiredCount = Math.max(
       0,
       resumeProjects.maxProjects - locked.length,
     );
-    const eligibleSet = new Set(resumeProjects.aiSelectableProjectIds);
-    const eligibleProjects = selectionItems.filter((p) =>
-      eligibleSet.has(p.id),
+    const eligibleProjects = selectionItems.filter((project) =>
+      selectable.has(project.id),
     );
     const picked = await pickProjectIdsForJob({
       jobDescription: args.jobDescription,
@@ -435,6 +450,14 @@ export async function prepareTailoredResumeForPdf(args: {
       desiredCount,
     });
     selectedIds = [...locked, ...picked];
+  } else {
+    const lockedSet = new Set(locked);
+    selectedIds = [
+      ...locked,
+      ...parseSelectedProjectIds(args.selectedProjectIds).filter(
+        (id) => selectable.has(id) && !lockedSet.has(id),
+      ),
+    ].slice(0, resumeProjects.maxProjects);
   }
 
   applyProjectVisibility({

--- a/orchestrator/src/server/services/rxresume/tailoring.test.ts
+++ b/orchestrator/src/server/services/rxresume/tailoring.test.ts
@@ -1,7 +1,41 @@
 import { describe, expect, it } from "vitest";
-import { extractProjectsFromResume } from "./tailoring";
+import { applyTailoredSkills, extractProjectsFromResume } from "./tailoring";
 
 describe("rxresume tailoring", () => {
+  it("preserves Reactive Resume v5 skill fields", () => {
+    const resume = {
+      sections: {
+        skills: {
+          items: [
+            {
+              id: "skill-1",
+              name: "Backend",
+              proficiency: "Advanced",
+              level: 4,
+              hidden: true,
+              keywords: ["Node.js"],
+            },
+          ],
+        },
+      },
+    };
+
+    applyTailoredSkills(resume, [
+      { name: "Platform", keywords: ["TypeScript"] },
+    ]);
+
+    expect(resume.sections.skills.items).toEqual([
+      {
+        id: "skill-1",
+        name: "Platform",
+        proficiency: "Advanced",
+        level: 4,
+        hidden: true,
+        keywords: ["TypeScript"],
+      },
+    ]);
+  });
+
   it("strips html from project catalog descriptions", () => {
     const { catalog, selectionItems } = extractProjectsFromResume({
       sections: {

--- a/orchestrator/src/server/services/rxresume/tailoring.ts
+++ b/orchestrator/src/server/services/rxresume/tailoring.ts
@@ -110,9 +110,11 @@ export function applyTailoredSkills(
   const template = existing[0] ?? null;
   if (!template) return;
 
-  skillsSection.items = skills.map((newSkill) => {
+  skillsSection.items = skills.map((newSkill, index) => {
     const match =
-      existing.find((item) => item.name === newSkill.name) ?? template;
+      existing.find((item) => item.name === newSkill.name) ??
+      existing[index] ??
+      template;
     const next: RecordLike = { ...match };
 
     if ("id" in next) {

--- a/orchestrator/src/server/services/summary.test.ts
+++ b/orchestrator/src/server/services/summary.test.ts
@@ -54,6 +54,8 @@ describe("generateTailoring", () => {
         summary: "Tailored summary",
         headline: "Senior Engineer",
         skills: [],
+        experience: [],
+        projects: [],
       },
     });
     vi.mocked(getSetting).mockResolvedValue(null);
@@ -106,7 +108,7 @@ describe("generateTailoring", () => {
     expect(request?.messages?.[0]?.content).toContain("Build APIs");
     expect(request?.messages?.[0]?.content).not.toContain("<strong>");
     expect(request?.messages?.[0]?.content).toContain(
-      '"basics":{"name":"Test User"',
+      '"basics":{"headline":"Engineer","summary":"Existing summary"}',
     );
   });
 
@@ -312,6 +314,78 @@ describe("generateTailoring", () => {
 
     const prompt = callJsonMock.mock.calls.at(-1)?.[0]?.messages?.[0]?.content;
     expect(prompt).not.toContain("keywords per category");
+  });
+
+  it("requires all five output fields and sends v5 evidence with stable IDs", async () => {
+    const profile = {
+      basics: { headline: "Engineer" },
+      summary: { content: "Source summary" },
+      sections: {
+        experience: {
+          hidden: false,
+          items: [
+            {
+              id: "experience-1",
+              company: "Example Labs",
+              position: "Engineer",
+              period: "2023 - Present",
+              description: "Contributed to an ongoing API pilot.",
+              hidden: false,
+            },
+          ],
+        },
+        projects: {
+          hidden: false,
+          items: [
+            {
+              id: "project-1",
+              name: "Prototype",
+              period: "2024",
+              description: "Built a TypeScript prototype.",
+              hidden: true,
+            },
+          ],
+        },
+      },
+    } as unknown as ResumeProfile;
+    callJsonMock.mockResolvedValueOnce({
+      success: true,
+      data: {
+        headline: "Platform Engineer",
+        summary: "Tailored summary",
+        skills: [],
+        experience: [
+          {
+            id: "experience-1",
+            bullets: ["Contributed to an ongoing API pilot."],
+          },
+        ],
+        projects: [
+          { id: "project-1", bullets: ["Built a TypeScript prototype."] },
+        ],
+      },
+    });
+
+    const result = await generateTailoring("Build APIs", profile);
+    const request = callJsonMock.mock.calls.at(-1)?.[0];
+    const prompt = request?.messages?.[0]?.content;
+
+    expect(result.success).toBe(true);
+    expect(request?.jsonSchema.schema.required).toEqual([
+      "headline",
+      "summary",
+      "skills",
+      "experience",
+      "projects",
+    ]);
+    expect(prompt).toContain('"id":"experience-1"');
+    expect(prompt).toContain("Contributed to an ongoing API pilot.");
+    expect(prompt).toContain('"id":"project-1"');
+    expect(prompt).toContain('"visible":false');
+    expect(prompt).toContain(
+      "Preserve qualifiers such as prototype, pilot, contributor, collaboration, and ongoing work.",
+    );
+    expect(prompt).toContain("Never transfer facts between roles or projects.");
   });
 
   it("includes both limits and constraints when all set", async () => {

--- a/orchestrator/src/server/services/summary.ts
+++ b/orchestrator/src/server/services/summary.ts
@@ -1,5 +1,5 @@
 /**
- * Service for generating tailored resume content (Summary, Headline, Skills).
+ * Service for generating source-linked tailored resume content.
  */
 
 import { logger } from "@infra/logger";
@@ -16,23 +16,37 @@ import {
   renderPromptTemplate,
 } from "./prompt-templates";
 import {
+  extractTailoringSource,
+  type FullTailoredData,
+  validateTailoringData,
+} from "./tailored-resume";
+import {
   getWritingStyle,
   stripKeywordLimitFromConstraints,
   stripLanguageDirectivesFromConstraints,
   stripWordLimitFromConstraints,
 } from "./writing-style";
 
-export interface TailoredData {
-  summary: string;
-  headline: string;
-  skills: Array<{ name: string; keywords: string[] }>;
-}
+export type TailoredData = FullTailoredData;
 
 export interface TailoringResult {
   success: boolean;
   data?: TailoredData;
   error?: string;
 }
+
+const SOURCE_LINKED_REWRITES_SCHEMA = {
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      bullets: { type: "array", items: { type: "string" } },
+    },
+    required: ["id", "bullets"],
+    additionalProperties: false,
+  },
+};
 
 /** JSON schema for resume tailoring response */
 const TAILORING_SCHEMA: JsonSchemaDefinition = {
@@ -68,14 +82,16 @@ const TAILORING_SCHEMA: JsonSchemaDefinition = {
           additionalProperties: false,
         },
       },
+      experience: SOURCE_LINKED_REWRITES_SCHEMA,
+      projects: SOURCE_LINKED_REWRITES_SCHEMA,
     },
-    required: ["headline", "summary", "skills"],
+    required: ["headline", "summary", "skills", "experience", "projects"],
     additionalProperties: false,
   },
 };
 
 /**
- * Generate tailored resume content (summary, headline, skills) for a job.
+ * Generate all source-linked tailored resume fields for a job.
  */
 export async function generateTailoring(
   jobDescription: string,
@@ -92,7 +108,7 @@ export async function generateTailoring(
   );
 
   const llm = await createConfiguredLlmService("tailoring");
-  const result = await llm.callJson<TailoredData>({
+  const result = await llm.callJson<unknown>({
     model,
     messages: [{ role: "user", content: prompt }],
     jsonSchema: TAILORING_SCHEMA,
@@ -111,21 +127,15 @@ export async function generateTailoring(
     };
   }
 
-  const { summary, headline, skills } = result.data;
-
-  // Basic validation
-  if (!summary || !headline || !Array.isArray(skills)) {
-    logger.warn("AI response missing required tailoring fields", result.data);
+  const validated = validateTailoringData(result.data, profile);
+  if (!validated.data) {
+    logger.warn("AI response failed source-linked tailoring validation", {
+      error: validated.error,
+    });
+    return { success: false, error: validated.error };
   }
 
-  return {
-    success: true,
-    data: {
-      summary: sanitizeText(summary || ""),
-      headline: sanitizeText(headline || ""),
-      skills: skills || [],
-    },
-  };
+  return { success: true, data: validated.data };
 }
 
 /**
@@ -167,29 +177,10 @@ async function buildTailoringPrompt(
       stripKeywordLimitFromConstraints(effectiveConstraints);
   }
 
-  // Extract only needed parts of profile to save tokens
-  const relevantProfile = {
-    basics: {
-      name: profile.basics?.name,
-      label: profile.basics?.label, // Original headline
-      summary: profile.basics?.summary,
-    },
-    skills: profile.sections?.skills,
-    projects: profile.sections?.projects?.items?.map((p) => ({
-      name: p.name,
-      description: p.description,
-      keywords: p.keywords,
-    })),
-    experience: profile.sections?.experience?.items?.map((e) => ({
-      company: e.company,
-      position: e.position,
-      summary: e.summary,
-    })),
-  };
-
+  const relevantProfile = extractTailoringSource(profile);
   const template = await getEffectivePromptTemplate("tailoringPromptTemplate");
 
-  return renderPromptTemplate(template, {
+  const rendered = renderPromptTemplate(template, {
     jobDescription,
     profileJson: JSON.stringify(relevantProfile),
     outputLanguage,
@@ -210,10 +201,15 @@ async function buildTailoringPrompt(
       ? `- Avoid these words or phrases: ${writingStyle.doNotUse}`
       : "",
   });
-}
 
-function sanitizeText(text: string): string {
-  return text
-    .replace(/\*\*[\s\S]*?\*\*/g, "") // remove markdown bold
-    .trim();
+  return `${rendered}
+
+SOURCE-LINKED CLAIM SAFETY (mandatory):
+- Return all five fields: headline, summary, skills, experience, and projects.
+- For experience and projects, use only IDs present in MY PROFILE.
+- Each bullet may use evidence only from that same source item. Never transfer facts between roles or projects.
+- Do not add employers, titles, tools, metrics, scale, ownership, outcomes, or production maturity absent from that source item.
+- Preserve qualifiers such as prototype, pilot, contributor, collaboration, and ongoing work.
+- Do not introduce a numerical token unless it appears in that same source item.
+- Return plain-text bullets; do not return HTML or Markdown.`;
 }

--- a/orchestrator/src/server/services/tailored-resume.test.ts
+++ b/orchestrator/src/server/services/tailored-resume.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyTailoredResumeArtifact,
+  createJobDescriptionHash,
+  createTailoredResumeArtifact,
+  createTailoringSourceHash,
+  extractTailoringSource,
+  parseValidTailoredResumeArtifact,
+  renderTailoredBullets,
+  validateTailoringData,
+} from "./tailored-resume";
+
+const sourceResume = () => ({
+  basics: { headline: "Software Engineer" },
+  summary: { content: "Builds reliable services.", hidden: false },
+  sections: {
+    skills: {
+      hidden: false,
+      items: [
+        {
+          id: "skill-1",
+          name: "Backend",
+          proficiency: "Advanced",
+          level: 4,
+          keywords: ["TypeScript"],
+          hidden: false,
+        },
+      ],
+    },
+    experience: {
+      hidden: false,
+      items: [
+        {
+          id: "experience-1",
+          company: "Example Labs",
+          position: "Engineer",
+          location: "Remote",
+          period: "2022 - 2024",
+          description: "<p>Contributed to a pilot used by 25 teams.</p>",
+          hidden: false,
+          roles: [],
+        },
+      ],
+    },
+    projects: {
+      hidden: false,
+      items: [
+        {
+          id: "project-1",
+          name: "Service Prototype",
+          period: "2024",
+          description: "Built a prototype API with TypeScript.",
+          hidden: true,
+        },
+      ],
+    },
+  },
+});
+
+const response = () => ({
+  headline: "Platform Engineer",
+  summary: "Engineer focused on reliable APIs.",
+  skills: [{ name: "Backend", keywords: ["TypeScript"] }],
+  experience: [
+    {
+      id: "experience-1",
+      bullets: ["Contributed to a pilot used by 25 teams."],
+    },
+  ],
+  projects: [
+    {
+      id: "project-1",
+      bullets: ["Built a TypeScript API prototype."],
+    },
+  ],
+});
+
+describe("source-linked resume tailoring", () => {
+  it("reads Reactive Resume v5 and legacy aliases consistently", () => {
+    const v5 = extractTailoringSource(sourceResume());
+    const legacy = extractTailoringSource({
+      basics: {
+        label: "Software Engineer",
+        summary: "Builds reliable services.",
+      },
+      sections: {
+        summary: { content: "Builds reliable services.", visible: true },
+        skills: {
+          visible: true,
+          items: [
+            {
+              name: "Backend",
+              description: "Advanced",
+              level: 4,
+              keywords: ["TypeScript"],
+              visible: true,
+            },
+          ],
+        },
+        experience: {
+          visible: true,
+          items: [
+            {
+              id: "experience-1",
+              company: "Example Labs",
+              position: "Engineer",
+              location: "Remote",
+              date: "2022 - 2024",
+              summary: "Contributed to a pilot used by 25 teams.",
+              visible: true,
+              roles: [],
+            },
+          ],
+        },
+        projects: {
+          visible: true,
+          items: [
+            {
+              id: "project-1",
+              name: "Service Prototype",
+              date: "2024",
+              summary: "Built a prototype API with TypeScript.",
+              visible: false,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(v5).toEqual(legacy);
+    expect(v5.experience[0].description).toContain("pilot used by 25 teams");
+    expect(v5.projects[0].visible).toBe(false);
+  });
+
+  it("rejects unknown and duplicate source IDs", () => {
+    expect(
+      validateTailoringData(
+        {
+          ...response(),
+          experience: [{ id: "unknown", bullets: ["Built APIs."] }],
+        },
+        sourceResume(),
+      ).error,
+    ).toContain("unknown id");
+
+    expect(
+      validateTailoringData(
+        {
+          ...response(),
+          projects: [
+            { id: "project-1", bullets: ["Built an API prototype."] },
+            { id: "project-1", bullets: ["Built a service prototype."] },
+          ],
+        },
+        sourceResume(),
+      ).error,
+    ).toContain("duplicate id");
+  });
+
+  it("drops invented numbers, preserves sourced numbers, and fails with no valid experience", () => {
+    const mixed = validateTailoringData(
+      {
+        ...response(),
+        experience: [
+          {
+            id: "experience-1",
+            bullets: [
+              "Scaled the service to 100 teams.",
+              "Contributed to the pilot used by 25 teams.",
+            ],
+          },
+        ],
+      },
+      sourceResume(),
+    );
+
+    expect(mixed.data?.experience[0].bullets).toEqual([
+      "Contributed to the pilot used by 25 teams.",
+    ]);
+    expect(
+      validateTailoringData(
+        {
+          ...response(),
+          experience: [
+            { id: "experience-1", bullets: ["Scaled to 100 teams."] },
+          ],
+        },
+        sourceResume(),
+      ).error,
+    ).toContain("no valid source-linked experience");
+  });
+
+  it("invalidates artifacts when the source or job description changes", () => {
+    const validated = validateTailoringData(response(), sourceResume()).data;
+    expect(validated).toBeDefined();
+    const artifact = createTailoredResumeArtifact(
+      validated!,
+      sourceResume(),
+      "Build platform APIs",
+      "2026-01-01T00:00:00.000Z",
+    );
+
+    expect(
+      parseValidTailoredResumeArtifact(
+        JSON.stringify(artifact),
+        sourceResume(),
+        "Build platform APIs",
+      ),
+    ).toEqual(artifact);
+    expect(
+      parseValidTailoredResumeArtifact(
+        JSON.stringify(artifact),
+        sourceResume(),
+        "Build data pipelines",
+      ),
+    ).toBeNull();
+
+    const changedResume = sourceResume();
+    changedResume.sections.experience.items[0].description =
+      "Contributed to an ongoing internal pilot.";
+    expect(
+      parseValidTailoredResumeArtifact(
+        JSON.stringify(artifact),
+        changedResume,
+        "Build platform APIs",
+      ),
+    ).toBeNull();
+    expect(createTailoringSourceHash(changedResume)).not.toBe(
+      artifact.sourceHash,
+    );
+    expect(createJobDescriptionHash("Build data pipelines")).not.toBe(
+      artifact.jobDescriptionHash,
+    );
+    expect(
+      parseValidTailoredResumeArtifact("{", sourceResume(), "Build APIs"),
+    ).toBeNull();
+  });
+
+  it("applies escaped HTML lists by stable ID without mutating the base resume", () => {
+    const base = sourceResume();
+    const workingCopy = structuredClone(base);
+    const artifact = {
+      version: 1 as const,
+      sourceHash: "a".repeat(64),
+      jobDescriptionHash: "b".repeat(64),
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      experience: [
+        {
+          id: "experience-1",
+          bullets: ['Improved A < B & called it "safe".'],
+        },
+      ],
+      projects: [{ id: "project-1", bullets: ["Kept the prototype."] }],
+    };
+
+    applyTailoredResumeArtifact(workingCopy, artifact);
+
+    expect(base.sections.experience.items[0].description).toContain("<p>");
+    expect(workingCopy.sections.experience.items[0].description).toBe(
+      '<ul><li>Improved A &lt; B &amp; called it &quot;safe&quot;.</li></ul>',
+    );
+    expect(workingCopy.sections.projects.items[0].description).toBe(
+      "<ul><li>Kept the prototype.</li></ul>",
+    );
+    expect(renderTailoredBullets(["A > B"])).toBe(
+      "<ul><li>A &gt; B</li></ul>",
+    );
+  });
+});

--- a/orchestrator/src/server/services/tailored-resume.ts
+++ b/orchestrator/src/server/services/tailored-resume.ts
@@ -1,0 +1,452 @@
+import { createHash } from "node:crypto";
+import type {
+  TailoredResumeArtifact,
+  TailoredResumeItem,
+} from "@shared/types";
+import { stripHtmlTags } from "@shared/utils/string";
+
+type RecordLike = Record<string, unknown>;
+
+export interface TailoredSkill {
+  name: string;
+  keywords: string[];
+}
+
+export interface FullTailoredData {
+  headline: string;
+  summary: string;
+  skills: TailoredSkill[];
+  experience: TailoredResumeItem[];
+  projects: TailoredResumeItem[];
+}
+
+export interface TailoringSourceItem extends RecordLike {
+  id: string;
+  description: string;
+}
+
+export interface TailoringSource {
+  basics: { headline: string; summary: string };
+  summaryVisible: boolean;
+  skillsVisible: boolean;
+  skills: Array<{
+    name: string;
+    proficiency: string;
+    level: number;
+    keywords: string[];
+    visible: boolean;
+  }>;
+  experienceVisible: boolean;
+  experience: TailoringSourceItem[];
+  projectsVisible: boolean;
+  projects: TailoringSourceItem[];
+}
+
+const MAX_ARTIFACT_CHARS = 250_000;
+const MAX_HEADLINE_CHARS = 200;
+const MAX_SUMMARY_CHARS = 4_000;
+const MAX_SKILLS = 50;
+const MAX_SKILL_NAME_CHARS = 100;
+const MAX_KEYWORDS_PER_SKILL = 50;
+const MAX_KEYWORD_CHARS = 100;
+const MAX_BULLETS_PER_ITEM = 20;
+const MAX_BULLET_CHARS = 1_000;
+const MAX_SOURCE_TEXT_CHARS = 20_000;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const NUMERICAL_TOKEN_PATTERN = /\d+(?:[.,]\d+)*%?/g;
+
+function asRecord(value: unknown): RecordLike | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as RecordLike)
+    : null;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function text(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function plainText(value: unknown, max = MAX_SOURCE_TEXT_CHARS): string {
+  return stripHtmlTags(text(value)).slice(0, max).trim();
+}
+
+function firstPlainText(max: number, ...values: unknown[]): string {
+  for (const value of values) {
+    const result = plainText(value, max);
+    if (result) return result;
+  }
+  return "";
+}
+
+function visible(record: RecordLike | null): boolean {
+  if (!record) return true;
+  if (typeof record.hidden === "boolean") return !record.hidden;
+  if (typeof record.visible === "boolean") return record.visible;
+  return true;
+}
+
+function uniqueItems(items: TailoringSourceItem[]): TailoringSourceItem[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    if (!item.id || seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+}
+
+/** Isolates Reactive Resume v5 and legacy aliases at the tailoring boundary. */
+export function extractTailoringSource(resume: unknown): TailoringSource {
+  const root = asRecord(resume) ?? {};
+  const basics = asRecord(root.basics) ?? {};
+  const rootSummary = asRecord(root.summary);
+  const sections = asRecord(root.sections) ?? {};
+  const sectionSummary = asRecord(sections.summary);
+  const skillsSection = asRecord(sections.skills);
+  const experienceSection = asRecord(sections.experience);
+  const projectsSection = asRecord(sections.projects);
+
+  const skills = asArray(skillsSection?.items).flatMap((raw) => {
+    const item = asRecord(raw);
+    if (!item) return [];
+    return [
+      {
+        name: plainText(item.name, MAX_SKILL_NAME_CHARS),
+        proficiency: firstPlainText(500, item.proficiency, item.description),
+        level:
+          typeof item.level === "number" && Number.isFinite(item.level)
+            ? item.level
+            : 0,
+        keywords: asArray(item.keywords)
+          .map((keyword) => plainText(keyword, MAX_KEYWORD_CHARS))
+          .filter(Boolean),
+        visible: visible(item),
+      },
+    ];
+  });
+
+  const experience = uniqueItems(
+    asArray(experienceSection?.items).flatMap((raw) => {
+      const item = asRecord(raw);
+      const id = text(item?.id).trim();
+      if (!item || !id) return [];
+      const roles = asArray(item.roles).flatMap((rawRole) => {
+        const role = asRecord(rawRole);
+        if (!role) return [];
+        return [
+          {
+            position: plainText(role.position, 500),
+            period: firstPlainText(500, role.period, role.date),
+            description: firstPlainText(
+              MAX_SOURCE_TEXT_CHARS,
+              role.description,
+              role.summary,
+            ),
+          },
+        ];
+      });
+      return [
+        {
+          id,
+          company: plainText(item.company, 500),
+          position: plainText(item.position, 500),
+          location: plainText(item.location, 500),
+          period: firstPlainText(500, item.period, item.date),
+          description: firstPlainText(
+            MAX_SOURCE_TEXT_CHARS,
+            item.description,
+            item.summary,
+          ),
+          roles,
+          visible: visible(item),
+        },
+      ];
+    }),
+  );
+
+  const projects = uniqueItems(
+    asArray(projectsSection?.items).flatMap((raw) => {
+      const item = asRecord(raw);
+      const id = text(item?.id).trim();
+      if (!item || !id) return [];
+      return [
+        {
+          id,
+          name: plainText(item.name, 500),
+          period: firstPlainText(500, item.period, item.date),
+          description: firstPlainText(
+            MAX_SOURCE_TEXT_CHARS,
+            item.description,
+            item.summary,
+          ),
+          keywords: asArray(item.keywords)
+            .map((keyword) => plainText(keyword, MAX_KEYWORD_CHARS))
+            .filter(Boolean),
+          visible: visible(item),
+        },
+      ];
+    }),
+  );
+
+  return {
+    basics: {
+      headline: firstPlainText(
+        MAX_HEADLINE_CHARS,
+        basics.headline,
+        basics.label,
+      ),
+      summary: firstPlainText(
+        MAX_SOURCE_TEXT_CHARS,
+        basics.summary,
+        rootSummary?.content,
+        sectionSummary?.content,
+      ),
+    },
+    summaryVisible: visible(rootSummary ?? sectionSummary),
+    skillsVisible: visible(skillsSection),
+    skills,
+    experienceVisible: visible(experienceSection),
+    experience,
+    projectsVisible: visible(projectsSection),
+    projects,
+  };
+}
+
+function sanitizeOutputText(value: unknown, max: number): string {
+  if (typeof value !== "string") return "";
+  return stripHtmlTags(value.replace(/\*\*/g, ""))
+    .replace(/\p{Cc}/gu, "")
+    .slice(0, max)
+    .trim();
+}
+
+function numericalTokens(value: string): Set<string> {
+  return new Set(value.match(NUMERICAL_TOKEN_PATTERN) ?? []);
+}
+
+function sourceEvidence(item: TailoringSourceItem): string {
+  const { id: _id, visible: _visible, ...evidence } = item;
+  return JSON.stringify(evidence);
+}
+
+function validateRewrites(args: {
+  value: unknown;
+  source: TailoringSourceItem[];
+  rejectInvalidNumbers?: boolean;
+}): { data?: TailoredResumeItem[]; error?: string } {
+  if (!Array.isArray(args.value)) return { error: "must be an array" };
+
+  const sourceById = new Map(args.source.map((item) => [item.id, item]));
+  const seen = new Set<string>();
+  const data: TailoredResumeItem[] = [];
+
+  for (const raw of args.value) {
+    const item = asRecord(raw);
+    const id = text(item?.id).trim();
+    if (!item || !id || !Array.isArray(item.bullets)) {
+      return { error: "contains a malformed item" };
+    }
+    if (seen.has(id)) return { error: `contains duplicate id ${id}` };
+    seen.add(id);
+
+    const source = sourceById.get(id);
+    if (!source) return { error: `contains unknown id ${id}` };
+    const allowedNumbers = numericalTokens(sourceEvidence(source));
+    const bullets: string[] = [];
+
+    for (const rawBullet of item.bullets) {
+      if (typeof rawBullet !== "string") {
+        return { error: `contains a non-text bullet for ${id}` };
+      }
+      const bullet = sanitizeOutputText(rawBullet, MAX_BULLET_CHARS);
+      if (!bullet) continue;
+      const introducesNumber = [...numericalTokens(bullet)].some(
+        (token) => !allowedNumbers.has(token),
+      );
+      if (introducesNumber) {
+        if (args.rejectInvalidNumbers) {
+          return { error: `contains an unsupported number for ${id}` };
+        }
+        continue;
+      }
+      if (bullets.length < MAX_BULLETS_PER_ITEM) bullets.push(bullet);
+    }
+
+    if (bullets.length > 0) data.push({ id, bullets });
+  }
+
+  return { data };
+}
+
+export function validateTailoringData(
+  value: unknown,
+  resume: unknown,
+): { data?: FullTailoredData; error?: string } {
+  const raw = asRecord(value);
+  if (!raw) return { error: "AI response is not an object" };
+
+  const headline = sanitizeOutputText(raw.headline, MAX_HEADLINE_CHARS);
+  const summary = sanitizeOutputText(raw.summary, MAX_SUMMARY_CHARS);
+  if (!headline || !summary || !Array.isArray(raw.skills)) {
+    return { error: "AI response is missing required tailoring fields" };
+  }
+
+  const skills: TailoredSkill[] = [];
+  for (const rawSkill of raw.skills.slice(0, MAX_SKILLS)) {
+    const skill = asRecord(rawSkill);
+    if (!skill || !Array.isArray(skill.keywords)) {
+      return { error: "AI response contains a malformed skill" };
+    }
+    const name = sanitizeOutputText(skill.name, MAX_SKILL_NAME_CHARS);
+    if (!name) return { error: "AI response contains an unnamed skill" };
+    skills.push({
+      name,
+      keywords: skill.keywords
+        .slice(0, MAX_KEYWORDS_PER_SKILL)
+        .map((keyword) => sanitizeOutputText(keyword, MAX_KEYWORD_CHARS))
+        .filter(Boolean),
+    });
+  }
+
+  const source = extractTailoringSource(resume);
+  const experience = validateRewrites({
+    value: raw.experience,
+    source: source.experience,
+  });
+  if (experience.error) return { error: `Experience ${experience.error}` };
+  const projects = validateRewrites({
+    value: raw.projects,
+    source: source.projects,
+  });
+  if (projects.error) return { error: `Projects ${projects.error}` };
+  if (source.experience.length > 0 && experience.data?.length === 0) {
+    return { error: "AI response contains no valid source-linked experience" };
+  }
+
+  return {
+    data: {
+      headline,
+      summary,
+      skills,
+      experience: experience.data ?? [],
+      projects: projects.data ?? [],
+    },
+  };
+}
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function createTailoringSourceHash(resume: unknown): string {
+  return sha256(JSON.stringify(extractTailoringSource(resume)));
+}
+
+export function createJobDescriptionHash(jobDescription: string): string {
+  return sha256(stripHtmlTags(jobDescription));
+}
+
+export function createTailoredResumeArtifact(
+  data: FullTailoredData,
+  resume: unknown,
+  jobDescription: string,
+  generatedAt = new Date().toISOString(),
+): TailoredResumeArtifact {
+  return {
+    version: 1,
+    sourceHash: createTailoringSourceHash(resume),
+    jobDescriptionHash: createJobDescriptionHash(jobDescription),
+    generatedAt,
+    experience: data.experience,
+    projects: data.projects,
+  };
+}
+
+export function parseValidTailoredResumeArtifact(
+  value: unknown,
+  resume: unknown,
+  jobDescription: string,
+): TailoredResumeArtifact | null {
+  if (!value) return null;
+  if (typeof value === "string" && value.length > MAX_ARTIFACT_CHARS) return null;
+
+  let raw: RecordLike | null;
+  try {
+    raw = asRecord(typeof value === "string" ? JSON.parse(value) : value);
+  } catch {
+    return null;
+  }
+  if (
+    !raw ||
+    raw.version !== 1 ||
+    !SHA256_PATTERN.test(text(raw.sourceHash)) ||
+    !SHA256_PATTERN.test(text(raw.jobDescriptionHash)) ||
+    Number.isNaN(Date.parse(text(raw.generatedAt))) ||
+    raw.sourceHash !== createTailoringSourceHash(resume) ||
+    raw.jobDescriptionHash !== createJobDescriptionHash(jobDescription)
+  ) {
+    return null;
+  }
+
+  const source = extractTailoringSource(resume);
+  const experience = validateRewrites({
+    value: raw.experience,
+    source: source.experience,
+    rejectInvalidNumbers: true,
+  });
+  const projects = validateRewrites({
+    value: raw.projects,
+    source: source.projects,
+    rejectInvalidNumbers: true,
+  });
+  if (
+    experience.error ||
+    projects.error ||
+    (source.experience.length > 0 && experience.data?.length === 0)
+  ) {
+    return null;
+  }
+
+  return {
+    version: 1,
+    sourceHash: text(raw.sourceHash),
+    jobDescriptionHash: text(raw.jobDescriptionHash),
+    generatedAt: text(raw.generatedAt),
+    experience: experience.data ?? [],
+    projects: projects.data ?? [],
+  };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export function renderTailoredBullets(bullets: string[]): string {
+  return `<ul>${bullets.map((bullet) => `<li>${escapeHtml(bullet)}</li>`).join("")}</ul>`;
+}
+
+export function applyTailoredResumeArtifact(
+  resumeData: RecordLike,
+  artifact: TailoredResumeArtifact,
+): void {
+  const sections = asRecord(resumeData.sections);
+  for (const [sectionName, rewrites] of [
+    ["experience", artifact.experience],
+    ["projects", artifact.projects],
+  ] as const) {
+    const section = asRecord(sections?.[sectionName]);
+    const byId = new Map(rewrites.map((item) => [item.id, item.bullets]));
+    for (const rawItem of asArray(section?.items)) {
+      const item = asRecord(rawItem);
+      const bullets = byId.get(text(item?.id));
+      if (item && bullets) item.description = renderTailoredBullets(bullets);
+    }
+  }
+}

--- a/shared/src/prompt-template-definitions.ts
+++ b/shared/src/prompt-template-definitions.ts
@@ -28,7 +28,7 @@ Writing style formality: {{formality}}.
   tailoringPromptTemplate: {
     label: "Resume tailoring prompt",
     description:
-      "Controls how summary, headline, and skills are generated for a job-specific resume.",
+      "Controls source-linked headline, summary, skills, experience, and project tailoring.",
     placeholders: [
       "jobDescription",
       "profileJson",
@@ -42,7 +42,7 @@ Writing style formality: {{formality}}.
     ] as const,
     defaultTemplate: `
 You are an expert resume writer tailoring a profile for a specific job application.
-You must return a JSON object with three fields: "headline", "summary", and "skills".
+You must return a JSON object with five fields: "headline", "summary", "skills", "experience", and "projects".
 
 JOB DESCRIPTION (JD):
 {{jobDescription}}
@@ -71,10 +71,21 @@ INSTRUCTIONS:
    - Return the full "items" array for the skills section, preserving the structure: { "name": "Frontend", "keywords": [...] }.
    - Write user-visible skill text in {{outputLanguage}} when natural, but keep exact JD terms, acronyms, and technology names when that helps ATS matching.
 
+4. "experience" (Array of Objects):
+   - Return { "id": "existing-id", "bullets": ["..."] } entries using only experience IDs in MY PROFILE.
+   - Rewrite bullets using evidence from that same experience item only.
+   - Keep unsupported or already-clear items unchanged by omitting them.
+
+5. "projects" (Array of Objects):
+   - Return { "id": "existing-id", "bullets": ["..."] } entries using only project IDs in MY PROFILE.
+   - Rewrite bullets using evidence from that same project item only.
+   - Keep unsupported or already-clear items unchanged by omitting them.
+
 WRITING STYLE PREFERENCES:
 - Tone: {{tone}}
 - Formality: {{formality}}
 - Output language for summary and skills: {{outputLanguage}}
+- Output language for experience and project bullets: {{outputLanguage}}
 {{constraintsBullet}}
 {{avoidTermsBullet}}
 
@@ -86,7 +97,9 @@ OUTPUT FORMAT (JSON):
 {
   "headline": "...",
   "summary": "...",
-  "skills": [ ... ]
+  "skills": [ ... ],
+  "experience": [{ "id": "existing-experience-id", "bullets": ["..."] }],
+  "projects": [{ "id": "existing-project-id", "bullets": ["..."] }]
 }
 `.trim(),
   },

--- a/shared/src/testing/factories.ts
+++ b/shared/src/testing/factories.ts
@@ -37,6 +37,7 @@ export const createJob = (overrides: Partial<Job> = {}): Job => ({
   tailoredSummary: null,
   tailoredHeadline: null,
   tailoredSkills: null,
+  tailoredResume: null,
   selectedProjectIds: null,
   pdfPath: null,
   pdfSource: null,

--- a/shared/src/types/jobs.ts
+++ b/shared/src/types/jobs.ts
@@ -171,6 +171,20 @@ export interface JobBrief {
   repeated_signals: string[];
 }
 
+export interface TailoredResumeItem {
+  id: string;
+  bullets: string[];
+}
+
+export interface TailoredResumeArtifact {
+  version: 1;
+  sourceHash: string;
+  jobDescriptionHash: string;
+  generatedAt: string;
+  experience: TailoredResumeItem[];
+  projects: TailoredResumeItem[];
+}
+
 export interface Job {
   id: string;
 
@@ -206,6 +220,7 @@ export interface Job {
   tailoredSummary: string | null; // Generated resume summary
   tailoredHeadline: string | null; // Generated resume headline
   tailoredSkills: string | null; // Generated resume skills (JSON)
+  tailoredResume: string | null; // Versioned source-linked bullet tailoring artifact (JSON)
   selectedProjectIds: string | null; // Comma-separated IDs of selected projects
   pdfPath: string | null; // Path to generated PDF
   pdfSource: JobPdfSource | null; // Whether PDF was system-generated or user-uploaded
@@ -566,6 +581,7 @@ export interface UpdateJobInput {
   tailoredSummary?: string;
   tailoredHeadline?: string;
   tailoredSkills?: string;
+  tailoredResume?: string | null;
   selectedProjectIds?: string;
   pdfPath?: string;
   pdfSource?: JobPdfSource | null;

--- a/shared/src/types/settings.ts
+++ b/shared/src/types/settings.ts
@@ -169,6 +169,13 @@ export interface ResumeProfile {
         date: string;
         summary: string;
         visible: boolean;
+        roles?: Array<{
+          position?: string;
+          period?: string;
+          date?: string;
+          description?: string;
+          summary?: string;
+        }>;
       }>;
     };
     [key: string]: unknown;


### PR DESCRIPTION
## Why

JobOps currently tailors headline, summary, and skills, but leaves experience and project bullets unchanged. This adds bullet tailoring while keeping every rewrite linked to an existing resume item and rejecting stale or structurally unsafe output.

## What changed

- generate headline, summary, skills, experience bullets, and project bullets in one tailoring request
- key bullet rewrites to existing experience, nested-role, and project IDs
- persist rewrites in a versioned `jobs.tailored_resume` JSON artifact with source-resume and job-description hashes
- centralize v5/legacy extraction, validation, sanitization, hashing, and application in one boundary module
- apply valid artifacts only to a cloned resume; never mutate the Resume Studio source document
- include the artifact in PDF freshness and automatic regeneration while preserving uploaded PDFs
- render rewritten nested-role descriptions through both Reactive Resume and the local LaTeX/Typst document model
- deduplicate and cap explicit project selections using configured `maxProjects`; use the same limit in the UI
- add migration, renderer, validation, freshness, regeneration, and project-selection coverage
- document the expanded tailoring scope and freshness behavior

## Safety behavior

- only existing stable source IDs are accepted; unknown and duplicate IDs are rejected
- the prompt constrains each rewrite to evidence from its linked item and forbids transfers between experiences, nested roles, or projects
- numerical claims absent from the linked source item are dropped programmatically
- generated text is sanitized and capped; HTML is escaped before list markup is created
- malformed or source/JD hash-stale artifacts are never applied
- safe empty rewrite arrays preserve original descriptions
- targeted regeneration of headline, summary, or skills does not replace the bullet artifact
- uploaded PDFs are never automatically replaced

## Validation — Node 22

- [x] repository suite excluding the Windows-blocked Gradcracker file: 279 files, 1,926 passed, 3 skipped
- [x] full-tree Biome on the exact commit: 1,009 files
- [x] shared and all workspace TypeScript checks
- [x] production client build
- [x] documentation build
- [x] isolated smoke test with generic data and stubbed LLM/Reactive Resume APIs:
  - artifact persisted
  - nested-role and project rewrites applied
  - base resume remained unchanged
  - targeted refresh preserved the artifact
  - stale artifact was rejected
  - uploaded PDF was skipped
- [ ] Linux CI

## Local limitation

`extractors/gradcracker/tests/run.test.ts` cannot run on Windows because `impit` cannot load a `win32-x64` native binding. It fails during import before collecting tests. Linux CI is authoritative for that suite; this change does not touch Gradcracker-specific code.

## Overlap with #697

Draft PR #697 remains open at `fc4ca0d` and centralizes project-selection rules in `shared/src/resume-projects.ts`. It overlaps this branch’s project-selection changes and duplicates its CSV-selection normalization. Whichever PR merges second will require a rebase. If #697 lands first, this branch can adopt its shared helper.

## Tradeoffs

- uses one nullable JSON artifact column rather than introducing new tables
- uses Node's built-in `crypto`; no new dependencies
- keeps compatibility and safety logic in one boundary module instead of spreading it across callers
- intentionally expands the existing top-level tailoring scope and remains a draft for design feedback
