### PR TITLE
Restrict database clearing to system admins

### DIFF
--- a/orchestrator/src/server/api/routes/database.test.ts
+++ b/orchestrator/src/server/api/routes/database.test.ts
@@ -2,6 +2,24 @@ import type { Server } from "node:http";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { startServer, stopServer } from "./test-utils";
 
+const AUTH_ENV = {
+  BASIC_AUTH_USER: "admin",
+  BASIC_AUTH_PASSWORD: "secret",
+  JWT_SECRET: "an-explicit-jwt-secret-with-at-least-32-chars",
+  JOBOPS_TEST_AUTH_BYPASS: "0",
+};
+
+async function login(baseUrl: string, username: string, password: string) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const body = await res.json();
+  expect(res.status).toBe(200);
+  return body.data.token as string;
+}
+
 describe.sequential("Database API routes", () => {
   let server: Server;
   let baseUrl: string;
@@ -31,5 +49,36 @@ describe.sequential("Database API routes", () => {
     expect(body.ok).toBe(true);
     expect(body.data.jobsDeleted).toBe(1);
     expect(typeof body.meta.requestId).toBe("string");
+  });
+
+  it("rejects database clearing for non-admin users", async () => {
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: AUTH_ENV,
+    }));
+
+    const adminToken = await login(baseUrl, "admin", "secret");
+    const createUserRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "regular",
+        password: "regular-secret",
+      }),
+    });
+    expect(createUserRes.status).toBe(201);
+
+    const regularToken = await login(baseUrl, "regular", "regular-secret");
+    const res = await fetch(`${baseUrl}/api/database`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${regularToken}` },
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
   });
 });

--- a/orchestrator/src/server/api/routes/database.ts
+++ b/orchestrator/src/server/api/routes/database.ts
@@ -1,16 +1,25 @@
-import { toAppError } from "@infra/errors";
+import { forbidden, toAppError } from "@infra/errors";
 import { fail, ok } from "@infra/http";
+import { isSystemAdmin } from "@infra/request-context";
 import { isDemoMode, sendDemoBlocked } from "@server/config/demo";
 import { clearDatabase } from "@server/db/clear";
 import { type Request, type Response, Router } from "express";
 
 export const databaseRouter = Router();
 
+function requireSystemAdmin(res: Response): boolean {
+  if (isSystemAdmin()) return true;
+  fail(res, forbidden("System admin access is required"));
+  return false;
+}
+
 /**
  * DELETE /api/database - Clear all data from the database
  */
 databaseRouter.delete("/", async (_req: Request, res: Response) => {
   try {
+    if (!requireSystemAdmin(res)) return;
+
     if (isDemoMode()) {
       return sendDemoBlocked(
         res,


### PR DESCRIPTION
## Summary
- require system-admin access before DELETE /api/database can clear shared data
- add regression coverage for non-admin users receiving 403 FORBIDDEN

## Validation
- rtk npm --workspace orchestrator run test:run -- src/server/api/routes/database.test.ts
- ./orchestrator/node_modules/.bin/biome ci .
- rtk npm run check:types:shared
- rtk npm --workspace orchestrator run check:types
- rtk npm --workspace gradcracker-extractor run check:types
- rtk npm --workspace ukvisajobs-extractor run check:types
- rtk npm --workspace orchestrator run build:client
- rtk npm --workspace orchestrator run test:run