### PR TITLE
fix: preserve RxResume section titles during document merge

### DIFF
--- a/orchestrator/src/server/services/rxresume/document.test.ts
+++ b/orchestrator/src/server/services/rxresume/document.test.ts
@@ -1,8 +1,40 @@
 import { describe, expect, it } from "vitest";
 import {
   buildDefaultReactiveResumeDocument,
+  mergeReactiveResumeV5Content,
   prepareReactiveResumeV5DocumentForExternalUse,
 } from "./document";
+import type { SectionType, V5ResumeData } from "./schema/v5";
+
+const STANDARD_SECTION_TITLES = {
+  profiles: "Profiles",
+  experience: "Work Experience",
+  education: "Education",
+  projects: "Projects",
+  skills: "Skills",
+  languages: "Languages",
+  interests: "Interests",
+  awards: "Awards",
+  certifications: "Certifications",
+  publications: "Publications",
+  volunteer: "Volunteer Experience",
+  references: "References",
+} satisfies Record<SectionType, string>;
+
+const STANDARD_SECTION_KEYS = Object.keys(
+  STANDARD_SECTION_TITLES,
+) as SectionType[];
+
+function buildV5Document(): V5ResumeData {
+  return buildDefaultReactiveResumeDocument() as V5ResumeData;
+}
+
+function mergeV5Documents(
+  upstream: V5ResumeData,
+  local: V5ResumeData,
+): V5ResumeData {
+  return mergeReactiveResumeV5Content(upstream, local) as V5ResumeData;
+}
 
 describe("prepareReactiveResumeV5DocumentForExternalUse", () => {
   it("wraps plain rich-text fields in HTML paragraphs for Reactive Resume", () => {
@@ -141,5 +173,161 @@ describe("prepareReactiveResumeV5DocumentForExternalUse", () => {
       (document.customSections as Array<Record<string, any>>)[0].items[0]
         .content,
     ).toBe("Extra note");
+  });
+});
+
+describe("mergeReactiveResumeV5Content", () => {
+  it("restores blank local titles from the upstream Reactive Resume document", () => {
+    const upstream = buildV5Document();
+    const local = buildV5Document();
+
+    upstream.summary.title = "Professional Summary";
+    local.summary.title = "   ";
+    local.summary.content = "Locally generated summary";
+
+    STANDARD_SECTION_KEYS.forEach((key, index) => {
+      upstream.sections[key].title = STANDARD_SECTION_TITLES[key];
+
+      // Hem boş string hem yalnızca boşluktan oluşan başlıkları sınıyoruz.
+      local.sections[key].title = index % 2 === 0 ? "" : "   ";
+    });
+
+    const merged = mergeV5Documents(upstream, local);
+
+    expect(merged.summary.title).toBe("Professional Summary");
+    expect(merged.summary.content).toBe("Locally generated summary");
+
+    for (const key of STANDARD_SECTION_KEYS) {
+      expect(merged.sections[key].title).toBe(STANDARD_SECTION_TITLES[key]);
+    }
+  });
+
+  it("preserves local section data while filling only its missing title", () => {
+    const upstream = buildV5Document();
+    const local = buildV5Document();
+
+    upstream.sections.experience.title = "Work History";
+
+    local.sections.experience.title = "";
+    local.sections.experience.columns = 2;
+    local.sections.experience.hidden = true;
+    local.sections.experience.items = [
+      {
+        id: "local-experience",
+        hidden: false,
+        company: "Local Company",
+        position: "Software Engineer",
+        location: "London",
+        period: "2025 - Present",
+        website: { url: "", label: "" },
+        description: "Built important software.",
+        roles: [],
+      },
+    ];
+    const localExperience = structuredClone(local.sections.experience);
+
+    const merged = mergeV5Documents(upstream, local);
+
+    expect(merged.sections.experience).toEqual({
+      ...localExperience,
+      title: "Work History",
+    });
+  });
+
+  it("keeps non-empty local titles and does not mutate either input", () => {
+    const upstream = buildV5Document();
+    const local = buildV5Document();
+
+    upstream.summary.title = "Upstream Summary";
+    local.summary.title = "About Me";
+
+    upstream.sections.experience.title = "Upstream Experience";
+    local.sections.experience.title = "My Career";
+
+    const upstreamBefore = structuredClone(upstream);
+    const localBefore = structuredClone(local);
+
+    const merged = mergeV5Documents(upstream, local);
+
+    expect(merged.summary.title).toBe("About Me");
+    expect(merged.sections.experience.title).toBe("My Career");
+
+    merged.summary.content = "Mutated merged summary";
+    merged.sections.experience.columns = 3;
+    merged.metadata.layout.pages[0].main.push("mutated");
+    merged.customSections.push({
+      id: "merged-only",
+      type: "summary",
+      title: "Merged only",
+      columns: 1,
+      hidden: false,
+      items: [],
+    });
+
+    // Sonucun nested alanları da input'lardan bağımsız olmalı.
+    expect(upstream).toEqual(upstreamBefore);
+    expect(local).toEqual(localBefore);
+  });
+
+  it("keeps a blank local title when the upstream title is also blank", () => {
+    const upstream = buildV5Document();
+    const local = buildV5Document();
+
+    upstream.summary.title = " \t ";
+    local.summary.title = "";
+    upstream.sections.education.title = "\n";
+    local.sections.education.title = "  ";
+
+    const merged = mergeV5Documents(upstream, local);
+
+    expect(merged.summary.title).toBe("");
+    expect(merged.sections.education.title).toBe("  ");
+  });
+
+  it("preserves upstream metadata and local custom sections unchanged", () => {
+    const upstream = buildV5Document();
+    const local = buildV5Document();
+
+    upstream.metadata.template = "pikachu";
+    upstream.metadata.layout.sidebarWidth = 42;
+    upstream.metadata.layout.pages[0] = {
+      fullWidth: true,
+      main: ["summary", "experience"],
+      sidebar: ["skills"],
+    };
+    upstream.customSections = [
+      {
+        id: "custom-section",
+        type: "summary",
+        title: "Upstream Custom Title",
+        columns: 1,
+        hidden: false,
+        items: [],
+      },
+    ];
+    local.customSections = [
+      {
+        id: "custom-section",
+        type: "summary",
+        title: " ",
+        columns: 2,
+        hidden: true,
+        items: [
+          {
+            id: "custom-item",
+            hidden: false,
+            content: "Local custom content",
+          },
+        ],
+      },
+    ];
+
+    const expectedMetadata = structuredClone(upstream.metadata);
+    const expectedCustomSections = structuredClone(local.customSections);
+
+    const merged = mergeV5Documents(upstream, local);
+
+    expect(merged.metadata).toEqual(expectedMetadata);
+    expect(merged.customSections).toEqual(expectedCustomSections);
   });
 });

--- a/orchestrator/src/server/services/rxresume/document.ts
+++ b/orchestrator/src/server/services/rxresume/document.ts
@@ -51,6 +51,8 @@ const DEFAULT_SIDEBAR_SECTIONS = [
   "publications",
 ];
 
+const STANDARD_SECTION_KEYS = Object.keys(defaultV5ResumeData.sections);
+
 function asRecord(value: unknown): RecordLike | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as RecordLike)
@@ -792,21 +794,54 @@ export function prepareReactiveResumeV5DocumentForExternalUse(
   };
 }
 
+function mergeSectionWithTitleFallback(
+  upstreamSection: unknown,
+  localSection: unknown,
+): RecordLike {
+  const upstream = asRecord(upstreamSection) ?? {};
+  const local = asRecord(localSection) ?? {};
+
+  const upstreamTitle = toText(upstream.title);
+  const localTitle = toText(local.title);
+
+  const resolvedTitle =
+    localTitle.trim().length === 0 && upstreamTitle.trim().length > 0
+      ? upstreamTitle
+      : localTitle;
+
+  return {
+    ...structuredClone(local),
+    title: resolvedTitle,
+  };
+}
+
 export function mergeReactiveResumeV5Content(
   templateInput: unknown,
   contentInput: unknown,
   options: { requestOrigin?: string | null } = {},
 ): RecordLike {
   void options;
+
   const template = parseV5ResumeData(templateInput) as RecordLike;
   const content = parseV5ResumeData(contentInput) as RecordLike;
+
+  const templateSections = asRecord(template.sections) ?? {};
+  const contentSections = asRecord(content.sections) ?? {};
+  const mergedSections: RecordLike = structuredClone(contentSections);
+
+  for (const sectionKey of STANDARD_SECTION_KEYS) {
+    mergedSections[sectionKey] = mergeSectionWithTitleFallback(
+      templateSections[sectionKey],
+      contentSections[sectionKey],
+    );
+  }
 
   return {
     ...template,
     picture: structuredClone(content.picture),
     basics: structuredClone(content.basics),
-    summary: structuredClone(content.summary),
-    sections: structuredClone(content.sections),
+    summary: mergeSectionWithTitleFallback(template.summary, content.summary),
+    sections: mergedSections,
     customSections: structuredClone(content.customSections),
   };
 }


### PR DESCRIPTION
## Summary

Fixes missing standard section headings in Reactive Resume v5 exports.

When JobOps merged the upstream Reactive Resume document with the local Resume Studio document, blank or whitespace-only local section titles replaced valid upstream titles. This caused headings such as Summary, Experience, Education, Skills, and Languages to disappear in RxResume exports.

This change:

- restores blank local summary and standard-section titles from their upstream counterparts
- preserves non-empty local titles
- keeps local content, items, columns, visibility settings, and other non-title data authoritative
- leaves custom-section behavior unchanged
- avoids mutating either input document
- derives standard-section keys from the canonical v5 defaults

## Testing

- Added regression tests for blank and whitespace-only titles
- Verified that non-empty local titles remain authoritative
- Verified that local section data, metadata/layout, and custom sections are preserved
- Verified that nested references are independent
- Ran the full CI-parity checks under Node 22:
  - Biome passed
  - All workspace type checks passed
  - Client build passed
  - Full test suite passed: 1921 tests, 3 skipped

Fixes #688