### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ Open-source tools and communities that make JobOps possible:
 
 <div align="center">
 
-<a href="https://www.star-history.com/#DaKheera47/job-ops&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#DaKheera47/job-ops&type=date&legend=top-left">
 <picture>
-<source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=DaKheera47/job-ops&type=date&theme=dark&legend=top-left" />
-<source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=DaKheera47/job-ops&type=date&legend=top-left" />
-<img alt="Star History Chart" src="https://api.star-history.com/svg?repos=DaKheera47/job-ops&type=date&legend=top-left" />
+<source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=DaKheera47/job-ops&type=date&theme=dark&legend=top-left" />
+<source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=DaKheera47/job-ops&type=date&legend=top-left" />
+<img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=DaKheera47/job-ops&type=date&legend=top-left" />
 </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken and no longer renders because of GitHub stargazer API restrictions. This change updates the chart to a maintained source so it works again. Documentation-only, with no impact on functionality.