### PR TITLE
feat: add score filter in orchestrator page

### DIFF
--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
@@ -65,6 +65,12 @@ const renderFilters = (
       max: null,
     },
     onSalaryFilterChange: vi.fn(),
+    scoreFilter: {
+      mode: "any" as const,
+      min: null,
+      max: null,
+    },
+    onScoreFilterChange: vi.fn(),
     postedWithinDays: null,
     onPostedWithinChange: vi.fn(),
     employmentTypes: [],

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.tsx
@@ -8,6 +8,7 @@ import { OrchestratorFilterBar } from "./filters/OrchestratorFilterBar";
 import { OrchestratorTabRow } from "./filters/OrchestratorTabRow";
 import { PostedWithinFilterPill } from "./filters/PostedWithinFilterPill";
 import { SalaryFilterPill } from "./filters/SalaryFilterPill";
+import { ScoreFilterPill } from "./filters/ScoreFilterPill";
 import { SortFilterPill } from "./filters/SortFilterPill";
 import { SourceFilterPill } from "./filters/SourceFilterPill";
 import { SponsorFilterPill } from "./filters/SponsorFilterPill";
@@ -27,6 +28,8 @@ export const OrchestratorFilters: React.FC<OrchestratorFiltersProps> = ({
   onSponsorFilterChange,
   salaryFilter,
   onSalaryFilterChange,
+  scoreFilter,
+  onScoreFilterChange,
   postedWithinDays,
   onPostedWithinChange,
   employmentTypes,
@@ -52,6 +55,8 @@ export const OrchestratorFilters: React.FC<OrchestratorFiltersProps> = ({
     sortDirectionLabel,
     salaryActive,
     salarySummary,
+    scoreActive,
+    scoreSummary,
   } = useFilterBarDerivedState({
     sourceFilter,
     sponsorFilter,
@@ -60,6 +65,7 @@ export const OrchestratorFilters: React.FC<OrchestratorFiltersProps> = ({
     employmentTypes,
     locationFilter,
     salaryFilter,
+    scoreFilter,
     sort,
     isFiltersOpen: isFiltersOpenProp,
     onFiltersOpenChange: onFiltersOpenChangeProp,
@@ -120,6 +126,13 @@ export const OrchestratorFilters: React.FC<OrchestratorFiltersProps> = ({
               onSalaryFilterChange={onSalaryFilterChange}
               salaryActive={salaryActive}
               salarySummary={salarySummary}
+            />
+
+            <ScoreFilterPill
+              scoreFilter={scoreFilter}
+              onScoreFilterChange={onScoreFilterChange}
+              scoreActive={scoreActive}
+              scoreSummary={scoreSummary}
             />
 
             <span className="mx-1 h-6 w-px bg-border" aria-hidden="true" />

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorJobWorkspaceContainer.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorJobWorkspaceContainer.tsx
@@ -62,6 +62,7 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
     sourceFilter: filters.sourceFilter,
     sponsorFilter: filters.sponsorFilter,
     salaryFilter: filters.salaryFilter,
+    scoreFilter: filters.scoreFilter,
     postedWithinDays: filters.postedWithinDays,
     employmentTypes: filters.employmentTypes,
     location: filters.location,
@@ -239,6 +240,7 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
           sourceFilter={filters.sourceFilter}
           sponsorFilter={filters.sponsorFilter}
           salaryFilter={filters.salaryFilter}
+          scoreFilter={filters.scoreFilter}
           postedWithinDays={filters.postedWithinDays}
           employmentTypes={filters.employmentTypes}
           locationFilter={filters.location}
@@ -258,6 +260,7 @@ export const OrchestratorJobWorkspaceContainer: React.FC<
           onSourceFilterChange={filters.setSourceFilter}
           onSponsorFilterChange={filters.setSponsorFilter}
           onSalaryFilterChange={filters.setSalaryFilter}
+          onScoreFilterChange={filters.setScoreFilter}
           onPostedWithinChange={filters.setPostedWithinDays}
           onEmploymentTypesChange={filters.setEmploymentTypes}
           onLocationFilterChange={filters.setLocation}

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorJobsWorkspace.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorJobsWorkspace.tsx
@@ -7,6 +7,7 @@ import type {
   JobDateFilter,
   JobSort,
   SalaryFilter,
+  ScoreFilter,
   SponsorFilter,
 } from "./constants";
 import { JobCommandBar } from "./JobCommandBar";
@@ -40,6 +41,7 @@ interface OrchestratorJobsWorkspaceProps {
   sourceFilter: JobSource | "all";
   sponsorFilter: SponsorFilter;
   salaryFilter: SalaryFilter;
+  scoreFilter: ScoreFilter;
   postedWithinDays: number | null;
   employmentTypes: EmploymentType[];
   locationFilter: string;
@@ -59,6 +61,7 @@ interface OrchestratorJobsWorkspaceProps {
   onSourceFilterChange: (value: JobSource | "all") => void;
   onSponsorFilterChange: (value: SponsorFilter) => void;
   onSalaryFilterChange: (value: SalaryFilter) => void;
+  onScoreFilterChange: (value: ScoreFilter) => void;
   onPostedWithinChange: (value: number | null) => void;
   onEmploymentTypesChange: (value: EmploymentType[]) => void;
   onLocationFilterChange: (value: string) => void;
@@ -95,6 +98,7 @@ export const OrchestratorJobsWorkspace: React.FC<
   sourceFilter,
   sponsorFilter,
   salaryFilter,
+  scoreFilter,
   postedWithinDays,
   employmentTypes,
   locationFilter,
@@ -114,6 +118,7 @@ export const OrchestratorJobsWorkspace: React.FC<
   onSourceFilterChange,
   onSponsorFilterChange,
   onSalaryFilterChange,
+  onScoreFilterChange,
   onPostedWithinChange,
   onEmploymentTypesChange,
   onLocationFilterChange,
@@ -152,6 +157,8 @@ export const OrchestratorJobsWorkspace: React.FC<
         onSponsorFilterChange={onSponsorFilterChange}
         salaryFilter={salaryFilter}
         onSalaryFilterChange={onSalaryFilterChange}
+        scoreFilter={scoreFilter}
+        onScoreFilterChange={onScoreFilterChange}
         postedWithinDays={postedWithinDays}
         onPostedWithinChange={onPostedWithinChange}
         employmentTypes={employmentTypes}

--- a/orchestrator/src/client/pages/orchestrator/constants.ts
+++ b/orchestrator/src/client/pages/orchestrator/constants.ts
@@ -106,6 +106,14 @@ export interface SalaryFilter {
   max: number | null;
 }
 
+export type ScoreFilterMode = "any" | "has" | "missing";
+
+export interface ScoreFilter {
+  mode: ScoreFilterMode;
+  min: number | null;
+  max: number | null;
+}
+
 export type EmploymentType =
   | "full_time"
   | "part_time"
@@ -164,6 +172,7 @@ export interface JobFilters {
   sourceFilter: JobSource | "all";
   sponsorFilter: SponsorFilter;
   salaryFilter: SalaryFilter;
+  scoreFilter: ScoreFilter;
   postedWithinDays: number | null;
   employmentTypes: EmploymentType[];
   location: string;

--- a/orchestrator/src/client/pages/orchestrator/filters/ScoreFilterPill.tsx
+++ b/orchestrator/src/client/pages/orchestrator/filters/ScoreFilterPill.tsx
@@ -1,0 +1,107 @@
+import { Star } from "lucide-react";
+import type React from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { ScoreFilterMode } from "../constants";
+import { FilterPill } from "./FilterPill";
+import { scoreModeOptions } from "./filterOptions";
+import type { ScoreFilterPillProps } from "./types";
+
+const clampScore = (value: number): number => Math.min(100, Math.max(0, value));
+
+export const ScoreFilterPill: React.FC<ScoreFilterPillProps> = ({
+  scoreFilter,
+  onScoreFilterChange,
+  scoreActive,
+  scoreSummary,
+}) => (
+  <FilterPill
+    icon={<Star />}
+    label="Score"
+    active={scoreActive}
+    summary={scoreSummary}
+  >
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+        <span>Score</span>
+        <Select
+          value={scoreFilter.mode}
+          onValueChange={(value) => {
+            const nextMode = value as ScoreFilterMode;
+            onScoreFilterChange({
+              mode: nextMode,
+              min: nextMode === "has" ? scoreFilter.min : null,
+              max: nextMode === "has" ? scoreFilter.max : null,
+            });
+          }}
+        >
+          <SelectTrigger
+            id="score-mode"
+            aria-label="Score filter mode"
+            className="h-8 w-[150px] text-foreground"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {scoreModeOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {scoreFilter.mode === "has" && (
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="space-y-1">
+            <Label htmlFor="score-min-filter">Minimum</Label>
+            <Input
+              id="score-min-filter"
+              value={scoreFilter.min == null ? "" : String(scoreFilter.min)}
+              onChange={(event) => {
+                const raw = event.target.value.trim();
+                const parsed = Number.parseInt(raw, 10);
+                onScoreFilterChange({
+                  ...scoreFilter,
+                  min: Number.isFinite(parsed) ? clampScore(parsed) : null,
+                });
+              }}
+              inputMode="numeric"
+              min={0}
+              max={100}
+              placeholder="e.g. 60"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="score-max-filter">Maximum</Label>
+            <Input
+              id="score-max-filter"
+              value={scoreFilter.max == null ? "" : String(scoreFilter.max)}
+              onChange={(event) => {
+                const raw = event.target.value.trim();
+                const parsed = Number.parseInt(raw, 10);
+                onScoreFilterChange({
+                  ...scoreFilter,
+                  max: Number.isFinite(parsed) ? clampScore(parsed) : null,
+                });
+              }}
+              inputMode="numeric"
+              min={0}
+              max={100}
+              placeholder="e.g. 90"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  </FilterPill>
+);

--- a/orchestrator/src/client/pages/orchestrator/filters/filterOptions.ts
+++ b/orchestrator/src/client/pages/orchestrator/filters/filterOptions.ts
@@ -3,6 +3,7 @@ import type {
   FilterTab,
   JobSort,
   SalaryFilterMode,
+  ScoreFilterMode,
   SponsorFilter,
 } from "../constants";
 
@@ -24,6 +25,15 @@ export const salaryModeOptions: Array<{
   { value: "at_least", label: "at least" },
   { value: "at_most", label: "at most" },
   { value: "between", label: "between" },
+];
+
+export const scoreModeOptions: Array<{
+  value: ScoreFilterMode;
+  label: string;
+}> = [
+  { value: "any", label: "Any" },
+  { value: "has", label: "Has a score" },
+  { value: "missing", label: "No score" },
 ];
 
 export const sortFieldOrder: JobSort["key"][] = [

--- a/orchestrator/src/client/pages/orchestrator/filters/filterUtils.ts
+++ b/orchestrator/src/client/pages/orchestrator/filters/filterUtils.ts
@@ -4,6 +4,7 @@ import type {
   JobDateFilter,
   JobSort,
   SalaryFilter,
+  ScoreFilter,
 } from "../constants";
 import { dateFilterDimensionOrder } from "../constants";
 
@@ -93,4 +94,19 @@ export const formatSalarySummary = (
     return `≥ ${formatMoney(salaryFilter.min)}`;
   }
   return null;
+};
+
+export const isScoreFilterActive = (scoreFilter: ScoreFilter) =>
+  scoreFilter.mode !== "any";
+
+export const formatScoreSummary = (scoreFilter: ScoreFilter): string | null => {
+  if (scoreFilter.mode === "missing") return "No score";
+  if (scoreFilter.mode !== "has") return null;
+
+  if (scoreFilter.min != null && scoreFilter.max != null) {
+    return `${scoreFilter.min}–${scoreFilter.max}`;
+  }
+  if (scoreFilter.min != null) return `≥ ${scoreFilter.min}`;
+  if (scoreFilter.max != null) return `≤ ${scoreFilter.max}`;
+  return "Has a score";
 };

--- a/orchestrator/src/client/pages/orchestrator/filters/types.ts
+++ b/orchestrator/src/client/pages/orchestrator/filters/types.ts
@@ -6,6 +6,7 @@ import type {
   JobDateFilter,
   JobSort,
   SalaryFilter,
+  ScoreFilter,
   SponsorFilter,
 } from "../constants";
 
@@ -20,6 +21,8 @@ export interface OrchestratorFiltersProps {
   onSponsorFilterChange: (value: SponsorFilter) => void;
   salaryFilter: SalaryFilter;
   onSalaryFilterChange: (value: SalaryFilter) => void;
+  scoreFilter: ScoreFilter;
+  onScoreFilterChange: (value: ScoreFilter) => void;
   postedWithinDays: number | null;
   onPostedWithinChange: (value: number | null) => void;
   employmentTypes: EmploymentType[];
@@ -77,6 +80,14 @@ export type SalaryFilterPillProps = Pick<
 > & {
   salaryActive: boolean;
   salarySummary: string | null;
+};
+
+export type ScoreFilterPillProps = Pick<
+  OrchestratorFiltersProps,
+  "scoreFilter" | "onScoreFilterChange"
+> & {
+  scoreActive: boolean;
+  scoreSummary: string | null;
 };
 
 export type SortFilterPillProps = Pick<

--- a/orchestrator/src/client/pages/orchestrator/filters/useFilterBarDerivedState.ts
+++ b/orchestrator/src/client/pages/orchestrator/filters/useFilterBarDerivedState.ts
@@ -5,14 +5,17 @@ import type {
   JobDateFilter,
   JobSort,
   SalaryFilter,
+  ScoreFilter,
   SponsorFilter,
 } from "../constants";
 import { postedWithinOptions } from "../constants";
 import { sponsorOptions } from "./filterOptions";
 import {
   formatSalarySummary,
+  formatScoreSummary,
   getDirectionOptions,
   isSalaryFilterActive,
+  isScoreFilterActive,
 } from "./filterUtils";
 
 interface UseFilterBarDerivedStateArgs {
@@ -23,6 +26,7 @@ interface UseFilterBarDerivedStateArgs {
   employmentTypes: EmploymentType[];
   locationFilter: string;
   salaryFilter: SalaryFilter;
+  scoreFilter: ScoreFilter;
   sort: JobSort;
   isFiltersOpen?: boolean;
   onFiltersOpenChange?: (open: boolean) => void;
@@ -36,6 +40,7 @@ export const useFilterBarDerivedState = ({
   employmentTypes,
   locationFilter,
   salaryFilter,
+  scoreFilter,
   sort,
   isFiltersOpen: isFiltersOpenProp,
   onFiltersOpenChange: onFiltersOpenChangeProp,
@@ -45,6 +50,7 @@ export const useFilterBarDerivedState = ({
   const onFiltersOpenChange = onFiltersOpenChangeProp ?? setInternalFiltersOpen;
 
   const salaryActive = isSalaryFilterActive(salaryFilter);
+  const scoreActive = isScoreFilterActive(scoreFilter);
 
   const activeFilterCount = useMemo(
     () =>
@@ -54,7 +60,8 @@ export const useFilterBarDerivedState = ({
       Number(postedWithinDays != null) +
       Number(employmentTypes.length > 0) +
       Number(locationFilter.trim() !== "") +
-      Number(salaryActive),
+      Number(salaryActive) +
+      Number(scoreActive),
     [
       sourceFilter,
       sponsorFilter,
@@ -63,6 +70,7 @@ export const useFilterBarDerivedState = ({
       employmentTypes.length,
       locationFilter,
       salaryActive,
+      scoreActive,
     ],
   );
 
@@ -81,15 +89,18 @@ export const useFilterBarDerivedState = ({
   )?.label;
 
   const salarySummary = formatSalarySummary(salaryFilter);
+  const scoreSummary = formatScoreSummary(scoreFilter);
 
   return {
     isFiltersOpen,
     onFiltersOpenChange,
     salaryActive,
+    scoreActive,
     activeFilterCount,
     postedWithinLabel,
     sponsorLabel,
     sortDirectionLabel,
     salarySummary,
+    scoreSummary,
   };
 };

--- a/orchestrator/src/client/pages/orchestrator/useFilteredJobs.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/useFilteredJobs.test.ts
@@ -28,6 +28,7 @@ const baseFilters: JobFilters = {
   sourceFilter: "all",
   sponsorFilter: "all",
   salaryFilter: { mode: "at_least", min: null, max: null },
+  scoreFilter: { mode: "any", min: null, max: null },
   postedWithinDays: null,
   employmentTypes: [],
   location: "",

--- a/orchestrator/src/client/pages/orchestrator/useFilteredJobs.ts
+++ b/orchestrator/src/client/pages/orchestrator/useFilteredJobs.ts
@@ -29,6 +29,7 @@ export const useFilteredJobs = (jobs: JobListItem[], filters: JobFilters) => {
     sourceFilter,
     sponsorFilter,
     salaryFilter,
+    scoreFilter,
     postedWithinDays,
     employmentTypes,
     location,
@@ -128,6 +129,21 @@ export const useFilteredJobs = (jobs: JobListItem[], filters: JobFilters) => {
       });
     }
 
+    if (scoreFilter.mode === "missing") {
+      filtered = filtered.filter((job) => job.suitabilityScore == null);
+    } else if (scoreFilter.mode === "has") {
+      filtered = filtered.filter((job) => {
+        if (job.suitabilityScore == null) return false;
+        if (scoreFilter.min != null && job.suitabilityScore < scoreFilter.min) {
+          return false;
+        }
+        if (scoreFilter.max != null && job.suitabilityScore > scoreFilter.max) {
+          return false;
+        }
+        return true;
+      });
+    }
+
     return [...filtered].sort((a, b) => compareJobs(a, b, sort));
   }, [
     jobs,
@@ -136,6 +152,7 @@ export const useFilteredJobs = (jobs: JobListItem[], filters: JobFilters) => {
     sourceFilter,
     sponsorFilter,
     salaryFilter,
+    scoreFilter,
     postedWithinDays,
     employmentTypes,
     location,

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorFilters.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorFilters.ts
@@ -9,6 +9,8 @@ import type {
   JobSort,
   SalaryFilter,
   SalaryFilterMode,
+  ScoreFilter,
+  ScoreFilterMode,
   SponsorFilter,
 } from "./constants";
 import {
@@ -30,6 +32,9 @@ const allowedSalaryModes: SalaryFilterMode[] = [
   "at_most",
   "between",
 ];
+const allowedScoreModes: ScoreFilterMode[] = ["any", "has", "missing"];
+const clampScoreValue = (value: number): number =>
+  Math.min(100, Math.max(0, value));
 const allowedSortKeys: JobSort["key"][] = [
   "datePosted",
   "discoveredAt",
@@ -161,6 +166,44 @@ export const useOrchestratorFilters = () => {
           else prev.set("salaryMax", String(value.max));
 
           prev.delete("minSalary");
+          return prev;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const scoreFilter = useMemo((): ScoreFilter => {
+    const modeRaw = searchParams.get("scoreMode") ?? "any";
+    const mode = allowedScoreModes.includes(modeRaw as ScoreFilterMode)
+      ? (modeRaw as ScoreFilterMode)
+      : "any";
+
+    const minRaw = searchParams.get("scoreMin");
+    const minParsed = minRaw == null ? Number.NaN : Number.parseInt(minRaw, 10);
+    const min = Number.isFinite(minParsed) ? clampScoreValue(minParsed) : null;
+
+    const maxRaw = searchParams.get("scoreMax");
+    const maxParsed = maxRaw == null ? Number.NaN : Number.parseInt(maxRaw, 10);
+    const max = Number.isFinite(maxParsed) ? clampScoreValue(maxParsed) : null;
+
+    return { mode, min, max };
+  }, [searchParams]);
+
+  const setScoreFilter = useCallback(
+    (value: ScoreFilter) => {
+      setSearchParams(
+        (prev) => {
+          if (value.mode === "any") prev.delete("scoreMode");
+          else prev.set("scoreMode", value.mode);
+
+          if (value.min == null) prev.delete("scoreMin");
+          else prev.set("scoreMin", String(clampScoreValue(value.min)));
+
+          if (value.max == null) prev.delete("scoreMax");
+          else prev.set("scoreMax", String(clampScoreValue(value.max)));
+
           return prev;
         },
         { replace: true },
@@ -324,6 +367,9 @@ export const useOrchestratorFilters = () => {
         prev.delete("salaryMin");
         prev.delete("salaryMax");
         prev.delete("minSalary");
+        prev.delete("scoreMode");
+        prev.delete("scoreMin");
+        prev.delete("scoreMax");
         prev.delete("postedWithin");
         prev.delete("employment");
         prev.delete("location");
@@ -346,6 +392,8 @@ export const useOrchestratorFilters = () => {
     setSponsorFilter,
     salaryFilter,
     setSalaryFilter,
+    scoreFilter,
+    setScoreFilter,
     postedWithinDays,
     setPostedWithinDays,
     employmentTypes,


### PR DESCRIPTION
It's useful in various scenario to be able to filter on jobs by their match scores.
- When a pipeline fails for any reason and you want to recalculate score manually for jobs without scores
- When you only want to see jobs above a certain threshold (say, 90)
- When you want to manually delete jobs under a certain threshold (say, 70)