### PR TITLE
Add FreeHire extractor to automatic job discovery

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ COPY extractors/ukvisajobs/package*.json ./extractors/ukvisajobs/
 COPY extractors/seek/package*.json ./extractors/seek/
 COPY extractors/fiveamsat/package*.json ./extractors/fiveamsat/
 COPY extractors/wazzuf/package*.json ./extractors/wazzuf/
+COPY extractors/freehire/package*.json ./extractors/freehire/
 COPY extractors/browser-utils/package*.json ./extractors/browser-utils/
 
 # Install build-time Node dependencies on the native builder platform. The
@@ -124,6 +125,7 @@ COPY extractors/ukvisajobs ./extractors/ukvisajobs
 COPY extractors/seek ./extractors/seek
 COPY extractors/fiveamsat ./extractors/fiveamsat
 COPY extractors/wazzuf ./extractors/wazzuf
+COPY extractors/freehire ./extractors/freehire
 COPY extractors/browser-utils ./extractors/browser-utils
 
 # ============================================================================
@@ -171,6 +173,7 @@ COPY extractors/ukvisajobs/package*.json ./extractors/ukvisajobs/
 COPY extractors/seek/package*.json ./extractors/seek/
 COPY extractors/fiveamsat/package*.json ./extractors/fiveamsat/
 COPY extractors/wazzuf/package*.json ./extractors/wazzuf/
+COPY extractors/freehire/package*.json ./extractors/freehire/
 COPY extractors/browser-utils/package*.json ./extractors/browser-utils/
 
 # Install production Node dependencies only.
@@ -266,6 +269,7 @@ COPY extractors/ukvisajobs ./extractors/ukvisajobs
 COPY extractors/seek ./extractors/seek
 COPY extractors/fiveamsat ./extractors/fiveamsat
 COPY extractors/wazzuf ./extractors/wazzuf
+COPY extractors/freehire ./extractors/freehire
 COPY extractors/browser-utils ./extractors/browser-utils
 
 # Create runtime directories.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,9 @@ services:
         - path: ./extractors/wazzuf
           target: /app/extractors/wazzuf
           action: sync+restart
+        - path: ./extractors/freehire/src
+          target: /app/extractors/freehire/src
+          action: sync+restart
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3001/health"]

--- a/docs-site/docs/extractors/freehire.md
+++ b/docs-site/docs/extractors/freehire.md
@@ -1,0 +1,56 @@
+---
+id: freehire
+title: FreeHire Extractor
+description: Public API-backed FreeHire job discovery integrated into automatic pipeline runs.
+sidebar_position: 10
+---
+
+## What it is
+
+Original website: [FreeHire](https://freehire.me/)
+
+This extractor searches FreeHire's public agent API and maps full job descriptions and enriched metadata into job-ops. It uses `GET /api/v1/agent/jobs/search`; no FreeHire account or API key is required.
+
+## Why it exists
+
+FreeHire aggregates jobs from many boards and exposes structured country, city, workplace, salary, skill, and seniority fields. Its public API adds broad coverage without browser automation or another credential.
+
+## How to use it
+
+1. Open **Run jobs** and choose **Automatic**.
+2. Enable **FreeHire** under **Sources**.
+3. Set search terms, country or cities, workplace types, and the usual result limit.
+4. Start the run.
+
+Defaults and constraints:
+
+- Search terms are sent to FreeHire one at a time.
+- Selected country, cities, and workplace types are passed to FreeHire as filters.
+- The shared result setting is capped at FreeHire's maximum of 100 jobs per search term.
+- Descriptions are requested as Markdown.
+- Job URLs point to the original upstream posting, so the existing job-ops URL de-duplication also removes overlap with other extractors.
+- FreeHire does not document a rate-limit allowance or availability SLA.
+
+## Common problems
+
+### FreeHire does not appear under Sources
+
+- Confirm the running build contains the FreeHire extractor package and shared source catalog entry.
+- Check `GET /api/freehire/health` for runtime discovery or upstream errors.
+
+### A run returns fewer jobs than requested
+
+- FreeHire may have fewer matching open jobs for the selected filters.
+- Each search term is limited to one API page of at most 100 jobs.
+- Broaden the search term, country, city, or workplace filters.
+
+### FreeHire temporarily fails
+
+- A FreeHire `429` or `503` response fails that extractor run without exposing the upstream response body.
+- Retry later or temporarily disable FreeHire while keeping other sources enabled.
+
+## Related pages
+
+- [Extractors Overview](/docs/next/extractors/overview)
+- [Pipeline Run](/docs/next/features/pipeline-run)
+- [Add an Extractor](/docs/next/workflows/add-an-extractor)

--- a/docs-site/docs/extractors/overview.md
+++ b/docs-site/docs/extractors/overview.md
@@ -22,6 +22,7 @@ Extractor integrations are now registered through manifests and loaded automatic
 | [Golang Jobs](/docs/next/extractors/golang-jobs) | Go-specific discovery through the public Golang Jobs feed | Depends on the site's public Supabase-backed schema staying stable; no credentials required | existing pipeline `searchTerms`, selected country/cities, `jobspyResultsWanted`, workplace type | Paginates the public jobs feed, maps location through the linked city record, then filters locally and de-duplicates by source id / URL |
 | [Jobindex](/docs/next/extractors/jobindex) | Denmark job search through Jobindex result pages | Denmark-only; city filtering depends on resolving selected cities to Jobindex `geoareaid` values | existing pipeline `searchTerms`, selected country/cities, `JOBINDEX_MAX_JOBS_PER_TERM` / automatic run budget | Parses the embedded Stash payload, applies resolved `geoareaid` filters when available, paginates result pages, maps card metadata and direct apply links, and de-duplicates by source id / URL |
 | [Seek](/docs/next/extractors/seek) | Australia/NZ job search via Apify | Requires Apify API token; actor runs incur cost ($1.50/1,000 results; free tier ~3,000/month) | `APIFY_TOKEN`, `SEEK_MAX_JOBS_PER_TERM`, `SEEK_APIFY_ACTOR_ID` | Calls the `unfenced-group/seek-com-au-scraper` Apify actor per term, maps results, and de-duplicates by source id / URL |
+| [FreeHire](/docs/next/extractors/freehire) | Broad job discovery through FreeHire's public agent API | No credentials required; API availability and rate limits are controlled by FreeHire | existing pipeline `searchTerms`, selected country/cities, `jobspyResultsWanted`, workplace type | Requests full Markdown descriptions and enriched job metadata, then de-duplicates original upstream URLs across sources |
 | [UKVisaJobs](/docs/next/extractors/ukvisajobs) | UK visa sponsorship-focused roles | Requires authenticated session and periodic token/cookie refresh | `UKVISAJOBS_EMAIL`, `UKVISAJOBS_PASSWORD`, `UKVISAJOBS_MAX_JOBS`, `UKVISAJOBS_SEARCH_KEYWORD` | API pagination + dataset output; orchestrator de-dupes and may fetch missing descriptions |
 | [Manual Import](/docs/next/extractors/manual) | One-off jobs not covered by scrapers | Inference quality depends on model/provider and input quality; some URLs cannot be fetched reliably | App/API endpoints (`/api/manual-jobs/infer`, `/api/manual-jobs/import`) | Accepts text/HTML/URL, runs inference, then saves and scores job after review |
 
@@ -35,6 +36,7 @@ Extractor integrations are now registered through manifests and loaded automatic
 - Use **Golang Jobs** when you want a niche Go-focused board that broad aggregators often miss.
 - Use **Jobindex** when targeting Denmark roles from the local Jobindex board.
 - Use **Seek** when targeting Australia/NZ roles via the Apify-powered Seek scraper.
+- Use **FreeHire** for broad API-backed coverage without another credential.
 - Use **Gradcracker** when targeting graduate pipelines in the UK.
 - Use **UKVisaJobs** for sponsorship-specific UK searches.
 - Use **Manual Import** when you already have a specific posting and need direct import.
@@ -63,6 +65,7 @@ Many runs combine sources: broad discovery first, then manual import for high-pr
 - [Golang Jobs](/docs/next/extractors/golang-jobs)
 - [Jobindex](/docs/next/extractors/jobindex)
 - [Seek](/docs/next/extractors/seek)
+- [FreeHire](/docs/next/extractors/freehire)
 - [UKVisaJobs](/docs/next/extractors/ukvisajobs)
 - [Manual Import](/docs/next/extractors/manual)
 - [Add an Extractor](/docs/next/workflows/add-an-extractor)

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -55,6 +55,7 @@ const sidebars: SidebarsConfig = {
         "extractors/golang-jobs",
         "extractors/jobindex",
         "extractors/seek",
+        "extractors/freehire",
         "extractors/manual",
         "extractors/ukvisajobs",
       ],

--- a/extractors/freehire/package.json
+++ b/extractors/freehire/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "freehire-extractor",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "FreeHire extractor backed by the public agent search API",
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "~5.9.0"
+  },
+  "scripts": {
+    "check:types": "tsc --noEmit"
+  }
+}

--- a/extractors/freehire/src/manifest.ts
+++ b/extractors/freehire/src/manifest.ts
@@ -1,0 +1,60 @@
+import { resolveSearchCities } from "@shared/search-cities.js";
+import type {
+  ExtractorManifest,
+  ExtractorProgressEvent,
+} from "@shared/types/extractors";
+import { type FreeHireProgressEvent, runFreeHire } from "./run";
+
+function toProgress(event: FreeHireProgressEvent): ExtractorProgressEvent {
+  const complete = event.type === "term_complete";
+  return {
+    phase: "list",
+    termsProcessed: complete ? event.termIndex : event.termIndex - 1,
+    termsTotal: event.termTotal,
+    currentUrl: event.searchTerm,
+    jobPagesEnqueued: complete ? event.jobsFoundTerm : undefined,
+    jobPagesProcessed: complete ? event.jobsFoundTerm : undefined,
+    detail: complete
+      ? `FreeHire: completed ${event.termIndex}/${event.termTotal} (${event.searchTerm}) with ${event.jobsFoundTerm ?? 0} jobs`
+      : `FreeHire: term ${event.termIndex}/${event.termTotal} (${event.searchTerm})`,
+  };
+}
+
+export const manifest: ExtractorManifest = {
+  id: "freehire",
+  displayName: "FreeHire",
+  providesSources: ["freehire"],
+  locationCapabilities: {
+    freehire: { supportedCountryKeys: null },
+  },
+  async run(context) {
+    if (context.shouldCancel?.()) return { success: true, jobs: [] };
+
+    const parsedLimit = context.settings.jobspyResultsWanted
+      ? Number.parseInt(context.settings.jobspyResultsWanted, 10)
+      : Number.NaN;
+    const result = await runFreeHire({
+      searchTerms: context.searchTerms,
+      selectedCountry: context.selectedCountry,
+      locations: resolveSearchCities({
+        list: context.sourceLocationPlan?.requestedCities,
+        single:
+          context.settings.searchCities ?? context.settings.jobspyLocation,
+      }),
+      workplaceTypes: context.settings.workplaceTypes
+        ? JSON.parse(context.settings.workplaceTypes)
+        : undefined,
+      maxJobsPerTerm: Number.isFinite(parsedLimit) ? parsedLimit : 50,
+      shouldCancel: context.shouldCancel,
+      onProgress: (event) => {
+        if (!context.shouldCancel?.()) context.onProgress?.(toProgress(event));
+      },
+    });
+
+    return result.success
+      ? { success: true, jobs: result.jobs }
+      : { success: false, jobs: [], error: result.error };
+  },
+};
+
+export default manifest;

--- a/extractors/freehire/src/run.ts
+++ b/extractors/freehire/src/run.ts
@@ -1,0 +1,231 @@
+import { getCountryIso2Code } from "@shared/location-support.js";
+import type { CreateJobInput } from "@shared/types/jobs";
+
+const FREEHIRE_SEARCH_URL = "https://freehire.me/api/v1/agent/jobs/search";
+
+export interface FreeHireProgressEvent {
+  type: "term_start" | "term_complete";
+  termIndex: number;
+  termTotal: number;
+  searchTerm: string;
+  jobsFoundTerm?: number;
+}
+
+export interface RunFreeHireOptions {
+  searchTerms?: string[];
+  selectedCountry?: string;
+  locations?: string[];
+  workplaceTypes?: Array<"remote" | "hybrid" | "onsite">;
+  maxJobsPerTerm?: number;
+  onProgress?: (event: FreeHireProgressEvent) => void;
+  shouldCancel?: () => boolean;
+  fetchImpl?: typeof fetch;
+}
+
+export interface FreeHireResult {
+  success: boolean;
+  jobs: CreateJobInput[];
+  error?: string;
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as UnknownRecord)
+    : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function asStringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.map(asString).filter((item): item is string => Boolean(item))
+    : [];
+}
+
+function asHttpUrl(value: unknown): string | undefined {
+  const raw = asString(value);
+  if (!raw) return undefined;
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function formatSalary(enrichment: UnknownRecord | null): string | undefined {
+  const minimum = asNumber(enrichment?.salary_min);
+  const maximum = asNumber(enrichment?.salary_max);
+  if (minimum === undefined && maximum === undefined) return undefined;
+
+  const format = (value: number) =>
+    new Intl.NumberFormat("en", { maximumFractionDigits: 0 }).format(value);
+  const amount =
+    minimum !== undefined && maximum !== undefined
+      ? `${format(minimum)}–${format(maximum)}`
+      : minimum !== undefined
+        ? `from ${format(minimum)}`
+        : `up to ${format(maximum as number)}`;
+  const currency = asString(enrichment?.salary_currency);
+  const period = asString(enrichment?.salary_period);
+
+  return `${currency ? `${currency} ` : ""}${amount}${period ? `/${period}` : ""}`;
+}
+
+export function mapFreeHireJob(value: unknown): CreateJobInput | null {
+  const row = asRecord(value);
+  const title = asString(row?.title);
+  const employer = asString(row?.company);
+  const jobUrl = asHttpUrl(row?.url);
+  if (!row || !title || !employer || !jobUrl) return null;
+
+  const enrichment = asRecord(row.enrichment);
+  const skills = asStringList(row.skills);
+  const domains = asStringList(enrichment?.domains);
+  const experienceYears = asNumber(enrichment?.experience_years_min);
+
+  return {
+    source: "freehire",
+    sourceJobId: asString(row.public_slug) ?? asString(row.external_id),
+    title,
+    employer,
+    jobUrl,
+    jobUrlDirect: jobUrl,
+    applicationLink: jobUrl,
+    location: asString(row.location),
+    jobDescription: asString(row.description) ?? asString(enrichment?.summary),
+    datePosted: asString(row.posted_at),
+    salary: formatSalary(enrichment),
+    salaryInterval: asString(enrichment?.salary_period),
+    salaryMinAmount: asNumber(enrichment?.salary_min),
+    salaryMaxAmount: asNumber(enrichment?.salary_max),
+    salaryCurrency: asString(enrichment?.salary_currency),
+    jobType: asString(enrichment?.employment_type),
+    isRemote: asString(row.work_mode) === "remote",
+    jobLevel: asString(enrichment?.seniority),
+    jobFunction: asString(enrichment?.category),
+    skills: skills.length > 0 ? skills.join(", ") : undefined,
+    companyIndustry: domains.length > 0 ? domains.join(", ") : undefined,
+    companyNumEmployees: asString(enrichment?.company_size),
+    experienceRange:
+      experienceYears === undefined ? undefined : `${experienceYears}+ years`,
+    workFromHomeType: asString(row.work_mode),
+  };
+}
+
+export function buildFreeHireSearchUrl(args: {
+  searchTerm: string;
+  selectedCountry?: string;
+  locations?: string[];
+  workplaceTypes?: Array<"remote" | "hybrid" | "onsite">;
+  limit: number;
+}): URL {
+  const url = new URL(FREEHIRE_SEARCH_URL);
+  url.searchParams.set("q", args.searchTerm);
+  url.searchParams.set("description_format", "markdown");
+  url.searchParams.set("sort", "posted_at");
+  url.searchParams.set("order", "desc");
+  url.searchParams.set("limit", String(Math.min(100, Math.max(1, args.limit))));
+
+  const countryCode = getCountryIso2Code(args.selectedCountry);
+  if (countryCode) url.searchParams.set("countries", countryCode);
+  if (args.locations?.length) {
+    url.searchParams.set("cities", args.locations.join(","));
+  }
+  if (args.workplaceTypes?.length) {
+    url.searchParams.set("work_mode", args.workplaceTypes.join(","));
+  }
+
+  return url;
+}
+
+export async function runFreeHire(
+  options: RunFreeHireOptions = {},
+): Promise<FreeHireResult> {
+  const searchTerms = options.searchTerms?.length
+    ? options.searchTerms
+    : ["software engineer"];
+  const maxJobsPerTerm = Number.isFinite(options.maxJobsPerTerm)
+    ? Math.max(1, Math.floor(options.maxJobsPerTerm as number))
+    : 50;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const jobs: CreateJobInput[] = [];
+  const seenUrls = new Set<string>();
+
+  try {
+    for (const [index, searchTerm] of searchTerms.entries()) {
+      if (options.shouldCancel?.()) return { success: true, jobs };
+
+      const termIndex = index + 1;
+      options.onProgress?.({
+        type: "term_start",
+        termIndex,
+        termTotal: searchTerms.length,
+        searchTerm,
+      });
+
+      // ponytail: one API page per term; paginate if runs need more than 100 results per term.
+      const url = buildFreeHireSearchUrl({
+        searchTerm,
+        selectedCountry: options.selectedCountry,
+        locations: options.locations,
+        workplaceTypes: options.workplaceTypes,
+        limit: maxJobsPerTerm,
+      });
+      const response = await fetchImpl(url, {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(20_000),
+      });
+      if (!response.ok) {
+        throw new Error(
+          `FreeHire request failed with status ${response.status}`,
+        );
+      }
+
+      const payload = asRecord((await response.json()) as unknown);
+      if (!Array.isArray(payload?.data)) {
+        throw new Error("FreeHire returned an invalid jobs response");
+      }
+
+      let jobsFoundTerm = 0;
+      for (const value of payload.data) {
+        const job = mapFreeHireJob(value);
+        if (!job || seenUrls.has(job.jobUrl)) continue;
+        seenUrls.add(job.jobUrl);
+        jobs.push(job);
+        jobsFoundTerm += 1;
+      }
+
+      options.onProgress?.({
+        type: "term_complete",
+        termIndex,
+        termTotal: searchTerms.length,
+        searchTerm,
+        jobsFoundTerm,
+      });
+    }
+
+    return { success: true, jobs };
+  } catch (error) {
+    return {
+      success: false,
+      jobs: [],
+      error:
+        error instanceof Error
+          ? error.message
+          : "Unexpected error while running FreeHire extractor",
+    };
+  }
+}

--- a/extractors/freehire/tests/manifest.test.ts
+++ b/extractors/freehire/tests/manifest.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/run", () => ({
+  runFreeHire: vi.fn(),
+}));
+
+describe("freehire manifest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("forwards shared automatic-run settings", async () => {
+    const { manifest } = await import("../src/manifest");
+    const { runFreeHire } = await import("../src/run");
+    vi.mocked(runFreeHire).mockResolvedValue({ success: true, jobs: [] });
+
+    await manifest.run({
+      source: "freehire",
+      selectedSources: ["freehire"],
+      settings: {
+        jobspyResultsWanted: "70",
+        workplaceTypes: '["remote","hybrid"]',
+        searchCities: "London",
+      },
+      searchTerms: ["backend engineer"],
+      selectedCountry: "uk",
+    });
+
+    expect(runFreeHire).toHaveBeenCalledWith(
+      expect.objectContaining({
+        maxJobsPerTerm: 70,
+        workplaceTypes: ["remote", "hybrid"],
+        locations: ["London"],
+        selectedCountry: "uk",
+      }),
+    );
+  });
+});

--- a/extractors/freehire/tests/run.test.ts
+++ b/extractors/freehire/tests/run.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildFreeHireSearchUrl,
+  mapFreeHireJob,
+  runFreeHire,
+} from "../src/run";
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => data,
+  } as Response;
+}
+
+describe("FreeHire extractor", () => {
+  it("builds a filtered public agent search URL", () => {
+    const url = buildFreeHireSearchUrl({
+      searchTerm: "backend engineer",
+      selectedCountry: "uk",
+      locations: ["London"],
+      workplaceTypes: ["remote", "hybrid"],
+      limit: 250,
+    });
+
+    expect(url.pathname).toBe("/api/v1/agent/jobs/search");
+    expect(url.searchParams.get("q")).toBe("backend engineer");
+    expect(url.searchParams.get("countries")).toBe("GB");
+    expect(url.searchParams.get("cities")).toBe("London");
+    expect(url.searchParams.get("work_mode")).toBe("remote,hybrid");
+    expect(url.searchParams.get("description_format")).toBe("markdown");
+    expect(url.searchParams.get("limit")).toBe("100");
+  });
+
+  it("maps FreeHire fields into a normalized job", () => {
+    expect(
+      mapFreeHireJob({
+        public_slug: "senior-go-engineer-acme-1a2b",
+        external_id: "123",
+        url: "https://boards.greenhouse.io/acme/jobs/123",
+        title: "Senior Go Engineer",
+        company: "Acme",
+        location: "Remote — EU",
+        description: "## About the role",
+        posted_at: "2026-06-18T00:00:00Z",
+        work_mode: "remote",
+        skills: ["go", "postgresql"],
+        enrichment: {
+          seniority: "senior",
+          category: "backend",
+          employment_type: "full_time",
+          experience_years_min: 5,
+          domains: ["fintech"],
+          company_size: "51-200",
+          salary_min: 90000,
+          salary_max: 130000,
+          salary_currency: "EUR",
+          salary_period: "year",
+        },
+      }),
+    ).toEqual(
+      expect.objectContaining({
+        source: "freehire",
+        sourceJobId: "senior-go-engineer-acme-1a2b",
+        title: "Senior Go Engineer",
+        employer: "Acme",
+        jobUrl: "https://boards.greenhouse.io/acme/jobs/123",
+        applicationLink: "https://boards.greenhouse.io/acme/jobs/123",
+        jobDescription: "## About the role",
+        datePosted: "2026-06-18T00:00:00Z",
+        salary: "EUR 90,000–130,000/year",
+        salaryMinAmount: 90000,
+        salaryMaxAmount: 130000,
+        salaryCurrency: "EUR",
+        jobType: "full_time",
+        isRemote: true,
+        jobLevel: "senior",
+        jobFunction: "backend",
+        skills: "go, postgresql",
+        companyIndustry: "fintech",
+        companyNumEmployees: "51-200",
+        experienceRange: "5+ years",
+      }),
+    );
+  });
+
+  it("fetches once per term and de-duplicates upstream URLs", async () => {
+    const row = {
+      public_slug: "job-1",
+      url: "https://example.com/jobs/1",
+      title: "Software Engineer",
+      company: "Acme",
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ data: [row] }))
+      .mockResolvedValueOnce(jsonResponse({ data: [row] }));
+
+    const result = await runFreeHire({
+      searchTerms: ["software", "engineer"],
+      fetchImpl: fetchMock,
+    });
+
+    expect(result).toEqual({ success: true, jobs: [expect.any(Object)] });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a status-only error for failed upstream requests", async () => {
+    const result = await runFreeHire({
+      fetchImpl: vi.fn().mockResolvedValue(jsonResponse({}, 503)),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      jobs: [],
+      error: "FreeHire request failed with status 503",
+    });
+  });
+});

--- a/extractors/freehire/tsconfig.json
+++ b/extractors/freehire/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2022",
+    "strict": true,
+    "noUnusedLocals": false,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["../../shared/src/*"]
+    }
+  },
+  "include": ["./src/**/*"]
+}

--- a/orchestrator/src/client/pages/orchestrator/constants.ts
+++ b/orchestrator/src/client/pages/orchestrator/constants.ts
@@ -15,9 +15,7 @@ export const PIPELINE_SOURCES_STORAGE_KEY = "jobops.pipeline.sources";
 export const PIPELINE_WATCHLIST_SOURCES_STORAGE_KEY =
   "jobops.pipeline.watchlist-sources";
 
-export const orderedSources: JobSource[] = [
-  ...PIPELINE_EXTRACTOR_SOURCE_IDS,
-].sort(
+export const orderedSources = [...PIPELINE_EXTRACTOR_SOURCE_IDS].sort(
   (left, right) =>
     EXTRACTOR_SOURCE_METADATA[left].order -
     EXTRACTOR_SOURCE_METADATA[right].order,

--- a/orchestrator/src/client/pages/orchestrator/usePipelineSources.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineSources.ts
@@ -57,7 +57,7 @@ export const usePipelineSources = (enabledSources?: readonly JobSource[]) => {
       if (!Array.isArray(parsed))
         return normalizeSources(allowedSources, allowedSources);
       const next = parsed.filter((value): value is JobSource =>
-        orderedSources.includes(value as JobSource),
+        orderedSources.includes(value),
       );
       migrateLegacyPipelineSourcesStorage(storageKey, raw);
       return normalizeSources(next, allowedSources);

--- a/orchestrator/src/client/pages/orchestrator/utils.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.test.ts
@@ -1,4 +1,8 @@
 import { createAppSettings, createJob } from "@shared/testing/factories.js";
+import {
+  EXTRACTOR_SOURCE_METADATA,
+  PIPELINE_EXTRACTOR_SOURCE_IDS,
+} from "@shared/extractors";
 import { describe, expect, it } from "vitest";
 import {
   extractEmploymentTypes,
@@ -24,20 +28,13 @@ describe("orchestrator utils", () => {
     expect(getEnabledSources(withoutKey)).not.toContain("adzuna");
   });
 
-  it("enables startupjobs without credentials", () => {
-    expect(getEnabledSources(createAppSettings())).toContain("startupjobs");
-  });
+  it("enables every credential-free pipeline source", () => {
+    const enabled = getEnabledSources(createAppSettings());
+    const credentialFree = PIPELINE_EXTRACTOR_SOURCE_IDS.filter(
+      (source) => !EXTRACTOR_SOURCE_METADATA[source].requiresCredentials,
+    );
 
-  it("enables workingnomads without credentials", () => {
-    expect(getEnabledSources(createAppSettings())).toContain("workingnomads");
-  });
-
-  it("enables golangjobs without credentials", () => {
-    expect(getEnabledSources(createAppSettings())).toContain("golangjobs");
-  });
-
-  it("enables jobindex without credentials", () => {
-    expect(getEnabledSources(createAppSettings())).toContain("jobindex");
+    expect(enabled).toEqual(expect.arrayContaining(credentialFree));
   });
 
   it("enables seek only when apify token is configured", () => {
@@ -45,10 +42,6 @@ describe("orchestrator utils", () => {
     const withoutToken = createAppSettings({ apifyTokenHint: null });
     expect(getEnabledSources(withToken)).toContain("seek");
     expect(getEnabledSources(withoutToken)).not.toContain("seek");
-  });
-
-  it("enables naukri without credentials", () => {
-    expect(getEnabledSources(createAppSettings())).toContain("naukri");
   });
 
   it("counts processing jobs in ready and discovered tabs", () => {

--- a/orchestrator/src/client/pages/orchestrator/utils.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.test.ts
@@ -1,8 +1,8 @@
-import { createAppSettings, createJob } from "@shared/testing/factories.js";
 import {
   EXTRACTOR_SOURCE_METADATA,
   PIPELINE_EXTRACTOR_SOURCE_IDS,
 } from "@shared/extractors";
+import { createAppSettings, createJob } from "@shared/testing/factories.js";
 import { describe, expect, it } from "vitest";
 import {
   extractEmploymentTypes,

--- a/orchestrator/src/client/pages/orchestrator/utils.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.ts
@@ -1,4 +1,5 @@
 import { getPostingDateSortValue } from "@client/lib/job-posting-age";
+import { EXTRACTOR_SOURCE_METADATA } from "@shared/extractors";
 import type { AppSettings, JobListItem, JobSource } from "@shared/types";
 import type {
   DateFilterDimension,
@@ -298,50 +299,11 @@ export const getEnabledSources = (
   const hasApifyToken = Boolean(settings.apifyTokenHint);
 
   for (const source of orderedSources) {
-    if (source === "gradcracker") {
-      enabled.push(source);
-      continue;
-    }
-    if (source === "ukvisajobs") {
-      if (hasUkVisaJobsAuth) enabled.push(source);
-      continue;
-    }
-    if (source === "adzuna") {
-      if (hasAdzunaAuth) enabled.push(source);
-      continue;
-    }
-    if (source === "seek") {
-      if (hasApifyToken) enabled.push(source);
-      continue;
-    }
-    if (source === "naukri") {
-      enabled.push(source);
-      continue;
-    }
-    if (source === "hiringcafe") {
-      enabled.push(source);
-      continue;
-    }
-    if (source === "startupjobs") {
-      enabled.push(source);
-      continue;
-    }
-    if (source === "workingnomads") {
-      enabled.push(source);
-      continue;
-    }
-    if (source === "golangjobs") {
-      enabled.push(source);
-      continue;
-    }
-    if (source === "jobindex") {
-      enabled.push(source);
-      continue;
-    }
     if (
-      source === "indeed" ||
-      source === "linkedin" ||
-      source === "glassdoor"
+      !EXTRACTOR_SOURCE_METADATA[source].requiresCredentials ||
+      (source === "ukvisajobs" && hasUkVisaJobsAuth) ||
+      (source === "adzuna" && hasAdzunaAuth) ||
+      (source === "seek" && hasApifyToken)
     ) {
       enabled.push(source);
     }

--- a/orchestrator/src/server/config/demo-defaults.data.ts
+++ b/orchestrator/src/server/config/demo-defaults.data.ts
@@ -264,6 +264,7 @@ export const DEMO_SOURCE_BASE_URLS: Record<JobSource, string> = {
   naukri: "https://www.naukri.com",
   fiveamsat: "https://khamsat.com",
   wazzuf: "https://wuzzuf.net",
+  freehire: "https://freehire.me",
   manual: "https://example.com",
 };
 

--- a/orchestrator/src/server/extractors/deployment.test.ts
+++ b/orchestrator/src/server/extractors/deployment.test.ts
@@ -53,6 +53,19 @@ describe("extractor deployment config", () => {
     );
   });
 
+  it("ships the FreeHire extractor in Docker runtime images", async () => {
+    const dockerfile = await readFile(resolve(process.cwd(), "../Dockerfile"), {
+      encoding: "utf8",
+    });
+
+    expect(dockerfile).toContain(
+      "COPY extractors/freehire/package*.json ./extractors/freehire/",
+    );
+    expect(dockerfile).toContain(
+      "COPY extractors/freehire ./extractors/freehire",
+    );
+  });
+
   it("does not install a vanilla Node Playwright Firefox binary", async () => {
     // Camoufox is the only supported browser in production. The vanilla Firefox
     // fallback was removed so that a missing Camoufox binary surfaces as a hard
@@ -101,6 +114,16 @@ describe("extractor deployment config", () => {
 
     expect(composeFile).toContain("path: ./extractors/jobindex/src");
     expect(composeFile).toContain("target: /app/extractors/jobindex/src");
+  });
+
+  it("syncs the FreeHire extractor in compose development mode", async () => {
+    const composeFile = await readFile(
+      resolve(process.cwd(), "../docker-compose.yml"),
+      { encoding: "utf8" },
+    );
+
+    expect(composeFile).toContain("path: ./extractors/freehire/src");
+    expect(composeFile).toContain("target: /app/extractors/freehire/src");
   });
 
   it("syncs the Workday career board package in compose development mode", async () => {

--- a/orchestrator/src/server/services/extractor-health.ts
+++ b/orchestrator/src/server/services/extractor-health.ts
@@ -141,6 +141,13 @@ const HEALTH_PROBE_CONFIG_BY_SOURCE: Record<
       wazzufMaxJobsPerTerm: "1",
     },
   },
+  freehire: {
+    searchTerm: DEFAULT_HEALTH_SEARCH_TERM,
+    selectedCountry: DEFAULT_HEALTH_SELECTED_COUNTRY,
+    settings: {
+      jobspyResultsWanted: "1",
+    },
+  },
   manual: {
     searchTerm: DEFAULT_HEALTH_SEARCH_TERM,
     selectedCountry: DEFAULT_HEALTH_SELECTED_COUNTRY,

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,6 +232,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "extractors/freehire": {
+      "name": "freehire-extractor",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "~5.9.0"
+      }
+    },
+    "extractors/freehire/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "extractors/freehire/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "extractors/golangjobs": {
       "name": "golangjobs-extractor",
       "version": "0.0.1",
@@ -17661,6 +17686,10 @@
           "optional": true
         }
       }
+    },
+    "node_modules/freehire-extractor": {
+      "resolved": "extractors/freehire",
+      "link": true
     },
     "node_modules/fresh": {
       "version": "0.5.2",

--- a/shared/src/extractors/index.ts
+++ b/shared/src/extractors/index.ts
@@ -16,6 +16,7 @@ export const EXTRACTOR_SOURCE_IDS = [
   "naukri",
   "fiveamsat",
   "wazzuf",
+  "freehire",
   "manual",
 ] as const;
 
@@ -85,6 +86,7 @@ export const EXTRACTOR_SOURCE_METADATA: Record<
   },
   fiveamsat: { label: "Khamsat", order: 109, category: "pipeline" },
   wazzuf: { label: "WUZZUF", order: 110, category: "pipeline" },
+  freehire: { label: "FreeHire", order: 115, category: "pipeline" },
   manual: { label: "Manual", order: 120, category: "manual" },
 };
 


### PR DESCRIPTION
## Summary

- Add a credential-free FreeHire extractor backed by its public agent search API
- Map enriched job metadata, apply location/workplace filters, cap results, and de-duplicate upstream URLs
- Register FreeHire across shared source metadata, health checks, Docker, Compose, docs, and demo defaults
- Simplify source enablement by using extractor credential metadata

## Testing

- Added FreeHire URL-building, job-mapping, fetching, de-duplication, error-handling, and manifest unit tests
- Updated orchestrator source-availability unit tests
- Added Docker and Compose deployment configuration tests