### PR TITLE
Fix Applied → In Progress pipeline workflow (#714)

### DIFF
--- a/docs-site/docs/features/in-progress-board.md
+++ b/docs-site/docs/features/in-progress-board.md
@@ -11,8 +11,9 @@ The In Progress Board is a kanban view for jobs that have moved beyond initial a
 
 ![In Progress Board kanban lanes](/img/features/in-progress-board.png)
 
-It groups jobs into post-application lanes:
+It groups jobs into lanes:
 
+- Applied
 - Recruiter Screen
 - Assessment
 - Team Match
@@ -20,6 +21,8 @@ It groups jobs into post-application lanes:
 - Final Round
 - Offer
 - Closed
+
+The **Applied** lane can be collapsed to a thin strip so it doesn't take up horizontal space, letting you focus on jobs that are actively moving through later stages. Your collapsed/expanded preference is remembered across visits.
 
 ## Why it exists
 
@@ -44,9 +47,9 @@ When you successfully move a job listing to the **Offer** stage (either by dragg
 
 ### Moving jobs into post-application
 
-Jobs typically move into post-application tracking when they receive a response after applying.
+Marking a job **Applied** puts it directly on the board in the Applied lane — there's no separate "move to in progress" step. From there, drag a card (or use the card menu's **Log event**) to record what actually happened: Recruiter Screen, Rejected, Withdrawn, or any other stage/outcome.
 
-This can happen via:
+Later stage changes can also happen via:
 
 - Tracking Inbox review/automation (recommended)
 - Manual stage transitions in job detail/timeline tools
@@ -76,8 +79,8 @@ curl -X POST "http://localhost:3001/api/jobs/<jobId>/stage-events" \
 
 ### Board is empty
 
-- Confirm jobs have status `in_progress`.
-- Confirm stage events exist for applied jobs expected on the board.
+- Confirm jobs have status `applied` or `in_progress`.
+- Check whether the Applied lane is collapsed — expand it from the chevron in its header.
 
 ### A card appears in an unexpected lane
 

--- a/docs-site/docs/features/keyboard-shortcuts.md
+++ b/docs-site/docs/features/keyboard-shortcuts.md
@@ -29,8 +29,7 @@ It shows the same tab-scoped shortcuts in a compact layout.
 - `k` or `ArrowUp`: previous job
 - `1`: Ready tab
 - `2`: Discovered tab
-- `3`: Applied tab
-- `4`: All Jobs tab
+- `3`: All Jobs tab
 - `ArrowLeft`: previous tab
 - `ArrowRight`: next tab
 

--- a/docs-site/docs/features/orchestrator.md
+++ b/docs-site/docs/features/orchestrator.md
@@ -81,7 +81,6 @@ Date filters work on every jobs tab:
 
 - `Ready`
 - `Discovered`
-- `Applied`
 - `All Jobs`
 
 Available date dimensions:
@@ -229,7 +228,6 @@ curl -X POST "http://localhost:3001/api/jobs/<jobId>/generate-pdf"
 
 - Open `Filters` and confirm at least one date dimension is selected.
 - Check that your date range matches the lifecycle timestamp you care about.
-- Remember that `Applied` still means jobs currently in the `applied` status, while `All Jobs` can be used for broader historical browsing.
 
 ## Related pages
 

--- a/orchestrator/src/client/lib/shortcut-map.ts
+++ b/orchestrator/src/client/lib/shortcut-map.ts
@@ -60,15 +60,9 @@ export const SHORTCUTS = {
     label: "Discovered tab",
     group: "tabs",
   },
-  tabApplied: {
+  tabAll: {
     key: "3",
     displayKey: "3",
-    label: "Applied tab",
-    group: "tabs",
-  },
-  tabAll: {
-    key: "4",
-    displayKey: "4",
     label: "All Jobs tab",
     group: "tabs",
   },

--- a/orchestrator/src/client/pages/InProgressBoardPage.test.tsx
+++ b/orchestrator/src/client/pages/InProgressBoardPage.test.tsx
@@ -59,6 +59,7 @@ vi.mock("../api", () => ({
   getJobStageEvents: vi.fn(),
   transitionJobStage: vi.fn(),
   updateJobStageEvent: vi.fn(),
+  getAuthScopedStorageKey: (key: string) => key,
 }));
 
 vi.mock("@/client/lib/celebrate", () => ({
@@ -158,6 +159,7 @@ const makeEvent = (overrides: Partial<StageEvent>): StageEvent => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
 
   vi.mocked(api.getJobs).mockResolvedValue({
     jobs: [makeJob({})],
@@ -189,7 +191,7 @@ describe("InProgressBoardPage", () => {
 
     await waitFor(() => {
       expect(api.getJobs).toHaveBeenCalledWith({
-        statuses: ["in_progress"],
+        statuses: ["applied", "in_progress"],
         view: "list",
       });
     });
@@ -207,6 +209,78 @@ describe("InProgressBoardPage", () => {
     );
 
     expect(await screen.findByText("Backend Engineer")).toBeInTheDocument();
+  });
+
+  it("keeps an applied job with no stage events in the Applied lane, not Recruiter Screen (#714)", async () => {
+    vi.mocked(api.getJobs).mockResolvedValue({
+      jobs: [makeJob({ status: "applied" })],
+      total: 1,
+      byStatus: {
+        discovered: 0,
+        processing: 0,
+        ready: 0,
+        applied: 1,
+        in_progress: 0,
+        skipped: 0,
+        expired: 0,
+      },
+      revision: "r1",
+    } as Awaited<ReturnType<typeof api.getJobs>>);
+    vi.mocked(api.getJobStageEvents).mockResolvedValue([]);
+
+    render(
+      <MemoryRouter>
+        <InProgressBoardPage />
+      </MemoryRouter>,
+    );
+
+    const appliedLane = await screen.findByRole("region", {
+      name: "Applied lane",
+    });
+    expect(
+      within(appliedLane).getByText("Backend Engineer"),
+    ).toBeInTheDocument();
+
+    const recruiterScreenLane = screen.getByRole("region", {
+      name: "Recruiter Screen lane",
+    });
+    expect(
+      within(recruiterScreenLane).queryByText("Backend Engineer"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("collapses and expands the Applied lane, persisting the preference", async () => {
+    const { unmount } = render(
+      <MemoryRouter>
+        <InProgressBoardPage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole("region", { name: "Applied lane" });
+    fireEvent.click(
+      screen.getByRole("button", { name: /collapse applied lane/i }),
+    );
+
+    const collapsedAppliedLane = screen.getByRole("region", {
+      name: "Applied lane",
+    });
+    expect(
+      within(collapsedAppliedLane).queryByText(
+        "Drop a card here or log a stage.",
+      ),
+    ).not.toBeInTheDocument();
+    unmount();
+
+    render(
+      <MemoryRouter>
+        <InProgressBoardPage />
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole("region", { name: "Applied lane" });
+    expect(
+      screen.getByRole("button", { name: /expand applied lane/i }),
+    ).toBeInTheDocument();
   });
 
   it("transitions a job stage when dropped into another lane", async () => {

--- a/orchestrator/src/client/pages/InProgressBoardPage.tsx
+++ b/orchestrator/src/client/pages/InProgressBoardPage.tsx
@@ -11,7 +11,13 @@ import {
   type StageEvent,
 } from "@shared/types.js";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowDownAZ, Columns3, Plus } from "lucide-react";
+import {
+  ArrowDownAZ,
+  ChevronLeft,
+  ChevronRight,
+  Columns3,
+  Plus,
+} from "lucide-react";
 import React from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { toast } from "sonner";
@@ -33,14 +39,13 @@ import {
 import { cn } from "@/lib/utils";
 import * as api from "../api";
 import { InProgressBoardCard } from "./InProgressBoardCard";
+import { IN_PROGRESS_BOARD_APPLIED_COLLAPSED_STORAGE_KEY } from "./orchestrator/constants";
 
 type BoardCard = {
   job: JobListItem;
   stage: ApplicationStage;
   latestEventAt: number | null;
 };
-
-type BoardStage = Exclude<ApplicationStage, "applied">;
 
 const sortByRecent = (a: BoardCard, b: BoardCard) => {
   if (a.latestEventAt != null && b.latestEventAt != null) {
@@ -57,12 +62,13 @@ const sortByTitle = (a: BoardCard, b: BoardCard) =>
 const sortByCompany = (a: BoardCard, b: BoardCard) =>
   a.job.employer.localeCompare(b.job.employer);
 
-const BOARD_STAGES = APPLICATION_STAGES.filter(
-  (stage) => stage !== "applied",
-) as BoardStage[];
+const BOARD_STAGES = APPLICATION_STAGES;
 
-const toBoardStage = (stage: ApplicationStage): BoardStage =>
-  stage === "applied" ? "recruiter_screen" : stage;
+const getAppliedCollapsedStorageKey = () =>
+  api.getAuthScopedStorageKey(IN_PROGRESS_BOARD_APPLIED_COLLAPSED_STORAGE_KEY);
+
+const readAppliedCollapsed = () =>
+  localStorage.getItem(getAppliedCollapsedStorageKey()) === "1";
 
 const getCardLeftAccentClass = (stage: ApplicationStage) => {
   if (stage === "technical_interview") {
@@ -110,12 +116,21 @@ export const InProgressBoardPage: React.FC = () => {
     job: JobListItem;
     stage: ApplicationStage;
   } | null>(null);
+  const [isAppliedCollapsed, setIsAppliedCollapsed] =
+    React.useState(readAppliedCollapsed);
+
+  React.useEffect(() => {
+    localStorage.setItem(
+      getAppliedCollapsedStorageKey(),
+      isAppliedCollapsed ? "1" : "0",
+    );
+  }, [isAppliedCollapsed]);
 
   const boardQuery = useQuery({
     queryKey: queryKeys.jobs.inProgressBoard(),
     queryFn: async () => {
       const response = await api.getJobs({
-        statuses: ["in_progress"],
+        statuses: ["applied", "in_progress"],
         view: "list",
       });
 
@@ -172,7 +187,8 @@ export const InProgressBoardPage: React.FC = () => {
           ? sortByCompany
           : sortByRecent;
 
-    const grouped: Record<BoardStage, BoardCard[]> = {
+    const grouped: Record<ApplicationStage, BoardCard[]> = {
+      applied: [],
       recruiter_screen: [],
       assessment: [],
       hiring_manager_screen: [],
@@ -183,7 +199,7 @@ export const InProgressBoardPage: React.FC = () => {
     };
 
     for (const card of cards) {
-      grouped[toBoardStage(card.stage)].push(card);
+      grouped[card.stage].push(card);
     }
 
     for (const stage of BOARD_STAGES) {
@@ -315,6 +331,8 @@ export const InProgressBoardPage: React.FC = () => {
             <div className="flex h-full min-w-max items-stretch gap-4">
               {BOARD_STAGES.map((stage) => {
                 const laneCards = lanes[stage];
+                const isCollapsedApplied =
+                  stage === "applied" && isAppliedCollapsed;
                 return (
                   <section
                     key={stage}
@@ -334,17 +352,48 @@ export const InProgressBoardPage: React.FC = () => {
                       }
                     }}
                     className={cn(
-                      "flex h-full w-[320px] flex-col rounded-xl border border-border/70 bg-muted/30 shadow-[0_10px_24px_-20px_rgba(0,0,0,0.8)] transition-colors",
+                      "flex h-full flex-col rounded-xl border border-border/70 bg-muted/30 shadow-[0_10px_24px_-20px_rgba(0,0,0,0.8)] transition-colors",
+                      isCollapsedApplied ? "w-11" : "w-[320px]",
                       dropTargetStage === stage &&
                         "border-sky-400/70 bg-sky-500/15",
                     )}
                   >
                     <header
-                      className={
-                        "flex items-center justify-between border-b border-border/60 px-3 py-2.5"
-                      }
+                      className={cn(
+                        "flex items-center border-b border-border/60 px-3 py-2.5",
+                        isCollapsedApplied
+                          ? "flex-col gap-2"
+                          : "justify-between",
+                      )}
                     >
-                      <h2 className="text-xs font-semibold tracking-[0.03em] text-foreground/90 uppercase">
+                      {stage === "applied" && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-6 w-6 shrink-0 text-muted-foreground"
+                          aria-label={
+                            isAppliedCollapsed
+                              ? "Expand Applied lane"
+                              : "Collapse Applied lane"
+                          }
+                          onClick={() =>
+                            setIsAppliedCollapsed((collapsed) => !collapsed)
+                          }
+                        >
+                          {isAppliedCollapsed ? (
+                            <ChevronRight className="h-3.5 w-3.5" />
+                          ) : (
+                            <ChevronLeft className="h-3.5 w-3.5" />
+                          )}
+                        </Button>
+                      )}
+                      <h2
+                        className={cn(
+                          "text-xs font-semibold tracking-[0.03em] text-foreground/90 uppercase",
+                          isCollapsedApplied && "[writing-mode:vertical-rl]",
+                        )}
+                      >
                         {STAGE_LABELS[stage]}
                       </h2>
                       <Badge
@@ -355,47 +404,54 @@ export const InProgressBoardPage: React.FC = () => {
                       </Badge>
                     </header>
 
-                    <div
-                      className={cn(
-                        "min-h-0 flex-1 space-y-2 p-2.5 [scrollbar-gutter:stable]",
-                        dragging ? "overflow-hidden" : "overflow-y-auto",
-                      )}
-                    >
-                      {laneCards.length === 0 ? (
-                        <div className="rounded-md border border-dashed border-border/35 bg-background/20 px-2.5 py-2 text-[11px] text-muted-foreground/80">
-                          Drop a card here or log a stage.
-                        </div>
-                      ) : (
-                        laneCards.map(({ job, latestEventAt, stage }) => (
-                          <InProgressBoardCard
-                            key={job.id}
-                            job={job}
-                            stage={stage}
-                            latestEventAt={latestEventAt}
-                            jobPageLinkState={jobPageLinkState}
-                            isMoving={movingJobId === job.id}
-                            cardClassName={getCardLeftAccentClass(stage)}
-                            onDragStart={(event) => {
-                              if (
-                                (event.target as HTMLElement).closest(
-                                  "[data-board-card-menu]",
-                                )
-                              ) {
-                                event.preventDefault();
-                                return;
+                    {isCollapsedApplied ? null : (
+                      <div
+                        className={cn(
+                          "min-h-0 flex-1 space-y-2 p-2.5 [scrollbar-gutter:stable]",
+                          dragging ? "overflow-hidden" : "overflow-y-auto",
+                        )}
+                      >
+                        {laneCards.length === 0 ? (
+                          <div className="rounded-md border border-dashed border-border/35 bg-background/20 px-2.5 py-2 text-[11px] text-muted-foreground/80">
+                            Drop a card here or log a stage.
+                          </div>
+                        ) : (
+                          laneCards.map(({ job, latestEventAt, stage }) => (
+                            <InProgressBoardCard
+                              key={job.id}
+                              job={job}
+                              stage={stage}
+                              latestEventAt={latestEventAt}
+                              jobPageLinkState={jobPageLinkState}
+                              isMoving={movingJobId === job.id}
+                              cardClassName={getCardLeftAccentClass(stage)}
+                              onDragStart={(event) => {
+                                if (
+                                  (event.target as HTMLElement).closest(
+                                    "[data-board-card-menu]",
+                                  )
+                                ) {
+                                  event.preventDefault();
+                                  return;
+                                }
+                                setDragging({
+                                  jobId: job.id,
+                                  fromStage: stage,
+                                });
+                                event.dataTransfer.effectAllowed = "move";
+                              }}
+                              onDragEnd={() => {
+                                setDragging(null);
+                                setDropTargetStage(null);
+                              }}
+                              onLogEvent={() =>
+                                setLogEventTarget({ job, stage })
                               }
-                              setDragging({ jobId: job.id, fromStage: stage });
-                              event.dataTransfer.effectAllowed = "move";
-                            }}
-                            onDragEnd={() => {
-                              setDragging(null);
-                              setDropTargetStage(null);
-                            }}
-                            onLogEvent={() => setLogEventTarget({ job, stage })}
-                          />
-                        ))
-                      )}
-                    </div>
+                            />
+                          ))
+                        )}
+                      </div>
+                    )}
                   </section>
                 );
               })}

--- a/orchestrator/src/client/pages/JobPage.tsx
+++ b/orchestrator/src/client/pages/JobPage.tsx
@@ -379,17 +379,6 @@ export const JobPage: React.FC = () => {
     });
   };
 
-  const handleMoveToInProgress = async () => {
-    await runAction("move-in-progress", async () => {
-      if (!job) return;
-      await updateJobMutation.mutateAsync({
-        id: job.id,
-        update: { status: "in_progress" },
-      });
-      toast.success("Moved to in progress");
-    });
-  };
-
   const handleSkip = async () => {
     await runAction("skip", async () => {
       if (!job) return;
@@ -496,7 +485,8 @@ export const JobPage: React.FC = () => {
     : null;
   const isClosedStage = currentStage === "closed";
   const isInProgress = job?.status === "in_progress";
-  const canLogEvents = isInProgress && !isClosedStage;
+  const isApplied = job?.status === "applied";
+  const canLogEvents = (isInProgress || isApplied) && !isClosedStage;
   const jobLink = job ? job.applicationLink || job.jobUrl : null;
   const isBusy = activeAction !== null;
   const isRegeneratingPdf = isPdfRegenerating(job);
@@ -508,7 +498,6 @@ export const JobPage: React.FC = () => {
   const pdfActionsDisabled = !job?.pdfPath || isRegeneratingPdf;
   const isDiscovered = job?.status === "discovered";
   const isReady = job?.status === "ready";
-  const isApplied = job?.status === "applied";
   const baseJobPath = id ? `/job/${id}` : "";
   const latestNote = notes[0] ?? null;
   const latestEvent = events.at(-1) ?? null;
@@ -836,12 +825,13 @@ export const JobPage: React.FC = () => {
                   </div>
                 </div>
                 <div className="p-4">
-                  {!isInProgress && (
+                  {!isInProgress && !isApplied && (
                     <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
-                      Move this job to In Progress to track application stages.
+                      Mark this job as applied to start tracking application
+                      stages.
                     </div>
                   )}
-                  {isInProgress && isClosedStage && (
+                  {(isInProgress || isApplied) && isClosedStage && (
                     <div className="mb-4 rounded-md border border-dashed border-border/60 p-3 text-sm text-muted-foreground">
                       This application is closed. Stage logging is disabled.
                     </div>
@@ -849,8 +839,8 @@ export const JobPage: React.FC = () => {
                   <JobTimeline
                     events={events}
                     discoveredAt={job.discoveredAt}
-                    onEdit={isInProgress ? handleEditEvent : undefined}
-                    onDelete={isInProgress ? confirmDeleteEvent : undefined}
+                    onEdit={canLogEvents ? handleEditEvent : undefined}
+                    onDelete={canLogEvents ? confirmDeleteEvent : undefined}
                   />
                 </div>
               </section>
@@ -895,7 +885,6 @@ export const JobPage: React.FC = () => {
               pdfDownloadLabel={pdfLabels.download}
               onStartTailoring={() => navigate(`/jobs/discovered/${job.id}`)}
               onMarkApplied={() => void handleMarkApplied()}
-              onMoveToInProgress={() => void handleMoveToInProgress()}
               onOpenLogEvent={() => setIsLogModalOpen(true)}
               onEditTailoring={() => navigate(`/jobs/ready/${job.id}`)}
               onViewPdf={() => {

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -587,6 +587,26 @@ describe("OrchestratorPage", () => {
     expect(screen.getByTestId("location").textContent).toContain("/discovered");
   });
 
+  it("redirects the removed Applied tab to the In Progress board", () => {
+    window.matchMedia = createMatchMedia(
+      true,
+    ) as unknown as typeof window.matchMedia;
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/applied"]}>
+        <LocationWatcher />
+        <Routes>
+          <Route path="/jobs/:tab" element={<OrchestratorPage />} />
+          <Route path="/jobs/:tab/:jobId" element={<OrchestratorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("location").textContent).toBe(
+      "/applications/in-progress",
+    );
+  });
+
   it("requests pipeline cancellation when running", async () => {
     mockIsPipelineRunning = true;
     window.matchMedia = createMatchMedia(
@@ -1594,7 +1614,7 @@ describe("OrchestratorPage", () => {
       expect(locationText()).toContain("/discovered");
     });
 
-    pressKey("4");
+    pressKey("3");
     await waitFor(() => {
       expect(locationText()).toContain("/all");
     });

--- a/orchestrator/src/client/pages/job-page/JobPageRightSidebar.test.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageRightSidebar.test.tsx
@@ -56,7 +56,6 @@ function renderRightSidebar(overrides: Parameters<typeof createJob>[0] = {}) {
       pdfDownloadLabel="Download old PDF"
       onStartTailoring={noop}
       onMarkApplied={noop}
-      onMoveToInProgress={noop}
       onOpenLogEvent={noop}
       onEditTailoring={noop}
       onViewPdf={noop}

--- a/orchestrator/src/client/pages/job-page/JobPageRightSidebar.tsx
+++ b/orchestrator/src/client/pages/job-page/JobPageRightSidebar.tsx
@@ -44,7 +44,6 @@ type JobPageRightSidebarProps = {
   pdfDownloadLabel: string;
   onStartTailoring: () => void;
   onMarkApplied: () => void;
-  onMoveToInProgress: () => void;
   onOpenLogEvent: () => void;
   onEditTailoring: () => void;
   onViewPdf: () => void;
@@ -76,7 +75,6 @@ export const JobPageRightSidebar: React.FC<JobPageRightSidebarProps> = ({
   pdfDownloadLabel,
   onStartTailoring,
   onMarkApplied,
-  onMoveToInProgress,
   onOpenLogEvent,
   onEditTailoring,
   onViewPdf,
@@ -136,20 +134,7 @@ export const JobPageRightSidebar: React.FC<JobPageRightSidebarProps> = ({
           </Button>
         )}
 
-        {isApplied && (
-          <Button
-            size="sm"
-            className="w-full justify-start"
-            variant="outline"
-            onClick={onMoveToInProgress}
-            disabled={isBusy}
-          >
-            <CheckCircle2 className="mr-1.5 h-3.5 w-3.5" />
-            Move to In Progress
-          </Button>
-        )}
-
-        {isInProgress && (
+        {(isApplied || isInProgress) && (
           <Button
             size="sm"
             className="w-full justify-start"

--- a/orchestrator/src/client/pages/orchestrator/JobCommandBar.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobCommandBar.test.tsx
@@ -226,7 +226,7 @@ describe("JobCommandBar", () => {
     );
     fireEvent.click(await screen.findByText("Platform Engineer"));
 
-    expect(onSelectJob).toHaveBeenCalledWith("applied", "applied-job");
+    expect(onSelectJob).toHaveBeenCalledWith("all", "applied-job");
   });
 
   it("returns only locked status results", async () => {

--- a/orchestrator/src/client/pages/orchestrator/JobCommandBar.utils.ts
+++ b/orchestrator/src/client/pages/orchestrator/JobCommandBar.utils.ts
@@ -106,7 +106,6 @@ export const getCommandGroup = (status: JobStatus): CommandGroupId => {
 export const getFilterTab = (status: JobStatus): FilterTab => {
   if (status === "ready") return "ready";
   if (status === "discovered" || status === "processing") return "discovered";
-  if (status === "applied") return "applied";
   return "all";
 };
 

--- a/orchestrator/src/client/pages/orchestrator/JobDetailPanel.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobDetailPanel.test.tsx
@@ -11,11 +11,22 @@ import {
   within,
 } from "@testing-library/react";
 import type React from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { JobDetailPanel } from "./JobDetailPanel";
 
+const LocationWatcher = () => {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+};
+
 const render = (ui: Parameters<typeof renderWithQueryClient>[0]) =>
-  renderWithQueryClient(ui);
+  renderWithQueryClient(
+    <MemoryRouter>
+      <LocationWatcher />
+      {ui}
+    </MemoryRouter>,
+  );
 
 const mockSettings = {
   settings: null as AppSettings | null,
@@ -581,9 +592,8 @@ describe("JobDetailPanel", () => {
     expect(onJobUpdated).toHaveBeenCalled();
   });
 
-  it("moves an applied job to in progress from the action button", async () => {
+  it("navigates to the In Progress board from an applied job's action button", async () => {
     const onJobUpdated = vi.fn().mockResolvedValue(undefined);
-    vi.mocked(api.updateJob).mockResolvedValue(undefined as any);
 
     await renderJobDetailPanel({
       activeTab: "all",
@@ -594,15 +604,16 @@ describe("JobDetailPanel", () => {
     });
 
     fireEvent.click(
-      screen.getByRole("button", { name: /move to in progress/i }),
+      screen.getByRole("button", { name: /view in progress board/i }),
     );
 
     await waitFor(() =>
-      expect(api.updateJob).toHaveBeenCalledWith("job-1", {
-        status: "in_progress",
-      }),
+      expect(screen.getByTestId("location")).toHaveTextContent(
+        "/applications/in-progress",
+      ),
     );
-    expect(onJobUpdated).toHaveBeenCalled();
+    expect(api.updateJob).not.toHaveBeenCalled();
+    expect(onJobUpdated).not.toHaveBeenCalled();
   });
 
   it("skips a job from the menu", async () => {

--- a/orchestrator/src/client/pages/orchestrator/JobDetailPanel.tsx
+++ b/orchestrator/src/client/pages/orchestrator/JobDetailPanel.tsx
@@ -55,6 +55,7 @@ import {
 } from "lucide-react";
 import type React from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 import { parseJobBrief } from "@/client/components/JobBriefPane";
 import { showErrorToast } from "@/client/lib/error-toast";
@@ -211,7 +212,7 @@ const getPrimaryAction = (job: Job): string => {
   if (job.status === "processing") return "Processing";
   if (job.status === "ready") return "Mark Applied";
   if (job.status === "discovered") return "Start Tailoring";
-  if (job.status === "applied") return "Move to In Progress";
+  if (job.status === "applied") return "View in Progress Board";
   if (job.status === "in_progress") return "In Progress";
   if (job.status === "skipped") return "Skipped";
   if (job.status === "expired") return "Expired";
@@ -289,10 +290,10 @@ export const JobDetailPanel: React.FC<JobDetailPanelProps> = ({
   onPauseRefreshChange,
   onRetrySelectedJob,
 }) => {
+  const navigate = useNavigate();
   const [inspectorTab, setInspectorTab] = useState<InspectorTab>("brief");
   const [isProcessing, setIsProcessing] = useState(false);
   const [isApplying, setIsApplying] = useState(false);
-  const [isMoving, setIsMoving] = useState(false);
   const [isEditDetailsOpen, setIsEditDetailsOpen] = useState(false);
   const [catalog, setCatalog] = useState<ResumeProjectCatalogItem[]>([]);
   const [isUploadingPdf, setIsUploadingPdf] = useState(false);
@@ -468,26 +469,17 @@ export const JobDetailPanel: React.FC<JobDetailPanelProps> = ({
       return;
     }
     if (selectedJob.status === "applied") {
-      try {
-        setIsMoving(true);
-        await api.updateJob(selectedJob.id, { status: "in_progress" });
-        trackProductEvent("jobs_job_action_completed", {
-          action: "move_in_progress",
-          result: "success",
-          from_status: selectedJob.status,
-          to_status: "in_progress",
-        });
-        toast.success("Moved to in progress");
-        await onJobUpdated();
-      } catch (error) {
-        showErrorToast(error, "Failed to move to in progress");
-      } finally {
-        setIsMoving(false);
-      }
+      trackProductEvent("jobs_job_action_completed", {
+        action: "view_in_progress_board",
+        result: "success",
+        from_status: selectedJob.status,
+        to_status: selectedJob.status,
+      });
+      navigate("/applications/in-progress");
       return;
     }
     setInspectorTab("brief");
-  }, [handleMarkApplied, onJobUpdated, selectedJob]);
+  }, [handleMarkApplied, navigate, selectedJob]);
 
   const handleJobListingOpened = useCallback(() => {
     if (!selectedJob) return;
@@ -670,10 +662,7 @@ export const JobDetailPanel: React.FC<JobDetailPanelProps> = ({
   }
 
   const primaryBusy =
-    isProcessing ||
-    isApplying ||
-    isMoving ||
-    selectedJob.status === "processing";
+    isProcessing || isApplying || selectedJob.status === "processing";
   const canGenerate = ["discovered", "ready"].includes(selectedJob.status);
   const canSkip = ["discovered", "ready"].includes(selectedJob.status);
   const isRegeneratingPdf = isPdfRegenerating(selectedJob);

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorFilters.test.tsx
@@ -51,7 +51,6 @@ const renderFilters = (
     counts: {
       ready: 2,
       discovered: 1,
-      applied: 3,
       all: 6,
     },
     onOpenCommandBar: vi.fn(),
@@ -134,8 +133,8 @@ describe("OrchestratorFilters", () => {
   it("notifies when tabs and command search shortcut are used", () => {
     const { props } = renderFilters();
 
-    fireEvent.mouseDown(screen.getByRole("tab", { name: /applied/i }));
-    expect(props.onTabChange).toHaveBeenCalledWith("applied");
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /all jobs/i }));
+    expect(props.onTabChange).toHaveBeenCalledWith("all");
 
     fireEvent.click(screen.getByRole("button", { name: /search jobs/i }));
     expect(props.onOpenCommandBar).toHaveBeenCalled();

--- a/orchestrator/src/client/pages/orchestrator/constants.ts
+++ b/orchestrator/src/client/pages/orchestrator/constants.ts
@@ -14,6 +14,8 @@ export const DEFAULT_PIPELINE_SOURCES: JobSource[] = [
 export const PIPELINE_SOURCES_STORAGE_KEY = "jobops.pipeline.sources";
 export const PIPELINE_WATCHLIST_SOURCES_STORAGE_KEY =
   "jobops.pipeline.watchlist-sources";
+export const IN_PROGRESS_BOARD_APPLIED_COLLAPSED_STORAGE_KEY =
+  "jobops.in-progress-board.applied-collapsed";
 
 export const orderedSources = [...PIPELINE_EXTRACTOR_SOURCE_IDS].sort(
   (left, right) =>
@@ -78,7 +80,7 @@ export const appliedDuplicateIndicator = {
   dot: "bg-yellow-400",
 };
 
-export type FilterTab = "ready" | "discovered" | "applied" | "all";
+export type FilterTab = "ready" | "discovered" | "all";
 export type DateFilterPreset = "7" | "14" | "30" | "90" | "custom";
 export type DateFilterDimension = "ready" | "applied" | "closed" | "discovered";
 
@@ -214,14 +216,12 @@ export const tabs: Array<{
     label: "Discovered",
     statuses: ["discovered", "processing"],
   },
-  { id: "applied", label: "Applied", statuses: ["applied"] },
   { id: "all", label: "All Jobs", statuses: [] },
 ];
 
 export const emptyStateCopy: Record<FilterTab, string> = {
   ready: "Run a search to discover and process new jobs.",
   discovered: "All discovered jobs have been processed.",
-  applied: "You have not applied to any jobs yet.",
   all: "No jobs in the system yet. Run a search to get started.",
 };
 

--- a/orchestrator/src/client/pages/orchestrator/filters/filterOptions.ts
+++ b/orchestrator/src/client/pages/orchestrator/filters/filterOptions.ts
@@ -48,7 +48,6 @@ export const sortFieldOrder: JobSort["key"][] = [
 export const tabDescriptions: Partial<Record<FilterTab, string>> = {
   discovered: "Jobs searched, ready to be tailored",
   ready: "Jobs with tailored CVs, ready to apply",
-  applied: "Jobs you've marked as applied",
 };
 
 export const datePresetOptions: Array<{

--- a/orchestrator/src/client/pages/orchestrator/useFilteredJobs.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/useFilteredJobs.test.ts
@@ -91,7 +91,7 @@ describe("useFilteredJobs", () => {
     expect(result.current.map((job) => job.id)).toEqual(["match"]);
   });
 
-  it("filters applied jobs by applied date", () => {
+  it("filters jobs by applied date", () => {
     const jobs: Job[] = [
       {
         ...baseJob,
@@ -111,7 +111,7 @@ describe("useFilteredJobs", () => {
       useFilteredJobs(
         jobs,
         makeFilters({
-          activeTab: "applied",
+          activeTab: "all",
           dateFilter: {
             dimensions: ["applied"],
             startDate: "2026-04-01",

--- a/orchestrator/src/client/pages/orchestrator/useFilteredJobs.ts
+++ b/orchestrator/src/client/pages/orchestrator/useFilteredJobs.ts
@@ -47,8 +47,6 @@ export const useFilteredJobs = (jobs: JobListItem[], filters: JobFilters) => {
       filtered = filtered.filter(
         (job) => job.status === "discovered" || job.status === "processing",
       );
-    } else if (activeTab === "applied") {
-      filtered = filtered.filter((job) => job.status === "applied");
     } else if (activeTab === "all") {
       const includeClosedJobs = dateFilter.dimensions.includes("closed");
       if (!includeClosedJobs) {

--- a/orchestrator/src/client/pages/orchestrator/useKeyboardShortcuts.ts
+++ b/orchestrator/src/client/pages/orchestrator/useKeyboardShortcuts.ts
@@ -129,7 +129,6 @@ export function useKeyboardShortcuts(args: UseKeyboardShortcutsArgs): void {
       // ── Tab switching ───────────────────────────────────────────────────
       [SHORTCUTS.tabReady.key]: () => setActiveTab("ready"),
       [SHORTCUTS.tabDiscovered.key]: () => setActiveTab("discovered"),
-      [SHORTCUTS.tabApplied.key]: () => setActiveTab("applied"),
       [SHORTCUTS.tabAll.key]: () => setActiveTab("all"),
       [SHORTCUTS.prevTabArrow.key]: (e) => {
         e.preventDefault();

--- a/orchestrator/src/client/pages/orchestrator/useOrchestratorNavigation.ts
+++ b/orchestrator/src/client/pages/orchestrator/useOrchestratorNavigation.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { type FilterTab, tabs } from "./constants";
 
-const validTabs: FilterTab[] = ["ready", "discovered", "applied", "all"];
+const validTabs: FilterTab[] = ["ready", "discovered", "all"];
 
 const commandSelectionFilterKeys = [
   "source",
@@ -52,7 +52,7 @@ export function useOrchestratorNavigation({
   const selectedJobId = jobId || null;
 
   useEffect(() => {
-    if (tab === "in_progress") {
+    if (tab === "in_progress" || tab === "applied") {
       navigate("/applications/in-progress", { replace: true });
       return;
     }

--- a/orchestrator/src/client/pages/orchestrator/utils.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.test.ts
@@ -55,7 +55,6 @@ describe("orchestrator utils", () => {
     expect(getJobCounts(jobs)).toEqual({
       ready: 2,
       discovered: 2,
-      applied: 1,
       all: 4,
     });
   });

--- a/orchestrator/src/client/pages/orchestrator/utils.ts
+++ b/orchestrator/src/client/pages/orchestrator/utils.ts
@@ -260,7 +260,6 @@ export const getJobCounts = (
   const byTab: Record<FilterTab, number> = {
     ready: 0,
     discovered: 0,
-    applied: 0,
     all: jobs.length,
   };
 
@@ -268,7 +267,6 @@ export const getJobCounts = (
     if (job.closedAt != null) continue;
     if (job.status === "in_progress") continue;
     if (job.status === "ready" || job.status === "processing") byTab.ready += 1;
-    if (job.status === "applied") byTab.applied += 1;
     if (job.status === "discovered" || job.status === "processing")
       byTab.discovered += 1;
   }


### PR DESCRIPTION
## Problem
The "Move to In Progress" action on an Applied job just flipped job.status to in_progress without logging a stage event. The In Progress Board then had to guess a stage for that job, defaulted it to "applied", but force-remapped "applied" -> "recruiter_screen" for lane grouping - so cards landed in Recruiter Screening despite nothing screening-related happening. There was also no direct way to mark an Applied job Rejected/Withdrawn without going through that fake step first.

## Fix
Per the issue discussion, Applied jobs now live directly on the In Progress Board instead of behind an artificial transition:

- The board queries `applied` and `in_progress` jobs and gives Applied its own real lane (no more recruiter_screen remap). The Applied lane is collapsible, with the collapsed/expanded preference persisted per workspace.
- The buggy status-only "Move to In Progress" action is gone. From Applied, "Log event" is available directly, reusing the existing LogEventModal/logJobStageEvent flow (which already supports Recruiter Screen, Rejected, Withdrawn, etc. and correctly writes a StageEvent).
- The Orchestrator job list's standalone "Applied" tab is removed, since it duplicated what the board now owns. Applied jobs remain reachable via "All Jobs"; old /jobs/applied links redirect to the In Progress board, mirroring the existing in_progress tab redirect.
- Docs and keyboard-shortcut numbering are updated to match.

### Preview
Here is the preview of the fixed workflow and the collapsable Applied column.

https://github.com/user-attachments/assets/91df39b4-3c12-4ca4-9180-ba34c77df55b

