### PR TITLE
Fix Resume Studio rendering never-saved edits after an autosave conflict

### DIFF
--- a/orchestrator/src/client/hooks/useDesignResumeStudio.test.tsx
+++ b/orchestrator/src/client/hooks/useDesignResumeStudio.test.tsx
@@ -1,0 +1,254 @@
+import * as api from "@client/api";
+import type { DesignResumeDocument, DesignResumeJson } from "@shared/types";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { showErrorToast } from "@/client/lib/error-toast";
+import { createTestQueryClient } from "../test/renderWithQueryClient";
+import { useDesignResumeStudio } from "./useDesignResumeStudio";
+
+const designResumeState = vi.hoisted(() => ({
+  document: null as unknown,
+}));
+
+vi.mock("@client/api", () => ({
+  updateDesignResume: vi.fn(),
+  getDesignResume: vi.fn(),
+  importDesignResumeFromRxResume: vi.fn(),
+  importDesignResumeFromFile: vi.fn(),
+  uploadDesignResumePictureFile: vi.fn(),
+  deleteDesignResumePicture: vi.fn(),
+  updateSetting: vi.fn(),
+}));
+
+vi.mock("@client/hooks/useDesignResume", () => ({
+  useDesignResume: () => ({
+    document: designResumeState.document,
+    status: { exists: true, documentId: "primary", updatedAt: null },
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@client/hooks/useSettings", () => ({
+  useSettings: () => ({ settings: null, isLoading: false }),
+}));
+
+vi.mock("@client/hooks/useTracerReadiness", () => ({
+  useTracerReadiness: () => ({ readiness: null }),
+}));
+
+vi.mock("@/client/lib/error-toast", () => ({
+  showErrorToast: vi.fn(),
+}));
+
+vi.mock("@/client/lib/private-pdf", () => ({
+  downloadDesignResumePdf: vi.fn(),
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  trackProductEvent: vi.fn(),
+  bucketCount: vi.fn(() => "1-5"),
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+function makeResumeJson(marker: string): DesignResumeJson {
+  return {
+    basics: { name: marker },
+    sections: { skills: { items: [] } },
+  } as unknown as DesignResumeJson;
+}
+
+function makeDocument(
+  revision: number,
+  marker = `server-rev-${revision}`,
+  updatedAt = "2026-08-01T00:00:00.000Z",
+): DesignResumeDocument {
+  return {
+    id: "primary",
+    title: "Resume Studio",
+    resumeJson: makeResumeJson(marker),
+    revision,
+    sourceResumeId: null,
+    sourceMode: null,
+    importedAt: "2026-08-01T00:00:00.000Z",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt,
+    assets: [],
+  } as DesignResumeDocument;
+}
+
+function draftBasicsName(draft: DesignResumeDocument | null): string {
+  const resumeJson = (draft?.resumeJson ?? {}) as {
+    basics?: { name?: string };
+  };
+  return resumeJson.basics?.name ?? "";
+}
+
+function renderStudioHook() {
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+  return renderHook(() => useDesignResumeStudio(), { wrapper });
+}
+
+async function flushAutosave() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(750);
+  });
+}
+
+const conflictError = () =>
+  Object.assign(
+    new Error("Resume Studio has changed. Refresh and try again."),
+    {
+      status: 409,
+      code: "CONFLICT",
+    },
+  );
+
+describe("useDesignResumeStudio autosave conflict handling", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    designResumeState.document = makeDocument(9);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("recovers from a revision conflict by rebasing onto the server revision and retrying", async () => {
+    vi.mocked(api.updateDesignResume)
+      .mockRejectedValueOnce(conflictError())
+      .mockResolvedValueOnce(makeDocument(11, "persisted"));
+    vi.mocked(api.getDesignResume).mockResolvedValue(makeDocument(10));
+
+    const { result } = renderStudioHook();
+    expect(result.current.draft?.revision).toBe(9);
+
+    act(() => {
+      result.current.updateResumeJson(() => makeResumeJson("local-edit"));
+    });
+
+    // First autosave: sent with the stale revision, rejected with a conflict.
+    await flushAutosave();
+    expect(api.updateDesignResume).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(api.updateDesignResume).mock.calls[0][0]).toMatchObject({
+      baseRevision: 9,
+    });
+
+    // Recovery: server document fetched, local edits kept, revision rebased.
+    expect(api.getDesignResume).toHaveBeenCalledTimes(1);
+    expect(result.current.draft?.revision).toBe(10);
+    expect(draftBasicsName(result.current.draft)).toBe("local-edit");
+    expect(result.current.dirty).toBe(true);
+
+    // Retry: saved with the rebased revision and the local content.
+    await flushAutosave();
+    expect(api.updateDesignResume).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(api.updateDesignResume).mock.calls[1][0]).toMatchObject({
+      baseRevision: 10,
+      document: expect.objectContaining({
+        basics: { name: "local-edit" },
+      }),
+    });
+    expect(result.current.saveState).toBe("saved");
+    expect(result.current.dirty).toBe(false);
+    expect(showErrorToast).not.toHaveBeenCalled();
+    // The overwrite of the concurrent writer is announced, not silent.
+    expect(toast.info).toHaveBeenCalledWith(
+      "Resume Studio was updated elsewhere. Your edits here were kept and re-saved.",
+    );
+  });
+
+  it("surfaces the error after repeated conflicts instead of retrying forever", async () => {
+    vi.mocked(api.updateDesignResume).mockRejectedValue(conflictError());
+    let serverRevision = 9;
+    vi.mocked(api.getDesignResume).mockImplementation(async () => {
+      serverRevision += 1;
+      return makeDocument(serverRevision);
+    });
+
+    const { result } = renderStudioHook();
+    act(() => {
+      result.current.updateResumeJson(() => makeResumeJson("local-edit"));
+    });
+
+    // 3 recovery attempts, then the 4th conflict surfaces as an error.
+    for (let i = 0; i < 4; i += 1) {
+      await flushAutosave();
+    }
+
+    expect(api.updateDesignResume).toHaveBeenCalledTimes(4);
+    expect(result.current.saveState).toBe("error");
+    expect(showErrorToast).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 409 }),
+      "Failed to save Resume Studio.",
+    );
+    // The local edits are still on screen, not silently discarded.
+    expect(draftBasicsName(result.current.draft)).toBe("local-edit");
+  });
+
+  it("does not adopt a refetched document older than the local draft", async () => {
+    const { result, rerender } = renderStudioHook();
+    expect(result.current.draft?.revision).toBe(9);
+
+    // A stale refetch (older revision, not newer by timestamp) must not
+    // clobber the newer draft.
+    designResumeState.document = makeDocument(8, "stale");
+    rerender();
+    expect(result.current.draft?.revision).toBe(9);
+
+    // A genuinely newer document is still adopted.
+    designResumeState.document = makeDocument(12, "newer");
+    rerender();
+    expect(result.current.draft?.revision).toBe(12);
+  });
+
+  it("adopts a re-imported document whose revision restarted but is newer by timestamp", async () => {
+    const { result, rerender } = renderStudioHook();
+    expect(result.current.draft?.revision).toBe(9);
+
+    // A re-import replaces the document server-side with revision 1 and a
+    // fresh updatedAt; a second mounted tab must adopt it on refetch.
+    designResumeState.document = makeDocument(
+      1,
+      "imported",
+      "2026-08-02T00:00:00.000Z",
+    );
+    rerender();
+    expect(result.current.draft?.revision).toBe(1);
+    expect(draftBasicsName(result.current.draft)).toBe("imported");
+  });
+
+  it("keeps a failed non-conflict save out of the recovery path", async () => {
+    vi.mocked(api.updateDesignResume).mockRejectedValue(
+      Object.assign(new Error("network down"), { status: 500 }),
+    );
+
+    const { result } = renderStudioHook();
+    act(() => {
+      result.current.updateResumeJson(() => makeResumeJson("local-edit"));
+    });
+
+    await flushAutosave();
+    expect(api.getDesignResume).not.toHaveBeenCalled();
+    expect(result.current.saveState).toBe("error");
+    expect(showErrorToast).toHaveBeenCalled();
+  });
+});

--- a/orchestrator/src/client/hooks/useDesignResumeStudio.ts
+++ b/orchestrator/src/client/hooks/useDesignResumeStudio.ts
@@ -134,34 +134,37 @@ export function useDesignResumeStudio() {
    * subsequent save fail while the UI keeps rendering never-persisted edits
    * until a full page reload.
    */
-  const recoverFromRevisionConflict = async (
-    saveError: unknown,
-  ): Promise<boolean> => {
-    if (!isRevisionConflict(saveError)) return false;
-    if (conflictRecoveryAttemptsRef.current >= MAX_CONFLICT_RECOVERY_ATTEMPTS) {
-      return false;
-    }
-    try {
-      const latest = await api.getDesignResume();
-      conflictRecoveryAttemptsRef.current += 1;
-      if (conflictRecoveryAttemptsRef.current === 1) {
-        // Saves replace the whole document, so re-saving after a rebase makes
-        // this tab win over whatever bumped the revision. Say so instead of
-        // overwriting silently.
-        toast.info(
-          "Resume Studio was updated elsewhere. Your edits here were kept and re-saved.",
-        );
+  const recoverFromRevisionConflict = useCallback(
+    async (saveError: unknown): Promise<boolean> => {
+      if (!isRevisionConflict(saveError)) return false;
+      if (
+        conflictRecoveryAttemptsRef.current >= MAX_CONFLICT_RECOVERY_ATTEMPTS
+      ) {
+        return false;
       }
-      setDraft((current) =>
-        current ? { ...latest, resumeJson: current.resumeJson } : latest,
-      );
-      setDirty(true);
-      setSaveState("idle");
-      return true;
-    } catch {
-      return false;
-    }
-  };
+      try {
+        const latest = await api.getDesignResume();
+        conflictRecoveryAttemptsRef.current += 1;
+        if (conflictRecoveryAttemptsRef.current === 1) {
+          // Saves replace the whole document, so re-saving after a rebase makes
+          // this tab win over whatever bumped the revision. Say so instead of
+          // overwriting silently.
+          toast.info(
+            "Resume Studio was updated elsewhere. Your edits here were kept and re-saved.",
+          );
+        }
+        setDraft((current) =>
+          current ? { ...latest, resumeJson: current.resumeJson } : latest,
+        );
+        setDirty(true);
+        setSaveState("idle");
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (
@@ -219,7 +222,15 @@ export function useDesignResumeStudio() {
     }, 700);
 
     return () => window.clearTimeout(timer);
-  }, [dirty, draft, document, notifyReadyPdfRefresh, queryClient, saveState, recoverFromRevisionConflict]);
+  }, [
+    dirty,
+    draft,
+    document,
+    notifyReadyPdfRefresh,
+    queryClient,
+    saveState,
+    recoverFromRevisionConflict,
+  ]);
 
   const setDesignResume = (next: DesignResumeDocument) => {
     queryClient.setQueryData(queryKeys.designResume.current(), next);

--- a/orchestrator/src/client/hooks/useDesignResumeStudio.ts
+++ b/orchestrator/src/client/hooks/useDesignResumeStudio.ts
@@ -219,7 +219,7 @@ export function useDesignResumeStudio() {
     }, 700);
 
     return () => window.clearTimeout(timer);
-  }, [dirty, draft, document, notifyReadyPdfRefresh, queryClient, saveState]);
+  }, [dirty, draft, document, notifyReadyPdfRefresh, queryClient, saveState, recoverFromRevisionConflict]);
 
   const setDesignResume = (next: DesignResumeDocument) => {
     queryClient.setQueryData(queryKeys.designResume.current(), next);

--- a/orchestrator/src/client/hooks/useDesignResumeStudio.ts
+++ b/orchestrator/src/client/hooks/useDesignResumeStudio.ts
@@ -37,6 +37,20 @@ import { downloadDesignResumePdf } from "@/client/lib/private-pdf";
 import { trackProductEvent } from "@/lib/analytics";
 import { queryKeys } from "../lib/queryKeys";
 
+/**
+ * How many autosave revision conflicts in a row we resolve automatically by
+ * rebasing onto the server document before giving up and surfacing the error.
+ * The counter re-arms on every local edit, so a temporarily racing writer
+ * (another tab, an import) cannot wedge saving permanently.
+ */
+const MAX_CONFLICT_RECOVERY_ATTEMPTS = 3;
+
+function isRevisionConflict(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const { status, code } = error as { status?: unknown; code?: unknown };
+  return status === 409 || code === "CONFLICT";
+}
+
 export function useDesignResumeStudio() {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -65,6 +79,7 @@ export function useDesignResumeStudio() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const importFileInputRef = useRef<HTMLInputElement>(null);
   const editVersionRef = useRef(0);
+  const conflictRecoveryAttemptsRef = useRef(0);
   const draftRef = useRef<DesignResumeDocument | null>(null);
   const readyPdfRefreshToastShownRef = useRef(false);
   draftRef.current = draft;
@@ -94,8 +109,59 @@ export function useDesignResumeStudio() {
 
   useEffect(() => {
     if (!document || dirty) return;
+    // Never adopt a stale refetch of the draft's own lineage: a slow GET can
+    // resolve after a save committed a newer revision, and adopting it would
+    // revert the studio to stale content and a stale revision that makes
+    // every following autosave fail with a conflict. A re-import legitimately
+    // resets the revision to 1, so a lower revision only counts as stale when
+    // the document is not newer by timestamp.
+    if (
+      draft &&
+      document.revision < draft.revision &&
+      document.updatedAt <= draft.updatedAt
+    ) {
+      return;
+    }
     setDraft(document);
-  }, [document, dirty]);
+  }, [document, dirty, draft]);
+
+  /**
+   * An autosave conflict means the server document moved on without us —
+   * another tab, an import, or a previously failed save. Rebase: adopt the
+   * server document's metadata (most importantly its revision) while keeping
+   * the local resumeJson, which holds the user's newest edits, then let the
+   * autosave cycle retry. Without this the stale revision makes every
+   * subsequent save fail while the UI keeps rendering never-persisted edits
+   * until a full page reload.
+   */
+  const recoverFromRevisionConflict = async (
+    saveError: unknown,
+  ): Promise<boolean> => {
+    if (!isRevisionConflict(saveError)) return false;
+    if (conflictRecoveryAttemptsRef.current >= MAX_CONFLICT_RECOVERY_ATTEMPTS) {
+      return false;
+    }
+    try {
+      const latest = await api.getDesignResume();
+      conflictRecoveryAttemptsRef.current += 1;
+      if (conflictRecoveryAttemptsRef.current === 1) {
+        // Saves replace the whole document, so re-saving after a rebase makes
+        // this tab win over whatever bumped the revision. Say so instead of
+        // overwriting silently.
+        toast.info(
+          "Resume Studio was updated elsewhere. Your edits here were kept and re-saved.",
+        );
+      }
+      setDraft((current) =>
+        current ? { ...latest, resumeJson: current.resumeJson } : latest,
+      );
+      setDirty(true);
+      setSaveState("idle");
+      return true;
+    } catch {
+      return false;
+    }
+  };
 
   useEffect(() => {
     if (
@@ -119,6 +185,7 @@ export function useDesignResumeStudio() {
           baseRevision,
           document: documentSnapshot,
         });
+        conflictRecoveryAttemptsRef.current = 0;
         if (editVersionRef.current === editVersionAtStart) {
           queryClient.setQueryData(queryKeys.designResume.current(), updated);
           queryClient.setQueryData(queryKeys.designResume.status(), {
@@ -145,6 +212,7 @@ export function useDesignResumeStudio() {
         );
         setSaveState("idle");
       } catch (saveError) {
+        if (await recoverFromRevisionConflict(saveError)) return;
         setSaveState("error");
         showErrorToast(saveError, "Failed to save Resume Studio.");
       }
@@ -183,6 +251,7 @@ export function useDesignResumeStudio() {
         baseRevision,
         document: documentSnapshot,
       });
+      conflictRecoveryAttemptsRef.current = 0;
 
       if (editVersionRef.current === editVersionAtStart) {
         setDesignResume(updated);
@@ -213,6 +282,7 @@ export function useDesignResumeStudio() {
     updater: (resumeJson: DesignResumeJson) => DesignResumeJson,
   ) => {
     editVersionRef.current += 1;
+    conflictRecoveryAttemptsRef.current = 0;
     setDraft((current) => {
       if (!current) return current;
       return {


### PR DESCRIPTION
In the Resume Studio, adding skills (and reordering items) can leave the list
showing entries that aren't really there: the new skill group renders, further
edits render, but none of it is saved — and only refreshing the page clears the
stale entries (discarding the edits with them). The save badge sits on
"Autosaving" and a small toast repeats "Resume Studio has changed. Refresh and
try again." / "Failed to save Resume Studio."

Root cause — the studio's autosave cannot recover from an optimistic-concurrency
conflict:

1. The studio autosaves the full document with a `baseRevision`; the server
   rejects a stale revision with 409 "Resume Studio has changed. Refresh and try
   again." (`updateCurrentDesignResume`).
2. Once the server-side revision has moved past the studio's local draft — a
   second tab, an import, a server-side write, or a previously failed save — the
   autosave `catch` only did `setSaveState("error")` and a toast. It never
   refetched or rebased, so **every subsequent autosave retried with the same
   stale `baseRevision` and got 409 forever**.
3. Meanwhile the UI keeps accepting edits into the local draft: skill groups you
   add and reorders you make render immediately but silently never persist. A
   refresh throws the local draft away and reloads the server document, which is
   why refreshing "clears" the phantom entries.
4. An aggravator makes the stale revision reachable in a single tab: the
   draft-sync effect (`if (!document || dirty) return; setDraft(document)`)
   adopted *any* refetched query-cache document when the draft wasn't dirty —
   including one older than the draft (a slow GET resolving after a PATCH
   committed a newer revision) — planting the stale revision that poisons every
   later autosave.

Reproduced end-to-end against a live dev instance: bump the server document
revision externally (as a second tab or import would), then add a skill group or
reorder in the studio. Every autosave fails `PATCH baseRevision N → 409`,
retrying with the same `N`; the list shows the new group/order; the server
doesn't have it; reloading the page reverts the list and the edits are gone.

## The fix

Two changes in `useDesignResumeStudio.ts`:

1. **Recover from revision conflicts by rebasing.** When an autosave fails with
   a 409, the hook now fetches the current server document and rebases: it
   adopts the server document's metadata — most importantly its revision — while
   keeping the local `resumeJson` (the user's newest edits), marks the draft
   dirty, and lets the normal autosave cycle retry. The next save goes out with
   the correct `baseRevision` and the user's content, and converges without any
   user intervention. Because saves replace the whole document, the retried save
   wins over whatever bumped the revision, so the first recovery announces
   itself with a toast ("Resume Studio was updated elsewhere. Your edits here
   were kept and re-saved.") rather than overwriting silently. Recovery is
   capped at 3 consecutive attempts per edit (`conflictRecoveryAttemptsRef`,
   re-armed on every local edit and reset on any successful save), so a
   persistently racing writer surfaces the existing error toast instead of
   looping.
2. **Never adopt a stale document over a newer draft.** The draft-sync effect
   now skips a query-cache document that is older than the local draft — lower
   revision *and* not newer by `updatedAt` — so a slow refetch can no longer
   revert the studio to stale content and a stale revision. The timestamp
   condition matters because a re-import legitimately resets the revision to 1:
   such a document is newer by `updatedAt` and is still adopted.

## Tradeoff

The studio's saves are full-document replacements with no merge infrastructure,
so concurrent edits from two tabs were always last-writer-wins in substance.
This PR keeps that model but changes *which* writer wins in the conflict case:
previously the conflicting tab wedged (and lost its own edits on the eventual
refresh, while the other tab's write survived); now the actively-edited tab
re-saves and wins, with a toast making the overwrite visible. A real merge (or
a user-facing conflict prompt) would be a larger follow-up; for the dominant
single-writer case — the reported bug — the rebase is exactly right, since the
"conflicting" revision belongs to the same editing session.

## Tests

New `useDesignResumeStudio.test.tsx` (the hook previously had no tests):

- **Recovers from a revision conflict**: first save 409s with `baseRevision: 9`,
  recovery fetches the rev-10 server doc, the draft keeps the local edit and
  adopts revision 10, and the retry saves `baseRevision: 10` with the local
  content. Fails on the code before this PR (no retry, save wedged in "error").
- **Gives up after repeated conflicts**: 3 automatic recoveries, then the 4th
  conflict surfaces the error toast — no unbounded retry loop — with the local
  edits still on screen.
- **Ignores a refetched document older than the local draft**, while still
  adopting a genuinely newer one. Fails on the code before this PR.
- **Adopts a re-imported document** whose revision restarted at 1 but whose
  timestamp is newer.
- **Non-conflict save errors keep the existing behavior** (no recovery fetch,
  error state + toast).

Verified live in the dev app: with the fix, the same externally-bumped-revision
scenario produces `PATCH baseRev 10 → 409`, an automatic rebase, and an
immediate `PATCH baseRev 11 → 200` carrying the same items — server state and UI
agree, no phantom entries, no refresh needed.

Full orchestrator suite + typecheck pass. (The 4 failures in
`job-posting-age.test.ts` / `ApplicationsPerDayChart.test.tsx` are date-sensitive
and fail identically on `main`.)
