### PR TITLE
Support hosted mode and remember search mode

### DIFF
--- a/docs-site/docs/features/pipeline-run.md
+++ b/docs-site/docs/features/pipeline-run.md
@@ -65,6 +65,9 @@ value in this browser. If you picked **Custom**, it reopens in Custom mode with
 the same values. The pipeline run itself still derives per-source caps from the
 saved budget when you start the run.
 
+Run Search also remembers whether you last used **Automatic** or **Manual** in
+this browser and reopens that mode next time.
+
 #### Search area
 
 **Map radius** is the default search-area mode. It does not require an address or postcode.

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -186,6 +186,8 @@ These flags only affect hosted mode. Leaving `JOBOPS_APP_MODE` unset keeps the c
 
 When hosted mode is active, first-run setup is disabled. Hosted users must be created through hosted signup when `JOBOPS_HOSTED_SIGNUPS_ENABLED=true`, or by a later tenant-owner/admin user-management flow. Hosted signup appears on `/sign-in` as a **Create account** tab only when hosted mode and hosted signups are both enabled.
 
+The Tracking Inbox is available only in local/self-hosted mode. Hosted mode hides it from navigation and redirects direct `/tracking-inbox` links to **Overview**.
+
 ## Codex sign-in
 
 For full Codex auth troubleshooting (including device-code authorization errors), see:

--- a/docs-site/docs/getting-started/self-hosting.md
+++ b/docs-site/docs/getting-started/self-hosting.md
@@ -151,7 +151,7 @@ Open:
 The onboarding flow saves three durable setup decisions:
 
 1. **Workspace account**: On brand-new installs, create the first username/password account directly in onboarding. This first account becomes the system admin and owns the initial private workspace.
-2. **Search preferences**: Save your country, optional preferred cities, workplace style, and whether you need visa sponsorship. JobOps applies these values as defaults for future runs and sponsor-aware features.
+2. **Search preferences**: Select a required country, optionally enter preferred cities, and choose workplace styles. Remote, hybrid, and onsite are selected by default, and visa sponsorship is enabled by default. JobOps applies these values as defaults for future runs and sponsor-aware features.
 3. **LLM provider**: Choose OpenRouter by default, or connect another supported hosted or local provider. The step completes only after the server verifies and persists the connection.
 4. **Resume review**: Upload a PDF/DOCX/Reactive Resume JSON, or connect Reactive Resume. JobOps shows the parsed resume and requires confirmation of the current document before setup completes.
 

--- a/orchestrator/src/client/App.test.tsx
+++ b/orchestrator/src/client/App.test.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import { MemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
+import { AppModeContext } from "./components/layout";
 import { useDemoInfo } from "./hooks/useDemoInfo";
 
 vi.mock("./hooks/useDemoInfo", () => ({
@@ -170,5 +171,26 @@ describe("App demo banner", () => {
     );
 
     expect(screen.getByText("design-resume-page")).toBeInTheDocument();
+  });
+
+  it("redirects hosted users away from Tracking Inbox", () => {
+    vi.mocked(useDemoInfo).mockReturnValue({
+      demoMode: false,
+      resetCadenceHours: 6,
+      lastResetAt: null,
+      nextResetAt: null,
+      baselineVersion: null,
+      baselineName: null,
+    });
+
+    render(
+      <AppModeContext.Provider value={{ appMode: "hosted", isPending: false }}>
+        <MemoryRouter initialEntries={["/tracking-inbox"]}>
+          <App />
+        </MemoryRouter>
+      </AppModeContext.Provider>,
+    );
+
+    expect(screen.getByText("overview")).toBeInTheDocument();
   });
 });

--- a/orchestrator/src/client/App.tsx
+++ b/orchestrator/src/client/App.tsx
@@ -15,6 +15,7 @@ import { CSSTransition, SwitchTransition } from "react-transition-group";
 
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
+import { AppModeContext } from "./components/layout";
 import { OnboardingGate } from "./components/OnboardingGate";
 import { useAnalyticsIdentity } from "./hooks/useAnalyticsIdentity";
 import { useDemoInfo } from "./hooks/useDemoInfo";
@@ -195,7 +196,10 @@ export const App: React.FC = () => {
                 <Route path="/settings" element={<SettingsPage />} />
                 <Route path="/tracer-links" element={<TracerLinksPage />} />
                 <Route path="/visa-sponsors" element={<VisaSponsorsPage />} />
-                <Route path="/tracking-inbox" element={<TrackingInboxPage />} />
+                <Route
+                  path="/tracking-inbox"
+                  element={<TrackingInboxRoute />}
+                />
                 <Route path="/watchlist" element={<WatchlistPage />} />
                 <Route path="/jobs/:tab" element={<OrchestratorPage />} />
                 <Route
@@ -212,3 +216,13 @@ export const App: React.FC = () => {
     </>
   );
 };
+
+function TrackingInboxRoute() {
+  const { appMode, isPending } = React.useContext(AppModeContext);
+
+  if (isPending) return null;
+  if (appMode === "hosted") {
+    return <Navigate to="/overview" replace />;
+  }
+  return <TrackingInboxPage />;
+}

--- a/orchestrator/src/client/components/layout.tsx
+++ b/orchestrator/src/client/components/layout.tsx
@@ -2,7 +2,8 @@
  * Shared layout components for consistent page structure.
  */
 
-import { logout } from "@client/api";
+import { getAppStatus, logout } from "@client/api";
+import { useQuery } from "@tanstack/react-query";
 import {
   ExternalLink,
   LogOut,
@@ -10,8 +11,7 @@ import {
   Menu,
   UserRound,
 } from "lucide-react";
-import type React from "react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -32,6 +32,7 @@ import {
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 import { useVersionCheck } from "../hooks/useVersionCheck";
+import { queryKeys } from "../lib/queryKeys";
 import {
   loadRememberedAuthUsers,
   type RememberedAuthUser,
@@ -39,6 +40,31 @@ import {
 import { isNavActive, NAV_LINKS } from "./navigation";
 import { StatusBadgeIndicator } from "./StatusIndicator";
 import { Tip } from "./Tip";
+
+export const AppModeContext = React.createContext({
+  appMode: "local" as "local" | "hosted",
+  isPending: false,
+});
+
+export const AppModeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const appStatusQuery = useQuery({
+    queryKey: queryKeys.app.status(),
+    queryFn: getAppStatus,
+  });
+
+  return (
+    <AppModeContext.Provider
+      value={{
+        appMode: appStatusQuery.data?.appMode ?? "local",
+        isPending: appStatusQuery.isPending,
+      }}
+    >
+      {children}
+    </AppModeContext.Provider>
+  );
+};
 
 const buildSignInPath = (username: string, nextPath: string): string => {
   const params = new URLSearchParams();
@@ -89,6 +115,11 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
   const navOpen = controlledNavOpen ?? internalNavOpen;
   const setNavOpen = onNavOpenChange ?? setInternalNavOpen;
   const { version, updateAvailable } = useVersionCheck();
+  const { appMode } = React.useContext(AppModeContext);
+  const navLinks =
+    appMode === "hosted"
+      ? NAV_LINKS.filter(({ to }) => to !== "/tracking-inbox")
+      : NAV_LINKS;
 
   useEffect(() => {
     if (navOpen) {
@@ -132,7 +163,7 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
                 <SheetTitle>JobOps</SheetTitle>
               </SheetHeader>
               <nav className="mt-6 flex flex-col gap-2">
-                {NAV_LINKS.map(({ to, label, icon: NavIcon, activePaths }) => (
+                {navLinks.map(({ to, label, icon: NavIcon, activePaths }) => (
                   <button
                     key={to}
                     type="button"

--- a/orchestrator/src/client/main.tsx
+++ b/orchestrator/src/client/main.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { AppErrorBoundary } from "@/client/components/AppErrorBoundary";
+import { AppModeProvider } from "@/client/components/layout";
 import { queryClient } from "@/client/lib/queryClient";
 import { App } from "./App";
 import "../index.css";
@@ -14,9 +15,11 @@ ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <AppErrorBoundary>
-          <App />
-        </AppErrorBoundary>
+        <AppModeProvider>
+          <AppErrorBoundary>
+            <App />
+          </AppErrorBoundary>
+        </AppModeProvider>
       </BrowserRouter>
     </QueryClientProvider>
   </React.StrictMode>,

--- a/orchestrator/src/client/pages/OnboardingPage.test.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.test.tsx
@@ -307,7 +307,7 @@ describe("OnboardingPage", () => {
       expect.objectContaining({
         has_country: true,
         city_count: 0,
-        requires_visa_sponsorship: false,
+        requires_visa_sponsorship: true,
       }),
     );
     expect(analyticsMocks.trackProductEvent).toHaveBeenCalledWith(

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -323,8 +323,8 @@ function LaunchSetup({
   const [cities, setCities] = useState("");
   const [workplaceTypes, setWorkplaceTypes] = useState<
     Array<"remote" | "hybrid" | "onsite">
-  >(["remote", "hybrid"]);
-  const [requiresVisaSponsorship, setRequiresVisaSponsorship] = useState(false);
+  >(["remote", "hybrid", "onsite"]);
+  const [requiresVisaSponsorship, setRequiresVisaSponsorship] = useState(true);
   const completionTrackedRef = useRef(false);
   const lastStepViewRef = useRef<string | null>(null);
   const lastStatusCheckRef = useRef<string | null>(null);
@@ -441,7 +441,7 @@ function LaunchSetup({
       setProfileBusy(true);
       applyStatus(
         await api.saveOnboardingProfile({
-          country: country.trim() || null,
+          country: country.trim(),
           cities: parsedCities,
           workplaceTypes,
           requiresVisaSponsorship,
@@ -715,7 +715,7 @@ function ProfileStep(props: {
       description="These preferences seed new runs and help Job Ops prioritize location-aware and visa-sponsor sources. You can change them later."
     >
       <div className="grid gap-5 sm:grid-cols-2">
-        <Field label="Country or market">
+        <Field label="Country or market (required)">
           <SearchableDropdown
             value={props.country}
             options={COUNTRY_OPTIONS}
@@ -780,7 +780,11 @@ function ProfileStep(props: {
       </Label>
       <StepActions
         onContinue={props.onContinue}
-        busy={props.busy || props.workplaceTypes.length === 0}
+        busy={
+          props.busy ||
+          !props.country.trim() ||
+          props.workplaceTypes.length === 0
+        }
         label="Save and continue"
       />
     </StepShell>

--- a/orchestrator/src/client/pages/OnboardingPage.tsx
+++ b/orchestrator/src/client/pages/OnboardingPage.tsx
@@ -298,12 +298,14 @@ function LaunchSetup({
 }) {
   const queryClient = useQueryClient();
   const onboarding = useOnboardingStatus();
-  const flow = useOnboardingFlow();
-  const designResume = useDesignResume();
   const appStatus = useQuery({
     queryKey: queryKeys.app.status(),
     queryFn: api.getAppStatus,
   });
+  const flow = useOnboardingFlow({
+    allowSelfHosted: appStatus.data?.appMode !== "hosted",
+  });
+  const designResume = useDesignResume();
   const profileQuery = useQuery<ResumeProfile>({
     queryKey: queryKeys.profile.current(),
     queryFn: api.getProfile,
@@ -611,6 +613,7 @@ function LaunchSetup({
               ) : (
                 <ResumeStep
                   flow={flow}
+                  allowSelfHosted={appStatus.data?.appMode !== "hosted"}
                   requirement={resumeRequirement}
                   profile={profileQuery.data ?? null}
                   hasResume={Boolean(resumeSource)}
@@ -786,6 +789,7 @@ function ProfileStep(props: {
 
 function ResumeStep({
   flow,
+  allowSelfHosted,
   requirement,
   profile,
   hasResume,
@@ -794,6 +798,7 @@ function ResumeStep({
   onConfirm,
 }: {
   flow: ReturnType<typeof useOnboardingFlow>;
+  allowSelfHosted: boolean;
   requirement: OnboardingRequirement | null;
   profile: ResumeProfile | null;
   hasResume: boolean;
@@ -811,6 +816,7 @@ function ResumeStep({
       >
         <BaseResumeStep
           allowReactiveResume
+          allowSelfHostedReactiveResume={allowSelfHosted}
           baseResumeValidation={toValidationState(requirement)}
           baseResumeValue={flow.watch("rxresumeBaseResumeId")}
           hasRxResumeAccess={Boolean(flow.rxresumeApiKeyHint)}

--- a/orchestrator/src/client/pages/OrchestratorPage.test.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.test.tsx
@@ -11,6 +11,7 @@ import { renderWithQueryClient } from "../test/renderWithQueryClient";
 import { OrchestratorPage } from "./OrchestratorPage";
 import type { AutomaticRunValues } from "./orchestrator/automatic-run";
 import type { FilterTab } from "./orchestrator/constants";
+import { RUN_MODE_STORAGE_KEY } from "./orchestrator/run-mode";
 
 const render = (ui: Parameters<typeof renderWithQueryClient>[0]) =>
   renderWithQueryClient(ui);
@@ -1167,6 +1168,28 @@ describe("OrchestratorPage", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /run search/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("reopens the search composer in the last selected mode", () => {
+    localStorage.setItem(RUN_MODE_STORAGE_KEY, "manual");
+    window.matchMedia = createMatchMedia(
+      true,
+    ) as unknown as typeof window.matchMedia;
+
+    render(
+      <MemoryRouter initialEntries={["/jobs/ready"]}>
+        <Routes>
+          <Route path="/jobs/:tab" element={<OrchestratorPage />} />
+          <Route path="/jobs/:tab/:jobId" element={<OrchestratorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    openAutomaticRunComposer();
+
+    expect(
+      screen.getByRole("heading", { name: /review job details/i }),
     ).toBeInTheDocument();
   });
 

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -2,7 +2,8 @@ import { ManualImportSheet } from "@client/components/ManualImportSheet";
 import { useSettings } from "@client/hooks/useSettings";
 import type { Job } from "@shared/types.js";
 import type React from "react";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { trackProductEvent } from "@/lib/analytics";
 import { OrchestratorHeader } from "./orchestrator/OrchestratorHeader";
 import { OrchestratorJobWorkspaceContainer } from "./orchestrator/OrchestratorJobWorkspaceContainer";
 import { OrchestratorSearchComposer } from "./orchestrator/OrchestratorSearchComposer";
@@ -96,6 +97,15 @@ export const OrchestratorPage: React.FC = () => {
   const isFirstRunWorkspace =
     !isLoading && jobs.length === 0 && !isPipelineRunning;
   const isSearchComposerVisible = isRunModeModalOpen || isFirstRunWorkspace;
+  const wasSearchComposerVisible = useRef(false);
+
+  useEffect(() => {
+    if (isSearchComposerVisible && !wasSearchComposerVisible.current) {
+      trackProductEvent("jobs_search_composer_opened", { mode: runMode });
+    }
+    wasSearchComposerVisible.current = isSearchComposerVisible;
+  }, [isSearchComposerVisible, runMode]);
+
   const canToggleSearchComposer = !isFirstRunWorkspace;
   const searchPresetProps = usePipelineSearchPresets({
     enabled: isSearchComposerVisible && runMode === "automatic",

--- a/orchestrator/src/client/pages/OrchestratorPage.tsx
+++ b/orchestrator/src/client/pages/OrchestratorPage.tsx
@@ -89,6 +89,10 @@ export const OrchestratorPage: React.FC = () => {
     navigateWithContext: navigation.navigateWithContext,
   });
 
+  const openPreferredRunMode = useCallback(() => {
+    openRunMode(runMode);
+  }, [openRunMode, runMode]);
+
   const isFirstRunWorkspace =
     !isLoading && jobs.length === 0 && !isPipelineRunning;
   const isSearchComposerVisible = isRunModeModalOpen || isFirstRunWorkspace;
@@ -107,11 +111,11 @@ export const OrchestratorPage: React.FC = () => {
       return;
     }
 
-    openRunMode("automatic");
+    openPreferredRunMode();
   }, [
     canToggleSearchComposer,
     isSearchComposerVisible,
-    openRunMode,
+    openPreferredRunMode,
     setIsRunModeModalOpen,
   ]);
 
@@ -129,7 +133,10 @@ export const OrchestratorPage: React.FC = () => {
         }
         onOpenAutomaticRun={handleToggleAutomaticRun}
         onCancelPipeline={handleCancelPipeline}
-        onOpenManualImport={() => setIsManualImportOpen(true)}
+        onOpenManualImport={() => {
+          setRunMode("manual");
+          setIsManualImportOpen(true);
+        }}
       />
 
       <main
@@ -174,7 +181,7 @@ export const OrchestratorPage: React.FC = () => {
             filters={filters}
             navigation={navigation}
             ui={ui}
-            openRunMode={openRunMode}
+            openRunMode={openPreferredRunMode}
           />
         )}
       </main>

--- a/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.test.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.test.tsx
@@ -124,4 +124,19 @@ describe("BaseResumeStep", () => {
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/Reactive Resume JSON/i)).not.toBeInTheDocument();
   });
+
+  it("hides self-hosted Reactive Resume controls when disabled", () => {
+    render(
+      <BaseResumeStep
+        {...defaultProps}
+        allowSelfHostedReactiveResume={false}
+        resumeSetupMode="rxresume"
+      />,
+    );
+
+    expect(
+      screen.queryByText("Self-hosted Reactive Resume?"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Custom URL")).not.toBeInTheDocument();
+  });
 });

--- a/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/BaseResumeStep.tsx
@@ -112,6 +112,7 @@ function ResumeImportProgress({
 
 export const BaseResumeStep: React.FC<{
   allowReactiveResume?: boolean;
+  allowSelfHostedReactiveResume?: boolean;
   baseResumeValidation: ValidationState;
   baseResumeValue: string | null;
   hasRxResumeAccess: boolean;
@@ -134,6 +135,7 @@ export const BaseResumeStep: React.FC<{
   onTemplateResumeChange: (value: string | null) => void;
 }> = ({
   allowReactiveResume = true,
+  allowSelfHostedReactiveResume = true,
   baseResumeValidation,
   baseResumeValue,
   hasRxResumeAccess,
@@ -280,6 +282,7 @@ export const BaseResumeStep: React.FC<{
         </>
       ) : (
         <RxResumeStep
+          allowSelfHosted={allowSelfHostedReactiveResume}
           baseResumeValue={baseResumeValue}
           hasRxResumeAccess={hasRxResumeAccess}
           isBusy={isBusy}

--- a/orchestrator/src/client/pages/onboarding/components/RxResumeStep.tsx
+++ b/orchestrator/src/client/pages/onboarding/components/RxResumeStep.tsx
@@ -10,6 +10,7 @@ export const RxResumeStep: React.FC<{
   isBusy: boolean;
   isResumeReady: boolean;
   hasRxResumeAccess: boolean;
+  allowSelfHosted?: boolean;
   isSelfHosted: boolean;
   rxresumeApiKey: string;
   rxresumeUrl: string;
@@ -21,6 +22,7 @@ export const RxResumeStep: React.FC<{
   onRxresumeUrlChange: (value: string) => void;
 }> = ({
   baseResumeValue,
+  allowSelfHosted = true,
   hasRxResumeAccess,
   isBusy,
   isResumeReady,
@@ -60,30 +62,34 @@ export const RxResumeStep: React.FC<{
         disabled={isBusy}
       />
 
-      <div className="rounded-lg border border-border/60 bg-muted/10 px-4 py-3">
-        <label
-          htmlFor="rxresume-self-hosted"
-          className="flex cursor-pointer items-start gap-3"
-        >
-          <Checkbox
-            id="rxresume-self-hosted"
-            checked={isSelfHosted}
-            onCheckedChange={(checked) => onSelfHostedChange(Boolean(checked))}
-            disabled={isBusy}
-          />
-          <div className="space-y-1">
-            <div className="text-sm font-medium">
-              Self-hosted Reactive Resume?
+      {allowSelfHosted ? (
+        <div className="rounded-lg border border-border/60 bg-muted/10 px-4 py-3">
+          <label
+            htmlFor="rxresume-self-hosted"
+            className="flex cursor-pointer items-start gap-3"
+          >
+            <Checkbox
+              id="rxresume-self-hosted"
+              checked={isSelfHosted}
+              onCheckedChange={(checked) =>
+                onSelfHostedChange(Boolean(checked))
+              }
+              disabled={isBusy}
+            />
+            <div className="space-y-1">
+              <div className="text-sm font-medium">
+                Self-hosted Reactive Resume?
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Turn this on only if you run your own instance and need a custom
+                base URL.
+              </p>
             </div>
-            <p className="text-xs text-muted-foreground">
-              Turn this on only if you run your own instance and need a custom
-              base URL.
-            </p>
-          </div>
-        </label>
-      </div>
+          </label>
+        </div>
+      ) : null}
 
-      {isSelfHosted ? (
+      {allowSelfHosted && isSelfHosted ? (
         <SettingsInput
           label="Custom URL"
           inputProps={{

--- a/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
+++ b/orchestrator/src/client/pages/onboarding/useOnboardingFlow.ts
@@ -22,7 +22,7 @@ import {
 } from "./analytics";
 import type { OnboardingFormData, ResumeSetupMode } from "./types";
 
-export function useOnboardingFlow() {
+export function useOnboardingFlow({ allowSelfHosted = true } = {}) {
   const queryClient = useQueryClient();
   const { settings, isLoading: settingsLoading } = useSettings();
   const { setBaseResumeId, syncBaseResumeId } =
@@ -87,11 +87,11 @@ export function useOnboardingFlow() {
       rxresumeApiKey: "",
       rxresumeBaseResumeId: selectedId,
     });
-    setIsRxResumeSelfHosted(Boolean(settings.rxresumeUrl));
+    setIsRxResumeSelfHosted(allowSelfHosted && Boolean(settings.rxresumeUrl));
     if (!resumeSetupModeTouchedRef.current) {
       setResumeSetupMode(selectedId ? "rxresume" : "upload");
     }
-  }, [reset, settings, syncBaseResumeId]);
+  }, [allowSelfHosted, reset, settings, syncBaseResumeId]);
 
   const llmProvider = watch("llmProvider");
   const selectedProvider = normalizeLlmProvider(
@@ -140,7 +140,7 @@ export function useOnboardingFlow() {
 
   const handleSaveRxresume = useCallback(async () => {
     const values = getValues();
-    const selfHosted = isRxResumeSelfHosted;
+    const selfHosted = allowSelfHosted && isRxResumeSelfHosted;
 
     trackProductEvent("onboarding_rxresume_verify_submitted", {
       self_hosted: selfHosted,
@@ -179,7 +179,13 @@ export function useOnboardingFlow() {
     } finally {
       setIsSaving(false);
     }
-  }, [getValues, isRxResumeSelfHosted, refreshOnboardingState, setValue]);
+  }, [
+    allowSelfHosted,
+    getValues,
+    isRxResumeSelfHosted,
+    refreshOnboardingState,
+    setValue,
+  ]);
 
   const handleRxresumeSelfHostedChange = useCallback(
     (next: boolean) => {

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.test.tsx
@@ -11,6 +11,7 @@ import {
 import type React from "react";
 import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { trackProductEvent } from "@/lib/analytics";
 import { AutomaticRunTab } from "./AutomaticRunTab";
 import { AUTOMATIC_PRESETS, RUN_MEMORY_STORAGE_KEY } from "./automatic-run";
 
@@ -69,6 +70,11 @@ vi.mock("@/components/ui/select", () => ({
 
 vi.mock("@/lib/user-location", () => ({
   getDetectedCountryKey: getDetectedCountryKeyMock,
+}));
+
+vi.mock("@/lib/analytics", () => ({
+  bucketQueryLength: vi.fn(() => "11_30"),
+  trackProductEvent: vi.fn(),
 }));
 
 vi.mock("@client/api", () => ({
@@ -274,6 +280,18 @@ describe("AutomaticRunTab", () => {
     expect(onSaveAndRun).not.toHaveBeenCalled();
     expect(onSetPipelineSources).toHaveBeenCalledWith(["linkedin"]);
     expect(screen.getByText("Review generated settings")).toBeInTheDocument();
+    expect(trackProductEvent).toHaveBeenCalledWith(
+      "jobs_search_composer_plan_generated",
+      {
+        result: "success",
+        prompt_length_bucket: "11_30",
+        source: "ai",
+      },
+    );
+    expect(trackProductEvent).toHaveBeenCalledWith(
+      "jobs_search_composer_details_opened",
+      { source: "generated_plan" },
+    );
     expect(
       screen.getByText("Focused the search on platform roles."),
     ).toBeInTheDocument();

--- a/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
+++ b/orchestrator/src/client/pages/orchestrator/AutomaticRunTab.tsx
@@ -31,6 +31,7 @@ import { showErrorToast } from "@/client/lib/error-toast";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { bucketQueryLength, trackProductEvent } from "@/lib/analytics";
 import { getDetectedCountryKey } from "@/lib/user-location";
 import { cn } from "@/lib/utils";
 import { AutomaticRankingPreferencesCard } from "./AutomaticRankingPreferencesCard";
@@ -680,6 +681,7 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
   const handleGenerateSearchPlan = async () => {
     const prompt = searchPrompt.trim();
     if (!prompt) return;
+    const promptLengthBucket = bucketQueryLength(prompt);
 
     setIsPlanningSearch(true);
     try {
@@ -687,13 +689,25 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
         prompt,
         currentConfig: currentSavedSearchConfig,
       });
+      trackProductEvent("jobs_search_composer_plan_generated", {
+        result: "success",
+        prompt_length_bucket: promptLengthBucket,
+        source: result.source,
+      });
       applySearchConfig(result.config);
       setSelectedSavedSearchId(null);
       setPlanSummary(result.summary);
       setPlanWarnings(result.warnings);
       setPlanSource(result.source);
+      trackProductEvent("jobs_search_composer_details_opened", {
+        source: "generated_plan",
+      });
       setAutomaticTab("details");
     } catch (error) {
+      trackProductEvent("jobs_search_composer_plan_generated", {
+        result: "error",
+        prompt_length_bucket: promptLengthBucket,
+      });
       showErrorToast(error, "Failed to generate search settings");
     } finally {
       setIsPlanningSearch(false);
@@ -801,7 +815,12 @@ export const AutomaticRunTab: React.FC<AutomaticRunTabProps> = ({
               planSource={planSource}
               onSearchPromptChange={setSearchPrompt}
               onGenerateSearchPlan={() => void handleGenerateSearchPlan()}
-              onConfigureManually={() => setAutomaticTab("details")}
+              onConfigureManually={() => {
+                trackProductEvent("jobs_search_composer_details_opened", {
+                  source: "manual",
+                });
+                setAutomaticTab("details");
+              }}
             />
           </TabsContent>
 

--- a/orchestrator/src/client/pages/orchestrator/OrchestratorSearchComposer.tsx
+++ b/orchestrator/src/client/pages/orchestrator/OrchestratorSearchComposer.tsx
@@ -60,7 +60,7 @@ export const OrchestratorSearchComposer: React.FC<
     open={true}
     mode={mode}
     showCloseButton={false}
-    showModeTabs={false}
+    showModeTabs
     settings={settings}
     enabledSources={enabledSources}
     pipelineSources={pipelineSources}

--- a/orchestrator/src/client/pages/orchestrator/RunModeModal.test.tsx
+++ b/orchestrator/src/client/pages/orchestrator/RunModeModal.test.tsx
@@ -1,6 +1,11 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { trackProductEvent } from "@/lib/analytics";
 import { RunModeModal } from "./RunModeModal";
+
+vi.mock("@/lib/analytics", () => ({
+  trackProductEvent: vi.fn(),
+}));
 
 vi.mock("@client/components/ManualImportFlow", () => ({
   ManualImportFlow: () => <div data-testid="manual-flow">Manual flow</div>,
@@ -33,6 +38,13 @@ describe("RunModeModal", () => {
 
     expect(screen.getByTestId("automatic-tab")).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: /manual/i })).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: /manual/i }));
+
+    expect(trackProductEvent).toHaveBeenCalledWith(
+      "jobs_search_composer_mode_changed",
+      { from_mode: "automatic", to_mode: "manual" },
+    );
   });
 
   it("can hide mode tabs for the full-page composer", () => {

--- a/orchestrator/src/client/pages/orchestrator/RunModeModal.tsx
+++ b/orchestrator/src/client/pages/orchestrator/RunModeModal.tsx
@@ -12,6 +12,7 @@ import { motion, useReducedMotion } from "framer-motion";
 import type React from "react";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { trackProductEvent } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import { AutomaticRunTab } from "./AutomaticRunTab";
 import type { AutomaticRunValues } from "./automatic-run";
@@ -147,7 +148,15 @@ export const RunModeModal: React.FC<RunModeModalProps> = ({
 
         <Tabs
           value={mode}
-          onValueChange={(value) => onModeChange(value as RunMode)}
+          onValueChange={(value) => {
+            const nextMode = value as RunMode;
+            if (nextMode === mode) return;
+            trackProductEvent("jobs_search_composer_mode_changed", {
+              from_mode: mode,
+              to_mode: nextMode,
+            });
+            onModeChange(nextMode);
+          }}
           className="flex min-h-0 flex-1 flex-col"
         >
           {showModeTabs ? (

--- a/orchestrator/src/client/pages/orchestrator/run-mode.ts
+++ b/orchestrator/src/client/pages/orchestrator/run-mode.ts
@@ -1,1 +1,25 @@
+import { getAuthScopedStorageKey } from "@/client/api/client";
+
 export type RunMode = "automatic" | "manual";
+
+export const RUN_MODE_STORAGE_KEY = "jobops.pipeline.run-mode.v1";
+
+export function loadRunMode(): RunMode {
+  try {
+    return localStorage.getItem(
+      getAuthScopedStorageKey(RUN_MODE_STORAGE_KEY),
+    ) === "manual"
+      ? "manual"
+      : "automatic";
+  } catch {
+    return "automatic";
+  }
+}
+
+export function saveRunMode(mode: RunMode): void {
+  try {
+    localStorage.setItem(getAuthScopedStorageKey(RUN_MODE_STORAGE_KEY), mode);
+  } catch {
+    // Ignore localStorage failures.
+  }
+}

--- a/orchestrator/src/client/pages/orchestrator/usePipelineControls.test.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineControls.test.ts
@@ -2,6 +2,7 @@ import { useSettings } from "@client/hooks/useSettings";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { trackProductEvent } from "@/lib/analytics";
+import { RUN_MODE_STORAGE_KEY } from "./run-mode";
 import { usePipelineControls } from "./usePipelineControls";
 
 vi.mock("@client/hooks/useSettings", () => ({
@@ -15,6 +16,7 @@ vi.mock("@/lib/analytics", () => ({
 describe("usePipelineControls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
     vi.mocked(useSettings).mockReturnValue({
       refreshSettings: vi.fn().mockResolvedValue(null),
     } as never);
@@ -52,5 +54,24 @@ describe("usePipelineControls", () => {
     );
     expect(loadJobs).toHaveBeenCalledOnce();
     expect(navigateWithContext).toHaveBeenCalledWith("ready", "job-1");
+  });
+
+  it("restores the last selected run mode", () => {
+    const args = {
+      isPipelineRunning: false,
+      setIsPipelineRunning: vi.fn(),
+      pipelineTerminalEvent: null,
+      pipelineSources: ["linkedin"],
+      loadJobs: vi.fn().mockResolvedValue(undefined),
+      navigateWithContext: vi.fn(),
+    };
+
+    const first = renderHook(() => usePipelineControls(args));
+    act(() => first.result.current.setRunMode("manual"));
+    first.unmount();
+
+    const second = renderHook(() => usePipelineControls(args));
+    expect(second.result.current.runMode).toBe("manual");
+    expect(localStorage.getItem(RUN_MODE_STORAGE_KEY)).toBe("manual");
   });
 });

--- a/orchestrator/src/client/pages/orchestrator/usePipelineControls.ts
+++ b/orchestrator/src/client/pages/orchestrator/usePipelineControls.ts
@@ -21,7 +21,7 @@ import {
   deriveExtractorLimits,
   serializeCityLocationsSetting,
 } from "./automatic-run";
-import type { RunMode } from "./run-mode";
+import { loadRunMode, type RunMode, saveRunMode } from "./run-mode";
 
 type UsePipelineControlsArgs = {
   isPipelineRunning: boolean;
@@ -64,7 +64,7 @@ export function usePipelineControls(
   } = args;
 
   const [isRunModeModalOpen, setIsRunModeModalOpen] = useState(false);
-  const [runMode, setRunMode] = useState<RunMode>("automatic");
+  const [runMode, setRunModeState] = useState<RunMode>(loadRunMode);
   const [isCancelling, setIsCancelling] = useState(false);
 
   const { refreshSettings } = useSettings();
@@ -99,10 +99,18 @@ export function usePipelineControls(
     toast.success("Search completed");
   }, [pipelineTerminalEvent, setIsPipelineRunning]);
 
-  const openRunMode = useCallback((mode: RunMode) => {
-    setRunMode(mode);
-    setIsRunModeModalOpen(true);
+  const setRunMode = useCallback((mode: RunMode) => {
+    setRunModeState(mode);
+    saveRunMode(mode);
   }, []);
+
+  const openRunMode = useCallback(
+    (mode: RunMode) => {
+      setRunMode(mode);
+      setIsRunModeModalOpen(true);
+    },
+    [setRunMode],
+  );
 
   const startPipelineRun = useCallback(
     async (config: {

--- a/orchestrator/src/lib/analytics.ts
+++ b/orchestrator/src/lib/analytics.ts
@@ -53,6 +53,21 @@ export function trackEvent(event: string, data?: Record<string, unknown>) {
 }
 
 type ProductEventMap = {
+  jobs_search_composer_opened: {
+    mode: "automatic" | "manual";
+  };
+  jobs_search_composer_mode_changed: {
+    from_mode: "automatic" | "manual";
+    to_mode: "automatic" | "manual";
+  };
+  jobs_search_composer_details_opened: {
+    source: "manual" | "generated_plan";
+  };
+  jobs_search_composer_plan_generated: {
+    result: "success" | "error";
+    prompt_length_bucket: string;
+    source?: "ai" | "fallback";
+  };
   jobs_pipeline_run_started: {
     mode: string;
     source_count?: number;

--- a/orchestrator/src/server/api/routes/onboarding.ts
+++ b/orchestrator/src/server/api/routes/onboarding.ts
@@ -30,7 +30,7 @@ const rxresumeActionSchema = z.object({
 });
 
 const profileActionSchema = z.object({
-  country: z.string().trim().max(100).optional().nullable(),
+  country: z.string().trim().min(1).max(100),
   cities: z.array(z.string().trim().min(1).max(120)).max(20),
   workplaceTypes: z
     .array(z.enum(["remote", "hybrid", "onsite"]))

--- a/orchestrator/src/server/services/onboarding-status.ts
+++ b/orchestrator/src/server/services/onboarding-status.ts
@@ -44,7 +44,7 @@ export type OnboardingModelActionInput = {
 };
 
 export type OnboardingProfileActionInput = {
-  country?: string | null;
+  country: string;
   cities: string[];
   workplaceTypes: Array<"remote" | "hybrid" | "onsite">;
   requiresVisaSponsorship: boolean;
@@ -750,7 +750,7 @@ export async function saveOnboardingProfileAction(
     {
       searchCities: input.cities.join("|"),
       workplaceTypes: input.workplaceTypes,
-      jobspyCountryIndeed: input.country?.trim() || null,
+      jobspyCountryIndeed: input.country.trim(),
       showSponsorInfo: input.requiresVisaSponsorship,
       onboardingProfileCompleted: true,
     },


### PR DESCRIPTION
## Summary
- Hide Tracking Inbox and self-hosted Reactive Resume controls in hosted mode.
- Require country during onboarding and broaden default search preferences.
- Persist the selected Automatic/Manual search mode per authenticated user.
- Add search-composer analytics and update documentation/tests.

## Validation
- Tests were not run as part of this push.