### PR TITLE
Fix cross-origin error handling in AppErrorBoundary

### DIFF
--- a/orchestrator/index.html
+++ b/orchestrator/index.html
@@ -10,6 +10,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <script
       defer
+      crossorigin="anonymous"
       src="https://umami.dakheera47.com/script.js"
       data-website-id="0dc42ed1-87c3-4ac0-9409-5a9b9588fe66"
     ></script>

--- a/orchestrator/src/client/components/AppErrorBoundary.test.tsx
+++ b/orchestrator/src/client/components/AppErrorBoundary.test.tsx
@@ -7,6 +7,7 @@ import {
   buildFatalIssueUrl,
   createFatalErrorSnapshot,
   FatalErrorScreen,
+  isOpaqueCrossOriginError,
   sanitizeCrashText,
 } from "./AppErrorBoundary";
 
@@ -108,6 +109,27 @@ describe("AppErrorBoundary", () => {
     expect(screen.queryByText(/abc\.def\.ghi/)).not.toBeInTheDocument();
   });
 
+  it("ignores opaque cross-origin 'Script error.' events without crashing", async () => {
+    renderBoundary(<div>Healthy app</div>, "/jobs/discovered/abc123");
+
+    act(() => {
+      window.dispatchEvent(
+        new ErrorEvent("error", {
+          message: "Script error.",
+          filename: "",
+          lineno: 0,
+          colno: 0,
+          // No `error` object — the browser hides details for cross-origin scripts.
+        }),
+      );
+    });
+
+    expect(screen.getByText("Healthy app")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: "Something went wrong" }),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the fatal fallback for unhandled promise rejections", async () => {
     renderBoundary(<div>Healthy app</div>, "/overview");
     const event = new Event("unhandledrejection", {
@@ -196,6 +218,31 @@ describe("AppErrorBoundary", () => {
     expect(decoded).toContain("token=[redacted]");
     expect(decoded).not.toContain("top-secret");
     expect(decoded).not.toContain("hunter2");
+  });
+
+  it("classifies opaque cross-origin errors, but not real Error events", () => {
+    expect(
+      isOpaqueCrossOriginError(
+        new ErrorEvent("error", { message: "Script error.", filename: "" }),
+      ),
+    ).toBe(true);
+    expect(
+      isOpaqueCrossOriginError(
+        new ErrorEvent("error", {
+          message: "anything",
+          filename: "",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isOpaqueCrossOriginError(
+        new ErrorEvent("error", {
+          message: "Real failure",
+          filename: "https://avasar.slotify.dev/app.js",
+          error: new Error("Real failure"),
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("redacts long opaque values", () => {

--- a/orchestrator/src/client/components/AppErrorBoundary.tsx
+++ b/orchestrator/src/client/components/AppErrorBoundary.tsx
@@ -280,6 +280,20 @@ function isRecoverableApiError(reason: unknown): boolean {
   );
 }
 
+/**
+ * Detects opaque cross-origin "Script error." events. When a script loaded from
+ * a different origin (without CORS) throws, browsers hide all details for
+ * security and fire a global error event with no real Error object, an empty
+ * filename, and the literal message "Script error.". These almost always come
+ * from third-party analytics scripts or browser extensions — they are not fatal
+ * to our app, so escalating them to the crash screen only produces repeated,
+ * non-actionable failures with no stack to debug.
+ */
+export function isOpaqueCrossOriginError(event: ErrorEvent): boolean {
+  if (event.error instanceof Error) return false;
+  return !event.filename || event.message === "Script error.";
+}
+
 export function AppErrorBoundary({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const route = `${location.pathname}${location.search}${location.hash}`;
@@ -292,6 +306,10 @@ export function AppErrorBoundary({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const handleError = (event: ErrorEvent) => {
+      if (isOpaqueCrossOriginError(event)) {
+        // Non-actionable third-party/extension noise — don't crash the app.
+        return;
+      }
       const reason = event.error ?? event.message;
       if (isRecoverableApiError(reason)) {
         event.preventDefault();


### PR DESCRIPTION
Improves error handling by detecting opaque cross-origin "Script error." events.
Prevents unnecessary app crashes by not escalating non-actionable errors from third-party or extension scripts.