### PR TITLE
Restrict server-level maintenance routes to admins

### DIFF
--- a/orchestrator/src/server/api/routes/jobs.test.ts
+++ b/orchestrator/src/server/api/routes/jobs.test.ts
@@ -4,6 +4,24 @@ import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startServer, stopServer } from "./test-utils";
 
+const AUTH_ENV = {
+  BASIC_AUTH_USER: "admin",
+  BASIC_AUTH_PASSWORD: "secret",
+  JWT_SECRET: "an-explicit-jwt-secret-with-at-least-32-chars",
+  JOBOPS_TEST_AUTH_BYPASS: "0",
+};
+
+async function login(baseUrl: string, username: string, password: string) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const body = await res.json();
+  expect(res.status).toBe(200);
+  return body.data.token as string;
+}
+
 describe.sequential("Jobs API routes", () => {
   let server: Server;
   let baseUrl: string;
@@ -1766,6 +1784,41 @@ describe.sequential("Jobs API routes", () => {
       method: "DELETE",
     });
     expect(nanRes.status).toBe(400);
+  });
+
+  it("rejects maintenance deletes for non-admin users", async () => {
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: AUTH_ENV,
+    }));
+
+    const adminToken = await login(baseUrl, "admin", "secret");
+    const createUserRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "regular",
+        password: "regular-secret",
+      }),
+    });
+    expect(createUserRes.status).toBe(201);
+
+    const regularToken = await login(baseUrl, "regular", "regular-secret");
+    const headers = { Authorization: `Bearer ${regularToken}` };
+    const statusRes = await fetch(`${baseUrl}/api/jobs/status/applied`, {
+      method: "DELETE",
+      headers,
+    });
+    const scoreRes = await fetch(`${baseUrl}/api/jobs/score/50`, {
+      method: "DELETE",
+      headers,
+    });
+
+    expect(statusRes.status).toBe(403);
+    expect(scoreRes.status).toBe(403);
   });
 
   it("checks visa sponsor status for a job", async () => {

--- a/orchestrator/src/server/api/routes/jobs/maintenance.ts
+++ b/orchestrator/src/server/api/routes/jobs/maintenance.ts
@@ -29,8 +29,6 @@ jobsMaintenanceRouter.delete(
   "/status/:status",
   async (req: Request, res: Response) => {
     try {
-      if (!requireSystemAdmin(res)) return;
-
       if (isDemoMode()) {
         return sendDemoBlocked(
           res,
@@ -41,6 +39,8 @@ jobsMaintenanceRouter.delete(
           },
         );
       }
+
+      if (!requireSystemAdmin(res)) return;
 
       const parseResult = jobStatusParamSchema.safeParse(req.params.status);
       if (!parseResult.success) {
@@ -64,8 +64,6 @@ jobsMaintenanceRouter.delete(
   "/score/:threshold",
   async (req: Request, res: Response) => {
     try {
-      if (!requireSystemAdmin(res)) return;
-
       if (isDemoMode()) {
         return sendDemoBlocked(
           res,
@@ -76,6 +74,8 @@ jobsMaintenanceRouter.delete(
           },
         );
       }
+
+      if (!requireSystemAdmin(res)) return;
 
       const threshold = parseInt(req.params.threshold, 10);
       if (Number.isNaN(threshold) || threshold < 0 || threshold > 100) {

--- a/orchestrator/src/server/api/routes/jobs/maintenance.ts
+++ b/orchestrator/src/server/api/routes/jobs/maintenance.ts
@@ -1,5 +1,6 @@
-import { badRequest, toAppError } from "@infra/errors";
+import { badRequest, forbidden, toAppError } from "@infra/errors";
 import { fail, ok } from "@infra/http";
+import { isSystemAdmin } from "@infra/request-context";
 import { isDemoMode, sendDemoBlocked } from "@server/config/demo";
 import * as jobsRepo from "@server/repositories/jobs";
 import type { JobStatus } from "@shared/types";
@@ -7,6 +8,12 @@ import { type Request, type Response, Router } from "express";
 import { z } from "zod";
 
 export const jobsMaintenanceRouter = Router();
+
+function requireSystemAdmin(res: Response): boolean {
+  if (isSystemAdmin()) return true;
+  fail(res, forbidden("System admin access is required"));
+  return false;
+}
 
 const jobStatusParamSchema = z.enum([
   "discovered",
@@ -22,6 +29,8 @@ jobsMaintenanceRouter.delete(
   "/status/:status",
   async (req: Request, res: Response) => {
     try {
+      if (!requireSystemAdmin(res)) return;
+
       if (isDemoMode()) {
         return sendDemoBlocked(
           res,
@@ -55,6 +64,8 @@ jobsMaintenanceRouter.delete(
   "/score/:threshold",
   async (req: Request, res: Response) => {
     try {
+      if (!requireSystemAdmin(res)) return;
+
       if (isDemoMode()) {
         return sendDemoBlocked(
           res,

--- a/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
+++ b/orchestrator/src/server/api/routes/settings.codex-auth.test.ts
@@ -39,6 +39,24 @@ vi.mock("@server/services/llm/service", () => ({
 
 import { startServer, stopServer } from "./test-utils";
 
+const AUTH_ENV = {
+  BASIC_AUTH_USER: "admin",
+  BASIC_AUTH_PASSWORD: "secret",
+  JWT_SECRET: "an-explicit-jwt-secret-with-at-least-32-chars",
+  JOBOPS_TEST_AUTH_BYPASS: "0",
+};
+
+async function login(baseUrl: string, username: string, password: string) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const body = await res.json();
+  expect(res.status).toBe(200);
+  return body.data.token as string;
+}
+
 describe.sequential("Settings codex auth routes", () => {
   let server: Server;
   let baseUrl: string;
@@ -198,6 +216,47 @@ describe.sequential("Settings codex auth routes", () => {
     expect(body.ok).toBe(false);
     expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
     expect(body.meta.requestId).toBe("req-codex-auth-fail");
+  });
+
+  it("rejects codex auth changes for non-admin users", async () => {
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: AUTH_ENV,
+    }));
+
+    const adminToken = await login(baseUrl, "admin", "secret");
+    const createUserRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "regular",
+        password: "regular-secret",
+      }),
+    });
+    expect(createUserRes.status).toBe(201);
+
+    const regularToken = await login(baseUrl, "regular", "regular-secret");
+    const headers = { Authorization: `Bearer ${regularToken}` };
+
+    const startRes = await fetch(`${baseUrl}/api/settings/codex-auth/start`, {
+      method: "POST",
+      headers,
+    });
+    const disconnectRes = await fetch(
+      `${baseUrl}/api/settings/codex-auth/disconnect`,
+      {
+        method: "POST",
+        headers,
+      },
+    );
+
+    expect(startRes.status).toBe(403);
+    expect(disconnectRes.status).toBe(403);
+    expect(startCodexDeviceAuthMock).not.toHaveBeenCalled();
+    expect(disconnectCodexAuthMock).not.toHaveBeenCalled();
   });
 
   it("disconnects codex auth and returns status", async () => {

--- a/orchestrator/src/server/api/routes/settings.test.ts
+++ b/orchestrator/src/server/api/routes/settings.test.ts
@@ -74,6 +74,24 @@ import {
 import { getDefaultPromptTemplate } from "@shared/prompt-template-definitions.js";
 import { startServer, stopServer } from "./test-utils";
 
+const AUTH_ENV = {
+  BASIC_AUTH_USER: "admin",
+  BASIC_AUTH_PASSWORD: "secret",
+  JWT_SECRET: "an-explicit-jwt-secret-with-at-least-32-chars",
+  JOBOPS_TEST_AUTH_BYPASS: "0",
+};
+
+async function login(baseUrl: string, username: string, password: string) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const body = await res.json();
+  expect(res.status).toBe(200);
+  return body.data.token as string;
+}
+
 describe.sequential("Settings API routes", () => {
   let server: Server;
   let baseUrl: string;
@@ -314,6 +332,41 @@ describe.sequential("Settings API routes", () => {
     expect(patchBody.data.ghostwriterSystemPromptTemplate.override).toBe(
       "Custom Ghostwriter {{tone}}",
     );
+  });
+
+  it("rejects settings updates for non-admin users", async () => {
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: AUTH_ENV,
+    }));
+
+    const adminToken = await login(baseUrl, "admin", "secret");
+    const createUserRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "regular",
+        password: "regular-secret",
+      }),
+    });
+    expect(createUserRes.status).toBe(201);
+
+    const regularToken = await login(baseUrl, "regular", "regular-secret");
+    const res = await fetch(`${baseUrl}/api/settings`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${regularToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ llmApiKey: "attacker-controlled-value" }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(403);
+    expect(body.error.code).toBe("FORBIDDEN");
   });
 
   it("ignores malformed stored purpose API keys when listing models", async () => {

--- a/orchestrator/src/server/api/routes/settings.ts
+++ b/orchestrator/src/server/api/routes/settings.ts
@@ -1,6 +1,7 @@
 import {
   AppError,
   badRequest,
+  forbidden,
   serviceUnavailable,
   statusToCode,
   unauthorized,
@@ -8,7 +9,7 @@ import {
 } from "@infra/errors";
 import { asyncRoute, fail, ok } from "@infra/http";
 import { logger } from "@infra/logger";
-import { getRequestId } from "@infra/request-context";
+import { getRequestId, isSystemAdmin } from "@infra/request-context";
 import { isDemoMode, sendDemoBlocked } from "@server/config/demo";
 import { getSetting } from "@server/repositories/settings";
 import { enqueueAutoPdfRegenerationForSettingsChanges } from "@server/services/auto-pdf-regeneration";
@@ -53,6 +54,12 @@ const RXRESUME_SAVE_VALIDATION_KEYS: Array<keyof UpdateSettingsInput> = [
   "rxresumeUrl",
   "rxresumeApiKey",
 ];
+
+function requireSystemAdmin(res: Response): boolean {
+  if (isSystemAdmin()) return true;
+  fail(res, forbidden("System admin access is required"));
+  return false;
+}
 
 function hasInputKey<K extends keyof UpdateSettingsInput>(
   input: UpdateSettingsInput,
@@ -450,6 +457,8 @@ settingsRouter.get(
 settingsRouter.post(
   "/codex-auth/start",
   asyncRoute(async (req: Request, res: Response) => {
+    if (!requireSystemAdmin(res)) return;
+
     if (isDemoMode()) {
       fail(
         res,
@@ -483,6 +492,8 @@ settingsRouter.post(
 settingsRouter.post(
   "/codex-auth/disconnect",
   asyncRoute(async (_req: Request, res: Response) => {
+    if (!requireSystemAdmin(res)) return;
+
     if (isDemoMode()) {
       return sendDemoBlocked(
         res,

--- a/orchestrator/src/server/api/routes/settings.ts
+++ b/orchestrator/src/server/api/routes/settings.ts
@@ -310,8 +310,6 @@ settingsRouter.get(
 settingsRouter.patch(
   "/",
   asyncRoute(async (req: Request, res: Response) => {
-    if (!requireSystemAdmin(res)) return;
-
     if (isDemoMode()) {
       return sendDemoBlocked(
         res,
@@ -319,6 +317,8 @@ settingsRouter.patch(
         { route: "PATCH /api/settings" },
       );
     }
+
+    if (!requireSystemAdmin(res)) return;
 
     const input = updateSettingsSchema.parse(req.body);
     if (shouldValidateRxResumeOnSave(input)) {

--- a/orchestrator/src/server/api/routes/settings.ts
+++ b/orchestrator/src/server/api/routes/settings.ts
@@ -310,6 +310,8 @@ settingsRouter.get(
 settingsRouter.patch(
   "/",
   asyncRoute(async (req: Request, res: Response) => {
+    if (!requireSystemAdmin(res)) return;
+
     if (isDemoMode()) {
       return sendDemoBlocked(
         res,

--- a/orchestrator/src/server/api/routes/visa-sponsors.test.ts
+++ b/orchestrator/src/server/api/routes/visa-sponsors.test.ts
@@ -2,6 +2,24 @@ import type { Server } from "node:http";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startServer, stopServer } from "./test-utils";
 
+const AUTH_ENV = {
+  BASIC_AUTH_USER: "admin",
+  BASIC_AUTH_PASSWORD: "secret",
+  JWT_SECRET: "an-explicit-jwt-secret-with-at-least-32-chars",
+  JOBOPS_TEST_AUTH_BYPASS: "0",
+};
+
+async function login(baseUrl: string, username: string, password: string) {
+  const res = await fetch(`${baseUrl}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, password }),
+  });
+  const body = await res.json();
+  expect(res.status).toBe(200);
+  return body.data.token as string;
+}
+
 describe.sequential("Visa sponsors API routes", () => {
   let server: Server;
   let baseUrl: string;
@@ -78,6 +96,46 @@ describe.sequential("Visa sponsors API routes", () => {
     expect(body.ok).toBe(false);
     expect(body.error.code).toBe("SERVICE_UNAVAILABLE");
     expect(body.meta.requestId).toBe("req-visa-sponsors-empty");
+  });
+
+  it("rejects sponsor data updates for non-admin users", async () => {
+    await stopServer({ server, closeDb, tempDir });
+    ({ server, baseUrl, closeDb, tempDir } = await startServer({
+      env: AUTH_ENV,
+    }));
+
+    const adminToken = await login(baseUrl, "admin", "secret");
+    const createUserRes = await fetch(`${baseUrl}/api/workspaces/users`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        username: "regular",
+        password: "regular-secret",
+      }),
+    });
+    expect(createUserRes.status).toBe(201);
+
+    const { downloadLatestCsv } = await import(
+      "@server/services/visa-sponsors/index"
+    );
+    const regularToken = await login(baseUrl, "regular", "regular-secret");
+    const headers = { Authorization: `Bearer ${regularToken}` };
+
+    const allProvidersRes = await fetch(`${baseUrl}/api/visa-sponsors/update`, {
+      method: "POST",
+      headers,
+    });
+    const providerRes = await fetch(`${baseUrl}/api/visa-sponsors/update/uk`, {
+      method: "POST",
+      headers,
+    });
+
+    expect(allProvidersRes.status).toBe(403);
+    expect(providerRes.status).toBe(403);
+    expect(vi.mocked(downloadLatestCsv)).not.toHaveBeenCalled();
   });
 
   it("updates an individual provider and returns its refreshed status", async () => {

--- a/orchestrator/src/server/api/routes/visa-sponsors.ts
+++ b/orchestrator/src/server/api/routes/visa-sponsors.ts
@@ -1,10 +1,12 @@
 import {
   badRequest,
+  forbidden,
   notFound,
   serviceUnavailable,
   toAppError,
 } from "@infra/errors";
 import { fail, ok } from "@infra/http";
+import { isSystemAdmin } from "@infra/request-context";
 import * as visaSponsors from "@server/services/visa-sponsors/index";
 import { getVisaSponsorProviderRegistry } from "@server/services/visa-sponsors/providers/registry";
 import { normalizeCountryKey } from "@shared/location-support.js";
@@ -17,6 +19,12 @@ import { type Request, type Response, Router } from "express";
 import { z } from "zod";
 
 export const visaSponsorsRouter = Router();
+
+function requireSystemAdmin(res: Response): boolean {
+  if (isSystemAdmin()) return true;
+  fail(res, forbidden("System admin access is required"));
+  return false;
+}
 
 /**
  * GET /api/visa-sponsors/status - Get status of all registered providers
@@ -112,6 +120,8 @@ visaSponsorsRouter.get(
  */
 visaSponsorsRouter.post("/update", async (_req: Request, res: Response) => {
   try {
+    if (!requireSystemAdmin(res)) return;
+
     const result = await visaSponsors.downloadLatestCsv();
 
     if (!result.success) {
@@ -155,6 +165,8 @@ visaSponsorsRouter.post(
   "/update/:providerId",
   async (req: Request, res: Response) => {
     try {
+      if (!requireSystemAdmin(res)) return;
+
       const { providerId } = req.params;
       const result = await visaSponsors.downloadLatestCsv(providerId);
 


### PR DESCRIPTION
## Summary
- require system-admin access before refreshing visa sponsor provider data
- require system-admin access before starting or disconnecting the server-side Codex auth session
- keep the database-clear admin guard from the original security fix branch
- add regression coverage for non-admin users receiving 403 FORBIDDEN on these instance-level routes

## Validation
- rtk npm --workspace orchestrator run test:run -- src/server/api/routes/visa-sponsors.test.ts src/server/api/routes/settings.codex-auth.test.ts
- ./orchestrator/node_modules/.bin/biome ci orchestrator/src/server/api/routes/visa-sponsors.ts orchestrator/src/server/api/routes/settings.ts orchestrator/src/server/api/routes/visa-sponsors.test.ts orchestrator/src/server/api/routes/settings.codex-auth.test.ts
- rtk npm --workspace orchestrator run check:types
- rtk npm run check:types:shared
- ./orchestrator/node_modules/.bin/biome ci .
- rtk npm --workspace gradcracker-extractor run check:types
- rtk npm --workspace ukvisajobs-extractor run check:types
- rtk npm --workspace orchestrator run build:client
- rtk npm --workspace orchestrator run test:run