### PR TITLE
Prevent hung extractors from blocking discovery

### DIFF
--- a/docs-site/docs/features/pipeline-run.md
+++ b/docs-site/docs/features/pipeline-run.md
@@ -153,6 +153,8 @@ through the active search term, location, and job board one value at a time.
   in-run title/employer deduplication.
 - A browser-check row pauses only the affected extractor. Use **Solve** to open
   the challenge viewer; other extractors continue running.
+- An extractor that does not finish within 10 minutes is marked as failed. The
+  remaining extractors continue instead of leaving the run stuck indefinitely.
 
 After discovery, the scoring card shows the job currently being ranked and
 updates its counters live. **Exceptional matches** counts jobs with a

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.test.ts
@@ -121,6 +121,76 @@ describe("discoverJobsStep", () => {
     );
   });
 
+  it("times out a hung extractor and continues with other sources", async () => {
+    vi.useFakeTimers();
+    try {
+      const settingsRepo = await import("@server/repositories/settings");
+      const registryModule = await import("@server/extractors/registry");
+      let hungContext: ExtractorRuntimeContext | undefined;
+      const hungManifest = {
+        id: "startupjobs",
+        displayName: "startup.jobs",
+        providesSources: ["startupjobs"],
+        run: vi.fn((context: ExtractorRuntimeContext) => {
+          hungContext = context;
+          return new Promise<never>(() => {});
+        }),
+      };
+      const healthyManifest = {
+        id: "jobspy",
+        displayName: "JobSpy",
+        providesSources: ["linkedin"],
+        run: vi.fn().mockResolvedValue({
+          success: true,
+          jobs: [
+            {
+              source: "linkedin",
+              title: "Engineer",
+              employer: "ACME",
+              jobUrl: "https://example.com/job",
+              location: "London, United Kingdom",
+            },
+          ],
+        }),
+      };
+
+      vi.mocked(settingsRepo.getAllSettings).mockResolvedValue({
+        searchTerms: JSON.stringify(["engineer"]),
+        jobspyCountryIndeed: "united kingdom",
+      } as any);
+      vi.mocked(registryModule.getExtractorRegistry).mockResolvedValue({
+        manifests: new Map([
+          ["startupjobs", hungManifest as any],
+          ["jobspy", healthyManifest as any],
+        ]),
+        manifestBySource: new Map([
+          ["startupjobs", hungManifest as any],
+          ["linkedin", healthyManifest as any],
+        ]),
+        availableSources: ["startupjobs", "linkedin"],
+      } as any);
+
+      const resultPromise = discoverJobsStep({
+        mergedConfig: {
+          ...baseConfig,
+          sources: ["startupjobs", "linkedin"],
+        },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(hungContext?.shouldCancel?.()).toBe(false);
+      await vi.runOnlyPendingTimersAsync();
+
+      await expect(resultPromise).resolves.toMatchObject({
+        discoveredJobs: [expect.objectContaining({ title: "Engineer" })],
+        sourceErrors: ["startupjobs: timed out after 10 minutes"],
+      });
+      expect(hungContext?.shouldCancel?.()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("overrides persisted extractor limits with the normalized run budget", async () => {
     const settingsRepo = await import("@server/repositories/settings");
     const registryModule = await import("@server/extractors/registry");

--- a/orchestrator/src/server/pipeline/steps/discover-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/discover-jobs.ts
@@ -35,6 +35,7 @@ import {
 import { discoverWatchlistJobsForPipeline } from "./watchlist-jobs";
 
 const DISCOVERY_CONCURRENCY = 3;
+const DISCOVERY_SOURCE_TIMEOUT_MS = 10 * 60 * 1000;
 
 type DiscoveryTaskResult = {
   discoveredJobs: CreateJobInput[];
@@ -49,6 +50,25 @@ type DiscoverySourceTask = {
   detail: string;
   run: () => Promise<DiscoveryTaskResult>;
 };
+
+async function withDiscoverySourceTimeout<T>(
+  run: Promise<T>,
+  onTimeout: () => void,
+): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeout = setTimeout(() => {
+      onTimeout();
+      reject(new Error("timed out after 10 minutes"));
+    }, DISCOVERY_SOURCE_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([run, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 function parseBlockedCompanyKeywords(raw: string | undefined): string[] {
   if (!raw) return [];
@@ -298,7 +318,9 @@ export async function discoverJobsStep(args: {
           ),
         ) as Record<string, string | undefined>;
 
-        const result = await manifest.run({
+        let timedOut = false;
+        const shouldCancel = () => timedOut || args.shouldCancel?.() === true;
+        const run = manifest.run({
           source: grouped.sources[0],
           selectedSources: grouped.sources,
           settings: filteredSettings,
@@ -313,8 +335,9 @@ export async function discoverJobsStep(args: {
             ],
           ),
           getExistingJobUrls,
-          shouldCancel: args.shouldCancel,
+          shouldCancel,
           onProgress: (event) => {
+            if (shouldCancel()) return;
             const role =
               searchTerms.find((term) => event.currentUrl === term) ??
               searchTerms.find((term) =>
@@ -349,6 +372,9 @@ export async function discoverJobsStep(args: {
               });
             }
           },
+        });
+        const result = await withDiscoverySourceTimeout(run, () => {
+          timedOut = true;
         });
 
         if (!result.success) {


### PR DESCRIPTION
## Summary
- Time out extractors that run longer than 10 minutes.
- Mark timed-out sources as failed while allowing other extractors to continue.
- Document the timeout behavior for pipeline discovery.

## Testing
- Added a unit test covering a hung extractor alongside a healthy source.