### PR TITLE
Persist Tectonic support-bundle cache to fix cold-start PDF renders

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,10 @@ services:
       - ./data:/app/data
       # Persist Codex login/session data for app-server provider
       - codex-home:/app/codex-home
+      # Persist Tectonic's LaTeX support-bundle cache. Without this, every
+      # container recreate re-downloads the support bundle on the first PDF
+      # render, which is slow and can fail with HTTP 429 rate-limiting.
+      - tectonic-cache:/root/.cache/Tectonic
     environment:
       # Server config
       - NODE_ENV=production
@@ -104,3 +108,4 @@ secrets:
 volumes:
   data:
   codex-home:
+  tectonic-cache:


### PR DESCRIPTION
## Problem

The first résumé→PDF render after starting a fresh container (or after any `docker compose up --force-recreate`) can fail. Tectonic downloads its LaTeX support bundle on first use into `/root/.cache/Tectonic`, and the compose file doesn't persist that path — so the cache is empty on every recreate, the bundle is re-fetched, and the download is sometimes rate-limited with **HTTP 429**, which fails the render.

## Root cause

`/root/.cache/Tectonic` is not mounted to a volume, so Tectonic's support-bundle cache does not survive a container recreate.

## Fix

Add a `tectonic-cache` named volume mounted at `/root/.cache/Tectonic`. After the first successful render the bundle is cached persistently, so subsequent renders are fast and work offline, and recreates no longer trigger a re-download.

## Testing

- Before: on a freshly recreated container with an empty cache, the first PDF render intermittently fails with a 429 from the bundle host.
- After: the bundle is fetched once, persists across `docker compose down`/`up` and `--force-recreate`, and renders succeed offline thereafter.

Compose-only; no application code changes. The mount path matches the container's existing `HOME=/root`, consistent with where Tectonic already writes its cache.
