### PR TITLE
Fix: make smart router schema compliant with strict JSON schema (#728)

### DIFF
--- a/orchestrator/src/server/services/post-application/ingestion/email-router.ts
+++ b/orchestrator/src/server/services/post-application/ingestion/email-router.ts
@@ -44,8 +44,20 @@ const SMART_ROUTER_SCHEMA: JsonSchemaDefinition = {
       },
       stageEventPayload: {
         type: ["object", "null"],
-        description: "Structured metadata for a potential stage event.",
-        additionalProperties: true,
+        description:
+          "Structured metadata for a potential stage event, or null.",
+        properties: {
+          note: {
+            type: ["string", "null"],
+            description: "Optional short note summarizing the event.",
+          },
+          suggestedStageTarget: {
+            type: ["string", "null"],
+            description: "Optional stage target suggestion.",
+          },
+        },
+        required: ["note", "suggestedStageTarget"],
+        additionalProperties: false,
       },
       reason: {
         type: "string",


### PR DESCRIPTION
## Summary
- Fix `SMART_ROUTER_SCHEMA` for post-application email ingestion by defining concrete properties (`note`, `suggestedStageTarget`) with `additionalProperties: false` on `stageEventPayload`.
- Resolves HTTP 400 `invalid_request_error` (`invalid_json_schema`) when classifying recruitment emails with OpenAI Structured Outputs (Codex, OpenAI, and other strict JSON schema providers).

Fixes #728

## Validation
- Ran end-to-end sync verification against Gmail; emails classified and matched with 99-100% confidence.
- `npm run check:types:shared`
- `npm --workspace orchestrator run check:types`
- `npm --workspace gradcracker-extractor run check:types`
- `npm --workspace ukvisajobs-extractor run check:types`
- `npm --workspace orchestrator run build:client`
- `npm --workspace orchestrator run test:run -- src/server/services/post-application`
