### PR TITLE
Fix scoring pipeline reporting transient LLM failures as configuration errors

### DIFF
--- a/orchestrator/src/server/pipeline/orchestrator.ts
+++ b/orchestrator/src/server/pipeline/orchestrator.ts
@@ -446,14 +446,13 @@ export async function runPipeline(
         jobsDiscovered,
       });
 
-      let unprocessedJobs: import("@shared/types").Job[] = [];
       let scoredJobs: import("./steps/types").ScoredJob[] = [];
 
       ensureNotCancelled(scopeKey);
       await persistResultSummary({ stage: "scoring" });
       while (true) {
         try {
-          ({ unprocessedJobs, scoredJobs } = await scoreJobsStep({
+          ({ scoredJobs } = await scoreJobsStep({
             profile,
             scoringInstructions: mergedConfig.scoringInstructions,
             visaSponsorCountryKey: mergedConfig.locationIntent?.selectedCountry,
@@ -538,7 +537,7 @@ export async function runPipeline(
       await notifyPipelineWebhookStep("pipeline.completed", {
         pipelineRunId: pipelineRun.id,
         jobsDiscovered,
-        jobsScored: unprocessedJobs.length,
+        jobsScored: scoredJobs.length,
         jobsProcessed: processedCount,
       });
 

--- a/orchestrator/src/server/pipeline/steps/score-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/score-jobs.test.ts
@@ -191,27 +191,27 @@ describe("scoreJobsStep auto-skip behavior", () => {
   it.each([
     { score: 90, exceptional: 0 },
     { score: 91, exceptional: 1 },
-  ])(
-    "reports $exceptional exceptional matches for a score of $score",
-    async ({ score, exceptional }) => {
-      const scorer = await import("@server/services/scorer");
-      const { progressHelpers } = await import("../progress");
-      vi.mocked(scorer.scoreJobSuitability).mockResolvedValue({
-        score,
-        reason: "Test score",
-        jobBrief: null,
-      });
+  ])("reports $exceptional exceptional matches for a score of $score", async ({
+    score,
+    exceptional,
+  }) => {
+    const scorer = await import("@server/services/scorer");
+    const { progressHelpers } = await import("../progress");
+    vi.mocked(scorer.scoreJobSuitability).mockResolvedValue({
+      score,
+      reason: "Test score",
+      jobBrief: null,
+    });
 
-      await scoreJobsStep({ profile: {} });
+    await scoreJobsStep({ profile: {} });
 
-      expect(progressHelpers.scoringJob).toHaveBeenCalledWith(
-        1,
-        1,
-        expect.objectContaining({ id: "job-1" }),
-        exceptional,
-      );
-    },
-  );
+    expect(progressHelpers.scoringJob).toHaveBeenCalledWith(
+      1,
+      1,
+      expect.objectContaining({ id: "job-1" }),
+      exceptional,
+    );
+  });
 
   it("does not auto-skip jobs when score equals threshold", async () => {
     const settingsRepo = await import("@server/repositories/settings");

--- a/orchestrator/src/server/pipeline/steps/score-jobs.test.ts
+++ b/orchestrator/src/server/pipeline/steps/score-jobs.test.ts
@@ -19,9 +19,15 @@ vi.mock("@server/repositories/settings", () => ({
   getSetting: vi.fn(),
 }));
 
-vi.mock("@server/services/scorer", () => ({
-  scoreJobSuitability: vi.fn(),
-}));
+vi.mock("@server/services/scorer", () => {
+  class LlmNotConfiguredError extends Error {}
+  class ScoringUnavailableError extends Error {}
+  return {
+    scoreJobSuitability: vi.fn(),
+    LlmNotConfiguredError,
+    ScoringUnavailableError,
+  };
+});
 
 vi.mock("@server/services/visa-sponsors/index", () => ({
   searchSponsors: vi.fn(),
@@ -185,27 +191,27 @@ describe("scoreJobsStep auto-skip behavior", () => {
   it.each([
     { score: 90, exceptional: 0 },
     { score: 91, exceptional: 1 },
-  ])("reports $exceptional exceptional matches for a score of $score", async ({
-    score,
-    exceptional,
-  }) => {
-    const scorer = await import("@server/services/scorer");
-    const { progressHelpers } = await import("../progress");
-    vi.mocked(scorer.scoreJobSuitability).mockResolvedValue({
-      score,
-      reason: "Test score",
-      jobBrief: null,
-    });
+  ])(
+    "reports $exceptional exceptional matches for a score of $score",
+    async ({ score, exceptional }) => {
+      const scorer = await import("@server/services/scorer");
+      const { progressHelpers } = await import("../progress");
+      vi.mocked(scorer.scoreJobSuitability).mockResolvedValue({
+        score,
+        reason: "Test score",
+        jobBrief: null,
+      });
 
-    await scoreJobsStep({ profile: {} });
+      await scoreJobsStep({ profile: {} });
 
-    expect(progressHelpers.scoringJob).toHaveBeenCalledWith(
-      1,
-      1,
-      expect.objectContaining({ id: "job-1" }),
-      exceptional,
-    );
-  });
+      expect(progressHelpers.scoringJob).toHaveBeenCalledWith(
+        1,
+        1,
+        expect.objectContaining({ id: "job-1" }),
+        exceptional,
+      );
+    },
+  );
 
   it("does not auto-skip jobs when score equals threshold", async () => {
     const settingsRepo = await import("@server/repositories/settings");
@@ -347,6 +353,105 @@ describe("scoreJobsStep auto-skip behavior", () => {
       0,
     );
     expect(vi.mocked(progressHelpers.scoringComplete)).toHaveBeenCalledWith(2);
+  });
+
+  it("continues scoring remaining jobs when one job fails transiently", async () => {
+    const jobsRepo = await import("@server/repositories/jobs");
+    const scorer = await import("@server/services/scorer");
+    const { progressHelpers } = await import("../progress");
+    const { logger } = await import("@infra/logger");
+
+    vi.mocked(jobsRepo.getUnscoredDiscoveredJobs).mockResolvedValue([
+      createJob({
+        id: "job-1",
+        title: "Failing Role",
+        employer: "Acme",
+        suitabilityScore: null,
+      }),
+      createJob({
+        id: "job-2",
+        title: "Healthy Role",
+        employer: "Beta",
+        suitabilityScore: null,
+      }),
+    ]);
+
+    vi.mocked(scorer.scoreJobSuitability)
+      .mockRejectedValueOnce(
+        new scorer.ScoringUnavailableError(
+          "AI scoring failed: No content in response",
+        ),
+      )
+      .mockResolvedValueOnce({
+        score: 72,
+        reason: "Second score",
+        jobBrief: null,
+      });
+
+    const result = await scoreJobsStep({ profile: {} });
+
+    expect(result.scoredJobs).toHaveLength(1);
+    expect(result.scoredJobs[0].id).toBe("job-2");
+    expect(vi.mocked(jobsRepo.updateJob)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(jobsRepo.updateJob)).toHaveBeenCalledWith(
+      "job-2",
+      expect.objectContaining({ suitabilityScore: 72 }),
+    );
+    expect(vi.mocked(progressHelpers.scoringComplete)).toHaveBeenCalledWith(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Job scoring failed — leaving unscored and continuing",
+      expect.objectContaining({ jobId: "job-1" }),
+    );
+  });
+
+  it("pauses the run when every early job fails transiently", async () => {
+    const jobsRepo = await import("@server/repositories/jobs");
+    const scorer = await import("@server/services/scorer");
+
+    vi.mocked(jobsRepo.getUnscoredDiscoveredJobs).mockResolvedValue(
+      Array.from({ length: 6 }, (_, index) =>
+        createJob({
+          id: `job-${index + 1}`,
+          title: `Role ${index + 1}`,
+          employer: "Acme",
+          suitabilityScore: null,
+        }),
+      ),
+    );
+
+    vi.mocked(scorer.scoreJobSuitability).mockRejectedValue(
+      new scorer.ScoringUnavailableError(
+        "AI scoring failed: No content in response",
+      ),
+    );
+
+    await expect(scoreJobsStep({ profile: {} })).rejects.toBeInstanceOf(
+      scorer.LlmNotConfiguredError,
+    );
+    expect(vi.mocked(jobsRepo.updateJob)).not.toHaveBeenCalled();
+  });
+
+  it("still halts the run when the LLM is genuinely not configured", async () => {
+    const jobsRepo = await import("@server/repositories/jobs");
+    const scorer = await import("@server/services/scorer");
+
+    vi.mocked(jobsRepo.getUnscoredDiscoveredJobs).mockResolvedValue([
+      createJob({
+        id: "job-1",
+        title: "Software Engineer",
+        employer: "Acme",
+        suitabilityScore: null,
+      }),
+    ]);
+
+    vi.mocked(scorer.scoreJobSuitability).mockRejectedValue(
+      new scorer.LlmNotConfiguredError("LLM API key not configured"),
+    );
+
+    await expect(scoreJobsStep({ profile: {} })).rejects.toBeInstanceOf(
+      scorer.LlmNotConfiguredError,
+    );
+    expect(vi.mocked(jobsRepo.updateJob)).not.toHaveBeenCalled();
   });
 
   it("stops before processing when cancellation is requested", async () => {

--- a/orchestrator/src/server/pipeline/steps/score-jobs.ts
+++ b/orchestrator/src/server/pipeline/steps/score-jobs.ts
@@ -1,7 +1,11 @@
 import { logger } from "@infra/logger";
 import * as jobsRepo from "@server/repositories/jobs";
 import * as settingsRepo from "@server/repositories/settings";
-import { scoreJobSuitability } from "@server/services/scorer";
+import {
+  LlmNotConfiguredError,
+  ScoringUnavailableError,
+  scoreJobSuitability,
+} from "@server/services/scorer";
 import * as visaSponsors from "@server/services/visa-sponsors/index";
 import { asyncPool } from "@server/utils/async-pool";
 import type { Job } from "@shared/types";
@@ -9,6 +13,16 @@ import { progressHelpers, updateProgress } from "../progress";
 import type { ScoredJob } from "./types";
 
 const SCORING_CONCURRENCY = 4;
+
+/**
+ * A lone job failing transiently should not stop the run, but when this many
+ * jobs have failed before anything scored at all, the AI integration is down
+ * across the board (dead endpoint, missing CLI binary, hard outage) and
+ * pausing for the user beats burning retries on every remaining job. With the
+ * per-call retries the LLM service already performs, sporadic provider blips
+ * effectively never produce this many consecutive failures.
+ */
+const SYSTEMIC_FAILURE_THRESHOLD = 3;
 
 export async function scoreJobsStep(args: {
   profile: Record<string, unknown>;
@@ -40,6 +54,7 @@ export async function scoreJobsStep(args: {
   const scoredJobs: ScoredJob[] = [];
   let completed = 0;
   let exceptional = 0;
+  let failed = 0;
   const scoringInstructions = args.scoringInstructions?.trim();
 
   await asyncPool({
@@ -77,12 +92,38 @@ export async function scoreJobsStep(args: {
       const scoringResultPromise = scoringInstructions
         ? scoreJobSuitability(job, args.profile, { scoringInstructions })
         : scoreJobSuitability(job, args.profile);
-      const {
-        score,
-        reason,
-        jobBrief,
-        jobUpdates = {},
-      } = await scoringResultPromise;
+      let scoringResult: Awaited<typeof scoringResultPromise>;
+      try {
+        scoringResult = await scoringResultPromise;
+      } catch (error) {
+        // Configuration errors still abort the pool — every remaining job
+        // would fail the same way until the user fixes their settings.
+        if (!(error instanceof ScoringUnavailableError)) throw error;
+        failed += 1;
+        completed += 1;
+        if (scoredJobs.length === 0 && failed >= SYSTEMIC_FAILURE_THRESHOLD) {
+          throw new LlmNotConfiguredError(
+            `AI scoring failed for the first ${failed} jobs (${error.message}). Check your LLM configuration in Settings → Integrations, then resume scoring.`,
+          );
+        }
+        logger.warn("Job scoring failed — leaving unscored and continuing", {
+          jobId: job.id,
+          title: job.title,
+          error: error.message,
+        });
+        progressHelpers.scoringJob(
+          completed,
+          unprocessedJobs.length,
+          {
+            id: job.id,
+            title: `${job.title} (failed)`,
+            employer: job.employer,
+          },
+          exceptional,
+        );
+        return;
+      }
+      const { score, reason, jobBrief, jobUpdates = {} } = scoringResult;
       if (args.shouldCancel?.()) return;
 
       let sponsorMatchScore = 0;
@@ -152,6 +193,7 @@ export async function scoreJobsStep(args: {
   progressHelpers.scoringComplete(scoredJobs.length);
   logger.info("Scoring step completed", {
     scoredJobs: scoredJobs.length,
+    failedJobs: failed,
     concurrency: SCORING_CONCURRENCY,
   });
 

--- a/orchestrator/src/server/services/ai-resilience.test.ts
+++ b/orchestrator/src/server/services/ai-resilience.test.ts
@@ -102,7 +102,7 @@ describe("AI Service Resilience", () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it("should throw LlmNotConfiguredError on API 500/400 errors", async () => {
+    it("should throw ScoringUnavailableError on API 5xx errors", async () => {
       vi.mocked(global.fetch).mockResolvedValue({
         ok: false,
         status: 500,
@@ -114,7 +114,7 @@ describe("AI Service Resilience", () => {
       );
     });
 
-    it("should throw LlmNotConfiguredError on Malformed/Invalid JSON in API response", async () => {
+    it("should throw ScoringUnavailableError on Malformed/Invalid JSON in API response", async () => {
       const mockResponse = {
         ok: true,
         json: async () => ({

--- a/orchestrator/src/server/services/llm/policies/configuration-error.test.ts
+++ b/orchestrator/src/server/services/llm/policies/configuration-error.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { isConfigurationFailure } from "./configuration-error";
+
+describe("isConfigurationFailure", () => {
+  it("flags a missing API key", () => {
+    expect(isConfigurationFailure("LLM API key not configured")).toBe(true);
+  });
+
+  it("flags rejected credentials", () => {
+    expect(isConfigurationFailure("LLM API error: 401 - Invalid API key")).toBe(
+      true,
+    );
+    expect(isConfigurationFailure("LLM API error: 403 - Forbidden")).toBe(true);
+  });
+
+  it("flags CLI providers that are not logged in", () => {
+    expect(
+      isConfigurationFailure(
+        "Codex is not authenticated in this container. Run `codex login` and try again.",
+      ),
+    ).toBe(true);
+    expect(isConfigurationFailure("Gemini CLI is not logged in")).toBe(true);
+  });
+
+  it("does not flag transient provider faults", () => {
+    expect(isConfigurationFailure("No content in response")).toBe(false);
+    expect(isConfigurationFailure("Rate limit exceeded")).toBe(false);
+    expect(isConfigurationFailure("LLM API error: 429 - slow down")).toBe(
+      false,
+    );
+    expect(isConfigurationFailure("LLM API error: 500 - internal error")).toBe(
+      false,
+    );
+    expect(isConfigurationFailure("Request timed out")).toBe(false);
+    expect(
+      isConfigurationFailure("Unable to parse JSON from model response"),
+    ).toBe(false);
+  });
+
+  it("does not flag a 404 or other 4xx as configuration", () => {
+    expect(isConfigurationFailure("LLM API error: 404 - not found")).toBe(
+      false,
+    );
+    expect(isConfigurationFailure("LLM API error: 400 - bad request")).toBe(
+      false,
+    );
+  });
+});

--- a/orchestrator/src/server/services/llm/policies/configuration-error.ts
+++ b/orchestrator/src/server/services/llm/policies/configuration-error.ts
@@ -1,0 +1,15 @@
+/**
+ * Failures that mean the LLM integration itself is misconfigured: a missing
+ * API key, credentials the provider rejects, or a CLI provider that is not
+ * logged in. These are the only failures worth pausing a run over and sending
+ * the user to Settings → Integrations; every other failure is a per-request
+ * fault (provider blip, malformed completion, rate limit) that changing
+ * settings cannot fix.
+ */
+export function isConfigurationFailure(message: string): boolean {
+  return (
+    message.includes("not configured") ||
+    /LLM API error: 40[13]\b/.test(message) ||
+    /not (authenticated|logged in)/i.test(message)
+  );
+}

--- a/orchestrator/src/server/services/llm/policies/retry-policy.test.ts
+++ b/orchestrator/src/server/services/llm/policies/retry-policy.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  EMPTY_RESPONSE_ERROR,
   getRetryDelayMs,
   parseRetryAfterMs,
   shouldRetryAttempt,
@@ -10,6 +11,21 @@ describe("shouldRetryAttempt", () => {
     expect(
       shouldRetryAttempt({ message: "Failed to parse JSON", status: 200 }),
     ).toBe(true);
+  });
+
+  it("retries empty completions", () => {
+    expect(
+      shouldRetryAttempt({ message: EMPTY_RESPONSE_ERROR, status: 200 }),
+    ).toBe(true);
+    expect(
+      shouldRetryAttempt({ message: EMPTY_RESPONSE_ERROR, status: undefined }),
+    ).toBe(true);
+  });
+
+  it("does not retry configuration errors", () => {
+    expect(shouldRetryAttempt({ message: "LLM API key not configured" })).toBe(
+      false,
+    );
   });
 
   it("retries on 429 and 5xx", () => {

--- a/orchestrator/src/server/services/llm/policies/retry-policy.ts
+++ b/orchestrator/src/server/services/llm/policies/retry-policy.ts
@@ -1,9 +1,16 @@
+/**
+ * A 2xx response whose completion carried no text. Shared with the LLM service
+ * so the throw site and the retry check cannot drift apart.
+ */
+export const EMPTY_RESPONSE_ERROR = "No content in response";
+
 export function shouldRetryAttempt(args: {
   message: string;
   status?: number;
 }): boolean {
   return (
     args.message.includes("parse") ||
+    args.message.includes(EMPTY_RESPONSE_ERROR) ||
     args.status === 429 ||
     (args.status !== undefined && args.status >= 500 && args.status <= 599) ||
     args.message.toLowerCase().includes("timeout") ||

--- a/orchestrator/src/server/services/llm/service.test.ts
+++ b/orchestrator/src/server/services/llm/service.test.ts
@@ -2,7 +2,26 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { ClaudeCliClient } from "./claude-cli/client";
 import { CodexClient } from "./codex/client";
 import { GeminiCliClient } from "./gemini-cli/client";
+import { EMPTY_RESPONSE_ERROR } from "./policies/retry-policy";
 import { LlmService } from "./service";
+import type { JsonSchemaDefinition } from "./types";
+
+const TEST_SCHEMA: JsonSchemaDefinition = {
+  name: "test",
+  schema: {
+    type: "object",
+    properties: { value: { type: "string" } },
+    required: ["value"],
+    additionalProperties: false,
+  },
+};
+
+function completionResponse(content: string): Response {
+  return new Response(JSON.stringify({ choices: [{ message: { content } }] }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
 
 describe("LlmService provider normalization", () => {
   afterEach(() => {
@@ -195,6 +214,49 @@ describe("LlmService provider normalization", () => {
 
     expect(models[0]).toBe("claude-sonnet-5");
     expect(models.length).toBeGreaterThan(1);
+  });
+
+  it("retries a 200 response whose completion is empty and succeeds on the next attempt", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(completionResponse(""))
+      .mockResolvedValueOnce(completionResponse('{"value":"ok"}'));
+
+    const llm = new LlmService({
+      provider: "openrouter",
+      apiKey: "sk-or-test",
+    });
+    const result = await llm.callJson<{ value: string }>({
+      model: "google/gemini-2.5-flash",
+      messages: [{ role: "user", content: "Return JSON." }],
+      jsonSchema: TEST_SCHEMA,
+      maxRetries: 2,
+      retryDelayMs: 1,
+    });
+
+    expect(result).toEqual({ success: true, data: { value: "ok" } });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the empty completion once the retry budget is exhausted", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => completionResponse(""));
+
+    const llm = new LlmService({
+      provider: "openrouter",
+      apiKey: "sk-or-test",
+    });
+    const result = await llm.callJson<{ value: string }>({
+      model: "google/gemini-2.5-flash",
+      messages: [{ role: "user", content: "Return JSON." }],
+      jsonSchema: TEST_SCHEMA,
+      maxRetries: 2,
+      retryDelayMs: 1,
+    });
+
+    expect(result).toEqual({ success: false, error: EMPTY_RESPONSE_ERROR });
+    expect(fetchSpy).toHaveBeenCalledTimes(3);
   });
 
   it("lists Requesty models from the /models endpoint", async () => {

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -12,6 +12,7 @@ import {
   rememberSuccessfulMode,
 } from "./policies/mode-selection";
 import {
+  EMPTY_RESPONSE_ERROR,
   getRetryDelayMs,
   parseRetryAfterMs,
   shouldRetryAttempt,
@@ -474,7 +475,7 @@ export class LlmService {
         const content = this.strategy.extractText(data);
 
         if (!content) {
-          throw new Error("No content in response");
+          throw new Error(EMPTY_RESPONSE_ERROR);
         }
 
         const parsed = parseJsonContent<T>(content, jobId);

--- a/orchestrator/src/server/services/scorer.test.ts
+++ b/orchestrator/src/server/services/scorer.test.ts
@@ -1038,7 +1038,7 @@ describe("salary penalty", () => {
       );
     });
 
-    it("should throw LlmNotConfiguredError for non-API-key errors", async () => {
+    it("should throw LlmNotConfiguredError when the provider rejects the credentials", async () => {
       const { scoreJobSuitability, LlmNotConfiguredError } = await import(
         "./scorer"
       );
@@ -1050,7 +1050,7 @@ describe("salary penalty", () => {
 
       callJsonMock.mockResolvedValue({
         success: false,
-        error: "Rate limit exceeded",
+        error: "LLM API error: 401 - Invalid API key",
       });
 
       const job = createJob({
@@ -1060,6 +1060,56 @@ describe("salary penalty", () => {
 
       await expect(scoreJobSuitability(job, {})).rejects.toThrow(
         LlmNotConfiguredError,
+      );
+    });
+
+    it("should throw ScoringUnavailableError for transient provider faults", async () => {
+      const { scoreJobSuitability, ScoringUnavailableError } = await import(
+        "./scorer"
+      );
+      getEffectiveSettingsMock.mockResolvedValue({
+        penalizeMissingSalary: { value: false, default: false, override: null },
+        missingSalaryPenalty: { value: 10, default: 10, override: null },
+        rxresumeBaseResumeId: "base-resume-123",
+      } as any);
+
+      callJsonMock.mockResolvedValue({
+        success: false,
+        error: "No content in response",
+      });
+
+      const job = createJob({
+        id: "test-job-2",
+        title: "Software Engineer",
+      });
+
+      await expect(scoreJobSuitability(job, {})).rejects.toThrow(
+        ScoringUnavailableError,
+      );
+    });
+
+    it("should throw ScoringUnavailableError when the AI returns no numeric score", async () => {
+      const { scoreJobSuitability, ScoringUnavailableError } = await import(
+        "./scorer"
+      );
+      getEffectiveSettingsMock.mockResolvedValue({
+        penalizeMissingSalary: { value: false, default: false, override: null },
+        missingSalaryPenalty: { value: 10, default: 10, override: null },
+        rxresumeBaseResumeId: "base-resume-123",
+      } as any);
+
+      callJsonMock.mockResolvedValue({
+        success: true,
+        data: { score: "not-a-number", reason: "Confused model" },
+      });
+
+      const job = createJob({
+        id: "test-job-3",
+        title: "Software Engineer",
+      });
+
+      await expect(scoreJobSuitability(job, {})).rejects.toThrow(
+        ScoringUnavailableError,
       );
     });
   });

--- a/orchestrator/src/server/services/scorer.ts
+++ b/orchestrator/src/server/services/scorer.ts
@@ -11,6 +11,7 @@ import {
   PATCHABLE_JOB_FIELDS,
   validateAndApplyJobPatches,
 } from "./job-fact-patches";
+import { isConfigurationFailure } from "./llm/policies/configuration-error";
 import type { JsonSchemaDefinition } from "./llm/types";
 import { stripMarkdownCodeFences } from "./llm/utils/json";
 import { createConfiguredLlmService, resolveLlmModel } from "./modelSelection";
@@ -21,6 +22,18 @@ export class LlmNotConfiguredError extends Error {
   constructor(message?: string) {
     super(message ?? "LLM API key not configured");
     this.name = "LlmNotConfiguredError";
+  }
+}
+
+/**
+ * A scoring attempt failed for a reason that is not a configuration problem —
+ * a transient provider fault, an unusable completion, an outage. The job can
+ * simply be scored again later; the user's settings need no attention.
+ */
+export class ScoringUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ScoringUnavailableError";
   }
 }
 
@@ -281,24 +294,31 @@ export async function scoreJobSuitability(
   });
 
   if (!result.success) {
-    logger.warn("Scoring failed — pausing pipeline", {
+    if (isConfigurationFailure(result.error)) {
+      logger.warn("Scoring failed — pausing pipeline", {
+        jobId: job.id,
+        error: result.error,
+      });
+      throw new LlmNotConfiguredError(
+        `AI scoring failed: ${result.error}. Check your LLM configuration in Settings → Integrations, then resume scoring.`,
+      );
+    }
+    logger.warn("Scoring failed", {
       jobId: job.id,
       error: result.error,
     });
-    throw new LlmNotConfiguredError(
-      `AI scoring failed: ${result.error}. Check your LLM configuration in Settings → Integrations, then resume scoring.`,
-    );
+    throw new ScoringUnavailableError(`AI scoring failed: ${result.error}`);
   }
 
   const { score, reason } = result.data;
 
   // Validate we got a reasonable response
   if (typeof score !== "number" || Number.isNaN(score)) {
-    logger.warn("Invalid score in AI response — pausing pipeline", {
+    logger.warn("Invalid score in AI response", {
       jobId: job.id,
     });
-    throw new LlmNotConfiguredError(
-      "AI returned invalid scoring data. Check your LLM configuration in Settings → Integrations, then resume scoring.",
+    throw new ScoringUnavailableError(
+      "AI returned invalid scoring data (no numeric score in the response)",
     );
   }
 


### PR DESCRIPTION
When a provider returns HTTP 200 with an empty completion, the scoring pipeline
aborts the whole run and shows:

> AI scoring failed: No content in response. Check your LLM configuration in
> Settings -> Integrations, then resume scoring.

The LLM configuration is fine. The same run scores ~98% of jobs successfully, and
the failing job scores normally on the next attempt with no settings change — a
real configuration error cannot score anything. On a run with ~1.5% per-call blip
rate and 138 jobs left, the chance of finishing without a halt is about 12%, so
the search appears to "always fail with an AI configuration error".

Three independent gaps compound into this:

1. **The retry budget never fires.** `service.ts` throws a plain
   `Error("No content in response")` for an empty 200 completion — with no
   `status` attached. `shouldRetryAttempt` matches nothing against that message
   and an undefined status, so the loop exits on attempt 0 even though the scorer
   explicitly asks for `maxRetries: 2`. With those retries, the per-job failure
   rate would drop from ~1.5% to ~1 in 296,000.
2. **Every failure is relabelled a configuration error.** `scorer.ts` wraps *any*
   unsuccessful result in `LlmNotConfiguredError`, so a transient provider blip is
   presented as a settings problem and pauses the pipeline at the
   orchestrator's reconfiguration gate until the user re-saves settings that were
   never wrong.
3. **One unlucky job halts the whole run.** `score-jobs.ts` drives scoring
   through `asyncPool` with no per-item handling, so the first failure stops
   scoring for every remaining job.

Deterministic repro: stub the provider to return
`200 {"choices":[{"message":{"content":""}}]}` for one request. Expected: the
request is retried. Actual (before this PR): it fails immediately and the
pipeline pauses for reconfiguration.

Related: #602 / #620 fixed empty responses on the ghostwriter path, but the
scoring path remained exposed because `shouldRetryAttempt` had no empty-content
clause.

## The fix

Three changes, each useful on its own:

1. **Retry empty completions** (`retry-policy.ts`, `service.ts`). The
   empty-completion message is hoisted into a shared `EMPTY_RESPONSE_ERROR`
   constant so the throw site and the retry check cannot drift apart, and
   `shouldRetryAttempt` now matches it — placed next to the `"parse"` clause,
   since both mean "the provider answered with a payload the client couldn't
   use". Genuine configuration errors (e.g. `"LLM API key not configured"`)
   still fail fast.
2. **Classify failures before pausing the pipeline** (`scorer.ts`, new
   `llm/policies/configuration-error.ts`). Only genuine configuration failures —
   missing API key, provider 401/403, a CLI provider that is not logged in —
   throw `LlmNotConfiguredError` and route to the Settings → Integrations pause.
   Everything else (empty completions after retries, malformed payloads, rate
   limits, outages) throws the new `ScoringUnavailableError` with the provider's
   own message and no misleading settings advice. The invalid-score path gets the
   same treatment.
3. **Don't halt the run for one job** (`score-jobs.ts`). A
   `ScoringUnavailableError` for one job is logged, surfaced in progress as
   `(failed)`, and the pool keeps scoring the remaining jobs. The job stays
   unscored and is picked up again by the next run (scoring already re-filters
   on `getUnscoredDiscoveredJobs`). `LlmNotConfiguredError` still aborts the
   pool — if the key is missing, every remaining job would fail identically, so
   pausing immediately remains correct.

   **Systemic failsafe:** message-based classification can't recognize every
   configuration problem (a missing CLI binary, a dead base URL, and raw CLI
   stderr all surface as ordinary errors). So if the first
   `SYSTEMIC_FAILURE_THRESHOLD` (3) jobs all fail with nothing scored at all,
   the run still pauses for reconfiguration instead of "successfully" scoring
   zero jobs. With the per-call retries above, a sporadic blip essentially
   can't produce 3 consecutive all-attempt failures (~4e-17 at the observed
   1.5% per-call rate), so the reported bug never trips this.

4. **Webhook accuracy** (`orchestrator.ts`). The `pipeline.completed` webhook
   reported `jobsScored` from the attempted-jobs count, which only equaled the
   scored count while a single failure aborted the run. It now reports the
   actually-scored count, matching the run summary.

## Tests

- `service.test.ts`: deterministic repro — a stubbed fetch returning a 200 with
  empty content is retried and succeeds on the next attempt; and after the
  budget is exhausted the empty completion is reported as-is. Both fail on the
  code before this PR (fetch is called exactly once).
- `retry-policy.test.ts`: empty completions retry; configuration errors don't.
- `configuration-error.test.ts`: classification table for config vs transient.
- `scorer.test.ts`: the test that pinned the old behavior ("throws
  LlmNotConfiguredError for non-API-key errors") now asserts the split:
  401 → `LlmNotConfiguredError`, empty completion / invalid score →
  `ScoringUnavailableError`.
- `score-jobs.test.ts`: one transiently failing job doesn't stop the others and
  is not persisted; every early job failing transiently pauses the run via the
  systemic failsafe; a genuine configuration error still halts the run.

Full orchestrator suite + typecheck pass. (The 4 failures in
`job-posting-age.test.ts` / `ApplicationsPerDayChart.test.tsx` are date-sensitive
and fail identically on `main`.)

## Tradeoffs and follow-ups

- A run where *some* jobs scored but the provider then degrades hard for the
  rest completes with those jobs unscored and warnings in the log (they are
  re-scored next run). Only an all-failures-from-the-start run pauses. A
  user-visible "N jobs could not be scored" summary would be a nice follow-up.
- The CLI providers have their own empty-response equivalent ("Codex turn
  completed but no assistant message text was returned"), which is not covered
  by the shared retry constant — same symptom, separate path, left as a
  follow-up.
- A model that always returns an empty completion now costs 3 requests per job
  instead of 1 before failing; that is the intended price of the retry budget
  the scorer already asks for.
