### PR TITLE
fix: don't fail a pipeline on the second scoring attempt

### DIFF
--- a/orchestrator/src/server/pipeline/llm-configuration.test.ts
+++ b/orchestrator/src/server/pipeline/llm-configuration.test.ts
@@ -1,0 +1,108 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../repositories/pipeline", () => ({
+  createPipelineRun: vi.fn(async () => ({
+    id: "run-llm-config-1",
+    startedAt: new Date().toISOString(),
+    completedAt: null,
+    status: "running",
+    jobsDiscovered: 0,
+    jobsProcessed: 0,
+    errorMessage: null,
+  })),
+  updatePipelineRun: vi.fn(async () => undefined),
+}));
+
+const scoreJobsStep = vi.fn();
+
+vi.mock("./steps", () => ({
+  loadProfileStep: vi.fn(async () => ({})),
+  discoverJobsStep: vi.fn(async () => ({
+    discoveredJobs: [],
+    sourceErrors: [],
+    pendingChallenges: [],
+  })),
+  importJobsStep: vi.fn(async () => ({
+    created: 0,
+    skipped: 0,
+    fuzzyMerged: 0,
+  })),
+  scoreJobsStep,
+  selectJobsStep: vi.fn(() => []),
+  processJobsStep: vi.fn(async () => ({ processedCount: 0 })),
+  notifyPipelineWebhookStep: vi.fn(async () => undefined),
+}));
+
+describe.sequential("pipeline LLM configuration handling", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    tempDir = await mkdtemp(join(tmpdir(), "job-ops-pipeline-llm-config-"));
+    process.env.DATA_DIR = tempDir;
+    process.env.NODE_ENV = "test";
+
+    await import("../db/migrate");
+  });
+
+  afterEach(async () => {
+    const { closeDb } = await import("../db/index");
+    closeDb();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("re-enters configuration_required on every repeated scoring failure instead of failing", async () => {
+    const { LlmNotConfiguredError } = await import("../services/scorer");
+
+    scoreJobsStep
+      .mockRejectedValueOnce(
+        new LlmNotConfiguredError("LLM API key not configured"),
+      )
+      .mockRejectedValueOnce(
+        new LlmNotConfiguredError("LLM API key not configured"),
+      )
+      .mockResolvedValueOnce({ unprocessedJobs: [], scoredJobs: [] });
+
+    const pipeline = await import("./orchestrator");
+    const pipelineRepo = await import("../repositories/pipeline");
+    const { getProgress } = await import("./progress");
+
+    const runPromise = pipeline.runPipeline({});
+
+    // First failure: pipeline should pause for configuration, not fail.
+    await vi.waitFor(() => {
+      expect(getProgress().step).toBe("configuration_required");
+    });
+    expect(scoreJobsStep).toHaveBeenCalledTimes(1);
+    expect(pipeline.resumePipelineScoring()).toEqual({ resolved: true });
+
+    // Second failure: must ALSO pause for configuration again, not blow past
+    // the catch and mark the pipeline failed.
+    await vi.waitFor(() => {
+      expect(scoreJobsStep).toHaveBeenCalledTimes(2);
+    });
+    await vi.waitFor(() => {
+      expect(getProgress().step).toBe("configuration_required");
+    });
+    expect(pipeline.resumePipelineScoring()).toEqual({ resolved: true });
+
+    const result = await runPromise;
+
+    expect(scoreJobsStep).toHaveBeenCalledTimes(3);
+    expect(result).toEqual(
+      expect.objectContaining({ success: true, jobsProcessed: 0 }),
+    );
+    expect(vi.mocked(pipelineRepo.updatePipelineRun)).not.toHaveBeenCalledWith(
+      "run-llm-config-1",
+      expect.objectContaining({ status: "failed" }),
+    );
+    expect(vi.mocked(pipelineRepo.updatePipelineRun)).toHaveBeenCalledWith(
+      "run-llm-config-1",
+      expect.objectContaining({ status: "completed" }),
+    );
+  });
+});

--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -451,16 +451,21 @@ export async function runPipeline(
 
       ensureNotCancelled(scopeKey);
       await persistResultSummary({ stage: "scoring" });
-      try {
-        ({ unprocessedJobs, scoredJobs } = await scoreJobsStep({
-          profile,
-          scoringInstructions: mergedConfig.scoringInstructions,
-          visaSponsorCountryKey: mergedConfig.locationIntent?.selectedCountry,
-          shouldCancel: () =>
-            getPipelineState(scopeKey).cancelRequestedAt !== null,
-        }));
-      } catch (error) {
-        if (error instanceof LlmNotConfiguredError) {
+      while (true) {
+        try {
+          ({ unprocessedJobs, scoredJobs } = await scoreJobsStep({
+            profile,
+            scoringInstructions: mergedConfig.scoringInstructions,
+            visaSponsorCountryKey: mergedConfig.locationIntent?.selectedCountry,
+            shouldCancel: () =>
+              getPipelineState(scopeKey).cancelRequestedAt !== null,
+          }));
+          break;
+        } catch (error) {
+          if (!(error instanceof LlmNotConfiguredError)) {
+            throw error;
+          }
+
           const message = error.message;
           progressHelpers.configurationRequired(message);
           pipelineLogger.warn("Pipeline paused — LLM not configured", error);
@@ -473,16 +478,6 @@ export async function runPipeline(
           ensureNotCancelled(scopeKey);
 
           pipelineLogger.info("LLM configured, resuming scoring");
-
-          ({ unprocessedJobs, scoredJobs } = await scoreJobsStep({
-            profile,
-            scoringInstructions: mergedConfig.scoringInstructions,
-            visaSponsorCountryKey: mergedConfig.locationIntent?.selectedCountry,
-            shouldCancel: () =>
-              getPipelineState(scopeKey).cancelRequestedAt !== null,
-          }));
-        } else {
-          throw error;
         }
       }
       await persistResultSummary({


### PR DESCRIPTION
Sometimes the scoring pipeline fails, and you have to use the "Restart scoring" button to get it going again. The problem is that this button is shown only once; if you press it and the pipeline fails yet again, it won't be shown at all, because the pipeline goes in the "failed" state instead of "configuration_required".