### PR TITLE
Fix Hiring Cafe: new domain, 429 rate-limit backoff, and cookie reuse via impit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/extractors/browser-utils/src/challenge.ts
+++ b/extractors/browser-utils/src/challenge.ts
@@ -20,6 +20,9 @@ const CF_CHALLENGE_MARKERS = [
   // Cloudflare's "managed challenge" / interstitial
   "cf-please-wait",
   "cf_chl_opt",
+  // Vercel's security checkpoint (used by e.g. hiringcafe.com behind CF)
+  "Vercel Security Checkpoint",
+  "vercel-protection",
 ] as const;
 
 /**

--- a/extractors/browser-utils/src/cookies.ts
+++ b/extractors/browser-utils/src/cookies.ts
@@ -6,7 +6,9 @@ import { CookieJar as ToughCookieJar } from "tough-cookie";
 /**
  * Cookies worth persisting — CF clearance and common session cookies.
  * cf_clearance is the main one: it proves the browser passed a challenge.
- * The others are supporting cookies CF uses during challenge flow.
+ * _vcrcs is Vercel's equivalent (sites like hiringcafe.com run Vercel's
+ * security checkpoint behind Cloudflare). The others are supporting cookies
+ * CF uses during challenge flow.
  */
 const PERSIST_COOKIE_NAMES = new Set([
   "cf_clearance",
@@ -14,7 +16,11 @@ const PERSIST_COOKIE_NAMES = new Set([
   "cf_chl_2",
   "cf_chl_prog",
   "__cflb",
+  "_vcrcs",
 ]);
+
+/** Cookies that prove a challenge was passed (Cloudflare or Vercel). */
+const CLEARANCE_COOKIE_NAMES = new Set(["cf_clearance", "_vcrcs"]);
 const DEFAULT_COOKIE_STORAGE_DIR = "./storage";
 const DATA_DIR_COOKIE_STORAGE_DIRNAME = "cloudflare-cookies";
 
@@ -64,7 +70,7 @@ function isExpired(cookie: PlaywrightCookie): boolean {
 }
 
 function hasClearanceCookie(cookies: PlaywrightCookie[]): boolean {
-  return cookies.some((cookie) => cookie.name === "cf_clearance");
+  return cookies.some((cookie) => CLEARANCE_COOKIE_NAMES.has(cookie.name));
 }
 
 async function readPersistedCookieJar(

--- a/extractors/browser-utils/src/solver.ts
+++ b/extractors/browser-utils/src/solver.ts
@@ -80,17 +80,19 @@ export async function solveChallenge(
       timeout: 30_000,
     });
 
-    // If there's no challenge, we're done — save cookies anyway since the
-    // browser session established a valid cf_clearance
+    // If there's no challenge, we're done — the site isn't challenging this
+    // browser at all (common when only the plain-HTTP fetch fingerprint gets
+    // blocked). Save whatever cookies exist, but don't demand a clearance
+    // cookie: none was ever issued, and erroring here would wrongly tell the
+    // user their solve failed.
     if (!(await isChallengePage(page))) {
       const cookiesSaved = await saveReusableCookies(
         context,
         extractorId,
         storageDir,
       );
-      if (cookiesSaved === null) return noReusableCookiesError();
       await showSolvedPage(page);
-      return { status: "solved", cookiesSaved };
+      return { status: "solved", cookiesSaved: cookiesSaved ?? 0 };
     }
 
     // Poll until the challenge is resolved or timeout

--- a/extractors/hiringcafe/package.json
+++ b/extractors/hiringcafe/package.json
@@ -5,6 +5,8 @@
   "description": "Hiring Cafe extractor backed by server-rendered search pages",
   "main": "src/main.ts",
   "dependencies": {
+    "browser-utils": "^0.0.1",
+    "impit": "^0.11.0",
     "job-ops-shared": "^1.0.0",
     "tsx": "^4.4.0"
   },

--- a/extractors/hiringcafe/src/run.ts
+++ b/extractors/hiringcafe/src/run.ts
@@ -10,13 +10,29 @@ import {
   toStringOrNull,
 } from "@shared/utils/type-conversion.js";
 import {
+  createPersistedFetchCookieJar,
+  getCloudflareCookieStorageDir,
+} from "browser-utils";
+import { Impit } from "impit";
+import {
   type HiringCafeCountryLocation,
   resolveHiringCafeCountryLocation,
 } from "./country-map.js";
 import { createDefaultSearchState } from "./default-search-state.js";
 
-const BASE_URL = "https://hiring.cafe/";
-const JOB_DETAIL_BASE_URL = "https://hiring.cafe/job/";
+const EXTRACTOR_ID = "hiringcafe";
+// hiring.cafe now 308-redirects to hiringcafe.com; target it directly so
+// challenge cookies are solved and reused on the same domain.
+const BASE_URL = "https://hiringcafe.com/";
+const JOB_DETAIL_BASE_URL = "https://hiringcafe.com/job/";
+// The site sits behind Cloudflare with Vercel hosting underneath — either
+// layer can serve the interstitial.
+const CHALLENGE_BODY_PATTERN =
+  /cloudflare|cf-browser-verification|challenge-platform|vercel security checkpoint|vercel-protection|_vcrcs/i;
+// Cloudflare rate-limits bursts of requests (429 + managed challenge after
+// ~4 rapid hits), so space requests out and back off before giving up.
+const REQUEST_DELAY_MS = 800;
+const RATE_LIMIT_RETRY_DELAYS_MS = [5_000, 15_000];
 const DEFAULT_MAX_JOBS_PER_TERM = 200;
 const DEFAULT_SEARCH_TERM = "web developer";
 const DEFAULT_DATE_FETCHED_PAST_N_DAYS = 30;
@@ -109,6 +125,62 @@ class HiringCafeChallengeError extends Error {
     this.name = "HiringCafeChallengeError";
     this.challengeUrl = challengeUrl;
   }
+}
+
+/**
+ * Default HTTP client: impit impersonates a real Firefox TLS fingerprint and
+ * shares the persisted cookie jar (and User-Agent) written by the headed
+ * challenge solver, so a solved cf_clearance/_vcrcs cookie is actually reused.
+ */
+async function createDefaultFetchImpl(): Promise<typeof fetch> {
+  const persistedCookies = await createPersistedFetchCookieJar(
+    EXTRACTOR_ID,
+    getCloudflareCookieStorageDir(),
+  );
+  const impit = new Impit({
+    browser: "firefox",
+    timeout: 30_000,
+    cookieJar: persistedCookies.cookieJar,
+    ...(persistedCookies.userAgent
+      ? { headers: { "user-agent": persistedCookies.userAgent } }
+      : {}),
+  });
+
+  // Impit enforces its own timeout and does not accept AbortSignal.
+  // ImpitResponse covers everything this extractor reads (ok/status/text).
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const { signal: _signal, ...rest } = init ?? {};
+    return impit.fetch(
+      typeof input === "string" ? input : input.toString(),
+      rest as Parameters<Impit["fetch"]>[1],
+    );
+  }) as unknown as typeof fetch;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Spaces requests out and retries 429 rate-limit responses with backoff, so a
+ * burst of detail-page fetches doesn't trip Cloudflare's rate rule (which
+ * serves a challenge page no human solve can meaningfully fix).
+ */
+function withThrottleAndRetry(fetchImpl: typeof fetch): typeof fetch {
+  let lastRequestAt = 0;
+  return (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const wait = lastRequestAt + REQUEST_DELAY_MS - Date.now();
+    if (wait > 0) await sleep(wait);
+    let response = await fetchImpl(input, init);
+    lastRequestAt = Date.now();
+    for (const delay of RATE_LIMIT_RETRY_DELAYS_MS) {
+      if (response.status !== 429) break;
+      await sleep(delay);
+      response = await fetchImpl(input, init);
+      lastRequestAt = Date.now();
+    }
+    return response;
+  }) as typeof fetch;
 }
 
 function toPositiveIntOrFallback(
@@ -320,7 +392,7 @@ function parseNextData(html: string, challengeUrl = BASE_URL): unknown {
     /<script[^>]*id=["']__NEXT_DATA__["'][^>]*>\s*([\s\S]*?)\s*<\/script>/i,
   );
   if (!match) {
-    if (/cloudflare|cf-browser-verification|challenge-platform/i.test(html)) {
+    if (CHALLENGE_BODY_PATTERN.test(html)) {
       throw new HiringCafeChallengeError(challengeUrl);
     }
     throw new Error(
@@ -405,14 +477,13 @@ async function fetchHiringCafeSearchPage(args: {
     headers: {
       accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       "accept-language": "en-US,en;q=0.9",
-      "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",
     },
     signal: AbortSignal.timeout(20_000),
   });
 
   const body = await response.text();
   if (!response.ok) {
-    if (/cloudflare|cf-browser-verification|challenge-platform/i.test(body)) {
+    if (CHALLENGE_BODY_PATTERN.test(body)) {
       throw new HiringCafeChallengeError(url);
     }
     const statusText = response.statusText ? ` ${response.statusText}` : "";
@@ -443,14 +514,13 @@ async function fetchHiringCafeJobDetail(args: {
     headers: {
       accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
       "accept-language": "en-US,en;q=0.9",
-      "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",
     },
     signal: AbortSignal.timeout(20_000),
   });
 
   const body = await response.text();
   if (!response.ok) {
-    if (/cloudflare|cf-browser-verification|challenge-platform/i.test(body)) {
+    if (CHALLENGE_BODY_PATTERN.test(body)) {
       throw new HiringCafeChallengeError(url.toString());
     }
     return null;
@@ -707,11 +777,12 @@ export async function runHiringCafe(
       : [null];
   const termTotal = searchTerms.length * runLocations.length;
   const workplaceTypes = parseWorkplaceTypes(options.workplaceTypes);
-  const fetchImpl = options.fetchImpl ?? fetch;
   const jobs: CreateJobInput[] = [];
   const seen = new Set<string>();
 
   try {
+    const fetchImpl =
+      options.fetchImpl ?? withThrottleAndRetry(await createDefaultFetchImpl());
     const countryLocation = resolveHiringCafeCountryLocation(country);
 
     for (let runIndex = 0; runIndex < runLocations.length; runIndex += 1) {

--- a/extractors/hiringcafe/tests/run.test.ts
+++ b/extractors/hiringcafe/tests/run.test.ts
@@ -155,7 +155,7 @@ describe("Hiring Cafe SSR parser", () => {
       }),
     );
 
-    expect(url.origin).toBe("https://hiring.cafe");
+    expect(url.origin).toBe("https://hiringcafe.com");
     expect(url.searchParams.get("searchState")).toBe(
       JSON.stringify({ searchQuery: "web developer" }),
     );
@@ -192,10 +192,10 @@ describe("runHiringCafe", () => {
       }),
     ]);
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining("https://hiring.cafe/"),
+      expect.stringContaining("https://hiringcafe.com/"),
       expect.objectContaining({
         headers: expect.objectContaining({
-          "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",
+          accept: expect.stringContaining("text/html"),
         }),
       }),
     );
@@ -221,7 +221,7 @@ describe("runHiringCafe", () => {
       },
     };
     const fetchMock = vi.fn((url: string) => {
-      if (url === "https://hiring.cafe/job/req-1") {
+      if (url === "https://hiringcafe.com/job/req-1") {
         return Promise.resolve(
           createTextResponse(createJobDetailHtml(detailJob)),
         );
@@ -243,10 +243,10 @@ describe("runHiringCafe", () => {
       jobDescription: "<p>Full detail page description.</p>",
     });
     expect(fetchMock).toHaveBeenCalledWith(
-      "https://hiring.cafe/job/req-1",
+      "https://hiringcafe.com/job/req-1",
       expect.objectContaining({
         headers: expect.objectContaining({
-          "user-agent": "Mozilla/5.0 (compatible; JobOps/1.0)",
+          accept: expect.stringContaining("text/html"),
         }),
       }),
     );
@@ -260,7 +260,7 @@ describe("runHiringCafe", () => {
       },
     });
     const fetchMock = vi.fn((url: string) => {
-      if (url === "https://hiring.cafe/job/req-1") {
+      if (url === "https://hiringcafe.com/job/req-1") {
         return Promise.resolve(
           createTextResponse("<html>challenges.cloudflare.com</html>"),
         );
@@ -278,7 +278,7 @@ describe("runHiringCafe", () => {
 
     expect(result).toMatchObject({
       success: false,
-      challengeRequired: "https://hiring.cafe/job/req-1",
+      challengeRequired: "https://hiringcafe.com/job/req-1",
     });
   });
 
@@ -290,7 +290,7 @@ describe("runHiringCafe", () => {
       },
     });
     const fetchMock = vi.fn((url: string) => {
-      if (url === "https://hiring.cafe/job/req-1") {
+      if (url === "https://hiringcafe.com/job/req-1") {
         return Promise.resolve(
           createTextResponse(createExpiredJobDetailHtml()),
         );
@@ -346,7 +346,7 @@ describe("runHiringCafe", () => {
     });
 
     const searchCall = fetchMock.mock.calls.find(([url]) =>
-      String(url).startsWith("https://hiring.cafe/"),
+      String(url).startsWith("https://hiringcafe.com/"),
     );
     const url = new URL(String(searchCall?.[0]));
     const searchState = JSON.parse(
@@ -391,7 +391,7 @@ describe("runHiringCafe", () => {
       ),
     ).toBe(false);
     const searchCall = fetchMock.mock.calls.find(([url]) =>
-      String(url).startsWith("https://hiring.cafe/"),
+      String(url).startsWith("https://hiringcafe.com/"),
     );
     const url = new URL(String(searchCall?.[0]));
     const searchState = JSON.parse(

--- a/package-lock.json
+++ b/package-lock.json
@@ -398,6 +398,8 @@
       "name": "hiringcafe-extractor",
       "version": "0.0.1",
       "dependencies": {
+        "browser-utils": "^0.0.1",
+        "impit": "^0.11.0",
         "job-ops-shared": "^1.0.0",
         "tsx": "^4.4.0"
       },


### PR DESCRIPTION
## Problem

Hiring Cafe searches fail with:

> `Solver error: Challenge appeared solved, but no reusable Cloudflare clearance cookie was saved.`

This is the remaining failure mode discussed in #645. Three things changed on hiring.cafe's side since the extractor was written:

1. **The site moved domains** — `hiring.cafe` now returns `308 Permanent Redirect` to `hiringcafe.com` (Cloudflare in front, Vercel hosting underneath).
2. **Cloudflare rate-limits request bursts** — after ~4 rapid requests it returns **HTTP 429 with a managed challenge page**. The extractor fired detail-page fetches back-to-back with plain Node `fetch` and a `JobOps/1.0` UA, tripping this immediately.
3. **The rate limit never challenges a real browser** — so when the user clicks *Solve*, the headed Camoufox opens, sees **no challenge at all**, no `cf_clearance` is ever issued, and the solver reports the misleading "no reusable clearance cookie" error. The solve can never succeed.

## Fix

**`extractors/hiringcafe`**
- Target `hiringcafe.com` directly, so challenge cookies are solved and reused on the same domain.
- Default HTTP client is now `impit` (Firefox TLS fingerprint impersonation, same as gradcracker), sharing the persisted solver cookie jar and User-Agent via `createPersistedFetchCookieJar` — a solved `cf_clearance`/`_vcrcs` cookie is now actually sent on retries. Previously the extractor never loaded saved cookies at all.
- Requests are spaced 800 ms apart, and 429 responses are retried with backoff (5 s, 15 s) before surfacing a challenge.
- Vercel security-checkpoint bodies are recognized as challenges.

**`extractors/browser-utils`**
- The solver no longer errors when the site never challenges the headed browser — nothing to save is not a failure; the pipeline resumes and the impit retry goes through.
- Vercel's `_vcrcs` clearance cookie is persisted and accepted alongside `cf_clearance`.
- Vercel checkpoint markers added to challenge-page detection.

**Windows DX (small bonus)**
- Added `.gitattributes` with `*.sh text eol=lf`. On Windows checkouts (`core.autocrlf=true`), `docker-entrypoint.sh` gets CRLF endings and a from-source Docker build crash-loops with `exec /app/docker-entrypoint.sh: no such file or directory`.

## Testing

- `npm run test:run -w hiringcafe-extractor` — 14/14 pass (URL/header expectations updated)
- browser-utils vitest — 16/16 pass
- `tsc --noEmit` clean on both workspaces
- Live smoke test against `hiringcafe.com`: search + detail enrichment returns real jobs with no challenge; without the throttle the 5th rapid request reproducibly returns the 429 challenge
- Full Docker build from source; Hiring Cafe searches work in the running app

## Tradeoffs / follow-ups

- Detail-page enrichment is now paced at ~1.25 req/s, so terms with many description-less hits take longer — preferable to tripping the rate limit and dead-ending the pipeline.
- If Cloudflare still challenges impit's fingerprint on some networks, the existing solve flow now works end-to-end for it (cookies are saved on `hiringcafe.com` and actually reused).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvbQca1fJo7APbUYpqjw3a
