### PR TITLE
Preserve manually entered job URLs during inference

### DIFF
--- a/docs-site/docs/extractors/manual.md
+++ b/docs-site/docs/extractors/manual.md
@@ -21,6 +21,8 @@ Manual import accepts:
 
 When a URL is provided, backend fetch attempts depend on whether the page can be resolved with `curl`. Some job sites block or heavily script content, so certain links will not resolve cleanly.
 
+If you enter a URL and paste the description manually, the URL you entered is preserved through AI inference and takes precedence over any inferred URL.
+
 ## 2) AI inference
 
 Endpoint:

--- a/orchestrator/src/client/components/ManualImportFlow.tsx
+++ b/orchestrator/src/client/components/ManualImportFlow.tsx
@@ -455,9 +455,8 @@ export const ManualImportFlow: React.FC<ManualImportFlowProps> = ({
         jobDescription: rawDescription,
       });
       const normalized = normalizeDraft(response.job, rawDescription.trim());
-      if (fetchedSourceUrl && !normalized.jobUrl) {
-        normalized.jobUrl = fetchedSourceUrl;
-      }
+      normalized.jobUrl =
+        fetchedSourceUrl || fetchUrl.trim() || normalized.jobUrl;
       setDraft(normalized);
       setWarning(response.warning ?? null);
       setImportSource(fetchedSourceUrl ? "fetched_url" : "pasted_description");

--- a/orchestrator/src/client/components/ManualImportSheet.test.tsx
+++ b/orchestrator/src/client/components/ManualImportSheet.test.tsx
@@ -419,6 +419,50 @@ describe("ManualImportSheet", () => {
       expect(urlInputs[0]).toHaveValue("https://example.com/job");
     });
 
+    it("preserves a manually entered URL when analyzing pasted text", async () => {
+      vi.mocked(api.inferManualJob).mockResolvedValue({
+        job: {
+          title: "Engineer",
+          employer: "Company",
+          jobUrl: "https://inferred.example.com/job",
+        },
+      });
+      vi.mocked(api.importManualJob).mockResolvedValue({ id: "job-2" } as any);
+
+      render(
+        <ManualImportSheet open onOpenChange={vi.fn()} onImported={vi.fn()} />,
+      );
+
+      fireEvent.change(
+        screen.getByPlaceholderText("https://example.com/job-posting"),
+        { target: { value: "https://www.linkedin.com/jobs/view/123" } },
+      );
+      fireEvent.change(
+        screen.getByPlaceholderText(
+          "Paste the full job description here, or fetch it from a URL above...",
+        ),
+        { target: { value: "Software Engineer role at Acme Corp" } },
+      );
+      fireEvent.click(screen.getByRole("button", { name: /analyze jd/i }));
+
+      await screen.findByPlaceholderText("e.g. Junior Backend Engineer");
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: /^(import & tailor|import without tailoring)$/i,
+        }),
+      );
+
+      await waitFor(() =>
+        expect(api.importManualJob).toHaveBeenCalledWith(
+          expect.objectContaining({
+            job: expect.objectContaining({
+              jobUrl: "https://www.linkedin.com/jobs/view/123",
+            }),
+          }),
+        ),
+      );
+    });
+
     it("reports fetched URL provenance when import completes", async () => {
       const onImported = vi.fn().mockResolvedValue(undefined);
 


### PR DESCRIPTION
## Summary

- preserve a manually entered job URL when the description is pasted instead of fetched
- give the explicit user-entered URL precedence over an inferred URL
- document the behavior and add regression coverage through import persistence

## Root cause

Manual import rebuilt the review draft from the inference response and only restored URLs captured by the auto-fetch path. A URL typed alongside a pasted description remained in component state but was not copied into the rebuilt draft.

## Impact

Users can paste descriptions from sites such as LinkedIn without re-entering the job URL during review or after import.

Closes #705

## Validation

- `./orchestrator/node_modules/.bin/biome ci .`
- shared, orchestrator, Gradcracker, and UKVisaJobs type checks
- orchestrator client production build
- docs production build
- focused ManualImportSheet tests: 14 passed
- full orchestrator suite: 1,922 passed, 3 skipped
