### PR TITLE
feat: add OrcaRouter as a first-class LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 
 MODEL=google/gemini-3-flash-preview
 
-# LLM provider (optional). Examples: openrouter, requesty, openai, gemini, gemini_cli, claude_cli, codex.
+# LLM provider (optional). Examples: openrouter, orcarouter, requesty, openai, gemini, gemini_cli, claude_cli, codex.
 # LLM_PROVIDER=gemini_cli
 # For Gemini (CLI): install @google/gemini-cli, run `gemini` and sign in (OAuth), or set
 # GEMINI_API_KEY in the environment. Optional overrides:

--- a/docs-site/docs/features/settings.md
+++ b/docs-site/docs/features/settings.md
@@ -43,7 +43,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
 ![Model settings section](/img/features/settings-model-section.png)
 
 - In hosted deployments with platform-managed LLM enabled, this section is hidden because provider, API key, and model selection are managed by the hosted platform.
-- Choose provider (`openrouter`, `requesty`, `lmstudio`, `ollama`, `openai`, `glm`, `gemini`, `gemini_cli`, `claude_cli`, `codex`)
+- Choose provider (`openrouter`, `orcarouter`, `requesty`, `lmstudio`, `ollama`, `openai`, `glm`, `gemini`, `gemini_cli`, `claude_cli`, `codex`)
 - Set provider-specific base URL/API key when required
 - Configure the default model/runtime, plus purpose-specific overrides for:
   - Scoring
@@ -64,6 +64,7 @@ Settings gives you runtime overrides for the key parts of discovery, scoring, ta
   - `gemini_cli`: a curated list of Gemini model ids the CLI typically supports (install [Gemini CLI](https://www.npmjs.com/package/@google/gemini-cli), run `gemini` and complete Google sign-in, or set `GEMINI_API_KEY` for the CLI; JobOps spawns headless `gemini -p ...` with `--approval-mode plan` and no JobOps API key field). **Resume import** uses the CLI with extracted text: DOCX is parsed locally; PDF uses local text extraction then JSON extraction via the CLI (scanned PDFs without a text layer may not import well).
   - `claude_cli`: a curated list of Claude model ids (install [Claude Code](https://www.npmjs.com/package/@anthropic-ai/claude-code), run `claude setup-token` to mint a long-lived token from a Claude Pro/Max/Team/Enterprise subscription and set it as `CLAUDE_CODE_OAUTH_TOKEN`, or set `ANTHROPIC_API_KEY` instead; JobOps spawns headless `claude -p ...` with `--permission-mode plan` and no JobOps API key field). **Resume import** uses the CLI with extracted text, same as `gemini_cli`: DOCX is parsed locally; PDF uses local text extraction then JSON extraction via the CLI.
   - `ollama`: locally installed Ollama models
+  - `orcarouter`: available models from the OrcaRouter gateway
 - `openrouter`, `lmstudio`, and `openai_compatible` stay manual-entry because JobOps cannot safely infer the exact model catalog from those providers
 - For GLM, JobOps uses `https://api.z.ai/api/paas/v4` by default. Override the base URL only when using another Z.AI-compatible endpoint such as a coding-plan endpoint.
 - Changing the provider clears stale model overrides in the form, so inherited fields follow the new provider default unless you explicitly choose a new override

--- a/orchestrator/src/client/pages/settings/utils.test.ts
+++ b/orchestrator/src/client/pages/settings/utils.test.ts
@@ -21,6 +21,9 @@ describe("settings utils", () => {
     expect(getLlmProviderConfig("openrouter").keyHelperHref).toBe(
       "https://openrouter.ai/keys",
     );
+    expect(getLlmProviderConfig("orcarouter").keyHelperHref).toBe(
+      "https://www.orcarouter.ai/console",
+    );
     expect(getLlmProviderConfig("openai").keyHelperHref).toBe(
       "https://platform.openai.com/api-keys",
     );
@@ -119,6 +122,7 @@ describe("settings utils", () => {
     expect(supportsLlmModelSuggestions("claude_cli")).toBe(true);
     expect(supportsLlmModelSuggestions("ollama")).toBe(true);
     expect(supportsLlmModelSuggestions("requesty")).toBe(true);
+    expect(supportsLlmModelSuggestions("orcarouter")).toBe(true);
     expect(supportsLlmModelSuggestions("openrouter")).toBe(false);
   });
 });

--- a/orchestrator/src/client/pages/settings/utils.ts
+++ b/orchestrator/src/client/pages/settings/utils.ts
@@ -22,6 +22,7 @@ export const formatSecretHint = (hint: string | null) =>
 
 export const LLM_PROVIDERS = [
   "openrouter",
+  "orcarouter",
   "requesty",
   "lmstudio",
   "ollama",
@@ -45,10 +46,12 @@ export const LLM_MODEL_SUGGESTION_PROVIDERS = [
   "claude_cli",
   "ollama",
   "requesty",
+  "orcarouter",
 ] as const;
 
 export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
   openrouter: "OpenRouter",
+  orcarouter: "OrcaRouter",
   requesty: "Requesty",
   lmstudio: "LM Studio",
   ollama: "Ollama",
@@ -64,6 +67,7 @@ export const LLM_PROVIDER_LABELS: Record<LlmProviderId, string> = {
 
 const PROVIDERS_WITH_API_KEY = new Set<LlmProviderId>([
   "openrouter",
+  "orcarouter",
   "requesty",
   "openai",
   "anthropic",
@@ -84,6 +88,8 @@ const PROVIDERS_WITH_BASE_URL = new Set<LlmProviderId>([
 const PROVIDER_HINTS: Record<LlmProviderId, string> = {
   openrouter:
     "OpenRouter uses your API key and supports model routing across providers.",
+  orcarouter:
+    "OrcaRouter uses your API key and routes requests across providers through an OpenAI-compatible endpoint with adaptive routing and guardrails.",
   requesty:
     "Requesty uses your API key and routes requests across providers through an OpenAI-compatible endpoint.",
   lmstudio: "LM Studio runs locally via its OpenAI-compatible server.",
@@ -111,6 +117,10 @@ const PROVIDER_KEY_HELPERS: Record<
   openrouter: {
     text: "Create a key at openrouter.ai",
     href: "https://openrouter.ai/keys",
+  },
+  orcarouter: {
+    text: "Create a key at orcarouter.ai/console",
+    href: "https://www.orcarouter.ai/console",
   },
   requesty: {
     text: "Create a key at app.requesty.ai/api-keys",

--- a/orchestrator/src/server/services/design-resume/import-file.ts
+++ b/orchestrator/src/server/services/design-resume/import-file.ts
@@ -42,6 +42,7 @@ type SupportedImportMediaType =
 type SupportedRuntimeProvider =
   | "openai"
   | "openrouter"
+  | "orcarouter"
   | "glm"
   | "gemini"
   | "gemini_cli"
@@ -337,6 +338,9 @@ function normalizeRuntimeProvider(
   if (normalized === "openrouter" || normalized === "open_router") {
     return "openrouter";
   }
+  if (normalized === "orcarouter" || normalized === "orca_router") {
+    return "orcarouter";
+  }
   const mapped = mapGlmProviderAlias(normalized ?? "");
   if (mapped === "glm") return "glm";
   if (mapped === "gemini") return "gemini";
@@ -465,7 +469,7 @@ function appendVersionedPath(baseUrl: string, path: string): string {
 
 function resolveChatCompletionsUrl(
   baseUrlOrEndpoint: string,
-  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio",
+  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio" | "orcarouter",
 ): string {
   const normalized = normalizeBaseUrlOrEndpoint(baseUrlOrEndpoint);
   if (
@@ -1107,7 +1111,7 @@ function parseReactiveResumeJsonFile(content: string): DesignResumeJson {
 }
 
 function buildCapabilityErrorMessage(provider: string): string {
-  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, Gemini, Gemini (CLI), Codex, OpenAI-compatible, Ollama, or LM Studio to import resumes. PDF and DOCX files can be converted to plain text locally before extraction when native file upload is unavailable.`;
+  return `Resume file import is not available for the current AI provider (${provider}). Connect OpenAI, OpenRouter, OrcaRouter, Gemini, Gemini (CLI), Codex, OpenAI-compatible, Ollama, or LM Studio to import resumes. PDF and DOCX files can be converted to plain text locally before extraction when native file upload is unavailable.`;
 }
 
 function isFileCapabilityError(message: string): boolean {
@@ -1164,6 +1168,7 @@ function isTextOnlyImportProvider(provider: SupportedRuntimeProvider): boolean {
     provider === "glm" ||
     provider === "ollama" ||
     provider === "lmstudio" ||
+    provider === "orcarouter" ||
     provider === "codex"
   );
 }
@@ -1172,6 +1177,7 @@ function providerRequiresApiKey(provider: SupportedRuntimeProvider): boolean {
   return (
     provider === "openai" ||
     provider === "openrouter" ||
+    provider === "orcarouter" ||
     provider === "gemini" ||
     provider === "glm"
   );
@@ -1497,16 +1503,17 @@ async function extractWithGemini(args: {
 }
 
 function getDefaultChatCompletionsBaseUrl(
-  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio",
+  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio" | "orcarouter",
 ): string {
   if (provider === "ollama") return "http://localhost:11434";
   if (provider === "lmstudio") return "http://localhost:1234";
   if (provider === "glm") return "https://api.z.ai/api/paas/v4";
+  if (provider === "orcarouter") return "https://api.orcarouter.ai/v1";
   return "https://api.openai.com";
 }
 
 async function extractWithTextChatCompletions(args: {
-  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio";
+  provider: "openai_compatible" | "glm" | "ollama" | "lmstudio" | "orcarouter";
   apiKey: string | null;
   baseUrl: string | null;
   model: string;
@@ -1799,7 +1806,8 @@ async function extractResumeFromProvider(args: {
     args.provider === "openai_compatible" ||
     args.provider === "glm" ||
     args.provider === "ollama" ||
-    args.provider === "lmstudio"
+    args.provider === "lmstudio" ||
+    args.provider === "orcarouter"
   ) {
     const text = args.documentText?.trim();
     if (!text) {

--- a/orchestrator/src/server/services/ghostwriter.ts
+++ b/orchestrator/src/server/services/ghostwriter.ts
@@ -337,6 +337,7 @@ async function imageInputCapabilityReason(
 
   if (
     provider === "openrouter" ||
+    provider === "orcarouter" ||
     provider === "openai_compatible" ||
     provider === "glm"
   ) {

--- a/orchestrator/src/server/services/llm/credentials.test.ts
+++ b/orchestrator/src/server/services/llm/credentials.test.ts
@@ -8,6 +8,7 @@ describe("resolveLlmApiKey", () => {
     process.env = { ...originalEnv };
     delete process.env.LLM_API_KEY;
     delete process.env.OPENROUTER_API_KEY;
+    delete process.env.ORCAROUTER_API_KEY;
   });
 
   afterEach(() => {
@@ -52,6 +53,17 @@ describe("resolveLlmApiKey", () => {
         provider: "openrouter",
       }),
     ).toBe("sk-openrouter");
+  });
+
+  it("falls back to ORCAROUTER_API_KEY for orcarouter providers", async () => {
+    process.env.ORCAROUTER_API_KEY = "sk-orca-test";
+    const { resolveLlmApiKey } = await loadResolver();
+
+    expect(
+      resolveLlmApiKey({
+        provider: "orcarouter",
+      }),
+    ).toBe("sk-orca-test");
   });
 
   it("ignores whitespace-only stored overrides", async () => {

--- a/orchestrator/src/server/services/llm/credentials.ts
+++ b/orchestrator/src/server/services/llm/credentials.ts
@@ -48,5 +48,12 @@ export function resolveLlmApiKey(options: {
     return toStringOrNull(getOriginalEnvValue("REQUESTY_API_KEY"));
   }
 
+  if (
+    provider === "orcarouter" &&
+    toStringOrNull(getOriginalEnvValue("ORCAROUTER_API_KEY"))
+  ) {
+    return toStringOrNull(getOriginalEnvValue("ORCAROUTER_API_KEY"));
+  }
+
   return null;
 }

--- a/orchestrator/src/server/services/llm/providers/index.ts
+++ b/orchestrator/src/server/services/llm/providers/index.ts
@@ -10,10 +10,12 @@ import { ollamaStrategy } from "./ollama";
 import { openAiStrategy } from "./openai";
 import { openAiCompatibleStrategy } from "./openai-compatible";
 import { openRouterStrategy } from "./openrouter";
+import { orcaRouterStrategy } from "./orcarouter";
 import { requestyStrategy } from "./requesty";
 
 export const strategies: Record<LlmProvider, ProviderStrategy> = {
   openrouter: openRouterStrategy,
+  orcarouter: orcaRouterStrategy,
   requesty: requestyStrategy,
   lmstudio: lmStudioStrategy,
   ollama: ollamaStrategy,

--- a/orchestrator/src/server/services/llm/providers/orcarouter.ts
+++ b/orchestrator/src/server/services/llm/providers/orcarouter.ts
@@ -1,0 +1,22 @@
+import { buildHeaders, joinUrl } from "../utils/http";
+import {
+  buildChatCompletionsBody,
+  createProviderStrategy,
+  extractChatCompletionsText,
+} from "./factory";
+
+export const orcaRouterStrategy = createProviderStrategy({
+  provider: "orcarouter",
+  defaultBaseUrl: "https://api.orcarouter.ai/v1",
+  requiresApiKey: true,
+  modes: ["json_schema", "json_object", "text", "none"],
+  validationPaths: ["/models"],
+  buildRequest: ({ mode, baseUrl, apiKey, model, messages, jsonSchema }) => {
+    return {
+      url: joinUrl(baseUrl, "/chat/completions"),
+      headers: buildHeaders({ apiKey, provider: "orcarouter" }),
+      body: buildChatCompletionsBody({ mode, model, messages, jsonSchema }),
+    };
+  },
+  extractText: extractChatCompletionsText,
+});

--- a/orchestrator/src/server/services/llm/providers/providers.test.ts
+++ b/orchestrator/src/server/services/llm/providers/providers.test.ts
@@ -7,6 +7,7 @@ import { ollamaStrategy } from "./ollama";
 import { openAiStrategy } from "./openai";
 import { openAiCompatibleStrategy } from "./openai-compatible";
 import { openRouterStrategy } from "./openrouter";
+import { orcaRouterStrategy } from "./orcarouter";
 import { requestyStrategy } from "./requesty";
 
 const schema = {
@@ -46,6 +47,18 @@ describe("provider adapters", () => {
           model: "openai/gpt-4o-mini",
         },
         expectedUrl: "https://router.requesty.ai/v1/chat/completions",
+        expectedResponseFormat: "json_schema",
+      },
+      {
+        name: "orcarouter-json_schema",
+        strategy: orcaRouterStrategy,
+        args: {
+          mode: "json_schema" as const,
+          baseUrl: "https://api.orcarouter.ai/v1",
+          apiKey: "x",
+          model: "openai/gpt-4o-mini",
+        },
+        expectedUrl: "https://api.orcarouter.ai/v1/chat/completions",
         expectedResponseFormat: "json_schema",
       },
       {
@@ -197,6 +210,7 @@ describe("provider adapters", () => {
       choices: [{ message: { content: "ok" } }],
     };
     expect(openRouterStrategy.extractText(response)).toBe("ok");
+    expect(orcaRouterStrategy.extractText(response)).toBe("ok");
     expect(requestyStrategy.extractText(response)).toBe("ok");
     expect(glmStrategy.extractText(response)).toBe("ok");
     expect(lmStudioStrategy.extractText(response)).toBe("ok");

--- a/orchestrator/src/server/services/llm/service.test.ts
+++ b/orchestrator/src/server/services/llm/service.test.ts
@@ -283,4 +283,29 @@ describe("LlmService provider normalization", () => {
     const [requestedUrl] = fetchSpy.mock.calls[0] ?? [];
     expect(String(requestedUrl)).toBe("https://router.requesty.ai/v1/models");
   });
+
+  it("lists OrcaRouter models from the /models endpoint", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            { id: "openai/gpt-4o-mini" },
+            { id: "anthropic/claude-sonnet-4-5" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const llm = new LlmService({
+      provider: "orcarouter",
+      apiKey: "sk-orca-test",
+    });
+    const models = await llm.listModels();
+
+    expect(models).toContain("openai/gpt-4o-mini");
+    expect(models).toContain("anthropic/claude-sonnet-4-5");
+    const [requestedUrl] = fetchSpy.mock.calls[0] ?? [];
+    expect(String(requestedUrl)).toBe("https://api.orcarouter.ai/v1/models");
+  });
 });

--- a/orchestrator/src/server/services/llm/service.ts
+++ b/orchestrator/src/server/services/llm/service.ts
@@ -246,7 +246,8 @@ export class LlmService {
       this.provider !== "glm" &&
       this.provider !== "gemini" &&
       this.provider !== "ollama" &&
-      this.provider !== "requesty"
+      this.provider !== "requesty" &&
+      this.provider !== "orcarouter"
     ) {
       return [];
     }
@@ -265,6 +266,9 @@ export class LlmService {
         return this.listGlmModels();
       }
       if (this.provider === "requesty") {
+        return this.listRequestyModels();
+      }
+      if (this.provider === "orcarouter") {
         return this.listRequestyModels();
       }
       return this.listOllamaModels();
@@ -696,6 +700,7 @@ function normalizeProvider(
   if (normalized === "ollama") return "ollama";
   if (normalized === "codex") return "codex";
   if (normalized === "requesty") return "requesty";
+  if (normalized === "orcarouter") return "orcarouter";
   if (normalized && normalized !== "openrouter") {
     logger.warn("Unknown LLM provider, defaulting to openrouter", {
       normalized,

--- a/orchestrator/src/server/services/llm/types.ts
+++ b/orchestrator/src/server/services/llm/types.ts
@@ -1,5 +1,6 @@
 export type LlmProvider =
   | "openrouter"
+  | "orcarouter"
   | "requesty"
   | "lmstudio"
   | "ollama"

--- a/orchestrator/src/server/services/modelSelection.ts
+++ b/orchestrator/src/server/services/modelSelection.ts
@@ -94,6 +94,7 @@ function getDefaultBaseUrlForProvider(
   )
     return null;
   if (normalized === "requesty") return "https://router.requesty.ai/v1";
+  if (normalized === "orcarouter") return "https://api.orcarouter.ai/v1";
   return "https://openrouter.ai";
 }
 

--- a/orchestrator/src/server/services/settings.ts
+++ b/orchestrator/src/server/services/settings.ts
@@ -59,6 +59,9 @@ function resolveDefaultLlmBaseUrl(provider: string): string {
   if (normalized === "requesty") {
     return "https://router.requesty.ai/v1";
   }
+  if (normalized === "orcarouter") {
+    return "https://api.orcarouter.ai/v1";
+  }
   return "https://openrouter.ai";
 }
 

--- a/shared/src/types/settings.ts
+++ b/shared/src/types/settings.ts
@@ -26,6 +26,7 @@ export interface ResumeProjectsSettings {
 
 export const LLM_PROVIDER_VALUES = [
   "openrouter",
+  "orcarouter",
   "requesty",
   "lmstudio",
   "ollama",


### PR DESCRIPTION
# Add OrcaRouter as a first-class LLM provider

## Why

JobOps positions itself as *"your ironman suit for job hunting"* and says it *"works with the model provider you already use"* — OpenRouter, Requesty, Gemini, and the rest are selectable by name in the model settings. When you use a gateway like that, you get a single OpenAI-compatible endpoint that spans many models, so you don't have to think about which upstream provider each model runs on.

[OrcaRouter](https://www.orcarouter.ai) is that same kind of gateway. It exposes a provider/model namespace across many models — OpenRouter-style — and adds adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Up until now a JobOps user could only reach it through the generic "OpenAI-compatible" option, typing in a bare base URL and a key. That works, but it treats OrcaRouter like an anonymous endpoint instead of the first-class provider it is.

This PR adds `orcarouter` to the provider picker exactly like OpenRouter and Requesty, so users get the label, the default base URL (`https://api.orcarouter.ai/v1`), the env-key fallback (`ORCAROUTER_API_KEY`), model discovery, and structured-output scoring/tailoring — no custom base URL required.

## What changed

The implementation mirrors the existing `requesty` adapter, which is the closest existing shape (an OpenAI-compatible gateway with a `/models` catalog):

- **Provider strategy** (`orchestrator/src/server/services/llm/providers/orcarouter.ts`): chat-completions request builder with `json_schema` / `json_object` / `text` / `none` modes and `/models` validation, built on the shared `createProviderStrategy` factory — same as Requesty and OpenRouter.
- **Registry & types**: added `orcarouter` to the `LlmProvider` union, the shared `LLM_PROVIDER_VALUES` enum, and the client `LLM_PROVIDERS`/`LLM_PROVIDER_LABELS`/hints so it appears in the Settings and onboarding pickers.
- **Default base URL resolution** across `settings.ts`, `modelSelection.ts`, and the onboarding validation path.
- **Env-key fallback** in `credentials.ts` so `ORCAROUTER_API_KEY` is honored when `LLM_API_KEY` isn't set (matching the `REQUESTY_API_KEY` behavior).
- **Model discovery**: `LlmService.listModels()` now routes `orcarouter` to the `/models` endpoint, so the Settings page offers a provider-aware model picker (like Requesty).
- **Resume import**: `orcarouter` is wired into the text-based chat-completions import path, so DOCX/PDF text extraction works for this provider too.
- **Ghostwriter**: `orcarouter` is treated as an image-capable gateway in the screenshot-context capability check, same as the other OpenAI-compatible gateways.
- **Tests**: provider request-building, model listing, key resolution, and client provider-config cases.
- **Docs**: the provider list in `docs-site/docs/features/settings.md` and `.env.example`.

## Verification

- `npm run check:all` (Biome) — clean
- `npm run check:types` — clean
- `npm run test:all` — 286 test files, 1962 tests passing
- `docs-site` production build — clean
- Live test against the OrcaRouter API through the new `LlmService` path: credential validation returned `valid: true`, model discovery returned 204 models, and a structured-output chat completion returned the expected JSON.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
